### PR TITLE
fix: pass -replace value-taking flag through to IaC tool

### DIFF
--- a/internal/iacargs/iacargs.go
+++ b/internal/iacargs/iacargs.go
@@ -41,6 +41,7 @@ var valueTakingFlags = []string{
 	"state-out",
 	"backup",
 	"target",
+	"replace",
 	"var",
 	"var-file",
 }

--- a/internal/iacargs/iacargs_test.go
+++ b/internal/iacargs/iacargs_test.go
@@ -81,6 +81,27 @@ func TestNew(t *testing.T) {
 			wantArgs:  nil,
 		},
 		{
+			name:      "replace with space-separated value",
+			input:     []string{"plan", "-replace", "aws_instance.foo", "-out=tfplan"},
+			wantCmd:   "plan",
+			wantFlags: []string{"-replace", "aws_instance.foo", "-out=tfplan"},
+			wantArgs:  nil,
+		},
+		{
+			name:      "multiple replace flags space-separated",
+			input:     []string{"plan", "-replace", "aws_instance.a", "-replace", "aws_instance.b"},
+			wantCmd:   "plan",
+			wantFlags: []string{"-replace", "aws_instance.a", "-replace", "aws_instance.b"},
+			wantArgs:  nil,
+		},
+		{
+			name:      "replace with equals value",
+			input:     []string{"plan", "-replace=aws_instance.foo"},
+			wantCmd:   "plan",
+			wantFlags: []string{"-replace=aws_instance.foo"},
+			wantArgs:  nil,
+		},
+		{
 			// Unknown flags are treated as boolean. If a new Terraform flag needs
 			// space-separated values, add it to valueTakingFlags list.
 			name:      "unknown flag treated as boolean",
@@ -254,6 +275,11 @@ func TestIacArgsRoundTrip(t *testing.T) {
 			name:  "state mv subcommand preserves order",
 			input: []string{"state", "mv", "-lock=false", "aws_instance.a", "aws_instance.b"},
 			want:  []string{"state", "mv", "-lock=false", "aws_instance.a", "aws_instance.b"},
+		},
+		{
+			name:  "replace flags keep their space-separated values (#6418)",
+			input: []string{"apply", "-replace", "aws_instance.a", "-replace", "aws_instance.b", "-auto-approve"},
+			want:  []string{"apply", "-replace", "aws_instance.a", "-replace", "aws_instance.b", "-auto-approve"},
 		},
 	}
 


### PR DESCRIPTION
## Description

`-replace` was being silently stripped of its value when passed in the space-separated form (`-replace ADDR`).

### Root cause

`internal/iacargs/iacargs.go` re-orders IaC tool arguments into `[command] [flags...] [arguments...]`. In `processFlag`, a flag only consumes its following space-separated value if its name appears in the `valueTakingFlags` whitelist. `replace` is not in that list, so it was treated as a boolean flag: the flag landed in `Flags`, and the resource address — a non-flag token — was classified as a positional `Argument` and re-emitted at the end of the command.

Result, given:

    terraform plan -replace A -replace B -out plan.tfplan

Terragrunt emitted:

    terraform plan -replace -replace -out plan.tfplan A B

Each `-replace` matched no address, and `A`/`B` were passed as positional plan arguments. The plan ran without forcing replacement of any resource — a silent correctness bug, no error raised.

### Fix

Add `"replace"` to `valueTakingFlags`. The inline form (`-replace=ADDR`) was already handled correctly via the `=` short-circuit, so this only restores the documented space-separated form.

## TODOs

- [x] I authored this code entirely myself
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated command parsing so `replace` is recognized as a value-taking flag, ensuring the following space-separated token is handled correctly.
  * Improved coverage to verify `-replace` works correctly for both `-replace=<value>` and space-separated forms, including repeated occurrences and round-trip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->