### PR TITLE
fix: apply extra_arguments env_vars when resolving dependency outputs

### DIFF
--- a/docs/src/data/changelog/v1.1.0/dependency-output-extra-args-env-vars.mdx
+++ b/docs/src/data/changelog/v1.1.0/dependency-output-extra-args-env-vars.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.0"
+category: "bug-fixes"
+---
+
+#### Apply `extra_arguments` env vars when resolving `dependency` outputs
+
+Resolving a `dependency` block's outputs now applies the `env_vars` from the unit's `terraform` `extra_arguments` blocks whose `commands` include `output`. Previously the optimized output paths ran `tofu output -json` without these variables, so a dependency whose backend relied on them (for example, OpenTofu state encryption keyed on a `TF_VAR_*` passphrase) failed with `Unable to compute static value`.

--- a/docs/src/data/changelog/v1.1.0/dependency-output-extra-args-env-vars.mdx
+++ b/docs/src/data/changelog/v1.1.0/dependency-output-extra-args-env-vars.mdx
@@ -5,4 +5,4 @@ category: "bug-fixes"
 
 #### Apply `extra_arguments` env vars when resolving `dependency` outputs
 
-Resolving a `dependency` block's outputs now applies the `env_vars` from the unit's `terraform` `extra_arguments` blocks whose `commands` include `output`. Previously the optimized output paths ran `tofu output -json` without these variables, so a dependency whose backend relied on them (for example, OpenTofu state encryption keyed on a `TF_VAR_*` passphrase) failed with `Unable to compute static value`.
+Resolving a `dependency` block's outputs now applies the `env_vars` from the unit's `terraform` `extra_arguments` blocks whose `commands` include `output`.

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -1189,12 +1190,10 @@ func applyExtraArgsEnvVarsForOutput(pctx *ParsingContext, terraformConfig *Terra
 		}
 
 		if pctx.Env == nil {
-			pctx.Env = map[string]string{}
+			pctx.Env = make(map[string]string, len(*arg.EnvVars))
 		}
 
-		for key, value := range *arg.EnvVars {
-			pctx.Env[key] = value
-		}
+		maps.Copy(pctx.Env, *arg.EnvVars)
 	}
 }
 

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1040,10 +1040,10 @@ func resolveOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Logger, 
 		pctx.IAMRoleOptions = iam.RoleOptions{}
 	}
 
-	// Validate and use TerragruntVersionConstraints.TerraformBinary for dependency
+	// Decode the terraform binary plus the terraform block so the dependency honors extra_arguments and source.
 	partialTerragruntConfig, err := PartialParseConfigFile(
 		ctx,
-		pctx.WithDecodeList(DependencyBlock).WithDiagnosticsSuppressed(l),
+		pctx.WithDecodeList(DependencyBlock, TerraformBlock).WithDiagnosticsSuppressed(l),
 		l,
 		targetConfig,
 		nil,
@@ -1057,20 +1057,8 @@ func resolveOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Logger, 
 		pctx.TFPath = partialTerragruntConfig.TerraformBinary
 	}
 
-	// Parse the target config terraform block so dependency output runs honor its extra_arguments and source.
-	terraformTGConfig, err := PartialParseConfigFile(
-		ctx,
-		pctx.WithDecodeList(TerraformBlock).WithDiagnosticsSuppressed(l),
-		l,
-		targetConfig,
-		nil,
-	)
-	if err != nil {
-		return nil, "", err
-	}
-
 	// Apply extra_arguments env_vars for the output command so env dependent backends can be read.
-	applyExtraArgsEnvVarsForOutput(pctx, terraformTGConfig.Terraform)
+	applyExtraArgsEnvVarsForOutput(pctx, partialTerragruntConfig.Terraform)
 
 	// If the Source is set, then we need to recompute it in the ctx of the target config.
 	if pctx.Source != "" {
@@ -1079,7 +1067,7 @@ func resolveOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Logger, 
 
 		// Finally, update the source to be the combined path between the terraform source in the target config, and the
 		// value before "//" in the original terragrunt options.
-		targetSource, err := GetTerragruntSourceForModule(moduleURL, filepath.Dir(targetConfig), terraformTGConfig)
+		targetSource, err := GetTerragruntSourceForModule(moduleURL, filepath.Dir(targetConfig), partialTerragruntConfig)
 		if err != nil {
 			return nil, "", err
 		}

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1057,24 +1057,29 @@ func resolveOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Logger, 
 		pctx.TFPath = partialTerragruntConfig.TerraformBinary
 	}
 
+	// Parse the target config terraform block so dependency output runs honor its extra_arguments and source.
+	terraformTGConfig, err := PartialParseConfigFile(
+		ctx,
+		pctx.WithDecodeList(TerraformBlock).WithDiagnosticsSuppressed(l),
+		l,
+		targetConfig,
+		nil,
+	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Apply extra_arguments env_vars for the output command so env dependent backends can be read.
+	applyExtraArgsEnvVarsForOutput(pctx, terraformTGConfig.Terraform)
+
 	// If the Source is set, then we need to recompute it in the ctx of the target config.
 	if pctx.Source != "" {
-		partialParseIncludedConfig, err := PartialParseConfigFile(
-			ctx,
-			pctx.WithDecodeList(TerraformBlock).WithDiagnosticsSuppressed(l),
-			l,
-			targetConfig,
-			nil,
-		)
-		if err != nil {
-			return nil, "", err
-		}
 		// Update the source value to be everything before "//" so that it can be recomputed
 		moduleURL, _ := getter.SourceDirSubdir(pctx.Source)
 
 		// Finally, update the source to be the combined path between the terraform source in the target config, and the
 		// value before "//" in the original terragrunt options.
-		targetSource, err := GetTerragruntSourceForModule(moduleURL, filepath.Dir(targetConfig), partialParseIncludedConfig)
+		targetSource, err := GetTerragruntSourceForModule(moduleURL, filepath.Dir(targetConfig), terraformTGConfig)
 		if err != nil {
 			return nil, "", err
 		}
@@ -1181,6 +1186,28 @@ func resolveOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Logger, 
 // canGetRemoteState returns true if the remote state block is not nil and dependency optimization is not disabled
 func canGetRemoteState(remoteState *remotestate.RemoteState) bool {
 	return remoteState != nil && !remoteState.DisableDependencyOptimization
+}
+
+// applyExtraArgsEnvVarsForOutput merges extra_arguments env_vars whose commands include output into pctx.Env
+func applyExtraArgsEnvVarsForOutput(pctx *ParsingContext, terraformConfig *TerraformConfig) {
+	if terraformConfig == nil {
+		return
+	}
+
+	for i := range terraformConfig.ExtraArgs {
+		arg := &terraformConfig.ExtraArgs[i]
+		if arg.EnvVars == nil || !slices.Contains(arg.Commands, tf.CommandNameOutput) {
+			continue
+		}
+
+		if pctx.Env == nil {
+			pctx.Env = map[string]string{}
+		}
+
+		for key, value := range *arg.EnvVars {
+			pctx.Env[key] = value
+		}
+	}
 }
 
 // terragruntAlreadyInit returns true if it detects that the module specified by the given terragrunt configuration is

--- a/pkg/config/dependency_internal_test.go
+++ b/pkg/config/dependency_internal_test.go
@@ -152,3 +152,110 @@ func FuzzResolveStackFilePath(f *testing.F) {
 		require.Equal(t, DefaultStackFile, filepath.Base(got), "resolveStackFilePath must return a path whose base is %s when ok=true (raw=%q target=%q got=%q)", DefaultStackFile, raw, target, got)
 	})
 }
+
+func TestApplyExtraArgsEnvVarsForOutput(t *testing.T) {
+	t.Parallel()
+
+	envVars := func(m map[string]string) *map[string]string { return &m }
+
+	tcs := []struct {
+		initial   map[string]string
+		terraform *TerraformConfig
+		want      map[string]string
+		name      string
+	}{
+		{
+			name:    "applies env vars when commands include output",
+			initial: map[string]string{},
+			terraform: &TerraformConfig{
+				ExtraArgs: []TerraformExtraArguments{
+					{Name: "secrets", Commands: []string{"output", "plan"}, EnvVars: envVars(map[string]string{"TF_VAR_passphrase": "secret"})},
+				},
+			},
+			want: map[string]string{"TF_VAR_passphrase": "secret"},
+		},
+		{
+			name:    "skips env vars when commands exclude output",
+			initial: map[string]string{},
+			terraform: &TerraformConfig{
+				ExtraArgs: []TerraformExtraArguments{
+					{Name: "secrets", Commands: []string{"apply", "plan"}, EnvVars: envVars(map[string]string{"TF_VAR_passphrase": "secret"})},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name:    "skips env vars when commands list is empty",
+			initial: map[string]string{},
+			terraform: &TerraformConfig{
+				ExtraArgs: []TerraformExtraArguments{
+					{Name: "secrets", Commands: nil, EnvVars: envVars(map[string]string{"TF_VAR_passphrase": "secret"})},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name:      "nil terraform config is a no-op",
+			initial:   map[string]string{"EXISTING": "value"},
+			terraform: nil,
+			want:      map[string]string{"EXISTING": "value"},
+		},
+		{
+			name:      "terraform config without extra args is a no-op",
+			initial:   map[string]string{"EXISTING": "value"},
+			terraform: &TerraformConfig{},
+			want:      map[string]string{"EXISTING": "value"},
+		},
+		{
+			name:    "nil env vars is a no-op",
+			initial: map[string]string{},
+			terraform: &TerraformConfig{
+				ExtraArgs: []TerraformExtraArguments{
+					{Name: "secrets", Commands: []string{"output"}, EnvVars: nil},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name:    "nil env map is initialized before applying",
+			initial: nil,
+			terraform: &TerraformConfig{
+				ExtraArgs: []TerraformExtraArguments{
+					{Name: "secrets", Commands: []string{"output"}, EnvVars: envVars(map[string]string{"KEY": "value"})},
+				},
+			},
+			want: map[string]string{"KEY": "value"},
+		},
+		{
+			name:    "later block wins on overlapping keys",
+			initial: map[string]string{},
+			terraform: &TerraformConfig{
+				ExtraArgs: []TerraformExtraArguments{
+					{Name: "first", Commands: []string{"output"}, EnvVars: envVars(map[string]string{"KEY": "first"})},
+					{Name: "second", Commands: []string{"output"}, EnvVars: envVars(map[string]string{"KEY": "second"})},
+				},
+			},
+			want: map[string]string{"KEY": "second"},
+		},
+		{
+			name:    "extra args env vars override existing env",
+			initial: map[string]string{"TF_VAR_passphrase": "old"},
+			terraform: &TerraformConfig{
+				ExtraArgs: []TerraformExtraArguments{
+					{Name: "secrets", Commands: []string{"output"}, EnvVars: envVars(map[string]string{"TF_VAR_passphrase": "new"})},
+				},
+			},
+			want: map[string]string{"TF_VAR_passphrase": "new"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pctx := &ParsingContext{Env: tc.initial}
+			applyExtraArgsEnvVarsForOutput(pctx, tc.terraform)
+			assert.Equal(t, tc.want, pctx.Env)
+		})
+	}
+}

--- a/test/fixtures/regressions/dependency-extra-args-env/module-a/main.tf
+++ b/test/fixtures/regressions/dependency-extra-args-env/module-a/main.tf
@@ -1,0 +1,3 @@
+output "test_output" {
+  value = "hello from module-a"
+}

--- a/test/fixtures/regressions/dependency-extra-args-env/module-a/terragrunt.hcl
+++ b/test/fixtures/regressions/dependency-extra-args-env/module-a/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = ".//"
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}

--- a/test/fixtures/regressions/dependency-extra-args-env/module-a/terragrunt.hcl
+++ b/test/fixtures/regressions/dependency-extra-args-env/module-a/terragrunt.hcl
@@ -1,7 +1,3 @@
-terraform {
-  source = ".//"
-}
-
 include "root" {
   path = find_in_parent_folders("root.hcl")
 }

--- a/test/fixtures/regressions/dependency-extra-args-env/module-b/main.tf
+++ b/test/fixtures/regressions/dependency-extra-args-env/module-b/main.tf
@@ -1,0 +1,7 @@
+variable "test_var" {
+  type = string
+}
+
+output "test_output" {
+  value = var.test_var
+}

--- a/test/fixtures/regressions/dependency-extra-args-env/module-b/terragrunt.hcl
+++ b/test/fixtures/regressions/dependency-extra-args-env/module-b/terragrunt.hcl
@@ -1,0 +1,15 @@
+terraform {
+  source = ".//"
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+dependency "module_a" {
+  config_path = "../module-a"
+}
+
+inputs = {
+  test_var = dependency.module_a.outputs.test_output
+}

--- a/test/fixtures/regressions/dependency-extra-args-env/module-b/terragrunt.hcl
+++ b/test/fixtures/regressions/dependency-extra-args-env/module-b/terragrunt.hcl
@@ -1,7 +1,3 @@
-terraform {
-  source = ".//"
-}
-
 include "root" {
   path = find_in_parent_folders("root.hcl")
 }

--- a/test/fixtures/regressions/dependency-extra-args-env/root.hcl
+++ b/test/fixtures/regressions/dependency-extra-args-env/root.hcl
@@ -1,0 +1,78 @@
+# Local backend so dependency output optimization is eligible.
+remote_state {
+  backend = "local"
+
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+
+  config = {
+    path = "terraform.tfstate"
+  }
+}
+
+# State encryption whose passphrase comes from a variable, not a literal.
+generate "encryption" {
+  path      = "_encryption.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-EOF
+    terraform {
+      encryption {
+        key_provider "pbkdf2" "default" {
+          passphrase    = var.state_passphrase
+          key_length    = 32
+          iterations    = 600000
+          salt_length   = 32
+          hash_function = "sha512"
+        }
+
+        method "aes_gcm" "default" {
+          keys = key_provider.pbkdf2.default
+        }
+
+        state {
+          enforced = true
+          method   = method.aes_gcm.default
+        }
+
+        plan {
+          enforced = true
+          method   = method.aes_gcm.default
+        }
+      }
+    }
+  EOF
+}
+
+# Declare the passphrase variable that the encryption block references.
+generate "passphrase_variable" {
+  path      = "_variables.tf"
+  if_exists = "overwrite"
+  contents  = <<-EOF
+    variable "state_passphrase" {
+      type      = string
+      sensitive = true
+    }
+  EOF
+}
+
+# Supply the passphrase to tofu only through extra_arguments env_vars.
+terraform {
+  extra_arguments "secrets" {
+    commands = [
+      "apply",
+      "destroy",
+      "import",
+      "init",
+      "output",
+      "plan",
+      "refresh",
+      "state",
+    ]
+
+    env_vars = {
+      TF_VAR_state_passphrase = "test-passphrase-1234567890"
+    }
+  }
+}

--- a/test/fixtures/regressions/dependency-extra-args-env/root.hcl
+++ b/test/fixtures/regressions/dependency-extra-args-env/root.hcl
@@ -12,67 +12,21 @@ remote_state {
   }
 }
 
-# State encryption whose passphrase comes from a variable, not a literal.
-generate "encryption" {
-  path      = "_encryption.tf"
-  if_exists = "overwrite_terragrunt"
-  contents  = <<-EOF
-    terraform {
-      encryption {
-        key_provider "pbkdf2" "default" {
-          passphrase    = var.state_passphrase
-          key_length    = 32
-          iterations    = 600000
-          salt_length   = 32
-          hash_function = "sha512"
-        }
-
-        method "aes_gcm" "default" {
-          keys = key_provider.pbkdf2.default
-        }
-
-        state {
-          enforced = true
-          method   = method.aes_gcm.default
-        }
-
-        plan {
-          enforced = true
-          method   = method.aes_gcm.default
-        }
-      }
-    }
-  EOF
-}
-
-# Declare the passphrase variable that the encryption block references.
-generate "passphrase_variable" {
-  path      = "_variables.tf"
-  if_exists = "overwrite"
-  contents  = <<-EOF
-    variable "state_passphrase" {
-      type      = string
-      sensitive = true
-    }
-  EOF
-}
-
-# Supply the passphrase to tofu only through extra_arguments env_vars.
+# Select a non-default workspace via an env var supplied only through extra_arguments.
 terraform {
-  extra_arguments "secrets" {
+  extra_arguments "workspace" {
     commands = [
+      "init",
+      "plan",
       "apply",
       "destroy",
-      "import",
-      "init",
-      "output",
-      "plan",
       "refresh",
       "state",
+      "output",
     ]
 
     env_vars = {
-      TF_VAR_state_passphrase = "test-passphrase-1234567890"
+      TF_WORKSPACE = "custom"
     }
   }
 }

--- a/test/integration_regressions_test.go
+++ b/test/integration_regressions_test.go
@@ -40,6 +40,7 @@ const (
 	testFixtureExposedIncludePartialParseError   = "fixtures/regressions/exposed-include-partial-parse-error"
 	testFixtureDAGQueueDisplay                   = "fixtures/regressions/dag-queue-display"
 	testFixtureAutoInitMarkerCachedModules       = "fixtures/regressions/auto-init-marker-with-cached-modules"
+	testFixtureDependencyExtraArgsEnv            = "fixtures/regressions/dependency-extra-args-env"
 )
 
 func TestNoAutoInit(t *testing.T) {
@@ -1158,4 +1159,28 @@ func findCachedFile(t *testing.T, cacheRoot, name string) string {
 	require.NoError(t, walkErr, "walking %s", cacheRoot)
 
 	return found
+}
+
+// TestDependencyExtraArgsEnvVarsResolveOutput checks that dependency output resolution honors extra_arguments env_vars
+func TestDependencyExtraArgsEnvVarsResolveOutput(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureDependencyExtraArgsEnv)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureDependencyExtraArgsEnv)
+	moduleAPath := filepath.Join(rootPath, "module-a")
+	moduleBPath := filepath.Join(rootPath, "module-b")
+
+	// applying module-a first routes the later resolution through the init-folder optimized output path
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+moduleAPath)
+	require.NoError(t, err)
+
+	// resolving module-a outputs here must decrypt module-a state using the extra_arguments passphrase
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+moduleBPath)
+	require.NoError(t, err)
+	assert.NotContains(t, stderr, "Unable to compute static value")
+
+	// confirm module-a output propagated through the dependency, not just a clean exit
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt output -raw test_output --non-interactive --working-dir "+moduleBPath)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "hello from module-a")
 }

--- a/test/integration_regressions_test.go
+++ b/test/integration_regressions_test.go
@@ -1166,18 +1166,17 @@ func TestDependencyExtraArgsEnvVarsResolveOutput(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureDependencyExtraArgsEnv)
-	rootPath := filepath.Join(tmpEnvPath, testFixtureDependencyExtraArgsEnv)
-	moduleAPath := filepath.Join(rootPath, "module-a")
-	moduleBPath := filepath.Join(rootPath, "module-b")
+	testPath := filepath.Join(tmpEnvPath, testFixtureDependencyExtraArgsEnv)
+	moduleAPath := filepath.Join(testPath, "module-a")
+	moduleBPath := filepath.Join(testPath, "module-b")
 
-	// applying module-a first routes the later resolution through the init-folder optimized output path
+	// apply the dependency so its state is written under the custom workspace selected by extra_arguments
 	_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+moduleAPath)
 	require.NoError(t, err)
 
-	// resolving module-a outputs here must decrypt module-a state using the extra_arguments passphrase
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+moduleBPath)
+	// resolving module-a outputs here must use the extra_arguments workspace to read the right state
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+moduleBPath)
 	require.NoError(t, err)
-	assert.NotContains(t, stderr, "Unable to compute static value")
 
 	// confirm module-a output propagated through the dependency, not just a clean exit
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt output -raw test_output --non-interactive --working-dir "+moduleBPath)


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

- Dependency output optimization paths (getTerragruntOutputJSONFromInitFolder / getTerragruntOutputJSONFromRemoteState) now apply terraform.extra_arguments.env_vars (for the output command) to pctx.Env, so env-dependent backends like OpenTofu state encryption resolve correctly
- Added regression integration test + 9-case unit test for the env-var merge logic

Fixes #6395.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency output resolution now honors `terraform.extra_arguments.env_vars` for output-related commands, so dependent modules use the intended runtime environment (including the correct workspace/state).

* **Tests**
  * Added unit coverage for when env vars are applied (only when `output` is enabled) and correct override behavior.
  * Added an integration regression test using fixtures that set a custom workspace via `env_vars`.

* **Documentation**
  * Updated the v1.1.0 changelog entry to reflect the improved behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->