### PR TITLE
chore: bump cicd to use opentofu 1.12.2

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.26.0"
-opentofu = "1.12.0"
+opentofu = "1.12.2"
 golangci-lint = "2.11.4"
 "go:github.com/goph/licensei/cmd/licensei" = "v0.9.0"
 "go:go.uber.org/mock/mockgen" = "v0.6.0"


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* Updated GitHub action to use the recently released Opentofu 1.12.2

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTofu tool version to 1.12.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->