### PR TITLE
fix: Fixing indenter style

### DIFF
--- a/internal/view/dag/dag.go
+++ b/internal/view/dag/dag.go
@@ -146,7 +146,7 @@ func NewTreeStyler(shouldColor bool) *TreeStyler {
 
 	return &TreeStyler{
 		shouldColor: shouldColor,
-		entryStyle:  lipgloss.NewStyle().Foreground(lipgloss.Color("240")).MarginRight(1),
+		entryStyle:  lipgloss.NewStyle().Foreground(lipgloss.Color("8")).MarginRight(1),
 		rootStyle:   lipgloss.NewStyle().Foreground(lipgloss.Color("35")),
 		colorizer:   colorizer,
 	}
@@ -168,6 +168,7 @@ func (s *TreeStyler) Style(t *tree.Tree) *tree.Tree {
 
 	return t.
 		EnumeratorStyle(s.entryStyle).
+		IndenterStyle(s.entryStyle).
 		RootStyle(s.rootStyle)
 }
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Before:

<img width="379" height="370" alt="Screenshot 2026-06-24 at 19 47 02" src="https://github.com/user-attachments/assets/ec273480-fa36-45a9-bc60-858f99d8225d" />

After:

<img width="375" height="602" alt="Screenshot 2026-06-24 at 19 47 20" src="https://github.com/user-attachments/assets/01ec209a-4b97-4dfd-afeb-ae543577a60f" />


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the tree view’s entry text color for better readability.
  * Applied consistent styling to indentation in tree enumerators, making the displayed hierarchy look more uniform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->