### PR TITLE
chore: drop usage of github.com/NYTimes/gziphandler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.26
 require (
 	cloud.google.com/go/storage v1.62.3
 	dario.cat/mergo v1.0.2
-	github.com/NYTimes/gziphandler v1.1.1
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,6 @@ github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSC
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
-github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
-github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -4,6 +4,7 @@ package helpers
 import (
 	"archive/zip"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -39,7 +40,6 @@ import (
 
 	"errors"
 
-	"github.com/NYTimes/gziphandler"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -587,7 +587,7 @@ func RunNetworkMirrorServer(t *testing.T, ctx context.Context, urlPrefix, provid
 
 	fs := http.FileServer(http.Dir(providerDir))
 
-	withGz := gziphandler.GzipHandler(http.StripPrefix(urlPrefix, fs))
+	withGz := GzipHandler(http.StripPrefix(urlPrefix, fs))
 
 	mux.HandleFunc(urlPrefix, func(resp http.ResponseWriter, req *http.Request) {
 		if token != "" {
@@ -1363,4 +1363,47 @@ func isAWSResourceNotFoundError(err error) bool {
 	return errors.As(err, &apiErr) && (apiErr.ErrorCode() == "NoSuchBucket" ||
 		apiErr.ErrorCode() == "NotFound" ||
 		apiErr.ErrorCode() == "ResourceNotFoundException")
+}
+
+// GzipHandler gzip-compresses responses when the client accepts gzip encoding.
+func GzipHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		if !strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
+			h.ServeHTTP(resp, req)
+			return
+		}
+
+		gz := gzip.NewWriter(resp)
+
+		defer func() { _ = gz.Close() }()
+
+		h.ServeHTTP(&gzipResponseWriter{ResponseWriter: resp, gz: gz}, req)
+	})
+}
+
+type gzipResponseWriter struct {
+	http.ResponseWriter
+	gz          *gzip.Writer
+	wroteHeader bool
+}
+
+func (w *gzipResponseWriter) WriteHeader(status int) {
+	if w.wroteHeader {
+		return
+	}
+
+	w.wroteHeader = true
+
+	// length no longer matches once the body is compressed
+	w.Header().Del("Content-Length")
+	w.Header().Set("Content-Encoding", "gzip")
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *gzipResponseWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	return w.gz.Write(b)
 }

--- a/test/integration_common_test.go
+++ b/test/integration_common_test.go
@@ -33,8 +33,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/NYTimes/gziphandler"
 )
 
 func createLogger() log.Logger {
@@ -70,7 +68,7 @@ func runNetworkMirrorServer(t *testing.T, ctx context.Context, urlPrefix, provid
 
 	fs := http.FileServer(http.Dir(providerDir))
 
-	withGz := gziphandler.GzipHandler(http.StripPrefix(urlPrefix, fs))
+	withGz := helpers.GzipHandler(http.StripPrefix(urlPrefix, fs))
 
 	mux.HandleFunc(urlPrefix, func(resp http.ResponseWriter, req *http.Request) {
 		if token != "" {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* replaced github.com/NYTimes/gziphandler with an internal implementation since it is used only in tests

Fixes #6361.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed external gzip compression dependency and replaced it with an internal implementation using Go's standard library for handling response compression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->