### PR TITLE
fix: Avoiding generation of the lockfile when users supply `-lockfile=readonly`

### DIFF
--- a/docs/src/data/changelog/v1.1.1/lockfile-readonly.mdx
+++ b/docs/src/data/changelog/v1.1.1/lockfile-readonly.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.1"
+category: "bug-fixes"
+---
+
+#### Respect `-lockfile=readonly` during provider caching
+
+When you pass `-lockfile=readonly` to `init`, Terragrunt no longer generates or updates `.terraform.lock.hcl` while warming the provider cache. Previously the cache step could write the lock file before OpenTofu/Terraform ran, so the read-only check always passed and silently defeated the flag.
+
+Terragrunt now leaves the lock file untouched and lets OpenTofu/Terraform enforce it, failing when the lock file is missing or incomplete. The flag is honored whether it is supplied on the command line or through the `TF_CLI_ARGS` or `TF_CLI_ARGS_init` environment variables.

--- a/internal/providercache/lockfile_readonly_test.go
+++ b/internal/providercache/lockfile_readonly_test.go
@@ -1,0 +1,74 @@
+package providercache_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/internal/providercache"
+	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLockfileReadonlyRequested(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		env  map[string]string
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "no lockfile flag",
+			args: []string{"init"},
+			want: false,
+		},
+		{
+			name: "flag with equals form",
+			args: []string{"init", "-lockfile=readonly"},
+			want: true,
+		},
+		{
+			name: "flag with space form",
+			args: []string{"init", "-lockfile", "readonly"},
+			want: true,
+		},
+		{
+			name: "double dash equals form",
+			args: []string{"init", "--lockfile=readonly"},
+			want: true,
+		},
+		{
+			name: "non-readonly mode is ignored",
+			args: []string{"init", "-lockfile=something"},
+			want: false,
+		},
+		{
+			name: "set via TF_CLI_ARGS_init",
+			args: []string{"init"},
+			env:  map[string]string{tf.EnvNameTFCLIArgsInit: "-lockfile=readonly"},
+			want: true,
+		},
+		{
+			name: "set via TF_CLI_ARGS alongside other args",
+			args: []string{"init"},
+			env:  map[string]string{tf.EnvNameTFCLIArgs: "-input=false -lockfile=readonly"},
+			want: true,
+		},
+		{
+			name: "unrelated env arg",
+			args: []string{"init"},
+			env:  map[string]string{tf.EnvNameTFCLIArgsInit: "-input=false"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := providercache.LockfileReadonlyRequested(clihelper.Args(tt.args), tt.env)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/providercache/providercache.go
+++ b/internal/providercache/providercache.go
@@ -241,7 +241,10 @@ func (pc *ProviderCache) TerraformCommandHook(
 
 	env := pc.providerCacheEnvironment(tfOpts.ShellOptions.Env, tfOpts.TofuImplementation, cliConfigFilename)
 
-	if output, err := pc.warmUpCache(ctx, l, tfOpts, cliConfigFilename, args, env, lockfileExists); err != nil {
+	lockfileReadonly := LockfileReadonlyRequested(args, env)
+
+	output, err := pc.warmUpCache(ctx, l, tfOpts, cliConfigFilename, args, env, lockfileExists, lockfileReadonly)
+	if err != nil {
 		return output, err
 	}
 
@@ -260,6 +263,7 @@ func (pc *ProviderCache) warmUpCache(
 	args clihelper.Args,
 	env map[string]string,
 	lockfileExists bool,
+	lockfileReadonly bool,
 ) (*util.CmdOutput, error) {
 	var (
 		cacheRequestID = uuid.New().String()
@@ -295,6 +299,18 @@ func (pc *ProviderCache) warmUpCache(
 	}
 
 	isUpgrade := tfOpts.TerraformCliArgs != nil && tfOpts.TerraformCliArgs.Contains("-upgrade")
+
+	// `-lockfile=readonly` asks OpenTofu/Terraform to verify that every provider is
+	// already recorded in `.terraform.lock.hcl` and to fail otherwise. If Terragrunt
+	// wrote the lock file here, that check would always pass, silently defeating the
+	// flag. Leave the lock file untouched and let OpenTofu/Terraform enforce it.
+	if lockfileReadonly {
+		l.Warnf("`%s=%s` is set, so Terragrunt will not generate or update %s in %s. "+
+			"OpenTofu/Terraform will fail if the lock file is missing or incomplete.",
+			tf.FlagNameLockfile, tf.LockfileModeReadonly, tf.TerraformLockFile, tfOpts.ShellOptions.WorkingDir)
+
+		return nil, nil
+	}
 
 	// If a lock file already existed before this run, skip writing to it — let
 	// OpenTofu/Terraform verify and manage the lock file during the actual init.
@@ -359,6 +375,48 @@ func (pc *ProviderCache) runTerraformWithCache(
 	}
 
 	return tf.RunCommandWithOutput(ctx, l, vexec.NewOSExec(), newTFOpts, args...)
+}
+
+// LockfileReadonlyRequested reports whether the user asked OpenTofu/Terraform to treat
+// `.terraform.lock.hcl` as read-only via `-lockfile=readonly`. The flag may be supplied
+// directly on the command line or through the `TF_CLI_ARGS` / `TF_CLI_ARGS_init`
+// environment variables that OpenTofu/Terraform reads for the `init` command.
+func LockfileReadonlyRequested(args clihelper.Args, env map[string]string) bool {
+	if argsRequestReadonlyLockfile(args) {
+		return true
+	}
+
+	for _, name := range []string{tf.EnvNameTFCLIArgs, tf.EnvNameTFCLIArgsInit} {
+		if argsRequestReadonlyLockfile(strings.Fields(env[name])) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// argsRequestReadonlyLockfile reports whether the given args set the lock file to
+// read-only mode, accepting both the `-lockfile=readonly` and `-lockfile readonly`
+// forms as well as their double-dash variants.
+func argsRequestReadonlyLockfile(args []string) bool {
+	for i, arg := range args {
+		name, value, hasValue := strings.Cut(arg, "=")
+
+		if name != tf.FlagNameLockfile && name != "-"+tf.FlagNameLockfile {
+			continue
+		}
+
+		if hasValue {
+			return value == tf.LockfileModeReadonly
+		}
+
+		// `-lockfile readonly` form: the mode is supplied as the next argument.
+		if i+1 < len(args) && args[i+1] == tf.LockfileModeReadonly {
+			return true
+		}
+	}
+
+	return false
 }
 
 // createLocalCLIConfig creates a local CLI config that merges the default/user configuration with our Provider Cache configuration.

--- a/internal/tf/tf.go
+++ b/internal/tf/tf.go
@@ -60,10 +60,20 @@ const (
 	// `platform` is a flag used with the `providers lock` command.
 	FlagNamePlatform = "-platform"
 
+	// `lockfile` is a flag used with the `init` command to control how the
+	// dependency lock file is handled. The `readonly` mode tells OpenTofu/Terraform
+	// to fail rather than create or update `.terraform.lock.hcl`.
+	FlagNameLockfile     = "-lockfile"
+	LockfileModeReadonly = "readonly"
+
 	EnvNameTFCLIConfigFile  = "TF_CLI_CONFIG_FILE"
 	EnvNameTFPluginCacheDir = "TF_PLUGIN_CACHE_DIR"
 	EnvNameTFTokenFmt       = "TF_TOKEN_%s"
 	EnvNameTFVarFmt         = "TF_VAR_%s"
+	// `TF_CLI_ARGS` and `TF_CLI_ARGS_init` are read by OpenTofu/Terraform to inject
+	// extra arguments. The suffixed form applies only to the `init` command.
+	EnvNameTFCLIArgs     = "TF_CLI_ARGS"
+	EnvNameTFCLIArgsInit = "TF_CLI_ARGS_init"
 
 	DefaultTFDataDir  = ".terraform"
 	TerraformLockFile = ".terraform.lock.hcl"

--- a/test/fixtures/provider-cache/lockfile-readonly/.gitignore
+++ b/test/fixtures/provider-cache/lockfile-readonly/.gitignore
@@ -1,0 +1,4 @@
+# No lock file is committed here on purpose. These tests assert how the provider
+# cache behaves when `.terraform.lock.hcl` is absent and `-lockfile=readonly`
+# is requested, so each run must start without one.
+.terraform.lock.hcl

--- a/test/fixtures/provider-cache/lockfile-readonly/main.tf
+++ b/test/fixtures/provider-cache/lockfile-readonly/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    null = {
+      # Source is not fully qualified so the registry is resolved dynamically
+      # based on the Terraform/OpenTofu implementation, allowing the provider
+      # cache to intercept requests.
+      source  = "hashicorp/null"
+      version = "3.2.2"
+    }
+  }
+}

--- a/test/fixtures/provider-cache/lockfile-readonly/terragrunt.hcl
+++ b/test/fixtures/provider-cache/lockfile-readonly/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/integration_provider_cache_lockfile_readonly_test.go
+++ b/test/integration_provider_cache_lockfile_readonly_test.go
@@ -1,0 +1,80 @@
+package test_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testFixtureProviderCacheLockfileReadonly = "fixtures/provider-cache/lockfile-readonly"
+
+// TestTerragruntProviderCacheLockfileReadonly is a regression test for GitHub issue
+// #6349. With the provider cache enabled, Terragrunt used to generate
+// `.terraform.lock.hcl` before running `init`, which satisfied OpenTofu/Terraform's
+// dependency check and silently defeated `-lockfile=readonly`. The cache must now
+// leave the lock file alone when that flag is set, whether it arrives on the command
+// line or through `TF_CLI_ARGS_init`, so init fails exactly as it does without the cache.
+//
+//nolint:paralleltest,tparallel // the env-var subtest relies on t.Setenv.
+func TestTerragruntProviderCacheLockfileReadonly(t *testing.T) {
+	lockfileName := ".terraform.lock.hcl"
+
+	t.Run("cache writes lock file without readonly", func(t *testing.T) {
+		appPath := copyProviderCacheLockfileReadonlyFixture(t)
+		providerCacheDir := helpers.TmpDirWOSymlinks(t)
+
+		helpers.RunTerragrunt(t, fmt.Sprintf(
+			"terragrunt run --provider-cache --provider-cache-dir %s --non-interactive --working-dir %s -- init",
+			providerCacheDir, appPath,
+		))
+
+		assert.True(t, util.FileExists(filepath.Join(appPath, lockfileName)),
+			"provider cache should generate the lock file when -lockfile=readonly is not set")
+	})
+
+	t.Run("readonly via flag is enforced", func(t *testing.T) {
+		appPath := copyProviderCacheLockfileReadonlyFixture(t)
+		providerCacheDir := helpers.TmpDirWOSymlinks(t)
+
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
+			"terragrunt run --provider-cache --provider-cache-dir %s "+
+				"--non-interactive --working-dir %s -- init -lockfile=readonly",
+			providerCacheDir, appPath,
+		))
+
+		require.Error(t, err, "init must fail because the lock file is missing and read-only")
+		assert.False(t, util.FileExists(filepath.Join(appPath, lockfileName)),
+			"provider cache must not generate the lock file when -lockfile=readonly is set")
+	})
+
+	t.Run("readonly via TF_CLI_ARGS_init is enforced", func(t *testing.T) {
+		t.Setenv(tf.EnvNameTFCLIArgsInit, fmt.Sprintf("%s=%s", tf.FlagNameLockfile, tf.LockfileModeReadonly))
+
+		appPath := copyProviderCacheLockfileReadonlyFixture(t)
+		providerCacheDir := helpers.TmpDirWOSymlinks(t)
+
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
+			"terragrunt run --provider-cache --provider-cache-dir %s --non-interactive --working-dir %s -- init",
+			providerCacheDir, appPath,
+		))
+
+		require.Error(t, err, "init must fail because the lock file is missing and read-only")
+		assert.False(t, util.FileExists(filepath.Join(appPath, lockfileName)),
+			"provider cache must not generate the lock file when TF_CLI_ARGS_init requests -lockfile=readonly")
+	})
+}
+
+func copyProviderCacheLockfileReadonlyFixture(t *testing.T) string {
+	t.Helper()
+
+	helpers.CleanupTerraformFolder(t, testFixtureProviderCacheLockfileReadonly)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureProviderCacheLockfileReadonly)
+
+	return filepath.Join(tmpEnvPath, testFixtureProviderCacheLockfileReadonly)
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6349.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terragrunt now respects `-lockfile=readonly` during provider cache warming and `init`.
  * The read-only setting works when passed on the command line or through Terraform CLI environment variables.

* **Bug Fixes**
  * Lock files are no longer created or updated during cache warming when read-only mode is enabled.
  * If the lock file is missing or incomplete, the underlying Terraform/OpenTofu behavior is now preserved.

* **Documentation**
  * Added a changelog entry describing the new lockfile behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->