### PR TITLE
chore: Adding env and writers to venv

### DIFF
--- a/internal/runner/run/venv.go
+++ b/internal/runner/run/venv.go
@@ -1,48 +1,70 @@
 package run
 
 import (
+	"io"
+
 	"github.com/gruntwork-io/terragrunt/internal/tflint"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/writer"
 )
 
 // Venv is the virtualized environment threaded through the hook execution
-// chain. It bundles the process-execution handle and the filesystem so
-// callers supply both per call rather than the run package holding them as
-// package-level state. The name avoids "Env" so it is not confused with
-// shell environment variables.
+// chain. It bundles the process-execution handle, the filesystem, the
+// shell environment, and the stdout/stderr writers so callers supply them
+// per call rather than the run package holding them as package-level
+// state. The name avoids "Env" so it is not confused with shell
+// environment variables. Env is shared by reference across the run and
+// mutated in place as hook, inputs, and extra-args contributions resolve.
 type Venv struct {
-	// Exec runs hook commands and the embedded tflint binary.
-	Exec vexec.Exec
-	// FS backs filesystem reads performed inside hooks, including
-	// tflint's .tflint.hcl discovery.
-	FS vfs.FS
+	Exec    vexec.Exec
+	FS      vfs.FS
+	Env     map[string]string
+	Writers writer.Writers
 }
 
-// OSVenv builds the production [Venv]: real OS process execution and the
-// real OS filesystem.
+// OSVenv builds the production [Venv]: real OS process execution, real
+// OS filesystem, an OS environment snapshot, and the real OS streams.
 func OSVenv() Venv {
-	return Venv{Exec: vexec.NewOSExec(), FS: vfs.NewOSFS()}
+	return FromRoot(venv.OSVenv())
 }
 
 // FromRoot projects the root [venv.Venv] threaded from the CLI entrypoint
-// into the run package's local Venv. The two carry the same handles but
-// are distinct types so the run package owns its own contract.
+// into the run package's local Venv.
 func FromRoot(v venv.Venv) Venv {
-	return Venv{Exec: v.Exec, FS: v.FS}
+	return Venv{Exec: v.Exec, FS: v.FS, Env: v.Env, Writers: v.Writers}
 }
 
-// ToRoot is the inverse of [FromRoot]: it projects a run.Venv back into
-// the root [venv.Venv] for callers (notably config.ParsingContext) that
-// hold the root type.
+// ToRoot is the inverse of [FromRoot], for callers (notably
+// config.ParsingContext) that hold the root type.
 func (v Venv) ToRoot() venv.Venv {
-	return venv.Venv{FS: v.FS, Exec: v.Exec}
+	return venv.Venv{FS: v.FS, Exec: v.Exec, Env: v.Env, Writers: v.Writers}
 }
 
-// tflintVenv translates a run.Venv into the tflint package's Venv. The
-// two carry the same handles but are distinct types so each package owns
-// its own contract.
+// tflintVenv translates a run.Venv into the tflint package's Venv.
 func (v Venv) tflintVenv() tflint.Venv {
-	return tflint.Venv{Exec: v.Exec, FS: v.FS}
+	return tflint.Venv{Exec: v.Exec, FS: v.FS, Env: v.Env, Writers: v.Writers}
+}
+
+// RequireEnv panics with [venv.ErrVenvEnvUnset] when Env is nil, guarding
+// functions that write into the shared environment.
+func (v Venv) RequireEnv() {
+	if v.Env == nil {
+		panic(venv.ErrVenvEnvUnset)
+	}
+}
+
+// WithWriter returns a copy of v whose primary writer is w.
+func (v Venv) WithWriter(w io.Writer) Venv {
+	v.Writers.Writer = w
+
+	return v
+}
+
+// WithErrWriter returns a copy of v whose error writer is w.
+func (v Venv) WithErrWriter(w io.Writer) Venv {
+	v.Writers.ErrWriter = w
+
+	return v
 }

--- a/internal/tflint/venv.go
+++ b/internal/tflint/venv.go
@@ -4,31 +4,34 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/writer"
 )
 
 // Venv is the virtualized environment passed to tflint operations. It
-// bundles the process-execution handle and the filesystem so callers
-// supply both per call rather than the tflint package holding them as
-// package-level state. The name avoids "Env" so it is not confused with
-// shell environment variables.
+// bundles the process-execution handle, the filesystem, the shell
+// environment, and the stdout/stderr writers so callers supply them per
+// call rather than the tflint package holding them as package-level
+// state. The name avoids "Env" so it is not confused with shell
+// environment variables.
 type Venv struct {
-	// Exec runs the tflint binary. Tests can substitute a stub via
-	// [vexec.NewMemExec].
-	Exec vexec.Exec
-	// FS is the filesystem tflint reads through when searching for
-	// .tflint.hcl and filtering optional var-files.
-	FS vfs.FS
+	Exec    vexec.Exec
+	FS      vfs.FS
+	Env     map[string]string
+	Writers writer.Writers
 }
 
-// OSVenv builds the production [Venv]: real OS process execution and the
-// real OS filesystem.
+// OSVenv builds the production [Venv] from a real-OS [venv.OSVenv].
 func OSVenv() Venv {
-	return Venv{Exec: vexec.NewOSExec(), FS: vfs.NewOSFS()}
+	return FromRoot(venv.OSVenv())
 }
 
 // FromRoot projects the root [venv.Venv] threaded from the CLI entrypoint
-// into the tflint package's local Venv. The two carry the same handles but
-// are distinct types so the tflint package owns its own contract.
+// into the tflint package's local Venv.
 func FromRoot(v venv.Venv) Venv {
-	return Venv{Exec: v.Exec, FS: v.FS}
+	return Venv{Exec: v.Exec, FS: v.FS, Env: v.Env, Writers: v.Writers}
+}
+
+// ToRoot is the inverse of [FromRoot], for callers that hold the root type.
+func (v Venv) ToRoot() venv.Venv {
+	return venv.Venv{FS: v.FS, Exec: v.Exec, Env: v.Env, Writers: v.Writers}
 }

--- a/internal/venv/venv.go
+++ b/internal/venv/venv.go
@@ -1,9 +1,10 @@
 // Package venv defines the root virtualized environment threaded from the
 // Terragrunt binary entrypoint down through the CLI and its commands.
 //
-// A [Venv] bundles the two side-effect handles every layer below the CLI
-// needs to do its work: [vfs.FS] for filesystem reads and writes, and
-// [vexec.Exec] for spawning subprocesses. Production code constructs the
+// A [Venv] bundles the side-effect handles every layer below the CLI needs
+// to do its work: [vfs.FS] for filesystem reads and writes, [vexec.Exec]
+// for spawning subprocesses, the shell environment variables read at
+// startup, and the stdout/stderr writers. Production code constructs the
 // real bundle once at the top via [OSVenv]; tests construct an in-memory
 // bundle and drive the full CLI through it.
 //
@@ -13,22 +14,109 @@
 package venv
 
 import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/writer"
 )
 
-// Venv is the root virtualized environment. It carries the filesystem
-// and process-execution handles that every Terragrunt operation needs.
+// ErrVenvEnvUnset is the panic value [Venv.RequireEnv] raises when Env is
+// nil. Production callers build the Venv through [OSVenv], so it points at a
+// test that forgot to set Env rather than a runtime condition.
+var ErrVenvEnvUnset = errors.New("venv.Venv.Env is required but unset")
+
+// Venv is the root virtualized environment. It carries the filesystem,
+// process-execution, environment-variable, and writer handles that every
+// Terragrunt operation needs. Env is shared by reference across the run and
+// mutated in place as provider-cache, hook, and inputs contributions resolve.
 type Venv struct {
-	// FS backs every filesystem read and write.
-	FS vfs.FS
-	// Exec spawns every subprocess: tofu, terraform, git, hooks,
-	// external auth providers, tflint.
-	Exec vexec.Exec
+	FS      vfs.FS
+	Exec    vexec.Exec
+	Env     map[string]string
+	Writers writer.Writers
 }
 
-// OSVenv builds the production [Venv]: the real OS filesystem and the
-// real OS process executor.
+// WithWriter returns a copy of v whose primary writer is w.
+func (v Venv) WithWriter(w io.Writer) Venv {
+	v.Writers.Writer = w
+
+	return v
+}
+
+// WithErrWriter returns a copy of v whose error writer is w.
+func (v Venv) WithErrWriter(w io.Writer) Venv {
+	v.Writers.ErrWriter = w
+
+	return v
+}
+
+// WithExec returns a copy of v whose process executor is exec.
+func (v Venv) WithExec(exec vexec.Exec) Venv {
+	v.Exec = exec
+
+	return v
+}
+
+// WithHandler returns a copy of v whose executor is an in-memory exec driven
+// by h, for the in-memory test bundles this package serves.
+func (v Venv) WithHandler(h vexec.Handler) Venv {
+	v.Exec = vexec.NewMemExec(h)
+
+	return v
+}
+
+// WithFS returns a copy of v backed by fs.
+func (v Venv) WithFS(fs vfs.FS) Venv {
+	v.FS = fs
+
+	return v
+}
+
+// WithEnv returns a copy of v whose shell environment is env. A nil env
+// becomes an empty map so the result still satisfies [Venv.RequireEnv].
+func (v Venv) WithEnv(env map[string]string) Venv {
+	if env == nil {
+		env = map[string]string{}
+	}
+
+	v.Env = env
+
+	return v
+}
+
+// RequireEnv panics with [ErrVenvEnvUnset] when Env is nil, guarding
+// functions that write into the shared environment.
+func (v Venv) RequireEnv() {
+	if v.Env == nil {
+		panic(ErrVenvEnvUnset)
+	}
+}
+
+// OSVenv builds the production [Venv]: the real OS filesystem, the real
+// OS process executor, a snapshot of the OS environment, and stdout/stderr
+// wired to the real OS streams.
 func OSVenv() Venv {
-	return Venv{FS: vfs.NewOSFS(), Exec: vexec.NewOSExec()}
+	return Venv{
+		FS:      vfs.NewOSFS(),
+		Exec:    vexec.NewOSExec(),
+		Env:     parseEnviron(os.Environ()),
+		Writers: writer.Writers{Writer: os.Stdout, ErrWriter: os.Stderr},
+	}
+}
+
+// parseEnviron turns os.Environ-style KEY=VALUE entries into a map. An entry
+// with no "=" maps the whole string to an empty value.
+func parseEnviron(environ []string) map[string]string {
+	out := make(map[string]string, len(environ))
+
+	for _, entry := range environ {
+		key, value, _ := strings.Cut(entry, "=")
+		out[key] = value
+	}
+
+	return out
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Continues the progress of getting the changes of https://github.com/gruntwork-io/terragrunt/pull/6092 delivered incrementally by adding envs and writers to the venv struct.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for carrying shared environment values and output writers through the runtime setup.
  * Added convenience options to override standard output and error streams when composing runtime settings.
* **Bug Fixes**
  * Improved environment handling by ensuring missing environment state is detected early instead of failing later.
  * Default runtime setup now includes the current process environment and standard output/error streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->