### PR TITLE
chore: Fixing legacy Windows per-drive key for environment variables

### DIFF
--- a/internal/venv/venv.go
+++ b/internal/venv/venv.go
@@ -103,19 +103,29 @@ func OSVenv() Venv {
 	return Venv{
 		FS:      vfs.NewOSFS(),
 		Exec:    vexec.NewOSExec(),
-		Env:     parseEnviron(os.Environ()),
+		Env:     ParseEnviron(os.Environ()),
 		Writers: writer.Writers{Writer: os.Stdout, ErrWriter: os.Stderr},
 	}
 }
 
-// parseEnviron turns os.Environ-style KEY=VALUE entries into a map. An entry
-// with no "=" maps the whole string to an empty value.
-func parseEnviron(environ []string) map[string]string {
+// ParseEnviron turns os.Environ-style KEY=VALUE entries into a map, splitting
+// on the first "=" after the leading byte. That leading byte is skipped so the
+// Windows per-drive working-directory variables, whose names begin with "="
+// (e.g. "=C:"), keep their names intact. Entries without a separator are dropped.
+func ParseEnviron(environ []string) map[string]string {
 	out := make(map[string]string, len(environ))
 
 	for _, entry := range environ {
-		key, value, _ := strings.Cut(entry, "=")
-		out[key] = value
+		if entry == "" {
+			continue
+		}
+
+		i := strings.IndexByte(entry[1:], '=')
+		if i < 0 {
+			continue
+		}
+
+		out[entry[:i+1]] = entry[i+2:]
 	}
 
 	return out

--- a/internal/venv/venv_test.go
+++ b/internal/venv/venv_test.go
@@ -1,0 +1,52 @@
+package venv_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseEnviron(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		want    map[string]string
+		name    string
+		environ []string
+	}{
+		{
+			name:    "standard entries",
+			environ: []string{"FOO=bar", "BAZ=qux"},
+			want:    map[string]string{"FOO": "bar", "BAZ": "qux"},
+		},
+		{
+			name:    "value contains equals",
+			environ: []string{"URL=https://example.com/?a=b"},
+			want:    map[string]string{"URL": "https://example.com/?a=b"},
+		},
+		{
+			name:    "empty value",
+			environ: []string{"EMPTY="},
+			want:    map[string]string{"EMPTY": ""},
+		},
+		{
+			name:    "entry without separator is dropped",
+			environ: []string{"NOSEP"},
+			want:    map[string]string{},
+		},
+		{
+			name:    "windows per-drive key keeps leading equals",
+			environ: []string{`=C:=C:\Users\alice`},
+			want:    map[string]string{`=C:`: `C:\Users\alice`},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, venv.ParseEnviron(tc.environ))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses feedback from #6404

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable parsing for virtual environment setup, including better handling of empty entries, values with extra `=`, and entries without a separator.
  * Preserved special Windows-style environment keys that begin with `=` so they are read correctly.

* **Tests**
  * Added coverage for common and edge-case environment variable formats to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->