### PR TITLE
fix: Adding support for detecting added/deleted changed files in Git diffs

### DIFF
--- a/docs/src/data/changelog/v1.1.0/git-filter-glob-read-add-delete.mdx
+++ b/docs/src/data/changelog/v1.1.0/git-filter-glob-read-add-delete.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.0"
+category: "bug-fixes"
+---
+
+#### Select units reading added or deleted glob files in Git-based filters
+
+Git-based filters (for example `terragrunt run --all --filter '[HEAD^1...HEAD]' -- plan`) now select units
+that read an added or deleted file through `mark_glob_as_read`, even when that file lives outside the unit's
+own directory. Previously only modified files outside a unit reached those units; adding or deleting a file
+the glob matched left the reading unit out of the run, so its real config change was skipped. Added files are
+matched against the newer reference, and deleted files against the older one where the file still exists.

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -508,9 +508,11 @@ func NewWorktrees(
 	return worktrees, outerErr
 }
 
-// expandDiffPaths processes a list of changed paths from a worktree diff, creating path filter expressions
-// for discovered units and stacks. primaryExprs receives filters for config files (units/stacks),
-// while fallbackExprs receives filters for non-config files adjacent to units in the "to" worktree.
+// expandDiffPaths processes a list of added or removed paths from a worktree diff, creating filter
+// expressions for affected units and stacks. primaryExprs receives filters for config files (units/stacks)
+// and for non-config files read by other units via a glob (e.g. mark_glob_as_read), since those must be
+// matched against the same worktree the file exists in. fallbackExprs receives path filters for non-config
+// files adjacent to a unit in the "to" worktree.
 func expandDiffPaths(paths []string, toPath string, primaryExprs, fallbackExprs *filter.Expressions) error {
 	for _, path := range paths {
 		dir := filepath.Dir(path)
@@ -543,7 +545,20 @@ func expandDiffPaths(paths []string, toPath string, primaryExprs, fallbackExprs 
 				}
 
 				*fallbackExprs = append(*fallbackExprs, expr)
+
+				continue
 			}
+
+			// The file isn't adjacent to a unit, but a unit may still read it via a glob
+			// (e.g. mark_glob_as_read). Track it with a reading filter so units that read it are
+			// selected. primaryExprs targets the worktree the file exists in: the "to" worktree for
+			// added files, the "from" worktree for removed files (where the deleted file is still present).
+			expr, err := filter.NewAttributeExpression(filter.AttributeReading, path)
+			if err != nil {
+				return fmt.Errorf("failed to create reading filter for %s: %w", path, err)
+			}
+
+			*primaryExprs = append(*primaryExprs, expr)
 		}
 	}
 

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -208,7 +208,7 @@ func TestExpressionExpansion(t *testing.T) {
 				case *filter.PathExpression:
 					toPaths = append(toPaths, expr.Value)
 				case *filter.AttributeExpression:
-					if expr.Key == "reading" {
+					if expr.Key == filter.AttributeReading {
 						toReadings = append(toReadings, expr.Value)
 					}
 				}
@@ -312,7 +312,7 @@ func TestExpansionAttributeReadingFilters(t *testing.T) {
 
 			for _, f := range toFilters {
 				if attrExpr, ok := f.Expression().(*filter.AttributeExpression); ok {
-					if attrExpr.Key == "reading" {
+					if attrExpr.Key == filter.AttributeReading {
 						readings = append(readings, attrExpr.Value)
 					}
 				}
@@ -327,7 +327,7 @@ func TestExpansionAttributeReadingFilters(t *testing.T) {
 
 				for _, f := range toFilters {
 					if attrExpr, ok := f.Expression().(*filter.AttributeExpression); ok {
-						if attrExpr.Key == "reading" && attrExpr.Value == expectedReading {
+						if attrExpr.Key == filter.AttributeReading && attrExpr.Value == expectedReading {
 							found = true
 
 							assert.Equal(t, "reading", attrExpr.Key, "Filter should have reading key")
@@ -348,12 +348,13 @@ func TestExpandWithUnitDirectoryDetection(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name               string
-		setupFilesystem    func(tmpDir string) error
-		diffs              *git.Diffs
-		expectedToPaths    []string
-		expectedToReadings []string
-		expectedFrom       int
+		name                 string
+		setupFilesystem      func(tmpDir string) error
+		diffs                *git.Diffs
+		expectedToPaths      []string
+		expectedToReadings   []string
+		expectedFromReadings []string
+		expectedFrom         int
 	}{
 		{
 			name: "removed file in unit directory creates path filter",
@@ -378,7 +379,7 @@ func TestExpandWithUnitDirectoryDetection(t *testing.T) {
 			expectedFrom:       0,
 		},
 		{
-			name: "removed file in non-unit directory creates no filter",
+			name: "removed file in non-unit directory creates reading filter against from worktree",
 			setupFilesystem: func(tmpDir string) error {
 				// Create non-unit directory (no terragrunt.hcl)
 				nonUnitDir := filepath.Join(tmpDir, "non-unit")
@@ -389,9 +390,10 @@ func TestExpandWithUnitDirectoryDetection(t *testing.T) {
 					"non-unit/some-file.tf",
 				},
 			},
-			expectedToPaths:    []string{},
-			expectedToReadings: []string{},
-			expectedFrom:       0,
+			expectedToPaths:      []string{},
+			expectedToReadings:   []string{},
+			expectedFromReadings: []string{"non-unit/some-file.tf"},
+			expectedFrom:         1,
 		},
 		{
 			name: "added file in unit directory creates path filter",
@@ -416,7 +418,7 @@ func TestExpandWithUnitDirectoryDetection(t *testing.T) {
 			expectedFrom:       0,
 		},
 		{
-			name: "added file in non-unit directory creates no filter",
+			name: "added file in non-unit directory creates reading filter against to worktree",
 			setupFilesystem: func(tmpDir string) error {
 				// Create non-unit directory (no terragrunt.hcl)
 				nonUnitDir := filepath.Join(tmpDir, "non-unit")
@@ -428,7 +430,7 @@ func TestExpandWithUnitDirectoryDetection(t *testing.T) {
 				},
 			},
 			expectedToPaths:    []string{},
-			expectedToReadings: []string{},
+			expectedToReadings: []string{"non-unit/new-file.tf"},
 			expectedFrom:       0,
 		},
 		{
@@ -540,6 +542,17 @@ func TestExpandWithUnitDirectoryDetection(t *testing.T) {
 			// Verify from filters count
 			assert.Len(t, fromFilters, tt.expectedFrom, "From filters count should match")
 
+			// Extract reading filters from fromFilters
+			fromReadings := []string{}
+
+			for _, f := range fromFilters {
+				if expr, ok := f.Expression().(*filter.AttributeExpression); ok && expr.Key == filter.AttributeReading {
+					fromReadings = append(fromReadings, expr.Value)
+				}
+			}
+
+			assert.ElementsMatch(t, tt.expectedFromReadings, fromReadings, "From reading filters should match")
+
 			// Extract path and reading filters from toFilters
 			toPathsMap := make(map[string]bool)
 			toReadings := []string{}
@@ -549,7 +562,7 @@ func TestExpandWithUnitDirectoryDetection(t *testing.T) {
 				case *filter.PathExpression:
 					toPathsMap[expr.Value] = true
 				case *filter.AttributeExpression:
-					if expr.Key == "reading" {
+					if expr.Key == filter.AttributeReading {
 						toReadings = append(toReadings, expr.Value)
 					}
 				}

--- a/test/integration_filter_test.go
+++ b/test/integration_filter_test.go
@@ -2256,3 +2256,63 @@ func TestFilterFlagWithMarkAsRead(t *testing.T) {
 		})
 	}
 }
+
+// TestFilterFlagWithGitFilterMarkGlobAsRead reproduces https://github.com/gruntwork-io/terragrunt/issues/6348:
+// when a file matched by mark_glob_as_read is added or deleted across a Git diff, the unit that reads
+// it via the glob must still be selected by a Git-based filter, even though the file lives outside the
+// unit's own directory. Added files are matched against the "to" worktree; deleted files are matched
+// against the "from" worktree, where the file still exists.
+func TestFilterFlagWithGitFilterMarkGlobAsRead(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	runner := helpers.InitTestGitRunner(t, tmpDir)
+
+	// Three units, each reading a sibling config directory via a glob. None of the watched files live
+	// in the unit's own directory, so only the reading filter can connect a config change to its unit.
+	units := map[string]string{
+		"unit-reads-added":     `locals { config = mark_glob_as_read("../shared-added/*.yml") }`,
+		"unit-reads-removed":   `locals { config = mark_glob_as_read("../shared-removed/*.yml") }`,
+		"unit-reads-untouched": `locals { config = mark_glob_as_read("../shared-untouched/*.yml") }`,
+	}
+
+	for name, contents := range units {
+		dir := filepath.Join(tmpDir, name)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "terragrunt.hcl"), []byte(contents), 0644))
+	}
+
+	// Baseline config files. shared-added is intentionally empty so the file lands as an addition later.
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "shared-removed"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "shared-removed", "old.yml"), []byte("a: 1\n"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "shared-untouched"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "shared-untouched", "keep.yml"), []byte("b: 2\n"), 0644))
+
+	require.NoError(t, runner.Add(t.Context(), "."))
+	require.NoError(t, runner.Commit(t.Context(), "Initial commit"))
+
+	if b, err := runner.Config(t.Context(), "init.defaultBranch"); err != nil || b != "main" {
+		require.NoError(t, runner.Checkout(t.Context(), "main", true))
+	}
+
+	require.NoError(t, runner.Checkout(t.Context(), "glob-read-test", true))
+
+	// Add a file the glob matches, and delete an existing one the glob matched.
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "shared-added"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "shared-added", "new.yml"), []byte("c: 3\n"), 0644))
+	require.NoError(t, os.RemoveAll(filepath.Join(tmpDir, "shared-removed")))
+
+	require.NoError(t, runner.Add(t.Context(), "."))
+	require.NoError(t, runner.Commit(t.Context(), "Add and remove glob-read config files"))
+
+	helpers.CleanupTerraformFolder(t, tmpDir)
+
+	cmd := "terragrunt find --no-color --working-dir " + tmpDir + " --filter '[HEAD~1...HEAD]'"
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.NoError(t, err, "stderr: %s", stderr)
+
+	results := strings.Fields(stdout)
+	assert.ElementsMatch(t, []string{"unit-reads-added", "unit-reads-removed"}, results,
+		"units reading added or removed glob files should be selected; untouched unit should not")
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6348.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git-based glob filter behavior: units with glob file matching configuration are now properly included in runs even when matched files are located outside the unit's directory.

* **Documentation**
  * Added v1.1.0 changelog entry documenting the glob filter improvements.

* **Tests**
  * Extended test coverage for glob-based file matching across git diffs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->