### PR TITLE
Fixing codespell lint error and adding codespell lint commands

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,10 +5,13 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
+    "prebuild": "cd .. && codespell",
     "build": "astro build && bun scripts/indexnow-ping.js",
     "preview": "astro preview",
     "astro": "astro",
-    "test": "bun test"
+    "test": "bun test",
+    "spell": "cd .. && codespell",
+    "spell:fix": "cd .. && codespell -w"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "prebuild": "cd .. && codespell",
+    "prebuild": "if command -v codespell >/dev/null 2>&1; then cd .. && codespell; else echo 'codespell not found on PATH; skipping spellcheck (run `mise install` to enable it locally)'; fi",
     "build": "astro build && bun scripts/indexnow-ping.js",
     "preview": "astro preview",
     "astro": "astro",

--- a/docs/src/env.d.ts
+++ b/docs/src/env.d.ts
@@ -1,0 +1,15 @@
+/// <reference types="astro/client" />
+/// <reference types="bun" />
+
+// `src/components/SiteTitle.astro` overrides Starlight's component and (like Starlight's own)
+// imports the configured logos from `virtual:starlight/user-images`. That module's types live in
+// Starlight's internal `virtual-internal.d.ts`, which isn't exposed to consumer projects, so
+// `astro check` can't resolve the import (it resolves fine at build time via Starlight's Vite
+// plugin). Redeclare it here to close the type gap.
+declare module 'virtual:starlight/user-images' {
+	type ImageMetadata = import('astro').ImageMetadata;
+	export const logos: {
+		dark?: ImageMetadata;
+		light?: ImageMetadata;
+	};
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added documentation spelling checks to the build workflow, with new scripts to run spell-check and apply fixes.
* **Bug Fixes**
  * Resolved a TypeScript type-checking gap for virtual Starlight image imports, improving compatibility with type validation tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->