### PR TITLE
fix: Fixing `update_source_with_cas` integration with `--no-cas`

### DIFF
--- a/docs/src/data/changelog/v1.1.0/cas-no-cas-terraform-update-source.mdx
+++ b/docs/src/data/changelog/v1.1.0/cas-no-cas-terraform-update-source.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.0"
+category: "bug-fixes"
+---
+
+#### Reject `update_source_with_cas` on a `terraform` block when CAS is disabled
+
+`terragrunt stack generate --no-cas` now fails when a generated unit's `terraform` block sets `update_source_with_cas = true`, instead of silently emitting the unit with its relative `source` unchanged. The relative source has no meaning once CAS is disabled, so the generated unit could not resolve its module. This matches the existing behavior for the same attribute on `unit` and `stack` blocks, and for a `run` invoked with `--no-cas`.

--- a/internal/cas/content.go
+++ b/internal/cas/content.go
@@ -260,7 +260,7 @@ func (c *Content) EnsureCopy(l log.Logger, v Venv, hash, src string) (err error)
 			return
 		}
 
-		if rmErr := v.FS.Remove(tempPath); rmErr != nil && !os.IsNotExist(rmErr) {
+		if rmErr := v.FS.Remove(tempPath); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
 			err = errors.Join(err, rmErr)
 		}
 	}()

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -2,6 +2,7 @@ package cas
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -10,10 +11,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/go-getter/v2"
+
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/hashicorp/go-getter/v2"
 )
 
 // RemoteSourceDetectors is the go-getter detector chain CAS applies to
@@ -317,7 +319,7 @@ func (c *CAS) processStackFile(
 	// The file may be a read-only hard link from the CAS store, so remove it
 	// before writing the rewritten content to avoid permission errors and to
 	// avoid mutating the stored blob.
-	if err := v.FS.Remove(stackFile); err != nil && !os.IsNotExist(err) {
+	if err := v.FS.Remove(stackFile); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to remove stack file before rewrite %s: %w", stackFile, err)
 	}
 
@@ -400,7 +402,7 @@ func (c *CAS) processUnitFile(
 	// The file may be a read-only hard link from the CAS store, so remove it
 	// before writing the rewritten content to avoid permission errors and to
 	// avoid mutating the stored blob.
-	if err := v.FS.Remove(unitFile); err != nil && !os.IsNotExist(err) {
+	if err := v.FS.Remove(unitFile); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to remove unit file before rewrite %s: %w", unitFile, err)
 	}
 

--- a/internal/git/server.go
+++ b/internal/git/server.go
@@ -452,7 +452,7 @@ func (s *Server) appendGitmodules(ctx context.Context, path, url string) error {
 	gmPath := filepath.Join(s.workDir, ".gitmodules")
 
 	existing, err := os.ReadFile(gmPath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("read .gitmodules: %w", err)
 	}
 

--- a/internal/remotestate/remote_state.go
+++ b/internal/remotestate/remote_state.go
@@ -3,6 +3,7 @@ package remotestate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -106,7 +107,7 @@ func (remote *RemoteState) Migrate(ctx context.Context, l log.Logger, exec vexec
 	}
 
 	defer func() {
-		if err := os.Remove(stateFile); err != nil && !os.IsNotExist(err) {
+		if err := os.Remove(stateFile); err != nil && !errors.Is(err, os.ErrNotExist) {
 			l.Warnf("Failed to remove temporary state file %s: %v", stateFile, err)
 		}
 	}()

--- a/internal/shell/git.go
+++ b/internal/shell/git.go
@@ -3,17 +3,19 @@ package shell
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/writer"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/hashicorp/go-version"
 )
 
 const (
@@ -133,7 +135,7 @@ func hasNestedGit(path, root string) (bool, error) {
 			return true, nil
 		}
 
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, os.ErrNotExist) {
 			return false, err
 		}
 

--- a/internal/tf/cache/services/provider_cache.go
+++ b/internal/tf/cache/services/provider_cache.go
@@ -431,7 +431,7 @@ func (cache *ProviderCache) newRequest(ctx context.Context, url string) (*http.R
 func RemoveStaleSymlink(fs vfs.FS, path string) error {
 	info, err := vfs.Lstat(fs, path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 

--- a/internal/tf/cache/services/provider_cache_test.go
+++ b/internal/tf/cache/services/provider_cache_test.go
@@ -5,11 +5,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 )
 
 func TestRemoveStaleSymlink(t *testing.T) {
@@ -34,7 +35,7 @@ func TestRemoveStaleSymlink(t *testing.T) {
 				t.Helper()
 
 				_, err := vfs.Lstat(fs, path)
-				assert.True(t, os.IsNotExist(err), "expected NotExist, got %v", err)
+				assert.ErrorIs(t, err, os.ErrNotExist, "expected NotExist, got %v", err)
 			},
 		},
 		{
@@ -51,7 +52,7 @@ func TestRemoveStaleSymlink(t *testing.T) {
 				t.Helper()
 
 				_, err := vfs.Lstat(fs, path)
-				assert.True(t, os.IsNotExist(err), "expected NotExist after remove, got %v", err)
+				assert.ErrorIs(t, err, os.ErrNotExist, "expected NotExist after remove, got %v", err)
 			},
 		},
 		{

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -152,11 +152,13 @@ func GenerateStackFile(ctx context.Context, l log.Logger, pctx *ParsingContext, 
 		strictControls:  pctx.StrictControls,
 	}
 
-	if err := generateUnits(ctx, l, &genOpts, pool, stackFile.Units); err != nil {
+	fs := pctx.Venv.FS
+
+	if err := generateUnits(ctx, l, fs, &genOpts, pool, stackFile.Units); err != nil {
 		return err
 	}
 
-	if err := generateStacks(ctx, l, &genOpts, pool, stackFile.Stacks); err != nil {
+	if err := generateStacks(ctx, l, fs, &genOpts, pool, stackFile.Stacks); err != nil {
 		return err
 	}
 
@@ -275,6 +277,39 @@ func validateUpdateSourceWithCAS(stackFile *StackConfig, stackFilePath string, c
 	return nil
 }
 
+// rejectTerraformUpdateSourceWithoutCAS rejects a generated unit whose terraform block sets
+// update_source_with_cas = true when CAS is disabled. validateUpdateSourceWithCAS only sees the
+// unit/stack blocks declared in the stack file; the terraform-block attribute lives in the unit's
+// own terragrunt.hcl, which is only available once the source is materialized. Without this check
+// the relative source would be copied verbatim and silently fail to resolve from the generated
+// location, since the cas:: rewrite that gives it meaning never runs.
+func rejectTerraformUpdateSourceWithoutCAS(fs vfs.FS, dest string) error {
+	unitFile := filepath.Join(dest, DefaultTerragruntConfigPath)
+
+	content, err := vfs.ReadFile(fs, unitFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to read generated unit file %s: %w", unitFile, err)
+	}
+
+	_, updateWithCAS, err := cas.ReadTerraformSourceInfo(content)
+	if err != nil {
+		return fmt.Errorf("failed to inspect terraform source in %s: %w", unitFile, err)
+	}
+
+	if !updateWithCAS {
+		return nil
+	}
+
+	return &cas.UpdateSourceWithCASRequiresCASError{
+		BlockType: "terraform",
+		Path:      unitFile,
+	}
+}
+
 // casSetup is the result of setupCAS: the CAS instance and Venv that
 // stack/unit generation threads through every CAS call, plus the
 // Enabled flag callers gate CAS features on. Enabled is false either
@@ -336,7 +371,7 @@ type generateOpts struct {
 // generateUnits iterates through a slice of Unit objects, generating each one by copying
 // source files to their destination paths and writing unit-specific values.
 // It logs the generating progress and returns any errors encountered during the operation.
-func generateUnits(ctx context.Context, l log.Logger, opts *generateOpts, pool *worker.Pool, units []*Unit) error {
+func generateUnits(ctx context.Context, l log.Logger, fs vfs.FS, opts *generateOpts, pool *worker.Pool, units []*Unit) error {
 	for _, unit := range units {
 		pool.Submit(func() error {
 			item := componentToGenerate{
@@ -360,7 +395,7 @@ func generateUnits(ctx context.Context, l log.Logger, opts *generateOpts, pool *
 				"unit_source": unit.Source,
 				"unit_path":   unit.Path,
 			}, func(ctx context.Context) error {
-				return generateComponent(ctx, l, opts, &item)
+				return generateComponent(ctx, l, fs, opts, &item)
 			})
 		})
 	}
@@ -370,7 +405,7 @@ func generateUnits(ctx context.Context, l log.Logger, opts *generateOpts, pool *
 
 // generateStacks generates each stack by resolving its destination path and copying files from the source.
 // It logs each operation and returns early if any error is encountered.
-func generateStacks(ctx context.Context, l log.Logger, opts *generateOpts, pool *worker.Pool, stacks []*Stack) error {
+func generateStacks(ctx context.Context, l log.Logger, fs vfs.FS, opts *generateOpts, pool *worker.Pool, stacks []*Stack) error {
 	for _, stack := range stacks {
 		pool.Submit(func() error {
 			item := componentToGenerate{
@@ -394,7 +429,7 @@ func generateStacks(ctx context.Context, l log.Logger, opts *generateOpts, pool 
 				"stack_source": stack.Source,
 				"stack_path":   stack.Path,
 			}, func(ctx context.Context) error {
-				return generateComponent(ctx, l, opts, &item)
+				return generateComponent(ctx, l, fs, opts, &item)
 			})
 		})
 	}
@@ -489,7 +524,7 @@ func validateGeneratedComponent(l log.Logger, cmp *componentToGenerate, opts *ge
 }
 
 // generateAutoInclude writes the autoinclude file for a component if one was resolved.
-func generateAutoInclude(l log.Logger, opts *generateOpts, cmp *componentToGenerate, dest string) error {
+func generateAutoInclude(l log.Logger, fs vfs.FS, opts *generateOpts, cmp *componentToGenerate, dest string) error {
 	if opts.autoIncludes == nil {
 		return nil
 	}
@@ -509,7 +544,7 @@ func generateAutoInclude(l log.Logger, opts *generateOpts, cmp *componentToGener
 	// The autoinclude resolves entirely in the stack file context, so the resolution-time eval context (functions
 	// scoped to the stack file, like the discovery path) is reused as-is: every expression except dependency.* is
 	// already a literal, and directory-context functions resolve where the autoinclude was authored.
-	if err := inthclparse.GenerateAutoIncludeFile(vfs.NewOSFS(), resolved, dest, resolved.SourceBytes, resolved.EvalCtx); err != nil {
+	if err := inthclparse.GenerateAutoIncludeFile(fs, resolved, dest, resolved.SourceBytes, resolved.EvalCtx); err != nil {
 		return fmt.Errorf("failed to write autoinclude for %s %s: %w", kind, cmp.name, err)
 	}
 
@@ -517,7 +552,7 @@ func generateAutoInclude(l log.Logger, opts *generateOpts, cmp *componentToGener
 }
 
 // generateComponent copies files from the source directory to the target destination and generates a corresponding values file.
-func generateComponent(ctx context.Context, l log.Logger, opts *generateOpts, cmp *componentToGenerate) error {
+func generateComponent(ctx context.Context, l log.Logger, fs vfs.FS, opts *generateOpts, cmp *componentToGenerate) error {
 	source := cmp.source
 	// Adjust source path using the provided source mapping configuration if available
 	source, err := adjustSourceWithMap(opts.sourceMap, source, opts.stackConfigPath)
@@ -541,6 +576,12 @@ func generateComponent(ctx context.Context, l log.Logger, opts *generateOpts, cm
 		return err
 	}
 
+	if !opts.casEnabled && cmp.kind == unitKind {
+		if err := rejectTerraformUpdateSourceWithoutCAS(fs, dest); err != nil {
+			return err
+		}
+	}
+
 	if err := validateGeneratedComponent(l, cmp, opts, dest); err != nil {
 		return err
 	}
@@ -549,7 +590,7 @@ func generateComponent(ctx context.Context, l log.Logger, opts *generateOpts, cm
 		return fmt.Errorf("failed to write values %v %w", cmp.name, err)
 	}
 
-	return generateAutoInclude(l, opts, cmp, dest)
+	return generateAutoInclude(l, fs, opts, cmp, dest)
 }
 
 // fetchComponentSource handles the paths for fetching a component's source:

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -712,7 +712,7 @@ func fetchViaCAS(
 	if copyErr := util.CopyFolderContentsWithFilter(l, result.ContentDir, dest, manifestName, func(_ string) bool {
 		return true
 	}); copyErr != nil {
-		if cleanupErr := os.RemoveAll(dest); cleanupErr != nil && !os.IsNotExist(cleanupErr) {
+		if cleanupErr := os.RemoveAll(dest); cleanupErr != nil && !errors.Is(cleanupErr, os.ErrNotExist) {
 			l.Debugf("Failed to clean partial CAS destination %s: %v", dest, cleanupErr)
 		}
 

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -2620,6 +2620,52 @@ func TestCASInStacksRejectsUpdateSourceWithCASWithNoCAS(t *testing.T) {
 	}
 }
 
+// TestCASInStacksRejectsTerraformUpdateSourceWithCASWithNoCAS verifies that stack
+// generation errors when a unit's terraform block declares update_source_with_cas = true
+// while --no-cas is set. Unlike the unit/stack-block attribute (validated up front from the
+// stack file), the terraform-block attribute lives in the unit's own terragrunt.hcl and is
+// only visible once the source is materialized, so it is checked during generation. Without
+// the check the relative source would be copied verbatim and silently fail to resolve.
+func TestCASInStacksRejectsTerraformUpdateSourceWithCASWithNoCAS(t *testing.T) {
+	t.Parallel()
+
+	catalog := helpers.TmpDirWOSymlinks(t)
+	liveDir := helpers.TmpDirWOSymlinks(t)
+
+	writeFile := func(rel, body string) {
+		full := filepath.Join(catalog, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+		require.NoError(t, os.WriteFile(full, []byte(body), 0644))
+	}
+
+	writeFile("modules/baz/main.tf", ``)
+	writeFile("units/bar/terragrunt.hcl", `terraform {
+  source = "../..//modules/baz"
+
+  update_source_with_cas = true
+}
+`)
+
+	// The unit block itself does NOT set update_source_with_cas, so the only opt-in is the
+	// terraform block inside the materialized unit.
+	liveStack := fmt.Sprintf(`unit "bar" {
+  source = %s
+  path   = "bar"
+}
+`, strconv.Quote(filepath.ToSlash(catalog)+"//units/bar"))
+	require.NoError(t, os.WriteFile(filepath.Join(liveDir, "terragrunt.stack.hcl"), []byte(liveStack), 0644))
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt stack generate --no-cas --non-interactive --working-dir "+liveDir,
+	)
+	require.Error(t, err)
+
+	combined := stderr + err.Error()
+	assert.Contains(t, combined, "update_source_with_cas")
+	assert.Contains(t, combined, "terraform")
+}
+
 // TestCASInStacksLocalSource verifies that CAS processing works end-to-end
 // when the top-level stack source is a local filesystem path rather than a
 // remote git URL. The catalog-like tree lives on disk, the live stack points


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

This was handled for stack generation, but not for cache generation in units.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to error when `terragrunt stack generate --no-cas` encounters a unit with `update_source_with_cas = true` in its terraform configuration, preventing silent misconfigurations.
  * Improved error handling consistency for file operations.

* **Documentation**
  * Updated changelog with validation behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->