### PR TITLE
chore: Log Windows console mode retrieval failures at debug level (#6374)

### DIFF
--- a/internal/os/exec/ptty_windows.go
+++ b/internal/os/exec/ptty_windows.go
@@ -5,7 +5,6 @@ package exec
 import (
 	"os"
 	"os/exec"
-	"strings"
 
 	"golang.org/x/sys/windows"
 

--- a/internal/os/exec/ptty_windows.go
+++ b/internal/os/exec/ptty_windows.go
@@ -12,8 +12,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
-const InvalidHandleErrorMessage = "The handle is invalid"
-
 // PrepareConsole enables support for escape sequences on Windows.
 // Returns true if virtual terminal processing was successfully enabled on at least one output handle.
 // https://stackoverflow.com/questions/56460651/golang-fmt-print-033c-and-fmt-print-x1bc-are-not-clearing-screenansi-es
@@ -94,11 +92,7 @@ func enableVirtualTerminalProcessing(logger log.Logger, file *os.File) bool {
 
 	handle := windows.Handle(file.Fd())
 	if err := windows.GetConsoleMode(handle, &mode); err != nil {
-		if strings.Contains(err.Error(), InvalidHandleErrorMessage) {
-			logger.Debugf("failed to get console mode: %v", err)
-		} else {
-			logger.Errorf("failed to get console mode: %v", err)
-		}
+		logger.Debugf("failed to get console mode: %v", err)
 
 		return false
 	}


### PR DESCRIPTION
## Description
Fixes #6374.

Update Windows console mode handling to log all `GetConsoleMode` failures at the `debug` level.
Previously, failures containing the `The handle is invalid` message were logged as debug, while all other failures were logged as errors.
Since failures to retrieve console mode are not fatal to application execution, this change reduces log noise by treating all such failures as debug information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows console handling by making console-mode diagnostics consistently emit debug logging when system checks fail.
  * Simplified failure-path behavior to use a single uniform debug log message rather than differing based on specific error text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->