### PR TITLE
chore: Addressing weekly test stats

### DIFF
--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -369,3 +369,39 @@ func TestGitRunner_WithWorkDirGetRepoRootWithRacing(t *testing.T) {
 
 	require.NoError(t, g.Wait())
 }
+
+// TestGitRunner_AddCommitCheckoutConfig drives the local-mutation wrappers
+// (ConfigSet, Add, Commit, Checkout) through a stage -> commit -> branch flow
+// against a fresh repository, and checks the state via the read helpers
+// (HasUncommittedChanges, GetCurrentBranch, Config) at each step.
+func TestGitRunner_AddCommitCheckoutConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	dir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(dir)
+	require.NoError(t, runner.Init(ctx))
+
+	require.NoError(t, runner.ConfigSet(ctx, "user.email", "test@example.com"))
+	require.NoError(t, runner.ConfigSet(ctx, "user.name", "Terragrunt Test"))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello"), 0o600))
+
+	require.NoError(t, runner.Add(ctx, "hello.txt"))
+	assert.True(t, runner.HasUncommittedChanges(ctx))
+
+	require.NoError(t, runner.Commit(ctx, "initial commit"))
+	assert.False(t, runner.HasUncommittedChanges(ctx))
+
+	require.NoError(t, runner.Checkout(ctx, "feature", true))
+	assert.Equal(t, "feature", runner.GetCurrentBranch(ctx))
+
+	email, err := runner.Config(ctx, "user.email")
+	require.NoError(t, err)
+	assert.Equal(t, "test@example.com", email)
+}

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -219,7 +219,9 @@ func TestDownloadTerraformSourceIfNecessaryLocalDirToAlreadyDownloadedDir(t *tes
 func TestDownloadTerraformSourceIfNecessaryRemoteUrlToEmptyDir(t *testing.T) {
 	t.Parallel()
 
-	canonicalURL := "github.com/gruntwork-io/terragrunt//test/fixtures/download-source/hello-world"
+	srv := helpers.NewGitServer(t)
+	srv.AddFixtures("test/fixtures/download-source/hello-world")
+	canonicalURL := srv.SourceURL("test/fixtures/download-source/hello-world", "")
 
 	downloadDir := helpers.TmpDirWOSymlinks(t)
 	defer os.Remove(downloadDir)
@@ -230,7 +232,9 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlToEmptyDir(t *testing.T) {
 func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDir(t *testing.T) {
 	t.Parallel()
 
-	canonicalURL := "github.com/gruntwork-io/terragrunt//test/fixtures/download-source/hello-world"
+	srv := helpers.NewGitServer(t)
+	srv.AddFixtures("test/fixtures/download-source/hello-world")
+	canonicalURL := srv.SourceURL("test/fixtures/download-source/hello-world", "")
 
 	downloadDir := helpers.TmpDirWOSymlinks(t)
 	defer os.Remove(downloadDir)
@@ -243,7 +247,9 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDir(t *te
 func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirDifferentVersion(t *testing.T) {
 	t.Parallel()
 
-	canonicalURL := "github.com/gruntwork-io/terragrunt//test/fixtures/download-source/hello-world?ref=v0.83.2"
+	srv := helpers.NewGitServer(t)
+	srv.AddFixtures("test/fixtures/download-source/hello-world")
+	canonicalURL := srv.SourceURL("test/fixtures/download-source/hello-world", "v0.83.2")
 
 	downloadDir := helpers.TmpDirWOSymlinks(t)
 	defer os.Remove(downloadDir)
@@ -256,8 +262,9 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirDiffer
 func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirSameVersion(t *testing.T) {
 	t.Parallel()
 
-	canonicalURL := "github.com/gruntwork-io/terragrunt//test/fixtures/" +
-		"download-source/hello-world-version-remote?ref=v0.83.2"
+	srv := helpers.NewGitServer(t)
+	srv.AddFixtures("test/fixtures/download-source/hello-world-version-remote")
+	canonicalURL := srv.SourceURL("test/fixtures/download-source/hello-world-version-remote", "v0.83.2")
 
 	downloadDir := helpers.TmpDirWOSymlinks(t)
 	defer os.Remove(downloadDir)
@@ -295,7 +302,9 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirSameVe
 func TestDownloadTerraformSourceIfNecessaryRemoteUrlOverrideSource(t *testing.T) {
 	t.Parallel()
 
-	canonicalURL := "github.com/gruntwork-io/terragrunt//test/fixtures/download-source/hello-world?ref=v0.83.2"
+	srv := helpers.NewGitServer(t)
+	srv.AddFixtures("test/fixtures/download-source/hello-world")
+	canonicalURL := srv.SourceURL("test/fixtures/download-source/hello-world", "v0.83.2")
 
 	downloadDir := helpers.TmpDirWOSymlinks(t)
 	defer os.Remove(downloadDir)
@@ -308,7 +317,10 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlOverrideSource(t *testing.T)
 func TestDownloadTerraformSourceIfNecessaryInvalidTerraformSource(t *testing.T) {
 	t.Parallel()
 
-	canonicalURL := "github.com/totallyfakedoesnotexist/notreal.git//foo?ref=v1.2.3"
+	// v1.2.3 is not among the server's seeded tags, so the clone fails
+	// offline and the download is reported as a DownloadingTerraformSourceErr.
+	srv := helpers.NewGitServer(t)
+	canonicalURL := srv.SourceURL("test/fixtures/download-source/hello-world", "v1.2.3")
 
 	downloadDir := helpers.TmpDirWOSymlinks(t)
 	defer os.Remove(downloadDir)
@@ -873,14 +885,14 @@ func TestDownloadSourceWithCASGitSource(t *testing.T) {
 
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
+	srv := helpers.NewGitServer(t)
+	srv.AddFixtures("test/fixtures/download/hello-world")
+
 	src := &tf.Source{
-		CanonicalSourceURL: parseURL(
-			t,
-			"github.com/gruntwork-io/terragrunt//test/fixtures/download/hello-world",
-		),
-		DownloadDir: tmpDir,
-		WorkingDir:  tmpDir,
-		VersionFile: filepath.Join(tmpDir, "version-file.txt"),
+		CanonicalSourceURL: parseURL(t, srv.SourceURL("test/fixtures/download/hello-world", "")),
+		DownloadDir:        tmpDir,
+		WorkingDir:         tmpDir,
+		VersionFile:        filepath.Join(tmpDir, "version-file.txt"),
 	}
 
 	opts, err := options.NewTerragruntOptionsForTest("./should-not-be-used")


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses test coverage drops and slow tests as reported in the weekly test breakdown.

Saves us about 20s in tests.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for git operations and source downloads with improved test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->