### PR TITLE
fix: Fixing Git materialization race HEAD update

### DIFF
--- a/docs/src/data/changelog/v1.1.0/cas-git-source-permission-denied.mdx
+++ b/docs/src/data/changelog/v1.1.0/cas-git-source-permission-denied.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.0"
+category: "bug-fixes"
+---
+
+#### Fix `permission denied` when CAS fetches a git source across filesystems
+
+With the CAS enabled, fetching a `git::` source could fail with `permission denied` on `.git/HEAD` or `.git/config`, sending Terragrunt back to the standard getter. It happened when the CAS store and the module's working directory sit on different filesystems, so the files are copied rather than hard-linked, and a read-only leftover from an interrupted run was in the way. Terragrunt now recovers from the leftover and completes the fetch.

--- a/internal/cas/content.go
+++ b/internal/cas/content.go
@@ -108,21 +108,52 @@ func (c *Content) Link(
 			}
 		}
 
-		tempPath := targetPath + ".tmp"
-		if err := vfs.WriteFile(v.FS, tempPath, data, desired); err != nil {
+		targetDir := filepath.Dir(targetPath)
+		if err := v.FS.MkdirAll(targetDir, DefaultDirPerms); err != nil {
 			return &WrappedError{
 				Op:   "write_target",
-				Path: tempPath,
+				Path: targetDir,
 				Err:  err,
 			}
 		}
 
-		// Reapply perms after write to override any umask masking.
+		// A unique, freshly-writable temp avoids a fixed "<target>.tmp":
+		// reopening that name fails with EACCES once a prior write (an
+		// interrupted run, or a concurrent Link to the same target) left it at
+		// the read-only `desired` mode.
+		tmp, err := vfs.CreateTemp(v.FS, targetDir, filepath.Base(targetPath)+".tmp")
+		if err != nil {
+			return &WrappedError{
+				Op:   "write_target",
+				Path: targetDir,
+				Err:  err,
+			}
+		}
+
+		tempPath := tmp.Name()
+
+		if _, err := tmp.Write(data); err != nil {
+			return &WrappedError{
+				Op:   "write_target",
+				Path: tempPath,
+				Err:  errors.Join(err, tmp.Close(), v.FS.Remove(tempPath)),
+			}
+		}
+
+		if err := tmp.Close(); err != nil {
+			return &WrappedError{
+				Op:   "write_target",
+				Path: tempPath,
+				Err:  errors.Join(err, v.FS.Remove(tempPath)),
+			}
+		}
+
+		// CreateTemp opens at 0o600, so set the requested mode before publishing.
 		if err := v.FS.Chmod(tempPath, desired); err != nil {
 			return &WrappedError{
 				Op:   "chmod_target",
 				Path: tempPath,
-				Err:  err,
+				Err:  errors.Join(err, v.FS.Remove(tempPath)),
 			}
 		}
 
@@ -130,7 +161,7 @@ func (c *Content) Link(
 			return &WrappedError{
 				Op:   "rename_target",
 				Path: tempPath,
-				Err:  err,
+				Err:  errors.Join(err, v.FS.Remove(tempPath)),
 			}
 		}
 

--- a/internal/cas/content_test.go
+++ b/internal/cas/content_test.go
@@ -358,6 +358,38 @@ func TestContent_Link(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, testData, got)
 	})
+
+	t.Run("copy path recovers from a stale read-only temp file", func(t *testing.T) {
+		t.Parallel()
+
+		v, err := cas.OSVenv()
+		require.NoError(t, err)
+
+		storeDir := t.TempDir()
+		targetDir := t.TempDir()
+		store := cas.NewStore(storeDir)
+
+		content := cas.NewContent(store)
+		testHash := testHashValue
+		testData := []byte("ref: refs/heads/master\n")
+
+		require.NoError(t, content.Store(l, v, testHash, testData))
+
+		// Mismatched store perms route Link through the copy path.
+		require.NoError(t, os.Chmod(filepath.Join(storeDir, testHash[:2], testHash), 0o644))
+
+		targetPath := filepath.Join(targetDir, "HEAD")
+
+		// An interrupted run can leave a read-only temp file behind. Opening
+		// it for writing fails with EACCES, so Link must not reuse it.
+		require.NoError(t, os.WriteFile(targetPath+".tmp", []byte("partial"), 0o444))
+
+		require.NoError(t, content.Link(t.Context(), v, testHash, targetPath, 0o644))
+
+		got, err := os.ReadFile(targetPath)
+		require.NoError(t, err)
+		assert.Equal(t, testData, got)
+	})
 }
 
 func TestContent_EnsureWithWait(t *testing.T) {

--- a/internal/cas/race_test.go
+++ b/internal/cas/race_test.go
@@ -130,3 +130,55 @@ func TestProcessStackComponentLocalSourceConcurrentWithRacing(t *testing.T) {
 		assert.Equal(t, results[0], results[i], "all concurrent runs must produce identical rewritten output")
 	}
 }
+
+// TestContentLinkConcurrentSameTargetWithRacing holds Link to its
+// concurrency-safety contract: linking the same blob to the same target from
+// several goroutines must not fail. A fixed read-only "<target>.tmp" broke
+// this, since the race losers opened the winner's 0o444 temp for write.
+func TestContentLinkConcurrentSameTargetWithRacing(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+
+	v, err := cas.OSVenv()
+	require.NoError(t, err)
+
+	storeDir := t.TempDir()
+	store := cas.NewStore(storeDir)
+	content := cas.NewContent(store)
+
+	const hash = "3333333333333333333333333333333333333333"
+	require.NoError(t, content.Store(l, v, hash, []byte("ref: refs/heads/master\n")))
+
+	// Leave the stored blob writable so its perms differ from the requested
+	// read-only result, forcing Link onto the copy path even on a
+	// same-device filesystem where the hard link would otherwise succeed.
+	require.NoError(t, os.Chmod(filepath.Join(storeDir, hash[:2], hash), 0o644))
+
+	targetDir := t.TempDir()
+	gitDir := filepath.Join(targetDir, ".git")
+	require.NoError(t, os.MkdirAll(gitDir, 0o755))
+	targetPath := filepath.Join(gitDir, "HEAD")
+
+	const workers = 8
+
+	errs := make([]error, workers)
+
+	var wg sync.WaitGroup
+
+	for i := range workers {
+		wg.Add(1)
+
+		go func(idx int) {
+			defer wg.Done()
+
+			errs[idx] = content.Link(t.Context(), v, hash, targetPath, 0o644)
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, e := range errs {
+		require.NoErrorf(t, e, "worker %d failed to link the shared target", i)
+	}
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6408.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file linking to better recover from stale read-only temporary files and interrupted runs.
  * Reduced permission-denied errors when fetching or copying content across filesystems.
  * Made concurrent linking to the same destination more reliable.

* **Tests**
  * Added coverage for recovery from stale temporary files.
  * Added a concurrency test to verify multiple simultaneous links succeed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->