### PR TITLE
chore: Addressing weekly tests stats (2026-06-22)

### DIFF
--- a/internal/cas/accessors_test.go
+++ b/internal/cas/accessors_test.go
@@ -1,0 +1,30 @@
+package cas_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCASStoreAccessors(t *testing.T) {
+	t.Parallel()
+
+	storePath := t.TempDir()
+
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	assert.Equal(t, storePath, c.StorePath())
+	assert.Equal(t, filepath.Join(storePath, "blobs"), c.BlobStore().Path())
+	assert.Equal(t, filepath.Join(storePath, "synth", "trees"), c.SynthStore().Path())
+}
+
+func TestGitStoreRootPath(t *testing.T) {
+	t.Parallel()
+
+	rootPath := t.TempDir()
+	assert.Equal(t, rootPath, cas.NewGitStore(rootPath).RootPath())
+}

--- a/internal/cli/commands/catalog/tui/component_test.go
+++ b/internal/cli/commands/catalog/tui/component_test.go
@@ -1,0 +1,118 @@
+package tui_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+)
+
+func TestComponent_TitlePrefersDocThenDirBasename(t *testing.T) {
+	t.Parallel()
+
+	readme := `<!-- Frontmatter
+name: VPC App
+-->
+# Heading
+`
+	withDoc := tui.NewComponentForTest(tui.ComponentKindModule, "github.com/acme/repo", "modules/vpc", readme)
+	assert.Equal(t, "VPC App", withDoc.Title(), "front-matter name wins")
+
+	noDocTitle := tui.NewComponentForTest(tui.ComponentKindModule, "github.com/acme/repo", "modules/vpc", "")
+	assert.Equal(t, "vpc", noDocTitle.Title(), "falls back to the directory basename")
+}
+
+func TestComponent_DescriptionFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	readme := `<!-- Frontmatter
+name: VPC App
+description: A VPC for application workloads.
+-->
+# VPC App
+`
+	withDesc := tui.NewComponentForTest(tui.ComponentKindModule, "github.com/acme/repo", "vpc", readme)
+	assert.Equal(t, "A VPC for application workloads.", withDesc.Description())
+
+	noDesc := tui.NewComponentForTest(tui.ComponentKindModule, "github.com/acme/repo", "vpc", "")
+	assert.Equal(t, "(no description found)", noDesc.Description())
+}
+
+func TestComponent_TagsAndMarkdownAndContent(t *testing.T) {
+	t.Parallel()
+
+	readme := `<!-- Frontmatter
+name: VPC App
+tags: [networking, aws]
+-->
+# VPC App
+Use ` + "`terragrunt`" + ` to apply.
+`
+	c := tui.NewComponentForTest(tui.ComponentKindModule, "github.com/acme/repo", "vpc", readme)
+
+	assert.Equal(t, []string{"networking", "aws"}, c.Tags())
+	assert.True(t, c.IsMarkDown(), "NewComponentForTest builds a Markdown doc")
+
+	raw := c.Content(false)
+	assert.Contains(t, raw, "`terragrunt`", "unstripped content keeps Markdown markup")
+
+	stripped := c.Content(true)
+	assert.Contains(t, stripped, "terragrunt", "stripped content keeps the word")
+	assert.NotContains(t, stripped, "`terragrunt`", "stripped content drops the backticks")
+}
+
+func TestComponentDoc_TitleFromFirstHeadingWithoutFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	doc := tui.NewComponentDoc("# Just A Heading\n\nbody\n", ".md")
+	assert.Equal(t, "Just A Heading", doc.Title())
+}
+
+func TestComponentDoc_DescriptionTruncatesToMaxLength(t *testing.T) {
+	t.Parallel()
+
+	long := "First sentence is short. " + strings.Repeat("word ", 60) + "tail."
+	readme := "<!-- Frontmatter\ndescription: " + long + "\n-->\n# Title\n"
+
+	doc := tui.NewComponentDoc(readme, ".md")
+
+	full := doc.Description(0)
+	capped := doc.Description(40)
+
+	assert.Equal(t, long, full, "maxLength 0 returns the whole description")
+	assert.Less(t, len(capped), len(full), "a small maxLength truncates")
+	assert.True(t, strings.HasSuffix(capped, "."), "truncation closes on a sentence boundary")
+}
+
+func TestFindComponentDoc(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reads README.md", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := vfs.NewMemMapFS()
+		dir := "/repo/vpc"
+		require.NoError(t, vfs.WriteFile(fsys, dir+"/README.md", []byte("# VPC\n"), 0o644))
+
+		doc, err := tui.FindComponentDoc(fsys, dir)
+		require.NoError(t, err)
+		assert.True(t, doc.IsMarkDown())
+		assert.Equal(t, "VPC", doc.Title())
+	})
+
+	t.Run("returns empty doc when no README", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := vfs.NewMemMapFS()
+		dir := "/repo/empty"
+		require.NoError(t, vfs.WriteFile(fsys, dir+"/main.tf", []byte("# not a readme\n"), 0o644))
+
+		doc, err := tui.FindComponentDoc(fsys, dir)
+		require.NoError(t, err)
+		assert.Empty(t, doc.Title(), "a component without a README yields a zero-value doc")
+	})
+}

--- a/internal/cli/commands/catalog/tui/copy_test.go
+++ b/internal/cli/commands/catalog/tui/copy_test.go
@@ -306,6 +306,38 @@ func TestCopyCmd_StdioSettersAreNoops(t *testing.T) {
 	})
 }
 
+// TestCopyCmd_RejectsValuesStubWhenPathIsDirectory verifies the values-stub
+// preflight refuses to proceed when the stub path is occupied by something
+// other than a regular file (here, a directory), since WriteValuesFile could
+// neither overwrite nor leave it alone safely.
+func TestCopyCmd_RejectsValuesStubWhenPathIsDirectory(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	repoDir := testRepoDir
+	writeFileFS(t, fsys, filepath.Join(repoDir, "vpc", "terragrunt.hcl"),
+		`locals { region = values.region }`)
+
+	repo := newFakeRepo(t, fsys, repoDir)
+
+	components, err := tui.NewComponentDiscovery().WithFS(fsys).Discover(repo)
+	require.NoError(t, err)
+	require.Len(t, components, 1)
+
+	workingDir := testWorkingDir
+	require.NoError(t, fsys.MkdirAll(filepath.Join(workingDir, "terragrunt.values.hcl"), 0o755))
+
+	opts := options.NewTerragruntOptions()
+	opts.WorkingDir = workingDir
+
+	err = tui.NewCopyCmd(logger.CreateLogger(), opts, components[0]).WithFS(fsys).Run()
+
+	var notRegularErr *tui.DestinationNotRegularError
+
+	require.ErrorAs(t, err, &notRegularErr)
+	assert.Equal(t, filepath.Join(workingDir, "terragrunt.values.hcl"), notRegularErr.Path)
+}
+
 // assertFileExistsFS asserts a file exists at path on fsys.
 func assertFileExistsFS(t *testing.T, fsys vfs.FS, path string) {
 	t.Helper()

--- a/internal/cli/commands/catalog/tui/form_fields_test.go
+++ b/internal/cli/commands/catalog/tui/form_fields_test.go
@@ -1,0 +1,90 @@
+package tui_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+)
+
+// TestFormFieldsFromParsedVariables_BoolStringRawTypes exercises the per-type
+// branches of field construction: bool defaults become checkboxes, string
+// defaults are JSON-unwrapped into literal-mode initials (falling back to the
+// raw value when not JSON), and every other type stays raw HCL.
+func TestFormFieldsFromParsedVariables_BoolStringRawTypes(t *testing.T) {
+	t.Parallel()
+
+	optional := []*config.ParsedVariable{
+		{Name: "enabled", Type: "bool", DefaultValue: "true"},
+		{Name: "disabled", Type: "bool", DefaultValue: "false"},
+		{Name: "unset_bool", Type: "bool", DefaultValue: ""},
+		{Name: "tier", Type: "string", DefaultValue: `"prod"`},
+		{Name: "raw_string", Type: "string", DefaultValue: "prod"},
+		{Name: "empty_string", Type: "string", DefaultValue: ""},
+		{Name: "count", Type: "number", DefaultValue: "5"},
+	}
+
+	fields := tui.FieldsFromParsedVariables(nil, optional)
+	require.Len(t, fields, len(optional))
+
+	byName := map[string]tui.FormField{}
+	for _, f := range fields {
+		byName[f.Name] = f
+	}
+
+	assert.True(t, byName["enabled"].Checkbox)
+	assert.True(t, byName["enabled"].Bool, `default "true" seeds the checkbox on`)
+	assert.True(t, byName["enabled"].BoolInitial)
+
+	assert.True(t, byName["disabled"].Checkbox)
+	assert.False(t, byName["disabled"].Bool, `default "false" seeds the checkbox off`)
+
+	assert.True(t, byName["unset_bool"].Checkbox)
+	assert.False(t, byName["unset_bool"].Bool, "an unparseable bool default falls back to false")
+
+	assert.True(t, byName["tier"].Literal)
+	assert.Equal(t, "prod", byName["tier"].Initial, "JSON string default is unwrapped")
+
+	assert.True(t, byName["raw_string"].Literal)
+	assert.Equal(t, "prod", byName["raw_string"].Initial, "non-JSON string default passes through")
+
+	assert.True(t, byName["empty_string"].Literal)
+	assert.Empty(t, byName["empty_string"].Initial, "an empty string default stays empty")
+
+	assert.False(t, byName["count"].Literal, "number stays raw HCL")
+	assert.False(t, byName["count"].Checkbox)
+	assert.Equal(t, "5", byName["count"].Initial)
+}
+
+// TestFormFieldsFromValuesReferences_StringAndComplexDefaults covers the
+// non-bool branches of newValuesField: a known-string optional becomes
+// literal-mode, while a complex value (here a tuple) stays raw HCL with the
+// default pre-formatted.
+func TestFormFieldsFromValuesReferences_StringAndComplexDefaults(t *testing.T) {
+	t.Parallel()
+
+	refs := tui.ValuesReferences{
+		Optional: []tui.OptionalValue{
+			{Name: "region", Default: cty.StringVal("us-east-1")},
+			{Name: "zones", Default: cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")})},
+		},
+	}
+
+	fields := tui.FieldsFromValuesReferences(refs)
+	require.Len(t, fields, 2)
+
+	assert.Equal(t, "region", fields[0].Name)
+	assert.True(t, fields[0].Literal, "string default is literal-mode")
+	assert.Equal(t, "string", fields[0].TypeStr)
+	assert.Equal(t, "us-east-1", fields[0].Initial)
+
+	assert.Equal(t, "zones", fields[1].Name)
+	assert.False(t, fields[1].Literal, "complex default stays raw HCL")
+	assert.False(t, fields[1].Checkbox)
+	assert.Equal(t, "any", fields[1].TypeStr)
+	assert.Equal(t, `["a", "b"]`, fields[1].Initial, "complex default is pre-formatted as HCL")
+}

--- a/internal/cli/commands/catalog/tui/form_fields_test.go
+++ b/internal/cli/commands/catalog/tui/form_fields_test.go
@@ -44,7 +44,7 @@ func TestFormFieldsFromParsedVariables_BoolStringRawTypes(t *testing.T) {
 	assert.False(t, byName["disabled"].Bool, `default "false" seeds the checkbox off`)
 
 	assert.True(t, byName["unset_bool"].Checkbox)
-	assert.False(t, byName["unset_bool"].Bool, "an unparseable bool default falls back to false")
+	assert.False(t, byName["unset_bool"].Bool, "an unparsable bool default falls back to false")
 
 	assert.True(t, byName["tier"].Literal)
 	assert.Equal(t, "prod", byName["tier"].Initial, "JSON string default is unwrapped")

--- a/internal/cli/commands/run/run.go
+++ b/internal/cli/commands/run/run.go
@@ -59,11 +59,19 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, v v
 	}
 
 	if opts.ReportSchemaFile != "" {
-		defer r.WriteSchemaToFile(v.FS, opts.ReportSchemaFile) //nolint:errcheck
+		defer func() {
+			if err := r.WriteSchemaToFile(v.FS, opts.ReportSchemaFile); err != nil {
+				l.Warnf("Failed to write report schema to %s: %v", opts.ReportSchemaFile, err)
+			}
+		}()
 	}
 
 	if opts.ReportFile != "" {
-		defer r.WriteToFile(v.FS, opts.ReportFile) //nolint:errcheck
+		defer func() {
+			if err := r.WriteToFile(v.FS, opts.ReportFile); err != nil {
+				l.Warnf("Failed to write report to %s: %v", opts.ReportFile, err)
+			}
+		}()
 	}
 
 	if opts.TerraformCommand == "" {

--- a/internal/cli/commands/run/run.go
+++ b/internal/cli/commands/run/run.go
@@ -59,11 +59,11 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, v v
 	}
 
 	if opts.ReportSchemaFile != "" {
-		defer r.WriteSchemaToFile(opts.ReportSchemaFile) //nolint:errcheck
+		defer r.WriteSchemaToFile(v.FS, opts.ReportSchemaFile) //nolint:errcheck
 	}
 
 	if opts.ReportFile != "" {
-		defer r.WriteToFile(opts.ReportFile) //nolint:errcheck
+		defer r.WriteToFile(v.FS, opts.ReportFile) //nolint:errcheck
 	}
 
 	if opts.TerraformCommand == "" {

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -337,6 +337,34 @@ func TestExpandBoundaryResolvesSymlinksConsistently(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+// TestExpandBoundaryAllowsExistingSymlinkedRoot is the happy-path counterpart:
+// when the walk root itself exists behind the boundary's symlink, the resolved
+// comparison recognizes it as inside the boundary rather than refusing it.
+func TestExpandBoundaryAllowsExistingSymlinkedRoot(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, fs.MkdirAll("/real/sub", 0o755))
+	require.NoError(t, vfs.WriteFile(fs, "/real/sub/a.yaml", nil, 0o644))
+	require.NoError(t, vfs.Symlink(fs, "/real", "/link"))
+
+	_, err := glob.Expand(fs, "/link/sub/*.yaml", glob.WithBoundary("/link"))
+	require.NoError(t, err, "an existing root behind the boundary symlink must be allowed")
+}
+
+// TestExpandRelativePatternWithLeadingWildcard pins that a metacharacter with
+// no preceding directory separator walks from the current directory ("."),
+// rather than mis-splitting the root.
+func TestExpandRelativePatternWithLeadingWildcard(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+
+	got, err := glob.Expand(fs, "*.yaml")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
 // TestLegacyExpandCollapsesGlobstar documents the reason LegacyExpand exists:
 // zglob collapses the separators flanking `**`, whereas Expand (gobwas) does
 // not. Switching the include_in_copy / exclude_from_copy call site from

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -353,16 +353,19 @@ func TestExpandBoundaryAllowsExistingSymlinkedRoot(t *testing.T) {
 }
 
 // TestExpandRelativePatternWithLeadingWildcard pins that a metacharacter with
-// no preceding directory separator walks from the current directory ("."),
-// rather than mis-splitting the root.
+// no preceding directory separator walks from the current directory rather than
+// mis-splitting the root: the root-level file matches while the nested one does
+// not, since "*" never crosses a separator.
 func TestExpandRelativePatternWithLeadingWildcard(t *testing.T) {
 	t.Parallel()
 
 	fs := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fs, "a.yaml", nil, 0o644))
+	require.NoError(t, vfs.WriteFile(fs, "sub/b.yaml", nil, 0o644))
 
 	got, err := glob.Expand(fs, "*.yaml")
 	require.NoError(t, err)
-	assert.Empty(t, got)
+	assert.Equal(t, []string{"a.yaml"}, got)
 }
 
 // TestLegacyExpandCollapsesGlobstar documents the reason LegacyExpand exists:

--- a/internal/report/report_options_test.go
+++ b/internal/report/report_options_test.go
@@ -1,0 +1,95 @@
+package report_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReportEndOptionsSetRunFields(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	r := report.NewReport()
+
+	path := filepath.Join(t.TempDir(), "unit")
+
+	run, err := r.EnsureRun(l, path,
+		report.WithCauseRunError("boom"),
+		report.WithRef("v1.2.3"),
+		report.WithCmd("plan"),
+		report.WithArgs([]string{"-no-color", "-input=false"}),
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, run.Cause)
+	assert.Equal(t, report.Cause("boom"), *run.Cause)
+	assert.Equal(t, "v1.2.3", run.Ref)
+	assert.Equal(t, "plan", run.Cmd)
+	assert.Equal(t, []string{"-no-color", "-input=false"}, run.Args)
+}
+
+func TestReportSortRuns(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	r := report.NewReport()
+
+	dir := t.TempDir()
+
+	first, err := r.EnsureRun(l, filepath.Join(dir, "first"))
+	require.NoError(t, err)
+
+	second, err := r.EnsureRun(l, filepath.Join(dir, "second"))
+	require.NoError(t, err)
+
+	// Force out-of-order start times so SortRuns has something to reorder.
+	base := time.Now()
+	first.Started = base.Add(time.Hour)
+	second.Started = base
+
+	r.SortRuns()
+
+	require.Len(t, r.Runs, 2)
+	assert.Equal(t, second.Path, r.Runs[0].Path, "earlier Started sorts first")
+	assert.Equal(t, first.Path, r.Runs[1].Path)
+}
+
+func TestReportWriteToFile(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	dir := t.TempDir()
+
+	t.Run("json format", func(t *testing.T) {
+		t.Parallel()
+
+		r := report.NewReport().WithFormat(report.FormatJSON)
+		_, err := r.EnsureRun(l, filepath.Join(dir, "json-unit"))
+		require.NoError(t, err)
+
+		out := filepath.Join(dir, "report.json")
+		require.NoError(t, r.WriteToFile(out))
+
+		raw, err := os.ReadFile(out)
+		require.NoError(t, err)
+		assert.Contains(t, string(raw), "json-unit")
+	})
+
+	t.Run("unsupported format errors", func(t *testing.T) {
+		t.Parallel()
+
+		r := report.NewReport()
+		_, err := r.EnsureRun(l, filepath.Join(dir, "no-format-unit"))
+		require.NoError(t, err)
+
+		require.Error(t, r.WriteToFile(filepath.Join(dir, "unused.out")),
+			"writing with no format set is rejected")
+	})
+}

--- a/internal/report/report_options_test.go
+++ b/internal/report/report_options_test.go
@@ -1,12 +1,12 @@
 package report_test
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,19 +65,22 @@ func TestReportWriteToFile(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	dir := t.TempDir()
+	dir := "/reports"
 
 	t.Run("json format", func(t *testing.T) {
 		t.Parallel()
+
+		fsys := vfs.NewMemMapFS()
+		require.NoError(t, fsys.MkdirAll(dir, 0o755))
 
 		r := report.NewReport().WithFormat(report.FormatJSON)
 		_, err := r.EnsureRun(l, filepath.Join(dir, "json-unit"))
 		require.NoError(t, err)
 
 		out := filepath.Join(dir, "report.json")
-		require.NoError(t, r.WriteToFile(out))
+		require.NoError(t, r.WriteToFile(fsys, out))
 
-		raw, err := os.ReadFile(out)
+		raw, err := vfs.ReadFile(fsys, out)
 		require.NoError(t, err)
 		assert.Contains(t, string(raw), "json-unit")
 	})
@@ -85,11 +88,13 @@ func TestReportWriteToFile(t *testing.T) {
 	t.Run("unsupported format errors", func(t *testing.T) {
 		t.Parallel()
 
+		fsys := vfs.NewMemMapFS()
+
 		r := report.NewReport()
 		_, err := r.EnsureRun(l, filepath.Join(dir, "no-format-unit"))
 		require.NoError(t, err)
 
-		require.Error(t, r.WriteToFile(filepath.Join(dir, "unused.out")),
+		require.Error(t, r.WriteToFile(fsys, filepath.Join(dir, "unused.out")),
 			"writing with no format set is rejected")
 	})
 }

--- a/internal/report/writer.go
+++ b/internal/report/writer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/invopop/jsonschema"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -229,38 +230,27 @@ func validateJSONReport(data []byte) error {
 }
 
 // WriteToFile writes the report to a file.
-func (r *Report) WriteToFile(path string) error {
-	tmpFile, err := os.CreateTemp("", "terragrunt-report-*")
-	if err != nil {
-		return err
+func (r *Report) WriteToFile(fsys vfs.FS, path string) error {
+	var writeBody func(io.Writer) error
+
+	switch r.format {
+	case FormatCSV:
+		writeBody = r.WriteCSV
+	case FormatJSON:
+		writeBody = r.WriteJSON
+	default:
+		return fmt.Errorf("unsupported format: %s", r.format)
 	}
 
 	r.mu.Lock()
 	r.SortRuns()
 	r.mu.Unlock()
 
-	switch r.format {
-	case FormatCSV:
-		err = r.WriteCSV(tmpFile)
-	case FormatJSON:
-		err = r.WriteJSON(tmpFile)
-	default:
-		return fmt.Errorf("unsupported format: %s", r.format)
-	}
-
-	if err != nil {
-		return fmt.Errorf("failed to write report: %w", err)
-	}
-
-	if err := tmpFile.Close(); err != nil {
-		return fmt.Errorf("failed to close report file: %w", err)
-	}
-
 	if r.workingDir != "" && !filepath.IsAbs(path) {
 		path = filepath.Join(r.workingDir, path)
 	}
 
-	return util.MoveFile(tmpFile.Name(), path)
+	return writeFileAtomic(fsys, path, writeBody)
 }
 
 // WriteCSV writes the report to a writer in CSV format.
@@ -391,26 +381,40 @@ func formatCause(r *Run, workingDir string) string {
 	return cause
 }
 
-// WriteSchemaToFile writes a JSON schema for the report to a file.
-func (r *Report) WriteSchemaToFile(path string) error {
-	tmpFile, err := os.CreateTemp("", "terragrunt-schema-*")
-	if err != nil {
-		return err
-	}
-
-	if err := WriteSchema(tmpFile); err != nil {
-		return fmt.Errorf("failed to write schema: %w", err)
-	}
-
-	if err := tmpFile.Close(); err != nil {
-		return fmt.Errorf("failed to close schema file: %w", err)
-	}
-
+// WriteSchemaToFile writes a JSON schema for the report to path on fsys.
+func (r *Report) WriteSchemaToFile(fsys vfs.FS, path string) error {
 	if r.workingDir != "" && !filepath.IsAbs(path) {
 		path = filepath.Join(r.workingDir, path)
 	}
 
-	return util.MoveFile(tmpFile.Name(), path)
+	return writeFileAtomic(fsys, path, WriteSchema)
+}
+
+// writeFileAtomic writes content produced by write into a temporary file in
+// path's directory and then renames it onto path, so a concurrent reader never
+// observes a partially written file and a failed write leaves no truncated one.
+// The temp file shares path's directory so the rename stays on one filesystem.
+func writeFileAtomic(fsys vfs.FS, path string, write func(w io.Writer) error) error {
+	tmpFile, err := vfs.CreateTemp(fsys, filepath.Dir(path), "terragrunt-report-")
+	if err != nil {
+		return err
+	}
+
+	tmpName := tmpFile.Name()
+
+	if err := write(tmpFile); err != nil {
+		return errors.Join(fmt.Errorf("failed to write report: %w", err), tmpFile.Close(), fsys.Remove(tmpName))
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return errors.Join(fmt.Errorf("failed to close report file: %w", err), fsys.Remove(tmpName))
+	}
+
+	if err := fsys.Rename(tmpName, path); err != nil {
+		return errors.Join(err, fsys.Remove(tmpName))
+	}
+
+	return nil
 }
 
 // WriteSchema writes a JSON schema for the report to a writer.

--- a/internal/runner/graph/graph.go
+++ b/internal/runner/graph/graph.go
@@ -100,7 +100,7 @@ func Run(ctx context.Context, l log.Logger, v run.Venv, opts *options.Terragrunt
 
 	if opts.ReportSchemaFile != "" {
 		defer func() {
-			if err := r.WriteSchemaToFile(opts.ReportSchemaFile); err != nil {
+			if err := r.WriteSchemaToFile(v.FS, opts.ReportSchemaFile); err != nil {
 				l.Warnf("Failed to write report schema to %s: %v", opts.ReportSchemaFile, err)
 			}
 		}()
@@ -108,7 +108,7 @@ func Run(ctx context.Context, l log.Logger, v run.Venv, opts *options.Terragrunt
 
 	if opts.ReportFile != "" {
 		defer func() {
-			if err := r.WriteToFile(opts.ReportFile); err != nil {
+			if err := r.WriteToFile(v.FS, opts.ReportFile); err != nil {
 				l.Warnf("Failed to write report to %s: %v", opts.ReportFile, err)
 			}
 		}()

--- a/internal/runner/runall/runall.go
+++ b/internal/runner/runall/runall.go
@@ -82,11 +82,19 @@ func Run(ctx context.Context, l log.Logger, v run.Venv, opts *options.Terragrunt
 	}
 
 	if opts.ReportSchemaFile != "" {
-		defer r.WriteSchemaToFile(v.FS, opts.ReportSchemaFile) //nolint:errcheck
+		defer func() {
+			if err := r.WriteSchemaToFile(v.FS, opts.ReportSchemaFile); err != nil {
+				l.Warnf("Failed to write report schema to %s: %v", opts.ReportSchemaFile, err)
+			}
+		}()
 	}
 
 	if opts.ReportFile != "" {
-		defer r.WriteToFile(v.FS, opts.ReportFile) //nolint:errcheck
+		defer func() {
+			if err := r.WriteToFile(v.FS, opts.ReportFile); err != nil {
+				l.Warnf("Failed to write report to %s: %v", opts.ReportFile, err)
+			}
+		}()
 	}
 
 	// Skip summary for programmatic interactions:

--- a/internal/runner/runall/runall.go
+++ b/internal/runner/runall/runall.go
@@ -82,11 +82,11 @@ func Run(ctx context.Context, l log.Logger, v run.Venv, opts *options.Terragrunt
 	}
 
 	if opts.ReportSchemaFile != "" {
-		defer r.WriteSchemaToFile(opts.ReportSchemaFile) //nolint:errcheck
+		defer r.WriteSchemaToFile(v.FS, opts.ReportSchemaFile) //nolint:errcheck
 	}
 
 	if opts.ReportFile != "" {
-		defer r.WriteToFile(opts.ReportFile) //nolint:errcheck
+		defer r.WriteToFile(v.FS, opts.ReportFile) //nolint:errcheck
 	}
 
 	// Skip summary for programmatic interactions:

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -192,6 +192,13 @@ func MkdirTemp(fs FS, dir, pattern string) (string, error) {
 	return afero.TempDir(fs, dir, pattern)
 }
 
+// CreateTemp creates a temporary file on the given filesystem. The file's name
+// is prefix followed by a random string; prefix is not a pattern, so any "*" in
+// it is taken literally.
+func CreateTemp(fs FS, dir, prefix string) (File, error) {
+	return afero.TempFile(fs, dir, prefix)
+}
+
 // Link creates a hard link. It delegates to LinkIfPossible for filesystems
 // that implement the HardLinker interface.
 func Link(fs FS, oldname, newname string) error {

--- a/test/helpers/package_pure_test.go
+++ b/test/helpers/package_pure_test.go
@@ -1,0 +1,90 @@
+package helpers_test
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGzipHandler(t *testing.T) {
+	t.Parallel()
+
+	const body = "hello provider mirror"
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, body)
+	})
+	handler := helpers.GzipHandler(inner)
+
+	t.Run("compresses when the client accepts gzip", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/aws.zip", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		res := rec.Result()
+		defer res.Body.Close()
+
+		assert.Equal(t, "gzip", res.Header.Get("Content-Encoding"))
+		assert.Empty(t, res.Header.Get("Content-Length"), "length is dropped once the body is compressed")
+
+		gz, err := gzip.NewReader(res.Body)
+		require.NoError(t, err)
+
+		got, err := io.ReadAll(gz)
+		require.NoError(t, err)
+		assert.Equal(t, body, string(got))
+	})
+
+	t.Run("passes through when the client does not accept gzip", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/aws.zip", nil)
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		res := rec.Result()
+		defer res.Body.Close()
+
+		assert.Empty(t, res.Header.Get("Content-Encoding"))
+
+		got, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		assert.Equal(t, body, string(got))
+	})
+}
+
+func TestMustAbs(t *testing.T) {
+	t.Parallel()
+
+	got := helpers.MustAbs(t, "some/rel/path")
+	assert.True(t, filepath.IsAbs(got), "MustAbs returns an absolute path")
+	assert.True(t, filepath.IsAbs(helpers.MustAbs(t, ".")))
+}
+
+func TestGetPathRelativeTo(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, filepath.Join("b", "c"),
+		helpers.GetPathRelativeTo(t, filepath.Join("/a", "b", "c"), "/a"))
+}
+
+func TestGetPathsRelativeTo(t *testing.T) {
+	t.Parallel()
+
+	paths := []string{filepath.Join("/a", "b"), filepath.Join("/a", "c", "d")}
+
+	got := helpers.GetPathsRelativeTo(t, "/a", paths)
+	assert.Equal(t, []string{"b", filepath.Join("c", "d")}, got)
+}

--- a/test/integration_local_dev_test.go
+++ b/test/integration_local_dev_test.go
@@ -20,14 +20,6 @@ func TestTerragruntSourceMap(t *testing.T) {
 	t.Parallel()
 
 	fixtureSourceMapPath := filepath.Join("fixtures", "source-map")
-	helpers.CleanupTerraformFolder(t, fixtureSourceMapPath)
-	tmpEnvPath := helpers.CopyEnvironment(t, fixtureSourceMapPath)
-	rootPath := filepath.Join(tmpEnvPath, fixtureSourceMapPath)
-	sourceMapArgs := fmt.Sprintf(
-		"--source-map %s --source-map %s",
-		"git::ssh://git@github.com/gruntwork-io/i-dont-exist.git="+tmpEnvPath,
-		"git::ssh://git@github.com/gruntwork-io/another-dont-exist.git="+tmpEnvPath,
-	)
 
 	testCases := []struct {
 		name     string
@@ -58,6 +50,15 @@ func TestTerragruntSourceMap(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			helpers.CleanupTerraformFolder(t, fixtureSourceMapPath)
+			tmpEnvPath := helpers.CopyEnvironment(t, fixtureSourceMapPath)
+			rootPath := filepath.Join(tmpEnvPath, fixtureSourceMapPath)
+			sourceMapArgs := fmt.Sprintf(
+				"--source-map %s --source-map %s",
+				"git::ssh://git@github.com/gruntwork-io/i-dont-exist.git="+tmpEnvPath,
+				"git::ssh://git@github.com/gruntwork-io/another-dont-exist.git="+tmpEnvPath,
+			)
 
 			tgPath := filepath.Join(rootPath, tc.name)
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

- **chore: Expanding test coverage a bit**
- **chore: Propagating v.FS into report writes**
- **chore: Removing some error suppressions**

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Report write failures now generate warnings in logs instead of being silently ignored.

* **Refactor**
  * Report writing now uses atomic file operations for improved reliability and data consistency.

* **Tests**
  * Expanded test coverage for report handling, form fields, glob expansion, catalog components, and utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->