### PR TITLE
chore: Move log flags off writers

### DIFF
--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -469,7 +469,7 @@ func initialSetup(cliCtx *clihelper.Context, l log.Logger, opts *options.Terragr
 		return err
 	}
 
-	if opts.Writers.LogShowAbsPaths {
+	if opts.LogShowAbsPaths {
 		l.Formatter().DisableRelativePaths()
 	}
 

--- a/internal/cli/flags/global/flags.go
+++ b/internal/cli/flags/global/flags.go
@@ -116,7 +116,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 		flags.NewFlag(&clihelper.BoolFlag{
 			Name:        ShowLogAbsPathsFlagName,
 			EnvVars:     tgPrefix.EnvVars(ShowLogAbsPathsFlagName),
-			Destination: &opts.Writers.LogShowAbsPaths,
+			Destination: &opts.LogShowAbsPaths,
 			Usage:       "Show absolute paths in logs.",
 		},
 			flags.WithDeprecatedEnvVars(terragruntPrefix.EnvVars(DeprecatedShowLogAbsPathsFlagName), opts.StrictControls)),

--- a/internal/configbridge/bridge.go
+++ b/internal/configbridge/bridge.go
@@ -44,6 +44,8 @@ func populateFromOpts(pctx *config.ParsingContext, opts *options.TerragruntOptio
 	pctx.StrictControls = opts.StrictControls
 	pctx.FeatureFlags = opts.FeatureFlags
 	pctx.Writers = opts.Writers
+	pctx.LogShowAbsPaths = opts.LogShowAbsPaths
+	pctx.LogDisableErrorSummary = opts.LogDisableErrorSummary
 	pctx.Env = opts.Env
 	pctx.IAMRoleOptions = opts.IAMRoleOptions
 	pctx.OriginalIAMRoleOptions = opts.OriginalIAMRoleOptions
@@ -75,7 +77,7 @@ func populateFromOpts(pctx *config.ParsingContext, opts *options.TerragruntOptio
 
 // ShellRunOptsFromOpts constructs shell.ShellOptions from TerragruntOptions.
 func ShellRunOptsFromOpts(opts *options.TerragruntOptions) *shell.ShellOptions {
-	return shell.NewShellOptions().
+	s := shell.NewShellOptions().
 		WithWorkingDir(opts.WorkingDir).
 		WithEnv(opts.Env).
 		WithWriters(opts.Writers).
@@ -86,6 +88,10 @@ func ShellRunOptsFromOpts(opts *options.TerragruntOptions) *shell.ShellOptions {
 		WithExperiments(opts.Experiments).
 		WithHeadless(opts.Headless).
 		WithForwardTFStdout(opts.ForwardTFStdout)
+	s.LogShowAbsPaths = opts.LogShowAbsPaths
+	s.LogDisableErrorSummary = opts.LogDisableErrorSummary
+
+	return s
 }
 
 // BackendOptsFromOpts constructs backend.Options from TerragruntOptions.
@@ -125,6 +131,8 @@ func TFRunOptsFromOpts(opts *options.TerragruntOptions) *tf.TFOptions {
 func NewRunOptions(opts *options.TerragruntOptions) *run.Options {
 	runOpts := run.NewOptions()
 	runOpts.Writers = opts.Writers
+	runOpts.LogShowAbsPaths = opts.LogShowAbsPaths
+	runOpts.LogDisableErrorSummary = opts.LogDisableErrorSummary
 	runOpts.TerragruntConfigPath = opts.TerragruntConfigPath
 	runOpts.OriginalTerragruntConfigPath = opts.OriginalTerragruntConfigPath
 	runOpts.WorkingDir = opts.WorkingDir

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -82,6 +82,9 @@ type ExecutionOptions struct {
 	ForwardTFStdout   bool
 	SuppressStdout    bool
 	AllocatePseudoTty bool
+
+	LogShowAbsPaths        bool
+	LogDisableErrorSummary bool
 }
 
 type engineInstance struct {
@@ -832,10 +835,10 @@ func invoke(
 				Output:          output,
 				WorkingDir:      runOptions.WorkingDir,
 				RootWorkingDir:  runOptions.RootWorkingDir,
-				LogShowAbsPaths: runOptions.Writers.LogShowAbsPaths,
+				LogShowAbsPaths: runOptions.LogShowAbsPaths,
 				Command:         runOptions.Command,
 				Args:            runOptions.Args,
-				DisableSummary:  runOptions.Writers.LogDisableErrorSummary,
+				DisableSummary:  runOptions.LogDisableErrorSummary,
 			}
 
 			return err

--- a/internal/runner/common/unit_runner.go
+++ b/internal/runner/common/unit_runner.go
@@ -52,7 +52,7 @@ func (runner *UnitRunner) runTerragrunt(
 	cfg *runcfg.RunConfig,
 	credsGetter *creds.Getter,
 ) error {
-	l.Debugf("Running %s", util.RelPathForLog(opts.RootWorkingDir, runner.Unit.Path(), opts.Writers.LogShowAbsPaths))
+	l.Debugf("Running %s", util.RelPathForLog(opts.RootWorkingDir, runner.Unit.Path(), opts.LogShowAbsPaths))
 
 	defer func() {
 		// Flush buffered output for this unit, if the writer supports it.

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -100,8 +100,8 @@ func DownloadTerraformSource(
 	if needsModuleCopy {
 		l.Debugf(
 			"Copying files from %s into %s",
-			util.RelPathForLog(opts.WorkingDir, opts.WorkingDir, opts.Writers.LogShowAbsPaths),
-			util.RelPathForLog(opts.RootWorkingDir, terraformSource.WorkingDir, opts.Writers.LogShowAbsPaths),
+			util.RelPathForLog(opts.WorkingDir, opts.WorkingDir, opts.LogShowAbsPaths),
+			util.RelPathForLog(opts.RootWorkingDir, terraformSource.WorkingDir, opts.LogShowAbsPaths),
 		)
 
 		// Always include the .tflint.hcl file, if it exists
@@ -136,7 +136,7 @@ func DownloadTerraformSource(
 		util.RelPathForLog(
 			opts.RootWorkingDir,
 			terraformSource.WorkingDir,
-			opts.Writers.LogShowAbsPaths,
+			opts.LogShowAbsPaths,
 		),
 	)
 	updatedOpts.WorkingDir = terraformSource.WorkingDir
@@ -185,7 +185,7 @@ func DownloadTerraformSourceIfNecessary(
 				util.RelPathForLog(
 					opts.RootWorkingDir,
 					terraformSource.WorkingDir,
-					opts.Writers.LogShowAbsPaths,
+					opts.LogShowAbsPaths,
 				),
 			)
 
@@ -348,8 +348,8 @@ func downloadSource(
 
 	l.Infof(
 		"Downloading Terraform configurations from %s into %s",
-		util.RelPathForLog(opts.RootWorkingDir, canonicalSourceURL, opts.Writers.LogShowAbsPaths),
-		util.RelPathForLog(opts.RootWorkingDir, src.DownloadDir, opts.Writers.LogShowAbsPaths))
+		util.RelPathForLog(opts.RootWorkingDir, canonicalSourceURL, opts.LogShowAbsPaths),
+		util.RelPathForLog(opts.RootWorkingDir, src.DownloadDir, opts.LogShowAbsPaths))
 
 	allowCAS := !opts.NoCAS
 

--- a/internal/runner/run/options.go
+++ b/internal/runner/run/options.go
@@ -88,6 +88,8 @@ type Options struct {
 	DisableBucketUpdate          bool
 	SourceUpdate                 bool
 	ForwardTFStdout              bool
+	LogShowAbsPaths              bool
+	LogDisableErrorSummary       bool
 }
 
 // Clone performs a deep copy of Options.
@@ -192,7 +194,7 @@ func (o *Options) DataDir() string {
 
 // shellRunOptions builds a *shell.ShellOptions from this Options.
 func (o *Options) shellRunOptions() *shell.ShellOptions {
-	return shell.NewShellOptions().
+	s := shell.NewShellOptions().
 		WithWorkingDir(o.WorkingDir).
 		WithEnv(o.Env).
 		WithWriters(o.Writers).
@@ -203,6 +205,10 @@ func (o *Options) shellRunOptions() *shell.ShellOptions {
 		WithExperiments(o.Experiments).
 		WithHeadless(o.Headless).
 		WithForwardTFStdout(o.ForwardTFStdout)
+	s.LogShowAbsPaths = o.LogShowAbsPaths
+	s.LogDisableErrorSummary = o.LogDisableErrorSummary
+
+	return s
 }
 
 // tfRunOptions builds a *tf.TFOptions from this Options.
@@ -237,6 +243,7 @@ func (o *Options) tflintRunOptions() *tflint.TFLintOptions {
 	return &tflint.TFLintOptions{
 		ShellOptions:         o.shellRunOptions(),
 		Writers:              o.Writers,
+		LogShowAbsPaths:      o.LogShowAbsPaths,
 		WorkingDir:           o.WorkingDir,
 		RootWorkingDir:       o.RootWorkingDir,
 		TerragruntConfigPath: o.TerragruntConfigPath,

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -295,7 +295,7 @@ func runTerragruntWithConfig(
 			// terragrunt.hcl. However, the default value for the user's working dir, set in options.go, IS just the
 			// parent dir of terragrunt.hcl, so these will likely always be the same.
 			// Use directory from OriginalTerragruntConfigPath to copy locks since WorkingDir point to cache directory
-			lockFileError = runcfg.CopyLockFile(l, opts.RootWorkingDir, opts.Writers.LogShowAbsPaths, opts.WorkingDir, filepath.Dir(opts.OriginalTerragruntConfigPath))
+			lockFileError = runcfg.CopyLockFile(l, opts.RootWorkingDir, opts.LogShowAbsPaths, opts.WorkingDir, filepath.Dir(opts.OriginalTerragruntConfigPath))
 		}
 
 		// If command failed, log a helpful message

--- a/internal/runner/runall/runall.go
+++ b/internal/runner/runall/runall.go
@@ -198,7 +198,7 @@ func RunAllOnStack(
 	l.Debugf("%s", rnr.GetStack().String())
 
 	isDestroy := opts.TerraformCliArgs.IsDestroyCommand(opts.TerraformCommand)
-	if err := rnr.LogUnitDeployOrder(l, isDestroy, opts.Writers.LogShowAbsPaths, opts.Experiments); err != nil {
+	if err := rnr.LogUnitDeployOrder(l, isDestroy, opts.LogShowAbsPaths, opts.Experiments); err != nil {
 		return err
 	}
 

--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -60,7 +60,7 @@ func CloneUnitOptions(
 
 	// Override logger prefix with display path (relative to discovery context) for cleaner logs
 	// unless --log-show-abs-paths is set
-	if !stackOpts.Writers.LogShowAbsPaths {
+	if !stackOpts.LogShowAbsPaths {
 		clonedLogger = clonedLogger.WithField(placeholders.WorkDirKeyName, unit.DisplayPath())
 	}
 

--- a/internal/shell/run_cmd.go
+++ b/internal/shell/run_cmd.go
@@ -42,12 +42,14 @@ type ShellOptions struct {
 	Telemetry     *telemetry.Options
 	Env           map[string]string
 
-	RootWorkingDir  string
-	WorkingDir      string
-	TFPath          string
-	Experiments     experiment.Experiments
-	Headless        bool
-	ForwardTFStdout bool
+	RootWorkingDir         string
+	WorkingDir             string
+	TFPath                 string
+	Experiments            experiment.Experiments
+	Headless               bool
+	ForwardTFStdout        bool
+	LogShowAbsPaths        bool
+	LogDisableErrorSummary bool
 }
 
 // NewShellOptions creates ShellOptions with sensible defaults:
@@ -282,22 +284,22 @@ func runCommand(
 
 			cmdOutput, err := engine.Run(ctx, l, e, &engine.ExecutionOptions{
 				Writers: writer.Writers{
-					Writer:                 writer.NewWrappedWriter(cmdStdout, runOpts.Writers.Writer),
-					ErrWriter:              writer.NewWrappedWriter(cmdStderr, runOpts.Writers.ErrWriter),
-					LogShowAbsPaths:        runOpts.Writers.LogShowAbsPaths,
-					LogDisableErrorSummary: runOpts.Writers.LogDisableErrorSummary,
+					Writer:    writer.NewWrappedWriter(cmdStdout, runOpts.Writers.Writer),
+					ErrWriter: writer.NewWrappedWriter(cmdStderr, runOpts.Writers.ErrWriter),
 				},
-				EngineOptions:     runOpts.EngineOptions,
-				EngineConfig:      runOpts.EngineConfig,
-				Env:               runOpts.Env,
-				WorkingDir:        cmdOpts.CommandDir,
-				RootWorkingDir:    runOpts.RootWorkingDir,
-				Command:           cmdOpts.Command,
-				Args:              cmdOpts.Args,
-				Headless:          runOpts.Headless,
-				ForwardTFStdout:   runOpts.ForwardTFStdout,
-				SuppressStdout:    cmdOpts.SuppressStdout,
-				AllocatePseudoTty: cmdOpts.NeedsPTY,
+				LogShowAbsPaths:        runOpts.LogShowAbsPaths,
+				LogDisableErrorSummary: runOpts.LogDisableErrorSummary,
+				EngineOptions:          runOpts.EngineOptions,
+				EngineConfig:           runOpts.EngineConfig,
+				Env:                    runOpts.Env,
+				WorkingDir:             cmdOpts.CommandDir,
+				RootWorkingDir:         runOpts.RootWorkingDir,
+				Command:                cmdOpts.Command,
+				Args:                   cmdOpts.Args,
+				Headless:               runOpts.Headless,
+				ForwardTFStdout:        runOpts.ForwardTFStdout,
+				SuppressStdout:         cmdOpts.SuppressStdout,
+				AllocatePseudoTty:      cmdOpts.NeedsPTY,
 			})
 			if err != nil {
 				return err
@@ -330,8 +332,8 @@ func runCommand(
 			Command:         cmdOpts.Command,
 			WorkingDir:      cmd.Dir(),
 			RootWorkingDir:  runOpts.RootWorkingDir,
-			LogShowAbsPaths: runOpts.Writers.LogShowAbsPaths,
-			DisableSummary:  runOpts.Writers.LogDisableErrorSummary,
+			LogShowAbsPaths: runOpts.LogShowAbsPaths,
+			DisableSummary:  runOpts.LogDisableErrorSummary,
 		}
 
 		return err
@@ -348,8 +350,8 @@ func runCommand(
 			Output:          *cmdOpts.Output,
 			WorkingDir:      cmd.Dir(),
 			RootWorkingDir:  runOpts.RootWorkingDir,
-			LogShowAbsPaths: runOpts.Writers.LogShowAbsPaths,
-			DisableSummary:  runOpts.Writers.LogDisableErrorSummary,
+			LogShowAbsPaths: runOpts.LogShowAbsPaths,
+			DisableSummary:  runOpts.LogDisableErrorSummary,
 		}
 
 		return err

--- a/internal/tflint/tflint.go
+++ b/internal/tflint/tflint.go
@@ -26,6 +26,7 @@ type TFLintOptions struct {
 	RootWorkingDir       string
 	TerragruntConfigPath string
 	MaxFoldersToCheck    int
+	LogShowAbsPaths      bool
 }
 
 const (
@@ -57,7 +58,7 @@ func RunTflintWithOpts(
 	}
 
 	l.Debugf("Using .tflint.hcl file in %s",
-		util.RelPathForLog(opts.RootWorkingDir, configFile, opts.Writers.LogShowAbsPaths))
+		util.RelPathForLog(opts.RootWorkingDir, configFile, opts.LogShowAbsPaths))
 
 	variables, err := InputsToTflintVar(cfg.Inputs)
 	if err != nil {
@@ -71,13 +72,13 @@ func RunTflintWithOpts(
 
 	l.Debugf(
 		"Initializing tflint in directory %s",
-		util.RelPathForLog(opts.RootWorkingDir, opts.WorkingDir, opts.Writers.LogShowAbsPaths),
+		util.RelPathForLog(opts.RootWorkingDir, opts.WorkingDir, opts.LogShowAbsPaths),
 	)
 
 	tflintArgs := hookExecute[1:]
 
-	configFileRel := util.RelPathForLog(opts.WorkingDir, configFile, opts.Writers.LogShowAbsPaths)
-	chdirRel := util.RelPathForLog(opts.RootWorkingDir, opts.WorkingDir, opts.Writers.LogShowAbsPaths)
+	configFileRel := util.RelPathForLog(opts.WorkingDir, configFile, opts.LogShowAbsPaths)
+	chdirRel := util.RelPathForLog(opts.RootWorkingDir, opts.WorkingDir, opts.LogShowAbsPaths)
 
 	// tflint init
 	initArgs := []string{"tflint", "--init", "--config", configFileRel, "--chdir", chdirRel}
@@ -267,8 +268,8 @@ func FindConfigInProject(l log.Logger, fs vfs.FS, opts *TFLintOptions) (string, 
 	for range opts.MaxFoldersToCheck {
 		currentDir := filepath.Dir(previousDir)
 		l.Debugf("Finding .tflint.hcl file from %s and going to %s",
-			util.RelPathForLog(opts.RootWorkingDir, previousDir, opts.Writers.LogShowAbsPaths),
-			util.RelPathForLog(opts.RootWorkingDir, currentDir, opts.Writers.LogShowAbsPaths))
+			util.RelPathForLog(opts.RootWorkingDir, previousDir, opts.LogShowAbsPaths),
+			util.RelPathForLog(opts.RootWorkingDir, currentDir, opts.LogShowAbsPaths))
 
 		if currentDir == previousDir {
 			return "", ConfigNotFound{cause: "Traversed all the day to the root"}
@@ -283,7 +284,7 @@ func FindConfigInProject(l log.Logger, fs vfs.FS, opts *TFLintOptions) (string, 
 
 		if exists {
 			l.Debugf("Found .tflint.hcl in %s",
-				util.RelPathForLog(opts.RootWorkingDir, fileToFind, opts.Writers.LogShowAbsPaths))
+				util.RelPathForLog(opts.RootWorkingDir, fileToFind, opts.LogShowAbsPaths))
 
 			return fileToFind, nil
 		}

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -3,17 +3,16 @@ package writer
 
 import "io"
 
-// Writers groups the writer-related fields that travel together across
-// TerragruntOptions, ParsingContext, shell.RunOptions and engine.ExecutionOptions.
+// Writers groups the stdout/stderr handles that travel together across
+// TerragruntOptions, ParsingContext, shell.ShellOptions and
+// engine.ExecutionOptions. The log-formatting flags that once rode along
+// here (LogShowAbsPaths, LogDisableErrorSummary) now live directly on those
+// structs.
 type Writers struct {
 	// Writer is the primary output writer (defaults to os.Stdout).
 	Writer io.Writer
 	// ErrWriter is the error output writer (defaults to os.Stderr).
 	ErrWriter io.Writer
-	// LogShowAbsPaths disables replacing full paths in logs with short relative paths.
-	LogShowAbsPaths bool
-	// LogDisableErrorSummary is a flag to skip the error summary.
-	LogDisableErrorSummary bool
 }
 
 // writerUnwrapper is any writer that can provide its underlying parent writer.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1170,7 +1170,7 @@ func ReadTerragruntConfig(ctx context.Context,
 	pctx *ParsingContext,
 	parserOptions []hclparse.Option,
 ) (*TerragruntConfig, error) {
-	l.Debugf("Reading Terragrunt config file at %s", util.RelPathForLog(pctx.RootWorkingDir, pctx.TerragruntConfigPath, pctx.Writers.LogShowAbsPaths))
+	l.Debugf("Reading Terragrunt config file at %s", util.RelPathForLog(pctx.RootWorkingDir, pctx.TerragruntConfigPath, pctx.LogShowAbsPaths))
 
 	pctx = pctx.WithParseOption(parserOptions)
 

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -350,7 +350,7 @@ func decodeDependencies(ctx context.Context, pctx *ParsingContext, l log.Logger,
 		// Cache miss - parse and cache
 
 		if !pctx.SkipOutputsResolution {
-			l.Debugf("Reading Terragrunt config file at %s", util.RelPathForLog(pctx.RootWorkingDir, depPath, pctx.Writers.LogShowAbsPaths))
+			l.Debugf("Reading Terragrunt config file at %s", util.RelPathForLog(pctx.RootWorkingDir, depPath, pctx.LogShowAbsPaths))
 		}
 
 		_, depCtx, err := pctx.WithDependencyConfigPath(l, depPath)
@@ -924,7 +924,7 @@ func getOutputJSONWithCaching(ctx context.Context, pctx *ParsingContext, l log.L
 	locks.Lock(targetConfig)
 	defer locks.Unlock(targetConfig)
 
-	l.Debugf("Getting output of dependency %s for config %s", util.RelPathForLog(pctx.RootWorkingDir, targetConfig, pctx.Writers.LogShowAbsPaths), util.RelPathForLog(pctx.RootWorkingDir, pctx.TerragruntConfigPath, pctx.Writers.LogShowAbsPaths))
+	l.Debugf("Getting output of dependency %s for config %s", util.RelPathForLog(pctx.RootWorkingDir, targetConfig, pctx.LogShowAbsPaths), util.RelPathForLog(pctx.RootWorkingDir, pctx.TerragruntConfigPath, pctx.LogShowAbsPaths))
 
 	var newJSONBytes []byte
 
@@ -1254,7 +1254,7 @@ func getTerragruntOutputJSONFromInitFolder(
 		util.RelPathForLog(
 			pctx.RootWorkingDir,
 			filepath.Dir(targetConfigPath),
-			pctx.Writers.LogShowAbsPaths,
+			pctx.LogShowAbsPaths,
 		),
 	)
 
@@ -1273,7 +1273,7 @@ func getTerragruntOutputJSONFromInitFolder(
 		util.RelPathForLog(
 			pctx.RootWorkingDir,
 			targetConfigPath,
-			pctx.Writers.LogShowAbsPaths,
+			pctx.LogShowAbsPaths,
 		),
 		jsonString,
 	)
@@ -1374,7 +1374,7 @@ func getTerragruntOutputJSONFromRemoteState(
 
 	// Check for a provider lock file and copy it to the working dir if it exists.
 	terragruntDir := filepath.Dir(pctx.TerragruntConfigPath)
-	if err := CopyLockFile(l, pctx.RootWorkingDir, pctx.Writers.LogShowAbsPaths, terragruntDir, tempWorkDir); err != nil {
+	if err := CopyLockFile(l, pctx.RootWorkingDir, pctx.LogShowAbsPaths, terragruntDir, tempWorkDir); err != nil {
 		return nil, err
 	}
 
@@ -1524,6 +1524,8 @@ func runTerragruntOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Lo
 
 	runOpts := run.NewOptions()
 	runOpts.Writers = runWriters
+	runOpts.LogShowAbsPaths = pctx.LogShowAbsPaths
+	runOpts.LogDisableErrorSummary = pctx.LogDisableErrorSummary
 	runOpts.TerragruntConfigPath = pctx.TerragruntConfigPath
 	runOpts.OriginalTerragruntConfigPath = pctx.OriginalTerragruntConfigPath
 	runOpts.WorkingDir = pctx.WorkingDir
@@ -1572,7 +1574,7 @@ func runTerragruntOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Lo
 
 // shellRunOptsFromPctx builds a *shell.ShellOptions from ParsingContext flat fields.
 func shellRunOptsFromPctx(pctx *ParsingContext) *shell.ShellOptions {
-	return shell.NewShellOptions().
+	s := shell.NewShellOptions().
 		WithWorkingDir(pctx.WorkingDir).
 		WithEnv(pctx.Env).
 		WithWriters(pctx.Writers).
@@ -1583,6 +1585,10 @@ func shellRunOptsFromPctx(pctx *ParsingContext) *shell.ShellOptions {
 		WithExperiments(pctx.Experiments).
 		WithHeadless(pctx.Headless).
 		WithForwardTFStdout(pctx.ForwardTFStdout)
+	s.LogShowAbsPaths = pctx.LogShowAbsPaths
+	s.LogDisableErrorSummary = pctx.LogDisableErrorSummary
+
+	return s
 }
 
 // tfRunOptsFromPctx builds a *tf.RunOptions from ParsingContext flat fields.

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -216,7 +216,7 @@ func handleIncludeForDependency(ctx context.Context, pctx *ParsingContext, l log
 				util.RelPathForLog(
 					pctx.RootWorkingDir,
 					includeConfig.Path,
-					pctx.Writers.LogShowAbsPaths,
+					pctx.LogShowAbsPaths,
 				),
 			)
 		case ShallowMerge:
@@ -225,7 +225,7 @@ func handleIncludeForDependency(ctx context.Context, pctx *ParsingContext, l log
 				util.RelPathForLog(
 					pctx.RootWorkingDir,
 					includeConfig.Path,
-					pctx.Writers.LogShowAbsPaths,
+					pctx.LogShowAbsPaths,
 				),
 			)
 
@@ -237,7 +237,7 @@ func handleIncludeForDependency(ctx context.Context, pctx *ParsingContext, l log
 				util.RelPathForLog(
 					pctx.RootWorkingDir,
 					includeConfig.Path,
-					pctx.Writers.LogShowAbsPaths,
+					pctx.LogShowAbsPaths,
 				),
 			)
 

--- a/pkg/config/locals.go
+++ b/pkg/config/locals.go
@@ -71,7 +71,7 @@ func EvaluateLocalsBlock(ctx context.Context, pctx *ParsingContext, l log.Logger
 			evaluatedLocals,
 		)
 		if err != nil {
-			l.Debugf("Encountered error while evaluating locals in file %s", util.RelPathForLog(pctx.RootWorkingDir, pctx.TerragruntConfigPath, pctx.Writers.LogShowAbsPaths))
+			l.Debugf("Encountered error while evaluating locals in file %s", util.RelPathForLog(pctx.RootWorkingDir, pctx.TerragruntConfigPath, pctx.LogShowAbsPaths))
 			return evaluatedLocals, err
 		}
 	}

--- a/pkg/config/parsing_context.go
+++ b/pkg/config/parsing_context.go
@@ -108,6 +108,8 @@ type ParsingContext struct {
 	SkipOutputsResolution            bool
 	NoStackValidate                  bool
 	NoCAS                            bool
+	LogShowAbsPaths                  bool
+	LogDisableErrorSummary           bool
 
 	// skipAutoIncludeMerge is set on contexts that parse the files an autoinclude pulls in through its
 	// own include blocks, so those files do not re-merge a sibling autoinclude. This bounds the merge to

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -137,7 +137,7 @@ func GenerateStackFile(ctx context.Context, l log.Logger, pctx *ParsingContext, 
 
 	genOpts := generateOpts{
 		rootWorkingDir:  pctx.RootWorkingDir,
-		logShowAbsPaths: pctx.Writers.LogShowAbsPaths,
+		logShowAbsPaths: pctx.LogShowAbsPaths,
 		sourceMap:       pctx.SourceMap,
 		noStackValidate: pctx.NoStackValidate,
 		stackConfigPath: pctx.TerragruntStackConfigPath,
@@ -1432,7 +1432,7 @@ func processLocals(ctx context.Context, l log.Logger, parser *ParsingContext, fi
 			evaluatedLocals,
 		)
 		if evalErr != nil {
-			l.Debugf("Encountered error while evaluating locals in file %s", util.RelPathForLog(parser.RootWorkingDir, file.ConfigPath, parser.Writers.LogShowAbsPaths))
+			l.Debugf("Encountered error while evaluating locals in file %s", util.RelPathForLog(parser.RootWorkingDir, file.ConfigPath, parser.LogShowAbsPaths))
 
 			return evalErr
 		}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -297,6 +297,11 @@ type TerragruntOptions struct {
 	NoHooks bool
 	// If set, disable automatic reading of .terragrunt-filters file.
 	NoFiltersFile bool
+	// LogShowAbsPaths disables replacing full paths in logs with short
+	// relative paths.
+	LogShowAbsPaths bool
+	// LogDisableErrorSummary suppresses the trailing error summary.
+	LogDisableErrorSummary bool
 }
 
 // TerragruntOptionsFunc is a functional option type used to pass options in certain integration tests


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

I'm breaking down the changes in https://github.com/gruntwork-io/terragrunt/pull/6092 as it has become unreviewable.

This initiates one of the changes, which is to move the `Log*` fields off `Writers`, so that the rest of the writers can be moved to `venv`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for controlling absolute path display in logs from a single top-level setting.
  * Added an option to suppress the trailing error summary in command output.

* **Bug Fixes**
  * Improved consistency in log and debug output so path formatting now follows the new settings across commands, config loading, dependency handling, and stack operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->