### PR TITLE
fix: Generate stacks in worktrees generated for `find`/`list`

### DIFF
--- a/docs/src/data/changelog/v1.1.0/find-list-git-filter-generated-stacks.mdx
+++ b/docs/src/data/changelog/v1.1.0/find-list-git-filter-generated-stacks.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.0"
+category: "bug-fixes"
+---
+
+#### Fix `find` and `list` missing units inside generated stacks for Git-based filters
+
+`terragrunt find` and `terragrunt list` with a Git-based filter (for example `--filter '[HEAD^1...HEAD]'`) now detect units inside generated stacks. Previously they did not generate stacks in the worktrees they create for the comparison, so no unit nested in a generated stack was ever surfaced, while `terragrunt run --all` with the same filter targeted those units correctly.
+
+This affected every change that lands inside a generated stack, including a modified `terragrunt.stack.hcl`, a change to a unit's own files, and a change to a file the stack reads via `read_terragrunt_config` or `mark_glob_as_read`.
+
+Stacks are generated only inside the comparison worktrees; `find` and `list` still do not generate stacks in your current working directory by default.

--- a/docs/src/data/changelog/v1.1.1/find-list-git-filter-generated-stacks.mdx
+++ b/docs/src/data/changelog/v1.1.1/find-list-git-filter-generated-stacks.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.1.0"
+version: "v1.1.1"
 category: "bug-fixes"
 ---
 

--- a/internal/cli/commands/find/find.go
+++ b/internal/cli/commands/find/find.go
@@ -35,7 +35,6 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		Include:           opts.Include,
 		Reading:           opts.Reading,
 		Filters:           opts.Filters,
-		Experiments:       opts.Experiments,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/commands/find/find.go
+++ b/internal/cli/commands/find/find.go
@@ -60,13 +60,8 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		}
 	}()
 
-	if len(worktrees.WorktreePairs) > 0 {
-		gen := generate.NewGenerator()
-
-		genErr := gen.GenerateStacks(ctx, l, opts.TerragruntOptions, worktrees, generate.WithWorktreeOnly())
-		if genErr != nil {
-			return fmt.Errorf("failed to generate stacks in worktrees: %w", genErr)
-		}
+	if err := generate.WorktreeStacks(ctx, l, opts.TerragruntOptions, worktrees); err != nil {
+		return err
 	}
 
 	d = d.WithWorktrees(worktrees)

--- a/internal/cli/commands/find/find.go
+++ b/internal/cli/commands/find/find.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/os/stdout"
 	"github.com/gruntwork-io/terragrunt/internal/queue"
+	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 
@@ -59,6 +60,15 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 			l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 		}
 	}()
+
+	if len(worktrees.WorktreePairs) > 0 {
+		gen := generate.NewGenerator()
+
+		genErr := gen.GenerateStacks(ctx, l, opts.TerragruntOptions, worktrees, generate.WithWorktreeOnly())
+		if genErr != nil {
+			return fmt.Errorf("failed to generate stacks in worktrees: %w", genErr)
+		}
+	}
 
 	d = d.WithWorktrees(worktrees)
 

--- a/internal/cli/commands/hcl/validate/validate.go
+++ b/internal/cli/commands/hcl/validate/validate.go
@@ -91,9 +91,8 @@ func RunValidate(ctx context.Context, l log.Logger, v run.Venv, opts *options.Te
 
 	// Create discovery with filter support if experiment enabled
 	d, err := discovery.NewForHCLCommand(l, discovery.HCLCommandOptions{
-		WorkingDir:  opts.WorkingDir,
-		Filters:     opts.Filters,
-		Experiments: opts.Experiments,
+		WorkingDir: opts.WorkingDir,
+		Filters:    opts.Filters,
 	})
 	if d != nil {
 		d = d.WithExec(v.Exec)
@@ -254,9 +253,8 @@ func RunValidateInputs(ctx context.Context, l log.Logger, v run.Venv, opts *opti
 	opts.NonInteractive = true
 
 	d, err := discovery.NewForHCLCommand(l, discovery.HCLCommandOptions{
-		WorkingDir:  opts.WorkingDir,
-		Filters:     opts.Filters,
-		Experiments: opts.Experiments,
+		WorkingDir: opts.WorkingDir,
+		Filters:    opts.Filters,
 	})
 	if d != nil {
 		d = d.WithExec(v.Exec)

--- a/internal/cli/commands/list/list.go
+++ b/internal/cli/commands/list/list.go
@@ -36,7 +36,6 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		WithRequiresParse: opts.Dependencies || opts.Mode == ModeDAG,
 		WithRelationships: opts.Dependencies || opts.Mode == ModeDAG,
 		Filters:           opts.Filters,
-		Experiments:       opts.Experiments,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/commands/list/list.go
+++ b/internal/cli/commands/list/list.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/os/stdout"
 	"github.com/gruntwork-io/terragrunt/internal/queue"
+	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
 	"github.com/gruntwork-io/terragrunt/internal/view/dag"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -60,6 +61,15 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 			l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 		}
 	}()
+
+	if len(worktrees.WorktreePairs) > 0 {
+		gen := generate.NewGenerator()
+
+		genErr := gen.GenerateStacks(ctx, l, opts.TerragruntOptions, worktrees, generate.WithWorktreeOnly())
+		if genErr != nil {
+			return fmt.Errorf("failed to generate stacks in worktrees: %w", genErr)
+		}
+	}
 
 	d = d.WithWorktrees(worktrees)
 

--- a/internal/cli/commands/list/list.go
+++ b/internal/cli/commands/list/list.go
@@ -61,13 +61,8 @@ func Run(ctx context.Context, l log.Logger, opts *Options) error {
 		}
 	}()
 
-	if len(worktrees.WorktreePairs) > 0 {
-		gen := generate.NewGenerator()
-
-		genErr := gen.GenerateStacks(ctx, l, opts.TerragruntOptions, worktrees, generate.WithWorktreeOnly())
-		if genErr != nil {
-			return fmt.Errorf("failed to generate stacks in worktrees: %w", genErr)
-		}
+	if err := generate.WorktreeStacks(ctx, l, opts.TerragruntOptions, worktrees); err != nil {
+		return err
 	}
 
 	d = d.WithWorktrees(worktrees)

--- a/internal/discovery/constructor.go
+++ b/internal/discovery/constructor.go
@@ -5,7 +5,6 @@ import (
 	"runtime"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -17,7 +16,6 @@ type DiscoveryCommandOptions struct {
 	WorkingDir        string
 	QueueConstructAs  string
 	Filters           filter.Filters
-	Experiments       experiment.Experiments
 	NoHidden          bool
 	Exclude           bool
 	Include           bool
@@ -28,16 +26,14 @@ type DiscoveryCommandOptions struct {
 
 // HCLCommandOptions contains options for HCL commands like hcl validate & format.
 type HCLCommandOptions struct {
-	WorkingDir  string
-	Filters     filter.Filters
-	Experiments experiment.Experiments
+	WorkingDir string
+	Filters    filter.Filters
 }
 
 // StackGenerateOptions contains options for stack generate commands.
 type StackGenerateOptions struct {
-	WorkingDir  string
-	Filters     filter.Filters
-	Experiments experiment.Experiments
+	WorkingDir string
+	Filters    filter.Filters
 }
 
 // NewForDiscoveryCommand creates a Discovery configured for discovery commands (find/list).

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -2978,3 +2978,112 @@ unit "myapp" {
 	err = generate.NewGenerator().GenerateStacks(t.Context(), l, opts, w)
 	require.NoError(t, err)
 }
+
+// TestWorktreePhase_Integration_WorktreeOnlyStackGeneration covers the find/list path
+// from https://github.com/gruntwork-io/terragrunt/issues/6347: a stack reads a config
+// file via read_terragrunt_config and only that config file changes. The reading-affected
+// stack must be surfaced by Git-based discovery, and the working tree must not gain a
+// generated .terragrunt-stack directory (find/list are read-only).
+func TestWorktreePhase_Integration_WorktreeOnlyStackGeneration(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	// Catalog unit the stack sources.
+	legacyUnitDir := filepath.Join(tmpDir, "catalog", "units", "legacy")
+	require.NoError(t, os.MkdirAll(legacyUnitDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(legacyUnitDir, "terragrunt.hcl"), []byte(`# Legacy unit`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(legacyUnitDir, "main.tf"), []byte(`# Intentionally empty`), 0o644))
+
+	commitChanges(t, runner, "Create catalog units")
+
+	// Stack that reads a sidecar config file via read_terragrunt_config.
+	stackDir := filepath.Join(tmpDir, "live", "stack")
+	require.NoError(t, os.MkdirAll(stackDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stackDir, "config.hcl"), []byte(`inputs = { version = "v1" }`), 0o644))
+
+	stackContent := `
+locals {
+  config = read_terragrunt_config("config.hcl")
+}
+
+unit "app" {
+  source = "${get_repo_root()}/catalog/units/legacy"
+  path   = "app"
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(stackDir, "terragrunt.stack.hcl"), []byte(stackContent), 0o644))
+
+	commitChanges(t, runner, "Create stack with read_terragrunt_config")
+
+	// Change only the sidecar config file, not the stack file.
+	require.NoError(t, os.WriteFile(filepath.Join(stackDir, "config.hcl"), []byte(`inputs = { version = "v2" }`), 0o644))
+
+	commitChanges(t, runner, "Update config file only")
+
+	l := logger.CreateLogger()
+	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
+
+	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		require.NoError(t, cleanupErr)
+	})
+
+	opts := options.NewTerragruntOptions()
+	opts.WorkingDir = tmpDir
+	opts.RootWorkingDir = tmpDir
+
+	parsedFilters, parseErr := filter.ParseFilterQueries(l, []string{"[HEAD~1...HEAD]"})
+	require.NoError(t, parseErr)
+
+	opts.Filters = parsedFilters
+	opts.Experiments = experiment.NewExperiments()
+	require.NoError(t, opts.Experiments.EnableExperiment(experiment.FilterFlag))
+
+	require.NoError(t, generate.NewGenerator().GenerateStacks(t.Context(), l, opts, w, generate.WithWorktreeOnly()))
+
+	// The working tree must stay untouched: no stack was generated under it.
+	_, statErr := os.Stat(filepath.Join(stackDir, ".terragrunt-stack"))
+	assert.True(t, os.IsNotExist(statErr),
+		"worktree-only generation must not generate .terragrunt-stack in the working directory")
+
+	discoveryContext := &component.DiscoveryContext{
+		WorkingDir: tmpDir,
+		Cmd:        "plan",
+	}
+
+	filters := make(filter.Filters, 0, len(gitExpressions))
+	for _, gitExpr := range gitExpressions {
+		filters = append(filters, filter.NewFilter(gitExpr, gitExpr.String()))
+	}
+
+	disc := discovery.NewDiscovery(tmpDir).
+		WithDiscoveryContext(discoveryContext).
+		WithWorktrees(w).
+		WithFilters(filters)
+
+	components, err := disc.Discover(t.Context(), l, opts)
+	require.NoError(t, err)
+
+	require.Contains(t, w.WorktreePairs, "[HEAD~1...HEAD]")
+	toWorktree := w.WorktreePairs["[HEAD~1...HEAD]"].ToWorktree.Path
+
+	stackRel, err := filepath.Rel(tmpDir, stackDir)
+	require.NoError(t, err)
+
+	expectedStack := filepath.Join(toWorktree, stackRel)
+
+	componentPaths := make([]string, 0, len(components))
+	for _, c := range components {
+		componentPaths = append(componentPaths, c.Path())
+	}
+
+	assert.Contains(t, componentPaths, expectedStack,
+		"stack reading the changed config file should be discovered via the Git filter; got: %v", componentPaths)
+}

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -788,7 +788,7 @@ func TestWorktreePhase_Integration_StackSourceOnlyInOneRef(t *testing.T) {
 	// The from-ref stack references catalog/units/app, which was removed from the checked-out
 	// tree; before the fix, get_repo_root() resolved to the original checkout and generation
 	// failed to fetch the source.
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, opts, w, generate.WithWorktreeOnly())
+	err = generate.WorktreeStacks(t.Context(), l, opts, w)
 	require.NoError(t, err)
 
 	pair := w.WorktreePairs["[HEAD~1...HEAD]"]
@@ -3127,7 +3127,7 @@ unit "app" {
 	opts.Experiments = experiment.NewExperiments()
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.FilterFlag))
 
-	require.NoError(t, generate.NewGenerator().GenerateStacks(t.Context(), l, opts, w, generate.WithWorktreeOnly()))
+	require.NoError(t, generate.WorktreeStacks(t.Context(), l, opts, w))
 
 	// The working tree must stay untouched: no stack was generated under it.
 	_, statErr := os.Stat(filepath.Join(stackDir, ".terragrunt-stack"))

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -719,6 +719,87 @@ unit "unit_to_be_untouched" {
 	assert.True(t, foundRemovedStack, "Removed stack should be discovered")
 }
 
+// TestWorktreePhase_Integration_StackSourceOnlyInOneRef reproduces the bug where a stack file
+// generated inside a git worktree resolved get_repo_root() against the original checkout rather
+// than the worktree. The unit source is renamed between refs, so each ref's source directory
+// exists only in that ref's worktree. Generation must run each stack file against its own
+// worktree; otherwise the "from" stack (which references a directory absent from the checked-out
+// ref) fails to fetch its source.
+func TestWorktreePhase_Integration_StackSourceOnlyInOneRef(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	writeCatalogUnit := func(name, marker string) {
+		unitDir := filepath.Join(tmpDir, "catalog", "units", name)
+		require.NoError(t, os.MkdirAll(unitDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(unitDir, "terragrunt.hcl"), []byte(`# `+marker), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(unitDir, "main.tf"), []byte(`# `+marker), 0o644))
+	}
+
+	stackDir := filepath.Join(tmpDir, "live")
+	require.NoError(t, os.MkdirAll(stackDir, 0o755))
+
+	writeStack := func(source string) {
+		contents := fmt.Sprintf(`unit "app" {
+	source = "${get_repo_root()}/catalog/units/%s"
+	path   = "app"
+}
+`, source)
+		require.NoError(t, os.WriteFile(filepath.Join(stackDir, "terragrunt.stack.hcl"), []byte(contents), 0o644))
+	}
+
+	// from ref (HEAD~1): source directory "app" exists and the stack points at it.
+	writeCatalogUnit("app", "from")
+	writeStack("app")
+	commitChanges(t, runner, "from: stack -> catalog/units/app")
+
+	// to ref (HEAD): the source directory is renamed, so "app" no longer exists in the checked-out
+	// tree. The stack change makes both refs' stacks eligible for worktree generation.
+	require.NoError(t, os.RemoveAll(filepath.Join(tmpDir, "catalog", "units", "app")))
+	writeCatalogUnit("new-app", "to")
+	writeStack("new-app")
+	commitChanges(t, runner, "to: stack -> catalog/units/new-app")
+
+	l := logger.CreateLogger()
+	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
+
+	wtOpts := worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	}
+	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		require.NoError(t, cleanupErr)
+	})
+
+	opts := options.NewTerragruntOptions()
+	opts.WorkingDir = tmpDir
+	opts.RootWorkingDir = tmpDir
+	parsedFilters, parseErr := filter.ParseFilterQueries(l, []string{"[HEAD~1...HEAD]"})
+	require.NoError(t, parseErr)
+
+	opts.Filters = parsedFilters
+	opts.Experiments = experiment.NewExperiments()
+
+	// The from-ref stack references catalog/units/app, which was removed from the checked-out
+	// tree; before the fix, get_repo_root() resolved to the original checkout and generation
+	// failed to fetch the source.
+	err = generate.NewGenerator().GenerateStacks(t.Context(), l, opts, w, generate.WithWorktreeOnly())
+	require.NoError(t, err)
+
+	pair := w.WorktreePairs["[HEAD~1...HEAD]"]
+	require.NotEmpty(t, pair)
+
+	assert.DirExists(t, filepath.Join(pair.FromWorktree.Path, "live", ".terragrunt-stack", "app"),
+		"from-ref stack should generate its unit from the from-worktree's catalog/units/app")
+	assert.DirExists(t, filepath.Join(pair.ToWorktree.Path, "live", ".terragrunt-stack", "app"),
+		"to-ref stack should generate its unit from the to-worktree's catalog/units/new-app")
+}
+
 // TestWorktreePhase_Integration_FileRename tests that file renames are detected.
 func TestWorktreePhase_Integration_FileRename(t *testing.T) {
 	t.Parallel()

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -53,43 +53,57 @@ func NewStackNode(filePath string) *StackNode {
 	}
 }
 
-// GenerateOption configures a stack generation run.
-type GenerateOption func(*generateOptions)
+// stackScope selects which stacks a generation run materializes.
+type stackScope int
 
-// generateOptions holds the resolved configuration for a stack generation run.
-type generateOptions struct {
-	worktreeOnly bool
-}
+const (
+	// allStacks generates stacks in the working directory and in any provided worktrees.
+	allStacks stackScope = iota
+	// worktreeStacksOnly generates only the worktree stacks, leaving the working directory untouched.
+	worktreeStacksOnly
+)
 
-func newGenerateOptions(genOpts ...GenerateOption) generateOptions {
-	var cfg generateOptions
-
-	for _, genOpt := range genOpts {
-		genOpt(&cfg)
+// WorktreeStacks generates the stacks that live inside the comparison worktrees, leaving the
+// working directory untouched. It is a no-op when no worktrees are present. find and list use it
+// to surface units nested in generated stacks without generating into the user's working directory.
+func WorktreeStacks(
+	ctx context.Context,
+	l log.Logger,
+	opts *options.TerragruntOptions,
+	wts *worktrees.Worktrees,
+) error {
+	if wts == nil || len(wts.WorktreePairs) == 0 {
+		return nil
 	}
 
-	return cfg
-}
-
-// WithWorktreeOnly restricts stack generation to the provided worktrees, leaving the
-// working directory untouched.
-func WithWorktreeOnly() GenerateOption {
-	return func(cfg *generateOptions) {
-		cfg.worktreeOnly = true
+	if err := NewGenerator().generateStacks(ctx, l, opts, wts, worktreeStacksOnly); err != nil {
+		return fmt.Errorf("failed to generate stacks in worktrees: %w", err)
 	}
+
+	return nil
 }
 
-// GenerateStacks generates the stack files using topological ordering to
-// prevent race conditions. Stack files are generated level by level, with
-// parent stacks completing before their children. Worktrees must be
-// provided by the caller if needed; this function will never create
+// GenerateStacks generates every stack file under the working directory, plus any worktree stacks
+// carried on wts. Worktrees must be provided by the caller if needed; this function never creates
 // worktrees internally.
 func (g *Generator) GenerateStacks(
 	ctx context.Context,
 	l log.Logger,
 	opts *options.TerragruntOptions,
 	wts *worktrees.Worktrees,
-	genOpts ...GenerateOption,
+) error {
+	return g.generateStacks(ctx, l, opts, wts, allStacks)
+}
+
+// generateStacks generates the stack files using topological ordering to prevent race conditions.
+// Stack files are generated level by level, with parent stacks completing before their children.
+// scope selects whether the working directory is included or only the worktree stacks carried on wts.
+func (g *Generator) generateStacks(
+	ctx context.Context,
+	l log.Logger,
+	opts *options.TerragruntOptions,
+	wts *worktrees.Worktrees,
+	scope stackScope,
 ) error {
 	workingDir, err := util.CanonicalResolvedPath(opts.WorkingDir, opts.WorkingDir)
 	if err != nil {
@@ -99,7 +113,7 @@ func (g *Generator) GenerateStacks(
 	g.locks.Lock(workingDir)
 	defer g.locks.Unlock(workingDir)
 
-	foundFiles, err := ListStackFiles(ctx, l, opts, wts, genOpts...)
+	foundFiles, err := ListStackFiles(ctx, l, opts, wts, scope)
 	if err != nil {
 		return fmt.Errorf("failed to list stack files in %s %w", opts.WorkingDir, err)
 	}
@@ -137,7 +151,7 @@ func (g *Generator) GenerateStacks(
 			return err
 		}
 
-		err := discoverAndAddNewNodes(ctx, l, opts, wts, workingDir, stackTrees, generatedFiles, level+1, genOpts...)
+		err := discoverAndAddNewNodes(ctx, l, opts, wts, workingDir, stackTrees, generatedFiles, level+1, scope)
 		if err != nil {
 			return err
 		}
@@ -224,9 +238,9 @@ func discoverAndAddNewNodes(
 	dependencyGraph map[string]*StackNode,
 	generatedFiles map[string]bool,
 	minLevel int,
-	genOpts ...GenerateOption,
+	scope stackScope,
 ) error {
-	newFiles, listErr := ListStackFiles(ctx, l, opts, worktrees, genOpts...)
+	newFiles, listErr := ListStackFiles(ctx, l, opts, worktrees, scope)
 	if listErr != nil {
 		return fmt.Errorf("failed to list stack files after level %d: %w", minLevel-1, listErr)
 	}
@@ -359,19 +373,17 @@ func addNewNodesToGraph(
 }
 
 // ListStackFiles returns canonical, symlink-resolved stack-file paths under the absolute opts.WorkingDir.
-// With WithWorktreeOnly, stack files in the working directory are skipped and only worktree stacks are returned.
+// For worktreeStacksOnly, stack files in the working directory are skipped and only worktree stacks are returned.
 func ListStackFiles(
 	ctx context.Context,
 	l log.Logger,
 	opts *options.TerragruntOptions,
 	worktrees *worktrees.Worktrees,
-	genOpts ...GenerateOption,
+	scope stackScope,
 ) ([]string, error) {
-	cfg := newGenerateOptions(genOpts...)
-
 	var discoveredComponents component.Components
 
-	if !cfg.worktreeOnly {
+	if scope != worktreeStacksOnly {
 		d, err := discovery.NewForStackGenerate(l, discovery.StackGenerateOptions{
 			WorkingDir: opts.WorkingDir,
 			Filters:    opts.Filters,
@@ -392,26 +404,15 @@ func ListStackFiles(
 	}
 
 	foundFiles := make([]string, 0, len(discoveredComponents)+len(worktreeStacks))
-	for _, c := range discoveredComponents {
-		if _, ok := c.(*component.Stack); !ok {
-			continue
-		}
 
-		canonical, err := util.CanonicalResolvedPath(filepath.Join(c.Path(), config.DefaultStackFile), opts.WorkingDir)
-		if err != nil {
-			return nil, err
-		}
-
-		foundFiles = append(foundFiles, canonical)
+	foundFiles, err = appendStackFilePaths(foundFiles, discoveredComponents, opts.WorkingDir)
+	if err != nil {
+		return nil, err
 	}
 
-	for _, c := range worktreeStacks {
-		canonical, err := util.CanonicalResolvedPath(filepath.Join(c.Path(), config.DefaultStackFile), opts.WorkingDir)
-		if err != nil {
-			return nil, err
-		}
-
-		foundFiles = append(foundFiles, canonical)
+	foundFiles, err = appendStackFilePaths(foundFiles, worktreeStacks, opts.WorkingDir)
+	if err != nil {
+		return nil, err
 	}
 
 	return foundFiles, nil
@@ -453,7 +454,7 @@ func ListStackFilesWithExcludes(
 		return nil, nil, err
 	}
 
-	foundFiles, err = appendWorktreeStackPaths(foundFiles, worktreeStacks, opts.WorkingDir)
+	foundFiles, err = appendStackFilePaths(foundFiles, worktreeStacks, opts.WorkingDir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -495,22 +496,27 @@ func collectStackAndExcludedPaths(
 	return foundFiles, excludedPaths, nil
 }
 
-// appendWorktreeStackPaths appends canonical stack-file paths for worktree stacks to foundFiles.
-func appendWorktreeStackPaths(
-	foundFiles []string,
-	worktreeStacks component.Components,
+// appendStackFilePaths appends the canonical terragrunt.stack.hcl path of every stack component in
+// components to dst, resolving each against workingDir. Non-stack components are skipped.
+func appendStackFilePaths(
+	dst []string,
+	components component.Components,
 	workingDir string,
 ) ([]string, error) {
-	for _, c := range worktreeStacks {
+	for _, c := range components {
+		if _, ok := c.(*component.Stack); !ok {
+			continue
+		}
+
 		canonical, err := util.CanonicalResolvedPath(filepath.Join(c.Path(), config.DefaultStackFile), workingDir)
 		if err != nil {
 			return nil, err
 		}
 
-		foundFiles = append(foundFiles, canonical)
+		dst = append(dst, canonical)
 	}
 
-	return foundFiles, nil
+	return dst, nil
 }
 
 // worktreeStacksToGenerate returns a slice of stacks that need to be generated from the worktree stacks.

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -198,7 +198,13 @@ func generateLevel(
 
 		wp.Submit(func() error {
 			_, pctx := configbridge.NewParsingContext(ctx, l, opts)
-			return config.GenerateStackFile(ctx, l, pctx, wp, node.FilePath)
+
+			scopedLogger, scopedPctx, err := pctx.WithConfigPath(l, node.FilePath)
+			if err != nil {
+				return err
+			}
+
+			return config.GenerateStackFile(ctx, scopedLogger, scopedPctx, wp, node.FilePath)
 		})
 	}
 

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -367,9 +367,8 @@ func ListStackFiles(
 
 	if !cfg.worktreeOnly {
 		d, err := discovery.NewForStackGenerate(l, discovery.StackGenerateOptions{
-			WorkingDir:  opts.WorkingDir,
-			Filters:     opts.Filters,
-			Experiments: opts.Experiments,
+			WorkingDir: opts.WorkingDir,
+			Filters:    opts.Filters,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create discovery for stack generate: %w", err)
@@ -424,9 +423,8 @@ func ListStackFilesWithExcludes(
 	worktrees *worktrees.Worktrees,
 ) ([]string, map[string]struct{}, error) {
 	d, err := discovery.NewForStackGenerate(l, discovery.StackGenerateOptions{
-		WorkingDir:  opts.WorkingDir,
-		Filters:     opts.Filters,
-		Experiments: opts.Experiments,
+		WorkingDir: opts.WorkingDir,
+		Filters:    opts.Filters,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create discovery for stack generate: %w", err)

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -53,6 +53,32 @@ func NewStackNode(filePath string) *StackNode {
 	}
 }
 
+// GenerateOption configures a stack generation run.
+type GenerateOption func(*generateOptions)
+
+// generateOptions holds the resolved configuration for a stack generation run.
+type generateOptions struct {
+	worktreeOnly bool
+}
+
+func newGenerateOptions(genOpts ...GenerateOption) generateOptions {
+	var cfg generateOptions
+
+	for _, genOpt := range genOpts {
+		genOpt(&cfg)
+	}
+
+	return cfg
+}
+
+// WithWorktreeOnly restricts stack generation to the provided worktrees, leaving the
+// working directory untouched.
+func WithWorktreeOnly() GenerateOption {
+	return func(cfg *generateOptions) {
+		cfg.worktreeOnly = true
+	}
+}
+
 // GenerateStacks generates the stack files using topological ordering to
 // prevent race conditions. Stack files are generated level by level, with
 // parent stacks completing before their children. Worktrees must be
@@ -63,6 +89,7 @@ func (g *Generator) GenerateStacks(
 	l log.Logger,
 	opts *options.TerragruntOptions,
 	wts *worktrees.Worktrees,
+	genOpts ...GenerateOption,
 ) error {
 	workingDir, err := util.CanonicalResolvedPath(opts.WorkingDir, opts.WorkingDir)
 	if err != nil {
@@ -72,7 +99,7 @@ func (g *Generator) GenerateStacks(
 	g.locks.Lock(workingDir)
 	defer g.locks.Unlock(workingDir)
 
-	foundFiles, err := ListStackFiles(ctx, l, opts, wts)
+	foundFiles, err := ListStackFiles(ctx, l, opts, wts, genOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to list stack files in %s %w", opts.WorkingDir, err)
 	}
@@ -110,7 +137,8 @@ func (g *Generator) GenerateStacks(
 			return err
 		}
 
-		if err := discoverAndAddNewNodes(ctx, l, opts, wts, workingDir, stackTrees, generatedFiles, level+1); err != nil {
+		err := discoverAndAddNewNodes(ctx, l, opts, wts, workingDir, stackTrees, generatedFiles, level+1, genOpts...)
+		if err != nil {
 			return err
 		}
 	}
@@ -190,8 +218,9 @@ func discoverAndAddNewNodes(
 	dependencyGraph map[string]*StackNode,
 	generatedFiles map[string]bool,
 	minLevel int,
+	genOpts ...GenerateOption,
 ) error {
-	newFiles, listErr := ListStackFiles(ctx, l, opts, worktrees)
+	newFiles, listErr := ListStackFiles(ctx, l, opts, worktrees, genOpts...)
 	if listErr != nil {
 		return fmt.Errorf("failed to list stack files after level %d: %w", minLevel-1, listErr)
 	}
@@ -324,24 +353,32 @@ func addNewNodesToGraph(
 }
 
 // ListStackFiles returns canonical, symlink-resolved stack-file paths under the absolute opts.WorkingDir.
+// With WithWorktreeOnly, stack files in the working directory are skipped and only worktree stacks are returned.
 func ListStackFiles(
 	ctx context.Context,
 	l log.Logger,
 	opts *options.TerragruntOptions,
 	worktrees *worktrees.Worktrees,
+	genOpts ...GenerateOption,
 ) ([]string, error) {
-	d, err := discovery.NewForStackGenerate(l, discovery.StackGenerateOptions{
-		WorkingDir:  opts.WorkingDir,
-		Filters:     opts.Filters,
-		Experiments: opts.Experiments,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create discovery for stack generate: %w", err)
-	}
+	cfg := newGenerateOptions(genOpts...)
 
-	discoveredComponents, err := d.Discover(ctx, l, opts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to discover stack files: %w", err)
+	var discoveredComponents component.Components
+
+	if !cfg.worktreeOnly {
+		d, err := discovery.NewForStackGenerate(l, discovery.StackGenerateOptions{
+			WorkingDir:  opts.WorkingDir,
+			Filters:     opts.Filters,
+			Experiments: opts.Experiments,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create discovery for stack generate: %w", err)
+		}
+
+		discoveredComponents, err = d.Discover(ctx, l, opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to discover stack files: %w", err)
+		}
 	}
 
 	worktreeStacks, err := worktreeStacksToGenerate(ctx, l, opts, worktrees)


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6347.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `terragrunt find` and `terragrunt list` now include generated-stack units when running with Git-filtered comparisons, so nested units are correctly detected within comparison worktrees.
  * HCL validation and related discovery flows no longer apply experiment-related behavior, improving consistency across commands.
* **Documentation**
  * Updated the `v1.1.1` changelog entry to clarify the Git-filtered scope for generated-stack fixes.
* **Tests**
  * Added integration coverage for worktree-only stack generation, including correct worktree-scoped `get_repo_root()` behavior and ensuring stacks are generated only where intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->