### PR TITLE
feat: add --discovery-boundary to constrain dependent discovery

### DIFF
--- a/docs/src/data/changelog/v1.1.0/discovery-boundary.mdx
+++ b/docs/src/data/changelog/v1.1.0/discovery-boundary.mdx
@@ -1,0 +1,17 @@
+---
+version: "v1.1.0"
+category: "new-features"
+order: 7
+---
+
+#### Constrain dependent discovery with `--discovery-boundary`
+
+When a filter requests dependents (a leading `...`), Terragrunt walks up the filesystem to find them, scanning and parsing every configuration up to the repository root. When a single repository hosts several independent Terragrunt roots, that walk can leave the intended root and traverse unrelated subtrees.
+
+The new `--discovery-boundary` flag (env `TG_DISCOVERY_BOUNDARY`) constrains the dependent walk to a chosen directory subtree, for both in-place discovery and Git-based filters:
+
+```bash
+terragrunt find --filter '...{./some/unit}' --discovery-boundary "$PWD"
+```
+
+When unset, behavior is unchanged — the walk extends to the repository root — so the flag is fully opt-in and backward compatible.

--- a/docs/src/data/commands/find.mdx
+++ b/docs/src/data/commands/find.mdx
@@ -89,6 +89,7 @@ flags:
   - queue-construct-as
   - filter
   - filter-affected
+  - discovery-boundary
 ---
 
 import { Aside, Badge } from '@astrojs/starlight/components';

--- a/docs/src/data/commands/list.mdx
+++ b/docs/src/data/commands/list.mdx
@@ -102,6 +102,7 @@ flags:
   - queue-construct-as
   - filter
   - filter-affected
+  - discovery-boundary
 ---
 
 import { Aside, Badge } from '@astrojs/starlight/components';

--- a/docs/src/data/commands/run.mdx
+++ b/docs/src/data/commands/run.mdx
@@ -30,6 +30,7 @@ flags:
   - dependency-fetch-output-from-state
   - disable-bucket-update
   - disable-command-validation
+  - discovery-boundary
   - download-dir
   - out-dir
   - engine-cache-path

--- a/docs/src/data/flags/discovery-boundary.mdx
+++ b/docs/src/data/flags/discovery-boundary.mdx
@@ -1,0 +1,34 @@
+---
+name: discovery-boundary
+description: Constrain dependent discovery to a directory subtree
+type: string
+env:
+  - TG_DISCOVERY_BOUNDARY
+---
+
+The `--discovery-boundary` flag constrains [dependent discovery](/features/filter/graph) to a chosen directory subtree.
+
+When a filter requests dependents (a leading `...`, such as `...{./some/unit}` or `...[main...HEAD]`), Terragrunt finds them by walking up the filesystem from the working directory, scanning and parsing every configuration it encounters, until it reaches a boundary. By default that boundary is the repository root.
+
+When a single repository hosts several independent Terragrunt roots, that walk can leave the root you are working in and traverse unrelated subtrees. Pointing `--discovery-boundary` at a directory restricts the walk to that subtree, so configurations outside it are never scanned, parsed, or returned. This applies both to in-place discovery and to Git-based filters that run inside temporary worktrees.
+
+When the flag is unset, behavior is unchanged: the walk extends to the repository root.
+
+## Usage
+
+```bash
+# Only consider dependents within the current directory subtree
+terragrunt find --filter '...{./some/unit}' --discovery-boundary "$PWD"
+
+# Works with Git-based dependent discovery as well
+terragrunt list --filter '...[main...HEAD]' --discovery-boundary ./infra
+```
+
+The value must be an existing directory. If it resolves outside the repository, dependent discovery has nothing in scope and no additional dependents are returned.
+
+## Supported Commands
+
+- [find](/reference/cli/commands/find)
+- [list](/reference/cli/commands/list)
+- [run](/reference/cli/commands/run)
+- [dag graph](/reference/cli/commands/dag/graph)

--- a/internal/cli/commands/dag/graph/cli.go
+++ b/internal/cli/commands/dag/graph/cli.go
@@ -23,6 +23,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions) *clihelper.Comman
 	sharedFlags = append(sharedFlags, shared.NewBackendFlags(opts, nil)...)
 	sharedFlags = append(sharedFlags, shared.NewFeatureFlags(opts, nil)...)
 	sharedFlags = append(sharedFlags, shared.NewFilterFlags(l, opts)...)
+	sharedFlags = append(sharedFlags, shared.NewDiscoveryBoundaryFlag(opts))
 
 	return &clihelper.Command{
 		Name: CommandName,

--- a/internal/cli/commands/dag/graph/cli_test.go
+++ b/internal/cli/commands/dag/graph/cli_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/dag/graph"
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,4 +71,16 @@ func BenchmarkRunGraphDependencies(b *testing.B) {
 			require.NoError(b, err)
 		})
 	}
+}
+
+// TestDiscoveryBoundaryFlagParses asserts the shared --discovery-boundary flag is wired into
+// `dag graph` and populates opts.DiscoveryBoundary.
+func TestDiscoveryBoundaryFlagParses(t *testing.T) {
+	t.Parallel()
+
+	opts := options.NewTerragruntOptions()
+	cmd := graph.NewCommand(logger.CreateLogger(), opts)
+
+	require.NoError(t, cmd.Flags.Parse(clihelper.Args{"--discovery-boundary", "/some/boundary"}))
+	assert.Equal(t, "/some/boundary", opts.DiscoveryBoundary)
 }

--- a/internal/cli/commands/find/cli.go
+++ b/internal/cli/commands/find/cli.go
@@ -41,7 +41,7 @@ func NewFlags(l log.Logger, opts *Options, prefix flags.Prefix) clihelper.Flags 
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 	filterFlags := shared.NewFilterFlags(l, opts.TerragruntOptions)
 
-	const numLocalFlags = 11
+	const numLocalFlags = 12
 
 	result := make(clihelper.Flags, 0, numLocalFlags+len(filterFlags))
 	result = append(result,
@@ -139,6 +139,7 @@ func NewFlags(l log.Logger, opts *Options, prefix flags.Prefix) clihelper.Flags 
 			Usage:       "Construct the queue as if a specific command was run.",
 			Aliases:     []string{QueueConstructAsFlagAlias},
 		}),
+		shared.NewDiscoveryBoundaryFlag(opts.TerragruntOptions),
 	)
 
 	return append(result, filterFlags...)

--- a/internal/cli/commands/find/find.go
+++ b/internal/cli/commands/find/find.go
@@ -26,6 +26,7 @@ import (
 func Run(ctx context.Context, l log.Logger, opts *Options) error {
 	d, err := discovery.NewForDiscoveryCommand(l, &discovery.DiscoveryCommandOptions{
 		WorkingDir:        opts.WorkingDir,
+		Boundary:          opts.DiscoveryBoundary,
 		QueueConstructAs:  opts.QueueConstructAs,
 		NoHidden:          opts.NoHidden,
 		WithRequiresParse: opts.Dependencies || opts.Mode == ModeDAG,

--- a/internal/cli/commands/find/find_test.go
+++ b/internal/cli/commands/find/find_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/find"
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -637,4 +638,83 @@ func TestColorizer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRunDiscoveryBoundaryExcludesOutOfBoundaryDependent runs `find` end-to-end and asserts
+// that --discovery-boundary (opts.DiscoveryBoundary) excludes a dependent living in a sibling
+// subtree outside the boundary, while a control run (no boundary) includes it.
+func TestRunDiscoveryBoundaryExcludesOutOfBoundaryDependent(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+	helpers.InitTestGitRunner(t, tmpDir)
+
+	projDir := filepath.Join(tmpDir, "proj")
+	baseDir := filepath.Join(projDir, "base")
+	appDir := filepath.Join(projDir, "app")
+	consumerDir := filepath.Join(tmpDir, "consumer")
+
+	for _, dir := range []string{baseDir, appDir, consumerDir} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, "terragrunt.hcl"), []byte(``), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "terragrunt.hcl"), []byte(`
+dependency "base" {
+  config_path = "../base"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(consumerDir, "terragrunt.hcl"), []byte(`
+dependency "base" {
+  config_path = "../proj/base"
+}
+`), 0o644))
+
+	run := func(boundary string) string {
+		tgOpts := options.NewTerragruntOptions()
+		tgOpts.WorkingDir = projDir
+		tgOpts.RootWorkingDir = projDir
+		tgOpts.DiscoveryBoundary = boundary
+
+		l := logger.CreateLogger()
+		l.Formatter().SetDisabledColors(true)
+
+		filters, err := filter.ParseFilterQueries(l, []string{`...{` + baseDir + `}`})
+		require.NoError(t, err)
+
+		opts := find.NewOptions(tgOpts)
+		opts.Filters = filters
+
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+
+		opts.Writers.Writer = w
+
+		require.NoError(t, find.Run(t.Context(), l, opts))
+		require.NoError(t, w.Close())
+
+		output, err := io.ReadAll(r)
+		require.NoError(t, err)
+
+		return string(output)
+	}
+
+	control := run("")
+	assert.Contains(t, control, "consumer", "control should include the out-of-boundary dependent")
+
+	bounded := run(projDir)
+	assert.Contains(t, bounded, "app", "in-boundary dependent should still be listed")
+	assert.NotContains(t, bounded, "consumer", "boundary should exclude the out-of-boundary dependent")
+}
+
+// TestDiscoveryBoundaryFlagParses asserts the shared --discovery-boundary flag is wired into
+// `find` and populates opts.DiscoveryBoundary.
+func TestDiscoveryBoundaryFlagParses(t *testing.T) {
+	t.Parallel()
+
+	tgOpts := options.NewTerragruntOptions()
+	cmdFlags := find.NewFlags(logger.CreateLogger(), find.NewOptions(tgOpts), nil)
+
+	require.NoError(t, cmdFlags.Parse(clihelper.Args{"--discovery-boundary", "/some/boundary"}))
+	assert.Equal(t, "/some/boundary", tgOpts.DiscoveryBoundary)
 }

--- a/internal/cli/commands/list/cli.go
+++ b/internal/cli/commands/list/cli.go
@@ -41,7 +41,7 @@ func NewFlags(l log.Logger, opts *Options, prefix flags.Prefix) clihelper.Flags 
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 	filterFlags := shared.NewFilterFlags(l, opts.TerragruntOptions)
 
-	const numLocalFlags = 9
+	const numLocalFlags = 10
 
 	result := make(clihelper.Flags, 0, numLocalFlags+len(filterFlags))
 	result = append(result,
@@ -128,6 +128,7 @@ func NewFlags(l log.Logger, opts *Options, prefix flags.Prefix) clihelper.Flags 
 			Usage:       "Construct the queue as if a specific command was run.",
 			Aliases:     []string{QueueConstructAsFlagAlias},
 		}),
+		shared.NewDiscoveryBoundaryFlag(opts.TerragruntOptions),
 	)
 
 	return append(result, filterFlags...)

--- a/internal/cli/commands/list/list.go
+++ b/internal/cli/commands/list/list.go
@@ -30,6 +30,7 @@ import (
 func Run(ctx context.Context, l log.Logger, opts *Options) error {
 	d, err := discovery.NewForDiscoveryCommand(l, &discovery.DiscoveryCommandOptions{
 		WorkingDir:        opts.WorkingDir,
+		Boundary:          opts.DiscoveryBoundary,
 		QueueConstructAs:  opts.QueueConstructAs,
 		NoHidden:          opts.NoHidden,
 		WithRequiresParse: opts.Dependencies || opts.Mode == ModeDAG,

--- a/internal/cli/commands/list/list_test.go
+++ b/internal/cli/commands/list/list_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/list"
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/view/dag"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -1030,4 +1031,16 @@ dependency "unit3" {
 `,
 		outputStr,
 	)
+}
+
+// TestDiscoveryBoundaryFlagParses asserts the shared --discovery-boundary flag is wired into
+// `list` and populates opts.DiscoveryBoundary.
+func TestDiscoveryBoundaryFlagParses(t *testing.T) {
+	t.Parallel()
+
+	tgOpts := options.NewTerragruntOptions()
+	cmdFlags := list.NewFlags(logger.CreateLogger(), list.NewOptions(tgOpts), nil)
+
+	require.NoError(t, cmdFlags.Parse(clihelper.Args{"--discovery-boundary", "/some/boundary"}))
+	assert.Equal(t, "/some/boundary", tgOpts.DiscoveryBoundary)
 }

--- a/internal/cli/commands/run/flags.go
+++ b/internal/cli/commands/run/flags.go
@@ -526,6 +526,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 	cmdFlags = cmdFlags.Add(shared.NewFilterFlags(l, opts)...)
 	cmdFlags = cmdFlags.Add(shared.NewParallelismFlag(opts))
 	cmdFlags = cmdFlags.Add(shared.NewCASFlags(opts, prefix)...)
+	cmdFlags = cmdFlags.Add(shared.NewDiscoveryBoundaryFlag(opts))
 
 	return cmdFlags.Sort()
 }

--- a/internal/cli/commands/run/flags_test.go
+++ b/internal/cli/commands/run/flags_test.go
@@ -38,3 +38,15 @@ func TestNoHooksFlagAllowedWithExperiment(t *testing.T) {
 	require.NoError(t, flags.RunActions(context.Background(), &clihelper.Context{}))
 	assert.True(t, opts.NoRunHooks)
 }
+
+// TestDiscoveryBoundaryFlagParses asserts the shared --discovery-boundary flag is wired into
+// `run` and populates opts.DiscoveryBoundary.
+func TestDiscoveryBoundaryFlagParses(t *testing.T) {
+	t.Parallel()
+
+	opts := options.NewTerragruntOptions()
+	flags := runcommand.NewFlags(logger.CreateLogger(), opts, nil)
+
+	require.NoError(t, flags.Parse(clihelper.Args{"--discovery-boundary", "/some/boundary"}))
+	assert.Equal(t, "/some/boundary", opts.DiscoveryBoundary)
+}

--- a/internal/cli/flags/shared/discoveryboundary.go
+++ b/internal/cli/flags/shared/discoveryboundary.go
@@ -1,0 +1,46 @@
+package shared
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+)
+
+// DiscoveryBoundaryFlagName is the name of the --discovery-boundary flag.
+const DiscoveryBoundaryFlagName = "discovery-boundary"
+
+// NewDiscoveryBoundaryFlag creates the shared --discovery-boundary flag. It
+// constrains dependent discovery (leading '...' filters) to a directory subtree
+// instead of walking up to the git root, and validates that the value is an
+// existing directory.
+func NewDiscoveryBoundaryFlag(opts *options.TerragruntOptions) *flags.Flag {
+	tgPrefix := flags.Prefix{flags.TgPrefix}
+
+	return flags.NewFlag(&clihelper.GenericFlag[string]{
+		Name:        DiscoveryBoundaryFlagName,
+		EnvVars:     tgPrefix.EnvVars(DiscoveryBoundaryFlagName),
+		Destination: &opts.DiscoveryBoundary,
+		Usage: "Constrain dependent discovery (leading '...' filters) to this directory" +
+			" subtree instead of walking up to the git root.",
+		Action: func(_ context.Context, _ *clihelper.Context, val string) error {
+			if val == "" {
+				return nil
+			}
+
+			info, err := os.Stat(val)
+			if err != nil {
+				return fmt.Errorf("--%s: %w", DiscoveryBoundaryFlagName, err)
+			}
+
+			if !info.IsDir() {
+				return fmt.Errorf("--%s %q is not a directory", DiscoveryBoundaryFlagName, val)
+			}
+
+			return nil
+		},
+	})
+}

--- a/internal/cli/flags/shared/discoveryboundary_test.go
+++ b/internal/cli/flags/shared/discoveryboundary_test.go
@@ -1,0 +1,56 @@
+package shared_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/flags/shared"
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDiscoveryBoundaryFlagValidation verifies that --discovery-boundary rejects values that
+// are not existing directories and accepts an existing directory.
+func TestDiscoveryBoundaryFlagValidation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	file := filepath.Join(dir, "file.txt")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
+
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "existing directory is accepted", value: dir, wantErr: false},
+		{name: "non-existent path is rejected", value: filepath.Join(dir, "missing"), wantErr: true},
+		{name: "file (not a directory) is rejected", value: file, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := options.NewTerragruntOptions()
+			cmdFlags := clihelper.Flags{shared.NewDiscoveryBoundaryFlag(opts)}
+
+			require.NoError(t, cmdFlags.Parse(clihelper.Args{"--discovery-boundary", tt.value}))
+
+			err := cmdFlags.RunActions(context.Background(), &clihelper.Context{})
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.value, opts.DiscoveryBoundary)
+		})
+	}
+}

--- a/internal/discovery/constructor.go
+++ b/internal/discovery/constructor.go
@@ -15,6 +15,7 @@ import (
 // DiscoveryCommandOptions contains options for discovery commands like find and list.
 type DiscoveryCommandOptions struct {
 	WorkingDir        string
+	Boundary          string
 	QueueConstructAs  string
 	Filters           filter.Filters
 	Experiments       experiment.Experiments
@@ -93,6 +94,10 @@ func NewForDiscoveryCommand(l log.Logger, opts *DiscoveryCommandOptions) (*Disco
 			Cmd:        cmd,
 			Args:       args,
 		})
+	}
+
+	if opts.Boundary != "" {
+		d = d.WithBoundary(opts.Boundary)
 	}
 
 	if len(opts.Filters) > 0 {

--- a/internal/discovery/options.go
+++ b/internal/discovery/options.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"path/filepath"
 	"slices"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
@@ -141,6 +142,28 @@ func (d *Discovery) WithRelationships() *Discovery {
 // WithGitRoot sets the git root directory for dependent discovery boundary.
 func (d *Discovery) WithGitRoot(gitRoot string) *Discovery {
 	d.gitRoot = gitRoot
+	return d
+}
+
+// WithBoundary constrains dependent discovery to the given directory subtree
+// instead of walking up to the git root. The value is resolved to an absolute,
+// symlink-evaluated path so it matches how gitRoot and worktree paths are stored.
+func (d *Discovery) WithBoundary(boundary string) *Discovery {
+	if boundary == "" {
+		return d
+	}
+
+	abs, err := filepath.Abs(boundary)
+	if err != nil {
+		abs = filepath.Clean(boundary)
+	}
+
+	if resolved, evalErr := filepath.EvalSymlinks(abs); evalErr == nil {
+		abs = resolved
+	}
+
+	d.boundary = abs
+
 	return d
 }
 

--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -216,15 +216,39 @@ func (p *GraphPhase) processGraphTarget(
 			return err
 		}
 
-		if state.discovery.gitRoot != "" {
+		// The effective boundary for the upstream dependent walk is the explicit
+		// --discovery-boundary when set, otherwise the git root (today's default).
+		boundary := state.discovery.boundary
+		if boundary == "" {
+			boundary = state.discovery.gitRoot
+		}
+
+		if boundary != "" {
 			startDir := state.discovery.workingDir
-			boundaryRoot := state.discovery.gitRoot
+			boundaryRoot := boundary
 
 			if dCtx := c.DiscoveryContext(); dCtx != nil &&
 				dCtx.WorkingDir != "" &&
 				dCtx.WorkingDir != state.discovery.workingDir {
-				startDir = dCtx.WorkingDir
-				boundaryRoot = dCtx.WorkingDir
+				// The target was discovered in a worktree: a full checkout rooted at
+				// dCtx.WorkingDir. Translate the real-tree paths into the worktree
+				// using their gitRoot-relative form.
+				worktreeRoot := dCtx.WorkingDir
+
+				if state.discovery.boundary != "" {
+					boundaryRoot = mapIntoWorktree(worktreeRoot, state.discovery.gitRoot, state.discovery.boundary)
+					startDir = mapIntoWorktree(worktreeRoot, state.discovery.gitRoot, state.discovery.workingDir)
+				} else {
+					// No boundary set: preserve the original whole-worktree behavior.
+					startDir = worktreeRoot
+					boundaryRoot = worktreeRoot
+				}
+			}
+
+			// Begin the walk inside the boundary even when the working dir is
+			// elsewhere; otherwise the prefix check would abort it immediately.
+			if !withinBoundary(startDir, boundaryRoot) {
+				startDir = boundaryRoot
 			}
 
 			l.Debugf(
@@ -781,4 +805,22 @@ func (p *GraphPhase) resolveDependency(
 	parent.AddDependency(addedComponent)
 
 	return addedComponent, nil
+}
+
+// mapIntoWorktree translates a real-tree path p (under repoRoot) into the
+// equivalent path inside worktreeRoot, using p's repo-relative form. It returns
+// worktreeRoot when p is repoRoot itself or escapes the repo (rel begins "..").
+func mapIntoWorktree(worktreeRoot, repoRoot, p string) string {
+	rel, err := filepath.Rel(util.ResolvePath(repoRoot), util.ResolvePath(p))
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return worktreeRoot
+	}
+
+	return filepath.Join(worktreeRoot, rel)
+}
+
+// withinBoundary reports whether dir is the boundary directory or a descendant of
+// it. It is the negation of isExternal and resolves symlinks for consistency.
+func withinBoundary(dir, boundary string) bool {
+	return !isExternal(boundary, dir)
 }

--- a/internal/discovery/phase_graph_boundary_test.go
+++ b/internal/discovery/phase_graph_boundary_test.go
@@ -1,0 +1,188 @@
+package discovery_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/internal/worktrees"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+// TestDiscoveryDependentBoundary_InPlace verifies that --discovery-boundary
+// (WithBoundary) constrains the upstream dependent walk to a directory subtree.
+//
+// Layout (git root = tmpDir, working dir = proj):
+//
+//	proj/base      <- target
+//	proj/app       <- depends on ../base       (in boundary)
+//	consumer       <- depends on ../proj/base   (sibling subtree, out of boundary)
+//
+// The filesystem phase only discovers units under the working dir (proj), so the
+// out-of-boundary consumer can only ever be reached by the upstream walk. Bounding
+// that walk to proj therefore excludes it; without a boundary it is included.
+func TestDiscoveryDependentBoundary_InPlace(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	projDir := filepath.Join(tmpDir, "proj")
+	baseDir := filepath.Join(projDir, "base")
+	appDir := filepath.Join(projDir, "app")
+	consumerDir := filepath.Join(tmpDir, "consumer")
+
+	for _, dir := range []string{baseDir, appDir, consumerDir} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, "terragrunt.hcl"), []byte(``), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "terragrunt.hcl"), []byte(`
+dependency "base" {
+  config_path = "../base"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(consumerDir, "terragrunt.hcl"), []byte(`
+dependency "base" {
+  config_path = "../proj/base"
+}
+`), 0o644))
+
+	run := func(boundary string) []string {
+		opts := options.NewTerragruntOptions()
+		opts.WorkingDir = projDir
+		opts.RootWorkingDir = projDir
+
+		filters, err := filter.ParseFilterQueries(logger.CreateLogger(), []string{`...{` + baseDir + `}`})
+		require.NoError(t, err)
+
+		d := discovery.NewDiscovery(projDir).
+			WithExec(memGitTopLevelExec(t, tmpDir)).
+			WithFilters(filters)
+
+		if boundary != "" {
+			d = d.WithBoundary(boundary)
+		}
+
+		configs, err := d.Discover(t.Context(), logger.CreateLogger(), opts)
+		require.NoError(t, err)
+
+		return configs.Filter(component.UnitKind).Paths()
+	}
+
+	// Control: no boundary, the walk reaches the git root and finds the sibling consumer.
+	control := run("")
+	assert.Contains(t, control, baseDir, "target should be discovered")
+	assert.Contains(t, control, appDir, "in-boundary dependent should be discovered")
+	assert.Contains(t, control, consumerDir, "without a boundary the out-of-boundary dependent is included")
+
+	// Bounded to proj: the out-of-boundary consumer is excluded, the in-boundary app remains.
+	bounded := run(projDir)
+	assert.Contains(t, bounded, baseDir, "target should still be discovered")
+	assert.Contains(t, bounded, appDir, "in-boundary dependent should still be discovered")
+	assert.NotContains(t, bounded, consumerDir, "boundary should exclude the out-of-boundary dependent")
+}
+
+// TestDiscoveryDependentBoundary_Worktree verifies that --discovery-boundary
+// constrains dependent discovery for Git-based filters, which run inside a full
+// worktree checkout. The boundary (a real-tree path) is translated into the
+// worktree before the upstream walk.
+//
+// Layout (git root = tmpDir): proj/base changes between HEAD~1 and HEAD; proj/app
+// depends on it (in boundary) and consumer depends on it (out of boundary). With
+// boundary = proj, the consumer is excluded; without it, it is included.
+func TestDiscoveryDependentBoundary_Worktree(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	createUnit(t, tmpDir, filepath.Join("proj", "base"), `# base`)
+	createUnit(t, tmpDir, filepath.Join("proj", "app"), `
+dependency "base" {
+  config_path = "../base"
+}
+`)
+	createUnit(t, tmpDir, "consumer", `
+dependency "base" {
+  config_path = "../proj/base"
+}
+`)
+	commitChanges(t, runner, "initial commit")
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, "proj", "base", "terragrunt.hcl"),
+		[]byte("locals {\n  changed = true\n}\n"), 0o644))
+	commitChanges(t, runner, "change base")
+
+	sep := string(filepath.Separator)
+
+	// Control: no boundary, the walk covers the whole worktree and finds the consumer.
+	control := runBoundaryWorktreeDiscovery(t, tmpDir, "")
+	assert.True(t, anyHasSuffix(control, sep+"consumer"),
+		"without a boundary the out-of-boundary dependent is included: %v", control)
+
+	// Bounded to proj: the consumer is excluded while the in-boundary app remains.
+	bounded := runBoundaryWorktreeDiscovery(t, tmpDir, filepath.Join(tmpDir, "proj"))
+	assert.True(t, anyHasSuffix(bounded, sep+"app"),
+		"in-boundary dependent should still be discovered: %v", bounded)
+	assert.False(t, anyHasSuffix(bounded, sep+"consumer"),
+		"boundary should exclude the out-of-boundary dependent: %v", bounded)
+}
+
+// runBoundaryWorktreeDiscovery runs a git-filter discovery for `...[HEAD~1...HEAD]`
+// from tmpDir, optionally constrained by boundary, and returns the unit paths.
+func runBoundaryWorktreeDiscovery(t *testing.T, tmpDir, boundary string) []string {
+	t.Helper()
+
+	l := logger.CreateLogger()
+
+	filters, err := filter.ParseFilterQueries(l, []string{"...[HEAD~1...HEAD]"})
+	require.NoError(t, err)
+
+	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: filters.UniqueGitFilters(),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l))
+	})
+
+	opts := options.NewTerragruntOptions()
+	opts.WorkingDir = tmpDir
+	opts.RootWorkingDir = tmpDir
+
+	d := discovery.NewDiscovery(tmpDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
+		WithWorktrees(w).
+		WithFilters(filters)
+
+	if boundary != "" {
+		d = d.WithBoundary(boundary)
+	}
+
+	components, err := d.Discover(t.Context(), l, opts)
+	require.NoError(t, err)
+
+	return components.Filter(component.UnitKind).Paths()
+}
+
+func anyHasSuffix(paths []string, suffix string) bool {
+	for _, p := range paths {
+		if strings.HasSuffix(p, suffix) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -135,8 +135,13 @@ type Discovery struct {
 	// workingDir is the directory to search for Terragrunt configurations.
 	workingDir string
 
-	// gitRoot is the git repository root, used as boundary for dependent discovery.
+	// gitRoot is the git repository root: the anchor for translating paths into
+	// worktrees and the default boundary for dependent discovery.
 	gitRoot string
+
+	// boundary, when set, constrains dependent discovery to this directory subtree
+	// instead of walking up to gitRoot. Empty means "use gitRoot".
+	boundary string
 
 	// graphTarget is the target path for graph filtering (prune to target + dependents).
 	graphTarget string

--- a/internal/runner/runnerpool/builder_helpers.go
+++ b/internal/runner/runnerpool/builder_helpers.go
@@ -107,6 +107,11 @@ func prepareDiscovery(
 		d = d.WithFilters(opts.Filters)
 	}
 
+	// Constrain dependent discovery to the configured boundary subtree, when set.
+	if opts.DiscoveryBoundary != "" {
+		d = d.WithBoundary(opts.DiscoveryBoundary)
+	}
+
 	// Apply worktrees for git filter expressions
 	if w := extractWorktrees(runnerOpts); w != nil {
 		d = d.WithWorktrees(w)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -155,6 +155,9 @@ type TerragruntOptions struct {
 	ReportFile string
 	// Path to a file containing filter queries, one per line. Default is .terragrunt-filters.
 	FiltersFile string
+	// DiscoveryBoundary constrains dependent discovery (leading `...` filters) to this
+	// directory subtree instead of walking up to the git root. Empty = git root (default).
+	DiscoveryBoundary string
 	// Report format.
 	ReportFormat report.Format
 	// Path to the report schema file.


### PR DESCRIPTION
## Description

Closes #6416.

When a filter requests **dependents** (a leading `...`, e.g. `...{some/unit}` or `...[main...HEAD]`), Terragrunt discovers them by walking *up* the filesystem from the working directory, scanning and parsing every configuration it finds, until it reaches a boundary. That boundary is hardcoded to the git repository root.

In a repository that hosts several independent Terragrunt roots under a single git root, this makes the dependent walk leave the root you are working in and traverse/parse unrelated subtrees.

This PR adds a `--discovery-boundary <dir>` flag (env `TG_DISCOVERY_BOUNDARY`) that constrains the dependent walk to a chosen directory subtree, for both in-place discovery and the git-filter case (temporary worktrees). **When unset, behavior is unchanged** — the boundary defaults to the git root — so the change is fully opt-in and backward compatible.

```bash
terragrunt find --filter '...{./some/unit}' --discovery-boundary "$PWD"
```

The flag is available on `find`, `list`, `run`, and `dag graph`.

## How it works

- `Discovery` keeps `gitRoot` (the real repo root — still the anchor used to translate paths into worktrees) and adds a separate `boundary`. The effective boundary for the dependent walk is `boundary` when set, otherwise `gitRoot` (today's default).
- The single behavioral change lives in `internal/discovery/phase_graph.go` (the `IncludeDependents` block that all commands route through):
  - **In-place:** `boundaryRoot = boundary`, `startDir = workingDir`.
  - **Worktree (git filter):** the real-tree boundary/working dir are translated into the worktree via their `gitRoot`-relative form, since the worktree is a full checkout rooted elsewhere. When `boundary` is unset, this preserves the previous whole-worktree behavior exactly.
- The flag is a shared flag (`internal/cli/flags/shared`) wired into `find`, `list`, `run`, and `dag graph`, and validates that the value is an existing directory.

## Tests

CI does not run automatically for fork PRs, so here is the local output.

Build and unit tests:

```
$ go build ./...
ok

$ go test ./internal/discovery/... ./internal/cli/commands/{find,list,run,dag}/... ./internal/cli/flags/shared/... ./internal/runner/runnerpool/...
ok  	github.com/gruntwork-io/terragrunt/internal/discovery
ok  	github.com/gruntwork-io/terragrunt/internal/cli/commands/find
ok  	github.com/gruntwork-io/terragrunt/internal/cli/commands/list
ok  	github.com/gruntwork-io/terragrunt/internal/cli/commands/run
ok  	github.com/gruntwork-io/terragrunt/internal/cli/commands/dag/graph
ok  	github.com/gruntwork-io/terragrunt/internal/cli/flags/shared
ok  	github.com/gruntwork-io/terragrunt/internal/runner/runnerpool
```

The full `go test ./internal/runner/...` suite also passes, and `golangci-lint run` (v2.11.4, the version pinned in `mise.toml`) reports **0 issues** on the touched packages.

New tests: discovery-level coverage for the in-place and worktree (git-filter) dependent walks, an end-to-end `find` test, flag-parsing tests for find/list/run/dag graph, and boundary validation.

Manual end-to-end, in a repo with a Terragrunt root subtree (`$PWD`) plus a dependent in a sibling subtree under the same git root:

```
$ terragrunt find --filter '...[C1...C2]...'                              # app, base, other/consumer
$ terragrunt find --filter '...[C1...C2]...' --discovery-boundary "$PWD"  # app, base   (consumer excluded)
$ terragrunt find --filter '...base'                                      # app, base, other/consumer
$ terragrunt find --filter '...base' --discovery-boundary "$PWD"          # app, base   (consumer excluded)
```

## Backwards compatibility

No backward-incompatible change. The flag is opt-in; unset reproduces current behavior exactly (the boundary defaults to the git root).

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] I authored this code entirely myself
- [X] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [X] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [X] Update the docs.
- [X] Update the changelog in the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `--discovery-boundary` option, configurable via environment variable, to limit discovery to a specific directory subtree.
  * Updated supported commands to include the new option: `find`, `list`, `run`, and `dag graph`.

* **Bug Fixes**
  * Discovery now stays within the selected boundary, helping avoid unexpected results when a repository contains multiple independent roots.
  * The new option works consistently for both local discovery and Git-based workflows.

* **Documentation**
  * Added documentation and examples for the new option, including usage details and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->