### PR TITLE
chore: Adding release attestation verification to install script

### DIFF
--- a/.github/workflows/install-script-test.yml
+++ b/.github/workflows/install-script-test.yml
@@ -23,3 +23,6 @@ jobs:
 
       - name: Run install script tests
         run: ./docs/tests/install_test.sh
+        env:
+          # Release attestation verification requires an authenticated GitHub CLI
+          GH_TOKEN: ${{ github.token }}

--- a/docs/public/install
+++ b/docs/public/install
@@ -27,11 +27,18 @@
 #   --commit SHA             Specify commit SHA for --tip or --test builds
 #   --verify-cosign          Use Cosign instead of GPG for signature verification
 #   --no-verify-sig          Skip GPG/Cosign signature verification
+#   --no-verify-attestation  Skip GitHub release attestation verification
 #   --no-verify              Skip SHA256 checksum verification
 #   -h, --help               Show this help message
 #
 # Signature verification (GPG) is enabled by default for versions >= v0.98.0.
 # Use --no-verify-sig to skip, or --verify-cosign to use Cosign instead of GPG.
+#
+# Release attestation verification is enabled by default for versions >= v1.1.0,
+# which are published as immutable releases. It checks the downloaded assets
+# against the release attestation using the GitHub CLI (gh) v2.81.0+, and is
+# skipped with a warning when gh is unavailable or unauthenticated.
+# Use --no-verify-attestation to skip.
 #
 # Environment:
 #   TERRAGRUNT_VERSION       Override version (same as -v)
@@ -46,6 +53,10 @@ readonly DEFAULT_INSTALL_DIR="${HOME}/.terragrunt/bin"
 readonly BINARY_NAME="terragrunt"
 # Minimum version that has signed release assets (GPG and Cosign)
 readonly MIN_SIGNED_VERSION="0.98.0"
+# Minimum version published as an immutable release with a release attestation
+readonly MIN_ATTESTED_VERSION="1.1.0"
+# Minimum GitHub CLI version that supports 'gh release verify-asset'
+readonly MIN_GH_ATTESTATION_VERSION="2.81.0"
 # Builds API base URL for tip/test builds
 readonly BUILDS_API_BASE="https://builds.terragrunt.com"
 
@@ -100,11 +111,17 @@ Options:
   --commit SHA             Specify commit SHA for --tip or --test builds
   --verify-cosign          Use Cosign instead of GPG for signature verification
   --no-verify-sig          Skip GPG/Cosign signature verification
+  --no-verify-attestation  Skip GitHub release attestation verification
   --no-verify              Skip SHA256 checksum verification
   -h, --help               Show this help message
 
 Signature verification (GPG) is enabled by default for versions >= v0.98.0.
 Use --no-verify-sig to skip, or --verify-cosign to use Cosign instead of GPG.
+
+Release attestation verification is enabled by default for versions >= v1.1.0,
+which are published as immutable releases. It requires an authenticated
+GitHub CLI (gh) v2.81.0+ and is skipped with a warning when unavailable.
+Use --no-verify-attestation to skip.
 
 Examples:
   # Install latest version
@@ -172,6 +189,23 @@ version_gte() {
 supports_signature_verification() {
     local version=$1
     version_gte "$version" "$MIN_SIGNED_VERSION"
+}
+
+# Check if version is published as an immutable release with a release attestation
+supports_attestation_verification() {
+    local version=$1
+    version_gte "$version" "$MIN_ATTESTED_VERSION"
+}
+
+# Check if an installed GitHub CLI supports 'gh release verify-asset'
+gh_supports_attestation_verification() {
+    command -v gh &>/dev/null || return 1
+
+    local gh_version
+    gh_version=$(gh --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+    [[ -n "$gh_version" ]] || return 1
+
+    version_gte "$gh_version" "$MIN_GH_ATTESTATION_VERSION"
 }
 
 # --- OS/Arch Detection ---
@@ -510,6 +544,44 @@ verify_signature() {
     esac
 }
 
+# Verify downloaded assets against the GitHub release attestation.
+# Skips with a warning when the release predates attestations or when a
+# capable, authenticated GitHub CLI is not available.
+verify_release_attestation() {
+    local version="$1"
+    local tmpdir="$2"
+    local binary_name="$3"
+
+    if ! supports_attestation_verification "$version"; then
+        warn "Skipping release attestation verification: not available for versions older than v${MIN_ATTESTED_VERSION}"
+        return 0
+    fi
+
+    if ! gh_supports_attestation_verification; then
+        warn "Skipping release attestation verification: requires GitHub CLI (gh) v${MIN_GH_ATTESTATION_VERSION} or later"
+        return 0
+    fi
+
+    if ! gh auth status &>/dev/null; then
+        warn "Skipping release attestation verification: GitHub CLI (gh) is not authenticated"
+        return 0
+    fi
+
+    info "Verifying release attestation..."
+
+    local asset
+    for asset in "SHA256SUMS" "$binary_name"; do
+        if ! gh release verify-asset "$version" "${tmpdir}/${asset}" --repo "$GITHUB_REPO" >/dev/null 2>&1; then
+            abort "Release attestation verification failed for ${asset}!
+
+The downloaded file does not match the asset recorded in the ${version} release attestation.
+It may be corrupted or tampered with."
+        fi
+    done
+
+    success "Release attestation verified"
+}
+
 # --- Shell RC Detection ---
 detect_shell_rc() {
     local shell_name
@@ -588,8 +660,9 @@ parse_args() {
     VERSION="${TERRAGRUNT_VERSION:-}"
     INSTALL_DIR="${TERRAGRUNT_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
     VERIFY_SHA=true
-    VERIFY_SIG="gpg"      # gpg (default), cosign, or empty (via --no-verify-sig)
-    SKIP_SIG_VERIFY=false # set by --no-verify-sig to disable signature verification
+    VERIFY_SIG="gpg"         # gpg (default), cosign, or empty (via --no-verify-sig)
+    SKIP_SIG_VERIFY=false    # set by --no-verify-sig to disable signature verification
+    VERIFY_ATTESTATION=true  # set to false by --no-verify-attestation
     FORCE=false
     BUILD_CHANNEL="" # "", "tip", or "test"
     COMMIT_SHA=""    # commit SHA for --commit
@@ -631,6 +704,10 @@ parse_args() {
             ;;
         --no-verify-sig)
             SKIP_SIG_VERIFY=true
+            shift
+            ;;
+        --no-verify-attestation)
+            VERIFY_ATTESTATION=false
             shift
             ;;
         --no-verify)
@@ -779,7 +856,12 @@ install_release() {
     download_binary "$version" "$binary_name" "$tmpdir"
     download_checksums "$version" "$tmpdir"
 
-    # Verify signature first (authenticates SHA256SUMS file)
+    # Verify release attestation first (binds downloaded assets to the immutable release)
+    if [[ "$VERIFY_ATTESTATION" == true ]]; then
+        verify_release_attestation "$version" "$tmpdir" "$binary_name"
+    fi
+
+    # Verify signature (authenticates SHA256SUMS file)
     if [[ -n "$VERIFY_SIG" ]]; then
         if supports_signature_verification "$version"; then
             verify_signature "$version" "$tmpdir/SHA256SUMS" "$tmpdir" "$VERIFY_SIG"

--- a/docs/src/data/changelog/v1.1.0/install-script-attestation.mdx
+++ b/docs/src/data/changelog/v1.1.0/install-script-attestation.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.0"
+category: "process-updates"
+---
+
+#### Install script verifies release attestations
+
+The install script now checks downloaded release assets against the release attestation that ships with [immutable releases](/process/releases#immutable-releases). For releases starting with `v1.1.0`, when an authenticated [GitHub CLI](https://cli.github.com/) (v2.81.0 or later) is available, the script verifies the checksums file and the binary against the attestation before installing, and aborts if either does not match the published release. The check is skipped with a warning when `gh` is unavailable, too old, or unauthenticated. Use `--no-verify-attestation` to opt out.

--- a/docs/tests/install_test.sh
+++ b/docs/tests/install_test.sh
@@ -86,6 +86,7 @@ test_help_output() {
 		[[ "$output" == *"--force"* ]] &&
 		[[ "$output" == *"--no-verify-sig"* ]] &&
 		[[ "$output" == *"--verify-cosign"* ]] &&
+		[[ "$output" == *"--no-verify-attestation"* ]] &&
 		[[ "$output" == *"--no-verify"* ]]
 }
 
@@ -415,6 +416,54 @@ test_gpg_is_default_signature_method() {
 		[[ "$output" == *"Signature verified"* ]]
 }
 
+test_attestation_verification() {
+	# Requires an authenticated GitHub CLI new enough for 'gh release verify-asset'
+	command -v gh &>/dev/null || {
+		echo "gh required"
+		return 1
+	}
+	gh auth status &>/dev/null || {
+		echo "authenticated gh required"
+		return 1
+	}
+
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064  # Intentional: expand tmpdir now, not at trap time
+	trap "rm -rf '$tmpdir'" RETURN
+
+	# v1.1.0-rc1 is the first release published with a release attestation
+	local output
+	output=$(bash "$INSTALL_SCRIPT" -d "$tmpdir" -v v1.1.0-rc1 --no-verify-sig 2>&1)
+	[[ "$output" == *"Verifying release attestation"* ]] &&
+		[[ "$output" == *"Release attestation verified"* ]] &&
+		[[ -f "$tmpdir/terragrunt" ]]
+}
+
+test_no_verify_attestation_skips() {
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064  # Intentional: expand tmpdir now, not at trap time
+	trap "rm -rf '$tmpdir'" RETURN
+
+	local output
+	output=$(bash "$INSTALL_SCRIPT" -d "$tmpdir" -v v1.1.0-rc1 --no-verify-sig --no-verify-attestation 2>&1)
+	[[ "$output" != *"attestation"* ]] &&
+		[[ -f "$tmpdir/terragrunt" ]]
+}
+
+test_old_version_skips_attestation() {
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064  # Intentional: expand tmpdir now, not at trap time
+	trap "rm -rf '$tmpdir'" RETURN
+
+	# v0.72.5 predates release attestations, should skip gracefully
+	local output
+	output=$(bash "$INSTALL_SCRIPT" -d "$tmpdir" -v v0.72.5 --no-verify-sig 2>&1)
+	[[ "$output" == *"Skipping release attestation verification: not available for versions older than"* ]]
+}
+
 # --- Platform-Specific Tests ---
 
 test_macos_shasum_fallback() {
@@ -602,6 +651,9 @@ main() {
 		skip_test "--no-verify-sig skips signature"
 		skip_test "Cosign signature verification"
 		skip_test "GPG is default signature method"
+		skip_test "Release attestation verification"
+		skip_test "--no-verify-attestation skips attestation"
+		skip_test "Old version skips attestation verification"
 		skip_test "Temp directory cleanup"
 	else
 		echo "--- Integration Tests (require network) ---"
@@ -621,6 +673,9 @@ main() {
 		run_test "--no-verify-sig skips signature" test_no_verify_sig_skips_signature
 		run_test "Cosign signature verification" test_cosign_signature_verification
 		run_test "GPG is default signature method" test_gpg_is_default_signature_method
+		run_test "Release attestation verification" test_attestation_verification
+		run_test "--no-verify-attestation skips attestation" test_no_verify_attestation_skips
+		run_test "Old version skips attestation verification" test_old_version_skips_attestation
 		run_test "Temp directory cleanup" test_temp_directory_cleanup
 	fi
 	echo ""


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds automatic release attestation verification to install script.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Installer now verifies release authenticity using GitHub release attestation for v1.1.0+
  * Added `--no-verify-attestation` flag to bypass attestation checks when needed

* **Documentation**
  * Updated installer help text with new attestation option documentation

* **Tests**
  * Added integration tests for attestation verification scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->