### PR TITLE
docs: Updating provider size claims for provider cache server docs

### DIFF
--- a/docs/src/content/docs/03-features/07-caching/02-provider-cache-server.mdx
+++ b/docs/src/content/docs/03-features/07-caching/02-provider-cache-server.mdx
@@ -20,7 +20,7 @@ The Provider Cache Server is a performance optimization. For more details on per
 
 ## Why caching is useful
 
-Let's imagine that your project consists of 50 Terragrunt units, and each of them uses the same `aws` provider. Without caching, each of them will download the provider from the Internet, and store it in its own `.terraform` directory. For clarity, the downloadable archive `terraform-provider-aws_5.36.0_darwin_arm64.zip` has a size of ~100MB, and when unzipped it takes up ~450MB of disk space. It's easy to calculate that initializing such a project with 50 modules will cost you 5GB of traffic and 22.5GB of free space instead of 100MB and 450MB using the cache.
+Let's imagine that your project consists of 50 Terragrunt units, and each of them uses the same `aws` provider. Without caching, each of them will download the provider from the Internet, and store it in its own `.terraform` directory. For clarity, the downloadable archive `terraform-provider-aws_6.50.0_darwin_arm64.zip` has a size of ~180MB, and when unzipped it takes up ~830MB of disk space. It's easy to calculate that initializing such a project with 50 units will cost you 9GB of traffic and over 40GB of free space instead of 180MB and 830MB using the cache.
 
 ## Why OpenTofu/Terraform's built-in provider caching doesn't work
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

These calculations needed an update.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the provider caching example with a newer Terraform AWS provider version, revising the associated performance metrics including download size, disk usage, and computed savings across multiple deployment units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->