### PR TITLE
chore: Addressing #6351 feedback

### DIFF
--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -218,14 +218,22 @@ func (o expandOptions) checkBoundary(fs vfs.FS, root string) error {
 	return nil
 }
 
-// resolvePath returns the symlink-resolved form of p, falling back to the
-// cleaned path when resolution fails, for example when p does not exist.
+// resolvePath returns the symlink-resolved form of p. EvalSymlinks resolves
+// only paths that exist, so resolving the longest existing ancestor and
+// rejoining the remaining components keeps an absent path comparable with a
+// resolved one instead of leaving it merely cleaned.
 func resolvePath(fs vfs.FS, p string) string {
+	p = filepath.Clean(p)
+
 	if resolved, err := vfs.EvalSymlinks(fs, p); err == nil {
 		return resolved
 	}
 
-	return filepath.Clean(p)
+	if parent := filepath.Dir(p); parent != p {
+		return filepath.Join(resolvePath(fs, parent), filepath.Base(p))
+	}
+
+	return p
 }
 
 // withinBoundary reports whether p is boundary or a descendant of it. Both

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -321,6 +321,22 @@ func TestExpandBoundary(t *testing.T) {
 	}
 }
 
+// TestExpandBoundaryResolvesSymlinksConsistently pins that the boundary check
+// treats a walk root the same whether or not it exists on disk. The boundary
+// crosses a symlink, so an absent root that cannot be symlink-resolved on its
+// own must still be recognized as inside it rather than wrongly refused.
+func TestExpandBoundaryResolvesSymlinksConsistently(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, fs.MkdirAll("/real", 0o755))
+	require.NoError(t, vfs.Symlink(fs, "/real", "/link"))
+
+	got, err := glob.Expand(fs, "/link/absent/*.yaml", glob.WithBoundary("/link"))
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
 // TestLegacyExpandCollapsesGlobstar documents the reason LegacyExpand exists:
 // zglob collapses the separators flanking `**`, whereas Expand (gobwas) does
 // not. Switching the include_in_copy / exclude_from_copy call site from


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses nit from #6351.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symlink resolution handling for paths with non-existent components, ensuring more consistent boundary path evaluation.
* **Tests**
  * Added test coverage for symlink resolution behavior in boundary path scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->