### PR TITLE
fix: Adding `--terragrunt-boundary` to `mark_glob_as_read`

### DIFF
--- a/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
@@ -1123,6 +1123,34 @@ A typical use case is a unit that consumes a directory of configuration files in
 
 If the pattern matches nothing, the function returns an empty list without error.
 
+### Boundary
+
+`mark_glob_as_read` confines glob expansion to a boundary directory. By default the boundary is the enclosing Git repository root; outside a Git repository, no boundary applies. A pattern whose walk would begin outside the boundary returns an error rather than expanding.
+
+This keeps a pattern that resolves higher than intended from walking a large portion of the filesystem. A pattern interpolated from an empty value is the common case: `"${local.dir}/{*.yaml}"` becomes `/{*.yaml}` when `local.dir` is `""`.
+
+Pass a leading `--terragrunt-boundary` argument to set the boundary explicitly. Use it to scope the walk to a subdirectory, or to widen it when a scan outside the repository root is intended. A relative value resolves against the working directory.
+
+```hcl
+locals {
+  # Restrict the walk to a subdirectory.
+  scoped = mark_glob_as_read("--terragrunt-boundary=/etc/terragrunt", "/etc/terragrunt/{*.yaml}")
+
+  # Remove the boundary entirely.
+  everything = mark_glob_as_read("--terragrunt-boundary=/", "/{*.yaml}")
+}
+```
+
+<Aside type="caution">
+A `? :` conditional does not skip the call. HCL evaluates both branches of a conditional before selecting one, so a guard such as `local.dir != "" ? mark_glob_as_read(...) : []` still expands the glob. Wrap the call in [`try`](https://opentofu.org/docs/language/functions/try/) so a boundary error recovers to a fallback:
+
+```hcl
+locals {
+  files = sort(try(mark_glob_as_read("${local.dir}/{*.yaml,*.yml,*.json}"), []))
+}
+```
+</Aside>
+
 ## constraint_check
 
 `constraint_check(version, constraint)` checks if a given version satisfies a given constraint.

--- a/docs/src/data/changelog/v1.1.0/mark-glob-as-read-root-scan.mdx
+++ b/docs/src/data/changelog/v1.1.0/mark-glob-as-read-root-scan.mdx
@@ -1,0 +1,25 @@
+---
+version: "v1.1.0"
+category: "bug-fixes"
+---
+
+#### `mark_glob_as_read` constrains its walk to a boundary
+
+`mark_glob_as_read` now confines glob expansion to a boundary directory. By default the boundary is the enclosing Git repository root; outside a Git repository it is unset. A pattern whose walk would begin outside the boundary returns an error instead of expanding.
+
+This bounds patterns that resolve higher than intended. For example, `"${local.dir}/{*.yaml}"` becomes `/{*.yaml}` when `local.dir` is empty, which previously walked the entire filesystem. A `? :` conditional does not prevent this, because HCL evaluates both branches of a conditional before selecting one. Wrapping the call in `try` lets the error fall back to a default:
+
+```hcl
+locals {
+  files = sort(try(mark_glob_as_read("${local.dir}/{*.yaml,*.yml,*.json}"), []))
+}
+```
+
+Pass a leading `--terragrunt-boundary` argument to set the boundary explicitly, for example to scope the walk to a subdirectory or to widen it to the filesystem root:
+
+```hcl
+locals {
+  scoped = mark_glob_as_read("--terragrunt-boundary=/etc/terragrunt", "/etc/terragrunt/{*.yaml}")
+  all    = mark_glob_as_read("--terragrunt-boundary=/", "/{*.yaml}")
+}
+```

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -41,6 +41,7 @@ package glob
 
 import (
 	"errors"
+	"fmt"
 	iofs "io/fs"
 	"path"
 	"path/filepath"
@@ -63,10 +64,16 @@ func Compile(pattern string) (Matcher, error) {
 	return gobwas.Compile(pattern, '/')
 }
 
-// ExpandOption configures the behavior of [Expand]. See [WithFilesOnly].
+// ErrOutsideBoundary reports that a pattern's walk root fell outside the
+// boundary supplied to [WithBoundary].
+var ErrOutsideBoundary = errors.New("glob pattern resolves outside the configured boundary")
+
+// ExpandOption configures the behavior of [Expand]. See [WithFilesOnly] and
+// [WithBoundary].
 type ExpandOption func(*expandOptions)
 
 type expandOptions struct {
+	boundary  string
 	filesOnly bool
 }
 
@@ -78,9 +85,22 @@ func WithFilesOnly() ExpandOption {
 	}
 }
 
+// WithBoundary constrains the directory [Expand] is allowed to walk. boundary
+// must be an absolute path. [Expand] returns [ErrOutsideBoundary] when the
+// pattern's walk root is not boundary or a descendant of it. An empty boundary
+// imposes no constraint.
+func WithBoundary(boundary string) ExpandOption {
+	return func(o *expandOptions) {
+		o.boundary = boundary
+	}
+}
+
 // Expand returns the absolute paths that match pattern on fs. The pattern
 // uses '/' as the separator on all platforms and '\' as the escape character.
 // A pattern that matches nothing returns an empty slice and a nil error.
+//
+// Pass [WithBoundary] to constrain the walk to a directory; a pattern whose
+// walk root falls outside it returns [ErrOutsideBoundary].
 //
 // Most callers pass [vfs.NewOSFS] for fs; tests can pass an in-memory
 // filesystem from [vfs.NewMemMapFS].
@@ -93,6 +113,10 @@ func Expand(fs vfs.FS, pattern string, opts ...ExpandOption) ([]string, error) {
 	pattern = path.Clean(pattern)
 
 	root, hasMeta := splitRoot(pattern)
+
+	if err := o.checkBoundary(fs, root); err != nil {
+		return nil, err
+	}
 
 	if !hasMeta {
 		info, err := fs.Stat(root)
@@ -176,4 +200,41 @@ func splitRoot(pattern string) (string, bool) {
 	}
 
 	return filepath.FromSlash(prefix), true
+}
+
+// checkBoundary reports whether walking from root is permitted. An empty
+// boundary imposes no constraint; otherwise root must fall inside it.
+func (o expandOptions) checkBoundary(fs vfs.FS, root string) error {
+	if o.boundary == "" {
+		return nil
+	}
+
+	// Compare symlink-resolved paths so a boundary and a walk root that differ
+	// only by a symlinked parent are recognized as the same location.
+	if !withinBoundary(resolvePath(fs, o.boundary), resolvePath(fs, root)) {
+		return fmt.Errorf("%w: %q is outside %q", ErrOutsideBoundary, root, o.boundary)
+	}
+
+	return nil
+}
+
+// resolvePath returns the symlink-resolved form of p, falling back to the
+// cleaned path when resolution fails, for example when p does not exist.
+func resolvePath(fs vfs.FS, p string) string {
+	if resolved, err := vfs.EvalSymlinks(fs, p); err == nil {
+		return resolved
+	}
+
+	return filepath.Clean(p)
+}
+
+// withinBoundary reports whether p is boundary or a descendant of it. Both
+// paths must already be cleaned.
+func withinBoundary(boundary, p string) bool {
+	rel, err := filepath.Rel(boundary, p)
+	if err != nil {
+		return false
+	}
+
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -3,7 +3,6 @@ package glob_test
 import (
 	"os"
 	"path/filepath"
-	"slices"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/glob"
@@ -249,14 +248,9 @@ func TestExpand(t *testing.T) {
 			got, err := glob.Expand(fs, tc.pattern, tc.opts...)
 			require.NoError(t, err)
 
-			// Sort both sides so the assertion is robust to walker ordering
-			// changes without asserting a specific traversal order.
-			slices.Sort(got)
-
-			want := slices.Clone(tc.want)
-			slices.Sort(want)
-
-			assert.Equal(t, want, got, "pattern %q", tc.pattern)
+			// ElementsMatch ignores order, so the assertion is robust to walker
+			// ordering changes without asserting a specific traversal order.
+			assert.ElementsMatch(t, tc.want, got, "pattern %q", tc.pattern)
 		})
 	}
 }
@@ -269,6 +263,62 @@ func TestExpandRejectsInvalidPattern(t *testing.T) {
 
 	_, err := glob.Expand(fs, "/mod/[unterminated")
 	require.Error(t, err)
+}
+
+func TestExpandBoundary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		wantErr error
+		name    string
+		pattern string
+		opts    []glob.ExpandOption
+		want    []string
+	}{
+		{
+			name:    "no boundary imposes no constraint",
+			pattern: "/{*.yaml}",
+			want:    []string{"/a.yaml"},
+		},
+		{
+			name:    "boundary at filesystem root permits a root walk",
+			pattern: "/{*.yaml}",
+			opts:    []glob.ExpandOption{glob.WithBoundary("/")},
+			want:    []string{"/a.yaml"},
+		},
+		{
+			name:    "walk root inside the boundary is allowed",
+			pattern: "/mod/*.yaml",
+			opts:    []glob.ExpandOption{glob.WithBoundary("/mod")},
+			want:    []string{"/mod/keep.yaml"},
+		},
+		{
+			name:    "walk root outside the boundary is refused",
+			pattern: "/other/*.yaml",
+			opts:    []glob.ExpandOption{glob.WithBoundary("/mod")},
+			wantErr: glob.ErrOutsideBoundary,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := vfs.NewMemMapFS()
+			require.NoError(t, vfs.WriteFile(fs, "/a.yaml", []byte{}, 0o644))
+			require.NoError(t, vfs.WriteFile(fs, "/mod/keep.yaml", []byte{}, 0o644))
+			require.NoError(t, vfs.WriteFile(fs, "/other/skip.yaml", []byte{}, 0o644))
+
+			got, err := glob.Expand(fs, tc.pattern, tc.opts...)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.want, got, "pattern %q", tc.pattern)
+		})
+	}
 }
 
 // TestLegacyExpandCollapsesGlobstar documents the reason LegacyExpand exists:
@@ -292,15 +342,12 @@ func TestLegacyExpandCollapsesGlobstar(t *testing.T) {
 	got, err := glob.LegacyExpand(pattern)
 	require.NoError(t, err)
 
-	slices.Sort(got)
-
 	want := []string{
 		filepath.Join(root, "root.tf"),
 		filepath.Join(root, "sub", "nested.tf"),
 	}
-	slices.Sort(want)
 
-	assert.Equal(t, want, got,
+	assert.ElementsMatch(t, want, got,
 		"zglob collapses `**` so root.tf matches even though it sits alongside sub/")
 }
 

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -1303,6 +1303,13 @@ func markAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []
 	return file, nil
 }
 
+// markGlobBoundaryFlag, when passed as a leading argument to mark_glob_as_read,
+// overrides the default Git-root boundary on the directory the glob may walk.
+// It accepts an inline value ("--terragrunt-boundary=/path") or the value as
+// the next argument ("--terragrunt-boundary", "/path"). Setting it to a
+// filesystem root effectively removes the boundary, permitting a full scan.
+const markGlobBoundaryFlag = "--terragrunt-boundary"
+
 // markGlobAsRead expands the given glob pattern and marks each matched file as
 // read. Pattern syntax follows the internal/glob package: '/' is the
 // separator, `**` matches any sequence of characters, `*` matches within a
@@ -1310,9 +1317,30 @@ func markAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []
 // collapses the flanking separators when the adjacent segments are literals,
 // so "a/**/*.tf" will not match "a/b.tf"; use "a/{*.tf,**/*.tf}" to cover
 // both depths. Returns the list of absolute file paths that were marked.
+//
+// The walk is constrained to a boundary directory so that a pattern built from
+// an empty string, such as the "/{*.yaml}" produced by "${dir}/{*.yaml}" when
+// dir is "", does not scan the whole filesystem. A leading
+// [markGlobBoundaryFlag] argument sets the boundary explicitly; otherwise it
+// defaults to the enclosing Git repository root. Outside a Git repository and
+// without the flag, no boundary applies.
 func markGlobAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, args []string) ([]string, error) {
+	boundary, args, err := parseMarkGlobBoundary(pctx, args)
+	if err != nil {
+		return nil, err
+	}
+
 	if len(args) != 1 {
 		return nil, WrongNumberOfParamsError{Func: FuncNameMarkGlobAsRead, Expected: "1", Actual: len(args)}
+	}
+
+	if boundary == "" {
+		// Default to the enclosing Git repository root. GitTopLevelDir errors
+		// when the working directory is not inside a repository (or git is
+		// unavailable); treat that as "no boundary" rather than a failure.
+		if repoRoot, repoErr := shell.GitTopLevelDir(ctx, l, pctx.Venv.Exec, pctx.Env, pctx.WorkingDir); repoErr == nil {
+			boundary = repoRoot
+		}
 	}
 
 	raw := args[0]
@@ -1328,8 +1356,21 @@ func markGlobAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, arg
 		pattern = path.Clean(filepath.ToSlash(pctx.WorkingDir) + "/" + raw)
 	}
 
-	matches, err := glob.Expand(vfs.NewOSFS(), pattern, glob.WithFilesOnly())
+	opts := []glob.ExpandOption{glob.WithFilesOnly()}
+	if boundary != "" {
+		opts = append(opts, glob.WithBoundary(boundary))
+	}
+
+	matches, err := glob.Expand(vfs.NewOSFS(), pattern, opts...)
 	if err != nil {
+		if errors.Is(err, glob.ErrOutsideBoundary) {
+			return nil, fmt.Errorf(
+				"mark_glob_as_read pattern %q resolves outside the boundary %q; "+
+					"widen the boundary by passing %s as the first argument, "+
+					"for example mark_glob_as_read(%q, %q): %w",
+				raw, boundary, markGlobBoundaryFlag, markGlobBoundaryFlag+"=/", raw, err)
+		}
+
 		return nil, fmt.Errorf("could not expand glob %q: %w", raw, err)
 	}
 
@@ -1341,6 +1382,47 @@ func markGlobAsRead(ctx context.Context, pctx *ParsingContext, l log.Logger, arg
 	}
 
 	return result, nil
+}
+
+// parseMarkGlobBoundary strips a leading [markGlobBoundaryFlag] from args and
+// returns the resolved absolute boundary directory alongside the remaining
+// arguments. A relative boundary is resolved against the unit's working
+// directory. An empty boundary means no flag was supplied.
+func parseMarkGlobBoundary(pctx *ParsingContext, args []string) (string, []string, error) {
+	if len(args) == 0 || !strings.HasPrefix(args[0], markGlobBoundaryFlag) {
+		return "", args, nil
+	}
+
+	// Clone before deleting: slices.Delete reuses the backing array, so
+	// mutating in place would leave residue in the HCL evaluator's slice.
+	args = slices.Clone(args)
+
+	var raw string
+
+	switch {
+	case args[0] == markGlobBoundaryFlag:
+		if len(args) < 2 { //nolint:mnd
+			return "", nil, fmt.Errorf("%s requires a directory value", markGlobBoundaryFlag)
+		}
+
+		raw = args[1]
+		args = slices.Delete(args, 0, 2) //nolint:mnd
+	case strings.HasPrefix(args[0], markGlobBoundaryFlag+"="):
+		raw = strings.TrimPrefix(args[0], markGlobBoundaryFlag+"=")
+		args = slices.Delete(args, 0, 1)
+	default:
+		return "", nil, fmt.Errorf("unrecognized flag %q for %s", args[0], FuncNameMarkGlobAsRead)
+	}
+
+	if raw == "" {
+		return "", nil, fmt.Errorf("%s requires a non-empty directory value", markGlobBoundaryFlag)
+	}
+
+	if !filepath.IsAbs(raw) {
+		raw = filepath.Join(pctx.WorkingDir, raw)
+	}
+
+	return filepath.Clean(raw), args, nil
 }
 
 // warnWhenFileNotMarkedAsRead warns when a file is not being marked as read, even though a user might expect it to be.

--- a/pkg/config/mark_as_read_test.go
+++ b/pkg/config/mark_as_read_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -77,6 +78,86 @@ func TestMarkGlobAsReadEscapesMetacharacter(t *testing.T) {
 	read := pctx.FilesRead.Paths()
 	assert.Contains(t, read, filepath.Join(dir, "a*b.tf"))
 	assert.NotContains(t, read, filepath.Join(dir, "acb.tf"))
+}
+
+// TestMarkGlobAsReadBoundaryFlag verifies that a leading --terragrunt-boundary
+// argument is stripped from the call and constrains the walk to the named
+// directory, leaving the remaining argument as the glob pattern. A relative
+// boundary resolves against the working directory.
+func TestMarkGlobAsReadBoundaryFlag(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	writeFile(t, filepath.Join(dir, "a.yaml"), "")
+	writeFile(t, filepath.Join(dir, "b.yaml"), "")
+	writeFile(t, filepath.Join(dir, "README.md"), "")
+
+	l := logger.CreateLogger()
+	configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, configPath)
+	pctx.WorkingDir = dir
+
+	hcl := `locals { matched = mark_glob_as_read("--terragrunt-boundary=.", "{*.yaml}") }`
+
+	out, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	read := pctx.FilesRead.Paths()
+	assert.Contains(t, read, filepath.Join(dir, "a.yaml"))
+	assert.Contains(t, read, filepath.Join(dir, "b.yaml"))
+	assert.NotContains(t, read, filepath.Join(dir, "README.md"))
+}
+
+// TestMarkGlobAsReadGitRootBoundary verifies the default boundary: inside a Git
+// repository, a pattern whose walk would start above the repository root is
+// rejected rather than expanded across the whole filesystem. A conditional does
+// not prevent this on its own, because HCL evaluates both branches of a `? :`
+// expression; try() is what turns the rejection into a recoverable empty list.
+func TestMarkGlobAsReadGitRootBoundary(t *testing.T) {
+	t.Parallel()
+
+	// git rev-parse reports the symlink-resolved root, so resolve the temp dir
+	// to keep the working directory and the discovered boundary comparable.
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	helpers.CreateGitRepo(t, root)
+
+	unitDir := filepath.Join(root, "unit")
+	require.NoError(t, os.MkdirAll(unitDir, 0o755))
+
+	l := logger.CreateLogger()
+	configPath := filepath.Join(unitDir, config.DefaultTerragruntConfigPath)
+
+	t.Run("pattern above the repository root errors", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, pctx := newTestParsingContext(t, configPath)
+		pctx.WorkingDir = unitDir
+
+		hcl := `locals { matched = mark_glob_as_read("/{*.yaml}") }`
+
+		_, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("try wrapper recovers to empty", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, pctx := newTestParsingContext(t, configPath)
+		pctx.WorkingDir = unitDir
+
+		hcl := `locals {
+  d       = ""
+  matched = local.d != "" ? sort(try(mark_glob_as_read("${local.d}/{*.yaml}"), [])) : []
+}`
+
+		out, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		assert.Empty(t, pctx.FilesRead.Paths())
+	})
 }
 
 // TestMarkManyAsReadMarksModuleSourceFilesByDefault pins the default behavior:


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6346.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Glob expansion is now constrained to a boundary directory, defaulting to the Git repository root
  * Added `--terragrunt-boundary` flag to explicitly set or remove the boundary
  * Returns error when glob patterns attempt to walk outside the configured boundary

* **Documentation**
  * Enhanced documentation with boundary behavior, flag usage, and error recovery guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->