### PR TITLE
fix: Only detect variables in root directory of module

### DIFF
--- a/docs/src/data/changelog/v1.1.0/scaffold-detect-variables-in-module-dir.mdx
+++ b/docs/src/data/changelog/v1.1.0/scaffold-detect-variables-in-module-dir.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.0"
+category: "bug-fixes"
+---
+
+#### Scaffold only detects variables in the module directory
+
+`terragrunt scaffold` now reads input variables from the module directory itself, matching what OpenTofu and Terraform load for a root module. Previously it scanned subdirectories too, so `variable` blocks defined in nested modules or examples leaked into the scaffolded inputs even though the module never exposes them.

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
@@ -262,7 +263,7 @@ func Prepare(
 	}
 
 	// extract variables from downloaded module
-	requiredVariables, optionalVariables, err := parseVariables(l, opts, tempDir)
+	requiredVariables, optionalVariables, err := parseVariables(l, v.FS, opts, tempDir)
 	if err != nil {
 		return nil, err
 	}
@@ -643,10 +644,11 @@ func prepareBoilerplateFiles(
 // parseVariables - parse variables from tf files.
 func parseVariables(
 	l log.Logger,
+	fsys vfs.FS,
 	opts *options.TerragruntOptions,
 	moduleDir string,
 ) ([]*config.ParsedVariable, []*config.ParsedVariable, error) {
-	inputs, err := config.ParseVariables(l, opts.Experiments, opts.StrictControls, moduleDir)
+	inputs, err := config.ParseVariables(l, fsys, opts.StrictControls, moduleDir)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -1430,28 +1430,27 @@ func (err PathIsNotFile) Error() string {
 	return err.path + " is not a file"
 }
 
-// ListTfFiles returns a list of all TF files in the specified directory.
-func ListTfFiles(directoryPath string, walkWithSymlinks bool) ([]string, error) {
-	var tfFiles []string
-
-	walkFunc := filepath.WalkDir
-	if walkWithSymlinks {
-		walkFunc = WalkDirWithSymlinks
+// ListTfFiles returns the OpenTofu/Terraform files in the given directory.
+func ListTfFiles(fsys vfs.FS, directoryPath string) ([]string, error) {
+	entries, err := vfs.ReadDirEntries(fsys, directoryPath)
+	if err != nil {
+		return nil, err
 	}
 
-	err := walkFunc(directoryPath, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
+	var tfFiles []string
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
 		}
 
-		if !d.IsDir() && IsTFFile(path) {
+		path := filepath.Join(directoryPath, entry.Name())
+		if IsTFFile(path) {
 			tfFiles = append(tfFiles, path)
 		}
+	}
 
-		return nil
-	})
-
-	return tfFiles, err
+	return tfFiles, nil
 }
 
 // IsDirectoryEmpty - returns true if the given path exists and is a empty directory.

--- a/internal/util/file_tofu_test.go
+++ b/internal/util/file_tofu_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -522,11 +523,11 @@ func TestListTfFiles(t *testing.T) {
 			expectedFiles: []string{},
 		},
 		{
-			description:   "Directory with nested .tofu files",
+			description:   "Nested files are ignored",
 			files:         []string{"main.tf", "modules/vpc/main.tofu"},
 			directories:   []string{"modules", "modules/vpc"},
-			expectedCount: 2,
-			expectedFiles: []string{"main.tf", "modules/vpc/main.tofu"},
+			expectedCount: 1,
+			expectedFiles: []string{"main.tf"},
 		},
 	}
 
@@ -547,7 +548,7 @@ func TestListTfFiles(t *testing.T) {
 				require.NoError(t, os.WriteFile(filePath, []byte("# Test file content"), 0644))
 			}
 
-			actual, err := util.ListTfFiles(tmpDir, false)
+			actual, err := util.ListTfFiles(vfs.NewOSFS(), tmpDir)
 			require.NoError(t, err)
 
 			assert.Len(t, actual, tc.expectedCount, "Expected %d files, got %d", tc.expectedCount, len(actual))
@@ -561,33 +562,6 @@ func TestListTfFiles(t *testing.T) {
 				assert.True(t, util.IsTFFile(foundFile), "Non-TF file %s found in results", foundFile)
 			}
 		})
-	}
-}
-
-func TestListTfFilesWithSymlinks(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := helpers.TmpDirWOSymlinks(t)
-
-	// Create a real directory with .tofu files
-	realDir := filepath.Join(tmpDir, "real-module")
-	require.NoError(t, os.MkdirAll(realDir, 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(realDir, "main.tofu"), []byte("# main"), 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(realDir, "variables.tf"), []byte("# vars"), 0644))
-
-	// Create a symlink to the real directory
-	linkDir := filepath.Join(tmpDir, "linked-module")
-	require.NoError(t, os.Symlink(realDir, linkDir))
-
-	// walkWithSymlinks=true should follow symlinks and find files
-	actual, err := util.ListTfFiles(tmpDir, true)
-	require.NoError(t, err)
-
-	// Should find files in both real dir and symlinked dir
-	assert.Len(t, actual, 4)
-
-	for _, foundFile := range actual {
-		assert.True(t, util.IsTFFile(foundFile), "Non-TF file %s found in results", foundFile)
 	}
 }
 

--- a/pkg/config/variable.go
+++ b/pkg/config/variable.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/strict"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/hcl/v2"
@@ -31,11 +31,9 @@ type ParsedVariable struct {
 }
 
 // ParseVariables - parse variables from tf files.
-func ParseVariables(l log.Logger, experiments experiment.Experiments, strictControls strict.Controls, directoryPath string) ([]*ParsedVariable, error) {
-	walkWithSymlinks := experiments.Evaluate(experiment.Symlinks)
-
+func ParseVariables(l log.Logger, fsys vfs.FS, strictControls strict.Controls, directoryPath string) ([]*ParsedVariable, error) {
 	// list all tf files
-	tfFiles, err := util.ListTfFiles(directoryPath, walkWithSymlinks)
+	tfFiles, err := util.ListTfFiles(fsys, directoryPath)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +44,12 @@ func ParseVariables(l log.Logger, experiments experiment.Experiments, strictCont
 	var parsedInputs []*ParsedVariable
 
 	for _, tfFile := range tfFiles {
-		if _, err := parser.ParseFromFile(tfFile); err != nil {
+		content, err := vfs.ReadFile(fsys, tfFile)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := parser.ParseFromBytes(content, tfFile); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/config/variable_test.go
+++ b/pkg/config/variable_test.go
@@ -1,10 +1,11 @@
 package config_test
 
 import (
+	"path/filepath"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ import (
 func TestScanVariables(t *testing.T) {
 	t.Parallel()
 
-	inputs, err := config.ParseVariables(logger.CreateLogger(), experiment.NewExperiments(), controls.New(), "../../test/fixtures/inputs")
+	inputs, err := config.ParseVariables(logger.CreateLogger(), vfs.NewOSFS(), controls.New(), "../../test/fixtures/inputs")
 	require.NoError(t, err)
 	assert.Len(t, inputs, 11)
 
@@ -42,10 +43,27 @@ func TestScanVariables(t *testing.T) {
 	assert.Equal(t, "[]", varByName["list_bool"].DefaultValuePlaceholder)
 }
 
+func TestParseVariablesIgnoresSubdirectories(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	moduleDir := "/module"
+
+	require.NoError(t, fsys.MkdirAll(filepath.Join(moduleDir, "sub"), 0755))
+	require.NoError(t, vfs.WriteFile(fsys, filepath.Join(moduleDir, "main.tf"), []byte(`variable "root" {}`), 0644))
+	require.NoError(t, vfs.WriteFile(fsys, filepath.Join(moduleDir, "sub", "main.tf"), []byte(`variable "nested" {}`), 0644))
+
+	inputs, err := config.ParseVariables(logger.CreateLogger(), fsys, controls.New(), moduleDir)
+	require.NoError(t, err)
+
+	require.Len(t, inputs, 1)
+	assert.Equal(t, "root", inputs[0].Name)
+}
+
 func TestScanDefaultVariables(t *testing.T) {
 	t.Parallel()
 
-	inputs, err := config.ParseVariables(logger.CreateLogger(), experiment.NewExperiments(), controls.New(), "../../test/fixtures/inputs-defaults")
+	inputs, err := config.ParseVariables(logger.CreateLogger(), vfs.NewOSFS(), controls.New(), "../../test/fixtures/inputs-defaults")
 	require.NoError(t, err)
 	assert.Len(t, inputs, 11)
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Prevents detection of irrelevant variables in subdirectories of root modules during scaffolding.

Fixes #6380

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `terragrunt scaffold` to read input variables from the module directory only, preventing variable blocks from nested modules and examples from leaking into scaffolded inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->