### PR TITLE
chore: Update cfg locking for units

### DIFF
--- a/internal/component/component.go
+++ b/internal/component/component.go
@@ -43,8 +43,6 @@ type Component interface {
 
 	lock()
 	unlock()
-	rLock()
-	rUnlock()
 
 	ensureDependency(Component)
 	ensureDependent(Component)

--- a/internal/component/component_test.go
+++ b/internal/component/component_test.go
@@ -238,9 +238,8 @@ func TestThreadSafeComponentsConcurrentAccess(t *testing.T) {
 	assert.Equal(t, 1, tsc.Len(), "should have exactly one component after concurrent adds")
 }
 
-// TestUnitGuardConfigParseWithRacing pins the no-double-parse guarantee: when
-// many goroutines race to parse the same unit, the parse runs exactly once and
-// the losers observe the winner's config.
+// TestUnitGuardConfigParseWithRacing verifies the parse runs exactly once when
+// many goroutines race to parse the same unit.
 func TestUnitGuardConfigParseWithRacing(t *testing.T) {
 	t.Parallel()
 

--- a/internal/component/component_test.go
+++ b/internal/component/component_test.go
@@ -2,9 +2,11 @@ package component_test
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -234,4 +236,36 @@ func TestThreadSafeComponentsConcurrentAccess(t *testing.T) {
 
 	// Should have exactly one component despite concurrent adds
 	assert.Equal(t, 1, tsc.Len(), "should have exactly one component after concurrent adds")
+}
+
+// TestUnitGuardConfigParseWithRacing pins the no-double-parse guarantee: when
+// many goroutines race to parse the same unit, the parse runs exactly once and
+// the losers observe the winner's config.
+func TestUnitGuardConfigParseWithRacing(t *testing.T) {
+	t.Parallel()
+
+	unit := component.NewUnit("/test/unit")
+
+	var parses atomic.Int32
+
+	var wg sync.WaitGroup
+
+	const goroutines = 32
+
+	for range goroutines {
+		wg.Go(func() {
+			err := unit.GuardConfigParse(func() error {
+				parses.Add(1)
+				unit.StoreConfig(&config.TerragruntConfig{})
+
+				return nil
+			})
+			assert.NoError(t, err)
+		})
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, int32(1), parses.Load(), "config should be parsed exactly once")
+	assert.NotNil(t, unit.Config(), "config should be populated after parsing")
 }

--- a/internal/component/stack.go
+++ b/internal/component/stack.go
@@ -24,7 +24,7 @@ type Stack struct {
 	dependencies     Components
 	dependents       Components
 	Units            []*Unit
-	mu               sync.RWMutex
+	mu               sync.Mutex
 	external         bool
 }
 
@@ -47,11 +47,17 @@ func (s *Stack) WithDiscoveryContext(ctx *DiscoveryContext) *Stack {
 
 // Config returns the parsed Stack configuration for this stack.
 func (s *Stack) Config() *config.StackConfig {
+	s.lock()
+	defer s.unlock()
+
 	return s.cfg
 }
 
 // StoreConfig stores the parsed Stack configuration for this stack.
 func (s *Stack) StoreConfig(cfg *config.StackConfig) {
+	s.lock()
+	defer s.unlock()
+
 	s.cfg = cfg
 }
 
@@ -96,11 +102,17 @@ func (s *Stack) SetExternal() {
 
 // Reading returns the list of files being read by this component.
 func (s *Stack) Reading() []string {
+	s.lock()
+	defer s.unlock()
+
 	return s.reading
 }
 
 // SetReading sets the list of files being read by this component.
 func (s *Stack) SetReading(files ...string) {
+	s.lock()
+	defer s.unlock()
+
 	s.reading = files
 }
 
@@ -143,16 +155,6 @@ func (s *Stack) lock() {
 // unlock unlocks the Stack.
 func (s *Stack) unlock() {
 	s.mu.Unlock()
-}
-
-// rLock locks the Stack for reading.
-func (s *Stack) rLock() {
-	s.mu.RLock()
-}
-
-// rUnlock unlocks the Stack for reading.
-func (s *Stack) rUnlock() {
-	s.mu.RUnlock()
 }
 
 // AddDependency adds a dependency to the Stack and vice versa.
@@ -199,16 +201,16 @@ func (s *Stack) AddDependent(dependent Component) {
 
 // Dependencies returns the dependencies of the Stack.
 func (s *Stack) Dependencies() Components {
-	s.rLock()
-	defer s.rUnlock()
+	s.lock()
+	defer s.unlock()
 
 	return s.dependencies
 }
 
 // Dependents returns the dependents of the Stack.
 func (s *Stack) Dependents() Components {
-	s.rLock()
-	defer s.rUnlock()
+	s.lock()
+	defer s.unlock()
 
 	return s.dependents
 }

--- a/internal/component/unit.go
+++ b/internal/component/unit.go
@@ -26,6 +26,7 @@ type Unit struct {
 	dependencies     Components
 	dependents       Components
 	mu               sync.Mutex
+	parseMu          sync.Mutex
 	external         bool
 	excluded         bool
 }
@@ -77,6 +78,23 @@ func (u *Unit) StoreConfig(cfg *config.TerragruntConfig) {
 	defer u.unlock()
 
 	u.cfg = cfg
+}
+
+// GuardConfigParse runs parse to populate this unit's config at most once, even
+// when called concurrently. Callers that lose the race skip parse and observe
+// the config stored by the winner.
+//
+// The guard is separate from the config mutex so a slow parse doesn't block
+// reads of an already-parsed unit.
+func (u *Unit) GuardConfigParse(parse func() error) error {
+	u.parseMu.Lock()
+	defer u.parseMu.Unlock()
+
+	if u.Config() != nil {
+		return nil
+	}
+
+	return parse()
 }
 
 // ConfigFile returns the discovered config filename for this unit.

--- a/internal/component/unit.go
+++ b/internal/component/unit.go
@@ -25,7 +25,7 @@ type Unit struct {
 	reading          []string
 	dependencies     Components
 	dependents       Components
-	mu               sync.RWMutex
+	mu               sync.Mutex
 	external         bool
 	excluded         bool
 }
@@ -51,7 +51,7 @@ func (u *Unit) WithReading(files ...string) *Unit {
 
 // WithConfig adds configuration to a Unit component.
 func (u *Unit) WithConfig(cfg *config.TerragruntConfig) *Unit {
-	u.cfg = cfg
+	u.StoreConfig(cfg)
 
 	return u
 }
@@ -65,11 +65,17 @@ func (u *Unit) WithDiscoveryContext(ctx *DiscoveryContext) *Unit {
 
 // Config returns the parsed Terragrunt configuration for this unit.
 func (u *Unit) Config() *config.TerragruntConfig {
+	u.lock()
+	defer u.unlock()
+
 	return u.cfg
 }
 
 // StoreConfig stores the parsed Terragrunt configuration for this unit.
 func (u *Unit) StoreConfig(cfg *config.TerragruntConfig) {
+	u.lock()
+	defer u.unlock()
+
 	u.cfg = cfg
 }
 
@@ -120,16 +126,25 @@ func (u *Unit) SetExcluded(excluded bool) {
 
 // Reading returns the list of files being read by this component.
 func (u *Unit) Reading() []string {
+	u.lock()
+	defer u.unlock()
+
 	return u.reading
 }
 
 // SetReading sets the list of files being read by this component.
 func (u *Unit) SetReading(files ...string) {
+	u.lock()
+	defer u.unlock()
+
 	u.reading = files
 }
 
 // Sources returns the list of sources for this component.
 func (u *Unit) Sources() []string {
+	u.lock()
+	defer u.unlock()
+
 	if u.cfg == nil || u.cfg.Terraform == nil || u.cfg.Terraform.Source == nil {
 		return []string{}
 	}
@@ -164,16 +179,6 @@ func (u *Unit) lock() {
 // unlock unlocks the Unit.
 func (u *Unit) unlock() {
 	u.mu.Unlock()
-}
-
-// rLock locks the Unit for reading.
-func (u *Unit) rLock() {
-	u.mu.RLock()
-}
-
-// rUnlock unlocks the Unit for reading.
-func (u *Unit) rUnlock() {
-	u.mu.RUnlock()
 }
 
 // AddDependency adds a dependency to the Unit and vice versa.
@@ -220,16 +225,16 @@ func (u *Unit) AddDependent(dependent Component) {
 
 // Dependencies returns the dependencies of the Unit.
 func (u *Unit) Dependencies() Components {
-	u.rLock()
-	defer u.rUnlock()
+	u.lock()
+	defer u.unlock()
 
 	return u.dependencies
 }
 
 // Dependents returns the dependents of the Unit.
 func (u *Unit) Dependents() Components {
-	u.rLock()
-	defer u.rUnlock()
+	u.lock()
+	defer u.unlock()
 
 	return u.dependents
 }
@@ -240,9 +245,9 @@ func (u *Unit) Dependents() Components {
 //
 //	Unit /path/to/unit (excluded: false, assume applied: false, dependencies: [/dep1, /dep2])
 func (u *Unit) String() string {
-	// Snapshot values under read lock to avoid data races
-	u.rLock()
-	defer u.rUnlock()
+	// Snapshot values under lock to avoid data races
+	u.lock()
+	defer u.unlock()
 
 	path := u.DisplayPath()
 	deps := make([]string, 0, len(u.dependencies))

--- a/internal/discovery/concurrent_parse_race_test.go
+++ b/internal/discovery/concurrent_parse_race_test.go
@@ -16,37 +16,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDiscovery_GraphParseStoresConfigConcurrentlyWithRacing reproduces, through
-// the public Discover entry point, the data race that the per-Unit cfg/reading
+// TestDiscovery_GraphConcurrentConfigAccessWithRacing reproduces, through the
+// public Discover entry point, the data race that the per-Unit cfg/reading
 // locks guard against.
 //
-// The graph phase parses a unit lazily, the first time it is reached, via
-// ensureParsed -> parseComponent -> Unit.StoreConfig/SetReading. ensureParsed
-// guards the parse with a check-then-act on Unit.Config(): if it is nil, parse
-// and store. That check is not atomic across goroutines. With a `{./**}...`
-// filter every unit is both a graph target (whose dependencies are walked in
-// its own goroutine) and a dependency of other targets, so a shared unit is
-// reached from two graph-phase goroutines at once. When both observe a nil
-// config before either stores, both call StoreConfig/SetReading on the same
-// Unit concurrently — a data race on cfg and reading.
+// The graph phase parses a unit lazily, via ensureParsed -> parseComponent ->
+// Unit.StoreConfig/SetReading. With a `{./**}...` filter every unit is both a
+// graph target (walked in its own goroutine) and a dependency of other targets,
+// so a shared unit is reached by several graph-phase goroutines at once.
+// GuardConfigParse serializes the parse so the config is stored a single time.
+// The goroutines that lose that race still read the unit's config concurrently
+// with the winner's store: the ensureParsed cache check and the downstream
+// dependency extraction both call Unit.Config(). Without the lock on
+// Config/StoreConfig (and Reading/SetReading), that read/write pair is a data
+// race on cfg and reading.
 //
-// The window between the nil check and the store is the parse duration, so the
-// shared unit is given a deliberately large config (a big remote_state map) to
-// widen it enough that the race detector reliably observes the overlap. The
-// fan-in of many leaves and the repeated Discover calls raise the odds that the
-// two parsers overlap within a single test run.
+// The shared unit is given a deliberately large config (a big remote_state map)
+// to lengthen the parse so the reads and the store reliably overlap. The fan-in
+// of many leaves and the repeated Discover calls raise the odds of overlap
+// within a single test run.
 //
 // To confirm the locks are load-bearing, drop the lock/unlock calls from Unit's
 // Config, StoreConfig, Reading, and SetReading and run this test with -race:
-// the detector reports the race inside the graph phase
-// (parseComponent -> Unit.StoreConfig). With the locks in place it passes.
-func TestDiscovery_GraphParseStoresConfigConcurrentlyWithRacing(t *testing.T) {
+// the detector reports the race between Unit.StoreConfig and Unit.Config inside
+// the graph phase. With the locks in place it passes.
+func TestDiscovery_GraphConcurrentConfigAccessWithRacing(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
-	// A large config widens the parse window so the concurrent re-parse is
-	// observable. remote_state is partially decoded during discovery, so its
+	// A large config lengthens the parse so the concurrent reads and the store
+	// overlap. remote_state is partially decoded during discovery, so its
 	// contents are actually walked rather than skipped.
 	var sharedConfig strings.Builder
 

--- a/internal/discovery/concurrent_parse_race_test.go
+++ b/internal/discovery/concurrent_parse_race_test.go
@@ -17,37 +17,23 @@ import (
 )
 
 // TestDiscovery_GraphConcurrentConfigAccessWithRacing reproduces, through the
-// public Discover entry point, the data race that the per-Unit cfg/reading
-// locks guard against.
+// public Discover entry point, the data race the per-Unit cfg/reading locks
+// guard against: the graph phase reaches a shared unit from several goroutines
+// at once, so one goroutine's parse stores the config while others read it.
 //
-// The graph phase parses a unit lazily, via ensureParsed -> parseComponent ->
-// Unit.StoreConfig/SetReading. With a `{./**}...` filter every unit is both a
-// graph target (walked in its own goroutine) and a dependency of other targets,
-// so a shared unit is reached by several graph-phase goroutines at once.
-// GuardConfigParse serializes the parse so the config is stored a single time.
-// The goroutines that lose that race still read the unit's config concurrently
-// with the winner's store: the ensureParsed cache check and the downstream
-// dependency extraction both call Unit.Config(). Without the lock on
-// Config/StoreConfig (and Reading/SetReading), that read/write pair is a data
-// race on cfg and reading.
-//
-// The shared unit is given a deliberately large config (a big remote_state map)
-// to lengthen the parse so the reads and the store reliably overlap. The fan-in
-// of many leaves and the repeated Discover calls raise the odds of overlap
-// within a single test run.
+// The shared unit gets a large config and many dependents, repeated across
+// several Discover calls, so the read/write overlap is reliably observable; a
+// smaller config or fewer iterations make the race intermittent.
 //
 // To confirm the locks are load-bearing, drop the lock/unlock calls from Unit's
-// Config, StoreConfig, Reading, and SetReading and run this test with -race:
-// the detector reports the race between Unit.StoreConfig and Unit.Config inside
-// the graph phase. With the locks in place it passes.
+// Config, StoreConfig, Reading, and SetReading and run with -race.
 func TestDiscovery_GraphConcurrentConfigAccessWithRacing(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
-	// A large config lengthens the parse so the concurrent reads and the store
-	// overlap. remote_state is partially decoded during discovery, so its
-	// contents are actually walked rather than skipped.
+	// remote_state is partially decoded during discovery, so a large block is
+	// walked during parse rather than skipped, which lengthens the parse.
 	var sharedConfig strings.Builder
 
 	sharedConfig.WriteString("remote_state {\n  backend = \"local\"\n")

--- a/internal/discovery/concurrent_parse_race_test.go
+++ b/internal/discovery/concurrent_parse_race_test.go
@@ -1,0 +1,95 @@
+package discovery_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDiscovery_GraphParseStoresConfigConcurrentlyWithRacing reproduces, through
+// the public Discover entry point, the data race that the per-Unit cfg/reading
+// locks guard against.
+//
+// The graph phase parses a unit lazily, the first time it is reached, via
+// ensureParsed -> parseComponent -> Unit.StoreConfig/SetReading. ensureParsed
+// guards the parse with a check-then-act on Unit.Config(): if it is nil, parse
+// and store. That check is not atomic across goroutines. With a `{./**}...`
+// filter every unit is both a graph target (whose dependencies are walked in
+// its own goroutine) and a dependency of other targets, so a shared unit is
+// reached from two graph-phase goroutines at once. When both observe a nil
+// config before either stores, both call StoreConfig/SetReading on the same
+// Unit concurrently — a data race on cfg and reading.
+//
+// The window between the nil check and the store is the parse duration, so the
+// shared unit is given a deliberately large config (a big remote_state map) to
+// widen it enough that the race detector reliably observes the overlap. The
+// fan-in of many leaves and the repeated Discover calls raise the odds that the
+// two parsers overlap within a single test run.
+//
+// To confirm the locks are load-bearing, drop the lock/unlock calls from Unit's
+// Config, StoreConfig, Reading, and SetReading and run this test with -race:
+// the detector reports the race inside the graph phase
+// (parseComponent -> Unit.StoreConfig). With the locks in place it passes.
+func TestDiscovery_GraphParseStoresConfigConcurrentlyWithRacing(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	// A large config widens the parse window so the concurrent re-parse is
+	// observable. remote_state is partially decoded during discovery, so its
+	// contents are actually walked rather than skipped.
+	var sharedConfig strings.Builder
+
+	sharedConfig.WriteString("remote_state {\n  backend = \"local\"\n")
+	sharedConfig.WriteString("  generate = { path = \"backend.tf\", if_exists = \"overwrite\" }\n  config = {\n")
+
+	for i := range 8000 {
+		fmt.Fprintf(&sharedConfig, "    k%d = \"v%d\"\n", i, i)
+	}
+
+	sharedConfig.WriteString("  }\n}\n")
+
+	vpcDir := filepath.Join(tmpDir, "vpc")
+	require.NoError(t, os.MkdirAll(vpcDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(vpcDir, "terragrunt.hcl"), []byte(sharedConfig.String()), 0644))
+
+	const leaves = 8
+
+	for i := range leaves {
+		leafDir := filepath.Join(tmpDir, fmt.Sprintf("app%d", i))
+		require.NoError(t, os.MkdirAll(leafDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(leafDir, "terragrunt.hcl"), []byte(`
+		dependency "vpc" {
+			config_path = "../vpc"
+		}
+		`), 0644))
+	}
+
+	l := logger.CreateLogger()
+	opts := &options.TerragruntOptions{
+		WorkingDir:     tmpDir,
+		RootWorkingDir: tmpDir,
+	}
+
+	filters, err := filter.ParseFilterQueries(l, []string{"{./**}..."})
+	require.NoError(t, err)
+
+	for range 8 {
+		d := discovery.NewDiscovery(tmpDir).
+			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
+			WithFilters(filters)
+
+		_, err := d.Discover(t.Context(), l, opts)
+		require.NoError(t, err)
+	}
+}

--- a/internal/discovery/phase_parse.go
+++ b/internal/discovery/phase_parse.go
@@ -124,7 +124,11 @@ func ensureParsed(
 		return nil
 	}
 
-	return parseComponent(ctx, l, c, opts, discovery)
+	// Graph and relationship goroutines can reach the same unit here at once,
+	// and the nil check above is only a fast path, not atomic with the parse.
+	return unit.GuardConfigParse(func() error {
+		return parseComponent(ctx, l, c, opts, discovery)
+	})
 }
 
 // ParsePhase parses HCL configurations for filter evaluation.

--- a/internal/discovery/phase_parse.go
+++ b/internal/discovery/phase_parse.go
@@ -124,8 +124,6 @@ func ensureParsed(
 		return nil
 	}
 
-	// Graph and relationship goroutines can reach the same unit here at once,
-	// and the nil check above is only a fast path, not atomic with the parse.
 	return unit.GuardConfigParse(func() error {
 		return parseComponent(ctx, l, c, opts, discovery)
 	})


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses a race I was noticing in some tests.

Also switches us over to a normal mutex from an rwmutex, as we're unlikely to see performance benefits from using the rwmutex in this usage.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when configuration is accessed or parsed from multiple goroutines at the same time.
  * Prevented duplicate parsing work during concurrent operations, reducing race conditions and inconsistent state.
  * Tightened synchronization around configuration, dependency, and reading data to make concurrent discovery more stable.

* **Tests**
  * Added coverage for concurrent parsing and discovery scenarios to help catch race-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->