### PR TITLE
chore: Signing GHA update

### DIFF
--- a/.github/scripts/release/sign-windows.ps1
+++ b/.github/scripts/release/sign-windows.ps1
@@ -295,20 +295,6 @@ function Sign-Binary {
     Write-Host "Successfully signed $BinaryPath"
 }
 
-function Verify-Signature {
-    param([string]$BinaryPath)
-
-    Write-Host "Verifying signature on: $BinaryPath"
-
-    & smctl.exe sign verify --input "$BinaryPath"
-
-    if ($LASTEXITCODE -ne 0) {
-        Write-Warning "Signature verification returned non-zero exit code (may be expected)"
-    } else {
-        Write-Host "Signature verified successfully"
-    }
-}
-
 function Main {
     # Verify environment variables
     Assert-EnvVar "SM_HOST"
@@ -358,10 +344,7 @@ function Main {
             Write-Host "Signing $($platform.binary) ($($platform.arch))..."
             Sign-Binary -BinaryPath $binaryPath
 
-            Write-Host "Verifying signature on $($platform.binary)..."
-            Verify-Signature -BinaryPath $binaryPath
-
-            Write-Host "✓ $($platform.binary): signed and verified"
+            Write-Host "✓ $($platform.binary): signed"
             $signedCount++
         } else {
             Write-Host "○ $($platform.binary) ($($platform.arch)): patched with resources only (not signed per config)"

--- a/.github/workflows/sign-windows.yml
+++ b/.github/workflows/sign-windows.yml
@@ -1,6 +1,10 @@
 name: Sign Windows Binaries
 
 on:
+  # TODO: remove temporary push trigger after signing test
+  push:
+    branches:
+      - gha-signing-upgrades
   workflow_dispatch:
     inputs:
       artifact_pattern:
@@ -118,7 +122,9 @@ jobs:
       - name: Download Windows build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: ${{ inputs.artifact_pattern }}
+          # TODO: restore inputs.artifact_pattern after signing test
+          # pattern: ${{ inputs.artifact_pattern }}
+          pattern: 'terragrunt_windows_*'
           path: artifacts/
           merge-multiple: true
 
@@ -162,7 +168,9 @@ jobs:
       - name: Upload Windows Binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ inputs.upload_artifact_name }}
+          # TODO: restore inputs.upload_artifact_name after signing test
+          # name: ${{ inputs.upload_artifact_name }}
+          name: 'windows-signed-files'
           path: |
             bin/terragrunt_windows_amd64.exe
             bin/terragrunt_windows_386.exe

--- a/.github/workflows/sign-windows.yml
+++ b/.github/workflows/sign-windows.yml
@@ -137,11 +137,11 @@ jobs:
         shell: pwsh
         run: .github/scripts/release/install-go-winres.ps1
 
-      # Install DigiCert smtools (smctl)
-      - name: Install DigiCert smtools
-        uses: digicert/ssm-code-signing@1d820463733701cf1484c7eb5d7d24a15ca2c454 # v1.2.1
+      # Install DigiCert smctl
+      - name: Install DigiCert smctl
+        uses: digicert/code-signing-software-trust-action@fae23a455ba4bde62b64fd7cb2f81ade788f5a95 # v1.2.1
         with:
-          force-download-tools: 'true'
+          simple-signing-mode: 'true'
 
       # Verify smctl is available
       - name: Verify smctl installation

--- a/.github/workflows/sign-windows.yml
+++ b/.github/workflows/sign-windows.yml
@@ -1,10 +1,6 @@
 name: Sign Windows Binaries
 
 on:
-  # TODO: remove temporary push trigger after signing test
-  push:
-    branches:
-      - gha-signing-upgrades
   workflow_dispatch:
     inputs:
       artifact_pattern:
@@ -122,9 +118,7 @@ jobs:
       - name: Download Windows build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          # TODO: restore inputs.artifact_pattern after signing test
-          # pattern: ${{ inputs.artifact_pattern }}
-          pattern: 'terragrunt_windows_*'
+          pattern: ${{ inputs.artifact_pattern }}
           path: artifacts/
           merge-multiple: true
 
@@ -168,9 +162,7 @@ jobs:
       - name: Upload Windows Binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # TODO: restore inputs.upload_artifact_name after signing test
-          # name: ${{ inputs.upload_artifact_name }}
-          name: 'windows-signed-files'
+          name: ${{ inputs.upload_artifact_name }}
           path: |
             bin/terragrunt_windows_amd64.exe
             bin/terragrunt_windows_386.exe


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* replace the archived, Node 20 `digicert/ssm-code-signing` action with its Node 24 replacement `digicert/code-signing-software-trust-action@v1.2.1`
* cleaned verification code

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows code signing infrastructure to use updated DigiCert signing tools and simplified signature verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->