### PR TITLE
fix #6420: deleted files being excluded from affected units in worktree discovery

### DIFF
--- a/internal/discovery/phase_worktree.go
+++ b/internal/discovery/phase_worktree.go
@@ -97,7 +97,16 @@ func (p *WorktreePhase) Run(ctx context.Context, l log.Logger, input *PhaseInput
 						return err
 					}
 
-					for _, c := range components {
+					// For reading-affected components discovered in the from-worktree, check if the unit
+					// still exists in the to-worktree. If yes, re-discover it there to avoid the -destroy
+					// flag that would incorrectly exclude it. This handles the case where a file tracked
+					// by mark_glob_as_read is deleted but the unit itself still exists.
+					mappedComponents, err := p.mapFromWorktreeReadingAffected(fromToCtx, l, input, pair, components)
+					if err != nil {
+						return err
+					}
+
+					for _, c := range mappedComponents {
 						discoveredComponents.EnsureComponent(c)
 					}
 
@@ -224,7 +233,78 @@ func (p *WorktreePhase) discoverInWorktree(
 	return components, nil
 }
 
-// discoverChangesInWorktreeStacks discovers changes in worktree stacks.
+// mapFromWorktreeReadingAffected checks which from-worktree components are reading-affected
+// (i.e., the unit still exists in the to-worktree) and re-discovers them in the to-worktree.
+// This avoids the -destroy flag that would incorrectly exclude reading-affected units.
+// Components whose units were actually deleted remain as from-worktree components.
+func (p *WorktreePhase) mapFromWorktreeReadingAffected(
+	ctx context.Context,
+	l log.Logger,
+	input *PhaseInput,
+	pair worktrees.WorktreePair,
+	fromComponents component.Components,
+) (component.Components, error) {
+	if len(fromComponents) == 0 {
+		return fromComponents, nil
+	}
+
+	var (
+		stillExistInTo  []component.Component
+		deletedFromOnly []component.Component
+	)
+
+	for _, c := range fromComponents {
+		relPath, err := filepath.Rel(pair.FromWorktree.Path, c.Path())
+		if err != nil {
+			deletedFromOnly = append(deletedFromOnly, c)
+			continue
+		}
+
+		toPath := filepath.Join(pair.ToWorktree.Path, relPath)
+		terragruntHCL := filepath.Join(toPath, "terragrunt.hcl")
+
+		if _, err := os.Stat(terragruntHCL); err == nil {
+			stillExistInTo = append(stillExistInTo, c)
+		} else {
+			deletedFromOnly = append(deletedFromOnly, c)
+		}
+	}
+
+	if len(stillExistInTo) == 0 {
+		return deletedFromOnly, nil
+	}
+
+	pathFilters := make(filter.Filters, 0, len(stillExistInTo))
+	for _, c := range stillExistInTo {
+		relPath, err := filepath.Rel(pair.FromWorktree.Path, c.Path())
+		if err != nil {
+			continue
+		}
+
+		pathExpr, err := filter.NewPathFilter(relPath)
+		if err != nil {
+			continue
+		}
+
+		pathFilters = append(pathFilters, filter.NewFilter(pathExpr, pathExpr.String()))
+	}
+
+	if len(pathFilters) == 0 {
+		return deletedFromOnly, nil
+	}
+
+	toComponents, err := p.discoverInWorktree(ctx, l, input, pair.ToWorktree, pathFilters, ToWorktreeKind)
+	if err != nil {
+		l.Debugf("Failed to re-discover reading-affected components in to-worktree: %v", err)
+		return append(deletedFromOnly, stillExistInTo...), nil
+	}
+
+	result := make(component.Components, 0, len(deletedFromOnly)+len(toComponents))
+	result = append(result, deletedFromOnly...)
+	result = append(result, toComponents...)
+
+	return result, nil
+}
 func (p *WorktreePhase) discoverChangesInWorktreeStacks(
 	ctx context.Context,
 	l log.Logger,

--- a/internal/discovery/phase_worktree.go
+++ b/internal/discovery/phase_worktree.go
@@ -217,6 +217,10 @@ func (p *WorktreePhase) discoverInWorktree(
 		WithDiscoveryContext(discoveryContext).
 		WithNumWorkers(p.numWorkers)
 
+	if len(discovery.configFilenames) > 0 {
+		subDiscovery = subDiscovery.WithConfigFilenames(discovery.configFilenames)
+	}
+
 	if discovery.suppressParseErrors {
 		subDiscovery = subDiscovery.WithSuppressParseErrors()
 	}
@@ -261,9 +265,13 @@ func (p *WorktreePhase) mapFromWorktreeReadingAffected(
 		}
 
 		toPath := filepath.Join(pair.ToWorktree.Path, relPath)
-		terragruntHCL := filepath.Join(toPath, "terragrunt.hcl")
+		configFile := c.ConfigFile()
+		if configFile == "" {
+			configFile = "terragrunt.hcl"
+		}
+		configPath := filepath.Join(toPath, configFile)
 
-		if _, err := os.Stat(terragruntHCL); err == nil {
+		if _, err := os.Stat(configPath); err == nil {
 			stillExistInTo = append(stillExistInTo, c)
 		} else {
 			deletedFromOnly = append(deletedFromOnly, c)
@@ -295,8 +303,7 @@ func (p *WorktreePhase) mapFromWorktreeReadingAffected(
 
 	toComponents, err := p.discoverInWorktree(ctx, l, input, pair.ToWorktree, pathFilters, ToWorktreeKind)
 	if err != nil {
-		l.Debugf("Failed to re-discover reading-affected components in to-worktree: %v", err)
-		return append(deletedFromOnly, stillExistInTo...), nil
+		return nil, err
 	}
 
 	result := make(component.Components, 0, len(deletedFromOnly)+len(toComponents))
@@ -407,6 +414,10 @@ func (p *WorktreePhase) walkChangedStack(
 			WithFilters(parentFilters).
 			WithNumWorkers(p.numWorkers)
 
+		if len(discovery.configFilenames) > 0 {
+			fromDiscovery = fromDiscovery.WithConfigFilenames(discovery.configFilenames)
+		}
+
 		var fromDiscoveryErr error
 
 		fromComponents, fromDiscoveryErr = fromDiscovery.Discover(discoveryCtx, l, input.Opts)
@@ -434,6 +445,10 @@ func (p *WorktreePhase) walkChangedStack(
 			WithDiscoveryContext(toDiscoveryContext).
 			WithFilters(parentFilters).
 			WithNumWorkers(p.numWorkers)
+
+		if len(discovery.configFilenames) > 0 {
+			toDiscovery = toDiscovery.WithConfigFilenames(discovery.configFilenames)
+		}
 
 		var toDiscoveryErr error
 

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -85,6 +85,60 @@ func TestWorktreePhase_Integration_UnitLifecycle(t *testing.T) {
 	assert.DirExists(t, expectedUnitToBeUntouched)
 }
 
+// TestWorktreePhase_Integration_DeletedReadingUnitRediscovered verifies that when a file
+// read by a unit is deleted, the unit is re-discovered in the to-worktree rather than being
+// left on the from-worktree path and treated as a removed unit.
+func TestWorktreePhase_Integration_DeletedReadingUnitRediscovered(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	unitDir := createUnit(t, tmpDir, "unit-reads-config", `locals {
+  config_files = mark_glob_as_read("../config/{*.yaml,*.yml}")
+}`)
+
+	configDir := filepath.Join(tmpDir, "config")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "item-a.yml"), []byte("a: 1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "item-b.yml"), []byte("b: 2\n"), 0o644))
+
+	commitChanges(t, runner, "Initial commit")
+
+	require.NoError(t, os.Remove(filepath.Join(configDir, "item-a.yml")))
+	commitChanges(t, runner, "Delete tracked config file")
+
+	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
+	components, w := runWorktreeDiscovery(t, tmpDir, gitExpressions, "plan", nil)
+
+	require.Contains(t, w.WorktreePairs, "[HEAD~1...HEAD]")
+	pair := w.WorktreePairs["[HEAD~1...HEAD]"]
+
+	fromPath := filepath.Join(pair.FromWorktree.Path, filepath.Base(unitDir))
+	toPath := filepath.Join(pair.ToWorktree.Path, filepath.Base(unitDir))
+
+	units := components.Filter(component.UnitKind)
+	unitPaths := units.Paths()
+
+	assert.Contains(t, unitPaths, toPath, "Deleted reading unit should be rediscovered in the to-worktree")
+	assert.NotContains(t, unitPaths, fromPath, "Deleted reading unit should not remain on the from-worktree path")
+
+	var found bool
+	for _, c := range units {
+		if c.Path() != toPath {
+			continue
+		}
+
+		found = true
+		dc := c.DiscoveryContext()
+		require.NotNil(t, dc)
+		assert.Equal(t, "HEAD", dc.Ref, "Rediscovered unit should be associated with the to-worktree ref")
+		assert.NotContains(t, dc.Args, "-destroy", "Rediscovered unit should not be treated as deleted")
+		break
+	}
+
+	assert.True(t, found, "Expected rediscovered unit to be present in worktree discovery results")
+}
+
 // TestWorktreePhase_Integration_CommandArgs tests command argument handling for worktrees.
 func TestWorktreePhase_Integration_CommandArgs(t *testing.T) {
 	t.Parallel()

--- a/internal/discovery/phase_worktree_internal_test.go
+++ b/internal/discovery/phase_worktree_internal_test.go
@@ -1,0 +1,97 @@
+package discovery
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/worktrees"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapFromWorktreeReadingAffected_UsesComponentConfigFile(t *testing.T) {
+	t.Parallel()
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+
+	fromUnitDir := filepath.Join(fromDir, "app")
+	toUnitDir := filepath.Join(toDir, "app")
+
+	require.NoError(t, os.MkdirAll(fromUnitDir, 0o755))
+	require.NoError(t, os.MkdirAll(toUnitDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(fromUnitDir, "custom.hcl"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(toUnitDir, "custom.hcl"), []byte(""), 0o644))
+
+	fromComponent := component.NewUnit(fromUnitDir)
+	fromComponent.SetConfigFile("custom.hcl")
+
+	phase := NewWorktreePhase(nil, 1)
+	l := logger.CreateLogger()
+	input := &PhaseInput{
+		Opts: &options.TerragruntOptions{WorkingDir: fromDir},
+		Discovery: NewDiscovery(fromDir).
+			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: fromDir}).
+			WithConfigFilenames([]string{"custom.hcl"}),
+	}
+
+	result, err := phase.mapFromWorktreeReadingAffected(
+		context.Background(),
+		l,
+		input,
+		worktrees.WorktreePair{
+			FromWorktree: worktrees.Worktree{Path: fromDir, Ref: "HEAD~1"},
+			ToWorktree:   worktrees.Worktree{Path: toDir, Ref: "HEAD"},
+		},
+		component.Components{fromComponent},
+	)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, toUnitDir, result[0].Path())
+	assert.Equal(t, "custom.hcl", result[0].ConfigFile())
+}
+
+func TestMapFromWorktreeReadingAffected_PropagatesRediscoveryErrors(t *testing.T) {
+	t.Parallel()
+
+	fromDir := t.TempDir()
+	toDir := t.TempDir()
+
+	fromUnitDir := filepath.Join(fromDir, "app")
+	toUnitDir := filepath.Join(toDir, "app")
+
+	require.NoError(t, os.MkdirAll(fromUnitDir, 0o755))
+	require.NoError(t, os.MkdirAll(toUnitDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(fromUnitDir, "terragrunt.hcl"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(toUnitDir, "terragrunt.hcl"), []byte(""), 0o644))
+
+	fromComponent := component.NewUnit(fromUnitDir)
+
+	phase := NewWorktreePhase(nil, 1)
+	l := logger.CreateLogger()
+	input := &PhaseInput{
+		Opts: &options.TerragruntOptions{WorkingDir: fromDir},
+		Discovery: NewDiscovery(fromDir).
+			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: fromDir, Cmd: "destroy"}),
+	}
+
+	result, err := phase.mapFromWorktreeReadingAffected(
+		context.Background(),
+		l,
+		input,
+		worktrees.WorktreePair{
+			FromWorktree: worktrees.Worktree{Path: fromDir, Ref: "HEAD~1"},
+			ToWorktree:   worktrees.Worktree{Path: toDir, Ref: "HEAD"},
+		},
+		component.Components{fromComponent},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Git-based filtering is not supported")
+	assert.Nil(t, result)
+}

--- a/test/integration_filter_test.go
+++ b/test/integration_filter_test.go
@@ -1,6 +1,7 @@
 package test_test
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -2315,4 +2316,175 @@ func TestFilterFlagWithGitFilterMarkGlobAsRead(t *testing.T) {
 	results := strings.Fields(stdout)
 	assert.ElementsMatch(t, []string{"unit-reads-added", "unit-reads-removed"}, results,
 		"units reading added or removed glob files should be selected; untouched unit should not")
+}
+
+// TestRunAllGitFilterMarkGlobAsReadDeleted verifies that `terragrunt run --all`
+// correctly selects units affected by deleted, added, or modified files tracked
+// via mark_glob_as_read. The critical scenario is deletion-only: when the ONLY
+// change in a commit is removing a config file that a unit reads via a glob, the
+// unit must still be selected for planning. This reproduces a bug where the
+// from-worktree component (discovered via reading filter) was incorrectly
+// excluded by applyFilterAllowDestroyExclusions because TranslateDiscoveryContextArgs
+// added -destroy to all from-worktree components regardless of whether the unit
+// itself was deleted or just reading-affected.
+func TestRunAllGitFilterMarkGlobAsReadDeleted(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		unitName      string
+		configDirName string
+		setupChange   func(t *testing.T, tmpDir string)
+		expectedUnits []string
+		description   string
+	}{
+		{
+			name:          "deleted-only config file selects reading unit",
+			unitName:      "unit-reads-removed",
+			configDirName: "config-removed",
+			setupChange: func(t *testing.T, tmpDir string) {
+				t.Helper()
+				require.NoError(t, os.Remove(filepath.Join(tmpDir, "config-removed", "item-a.yml")))
+			},
+			expectedUnits: []string{"unit-reads-removed"},
+			description:   "Deleting the ONLY tracked file should still select the reading unit (the critical bug case)",
+		},
+		{
+			name:          "modified config file selects reading unit",
+			unitName:      "unit-reads-modified",
+			configDirName: "config-modified",
+			setupChange: func(t *testing.T, tmpDir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(
+					filepath.Join(tmpDir, "config-modified", "item-a.yml"),
+					[]byte("modified: true\n"), 0644))
+			},
+			expectedUnits: []string{"unit-reads-modified"},
+			description:   "Modifying a file tracked by mark_glob_as_read should select the reading unit",
+		},
+		{
+			name:          "added config file selects reading unit",
+			unitName:      "unit-reads-added",
+			configDirName: "config-added",
+			setupChange: func(t *testing.T, tmpDir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(
+					filepath.Join(tmpDir, "config-added", "item-new.yml"),
+					[]byte("new: true\n"), 0644))
+			},
+			expectedUnits: []string{"unit-reads-added"},
+			description:   "Adding a file tracked by mark_glob_as_read should select the reading unit",
+		},
+		{
+			name:          "deleted config file with other modification selects reading unit",
+			unitName:      "unit-reads-deleted-modified",
+			configDirName: "config-deleted-modified",
+			setupChange: func(t *testing.T, tmpDir string) {
+				t.Helper()
+				require.NoError(t, os.Remove(filepath.Join(tmpDir, "config-deleted-modified", "item-a.yml")))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(tmpDir, "config-deleted-modified", "item-b.yml"),
+					[]byte("b: modified\n"), 0644))
+			},
+			expectedUnits: []string{"unit-reads-deleted-modified"},
+			description:   "Deleting a tracked file alongside another modification should select the reading unit",
+		},
+		{
+			name:          "deleted config file with other addition selects reading unit",
+			unitName:      "unit-reads-deleted-added",
+			configDirName: "config-deleted-added",
+			setupChange: func(t *testing.T, tmpDir string) {
+				t.Helper()
+				require.NoError(t, os.Remove(filepath.Join(tmpDir, "config-deleted-added", "item-a.yml")))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(tmpDir, "config-deleted-added", "item-new.yml"),
+					[]byte("new: true\n"), 0644))
+			},
+			expectedUnits: []string{"unit-reads-deleted-added"},
+			description:   "Deleting a tracked file alongside another addition should select the reading unit",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := helpers.TmpDirWOSymlinks(t)
+			runner := helpers.InitTestGitRunner(t, tmpDir)
+
+			unitDir := filepath.Join(tmpDir, tc.unitName)
+			require.NoError(t, os.MkdirAll(unitDir, 0755))
+
+			hclContent := `locals {
+			  config_files = mark_glob_as_read("../` + tc.configDirName + `/{*.yaml,*.yml}")
+			}`
+			require.NoError(t, os.WriteFile(
+				filepath.Join(unitDir, "terragrunt.hcl"), []byte(hclContent), 0644))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(unitDir, "main.tf"), []byte("# minimal"), 0644))
+
+			configDir := filepath.Join(tmpDir, tc.configDirName)
+			require.NoError(t, os.MkdirAll(configDir, 0755))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(configDir, "item-a.yml"), []byte("a: 1\n"), 0644))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(configDir, "item-b.yml"), []byte("b: 2\n"), 0644))
+
+			require.NoError(t, runner.Add(t.Context(), "."))
+			require.NoError(t, runner.Commit(t.Context(), "Baseline with unit and config files"))
+
+			if b, err := runner.Config(t.Context(), "init.defaultBranch"); err != nil || b != "main" {
+				require.NoError(t, runner.Checkout(t.Context(), "main", true))
+			}
+
+			require.NoError(t, runner.Checkout(t.Context(), "test-change", true))
+
+			tc.setupChange(t, tmpDir)
+
+			require.NoError(t, runner.Add(t.Context(), "."))
+			require.NoError(t, runner.Commit(t.Context(), "Apply change to tracked config files"))
+
+			helpers.CleanupTerraformFolder(t, tmpDir)
+
+			reportFilePath := filepath.Join(tmpDir, helpers.ReportFile)
+			cmd := fmt.Sprintf(
+				"terragrunt run --all --non-interactive --no-color "+
+					"--working-dir %s --filter '[HEAD~1...HEAD]' --report-file %s -- plan",
+				tmpDir, reportFilePath,
+			)
+
+			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+			if err != nil && !strings.Contains(stderr, "terraform") && !strings.Contains(stderr, "tofu") {
+				require.NoError(t, err, "Unexpected error\nstdout: %s\nstderr: %s", stdout, stderr)
+			}
+
+			assert.FileExists(t, reportFilePath, "Report file should exist at %s", reportFilePath)
+
+			runs, parseErr := report.ParseJSONRunsFromFile(reportFilePath)
+			require.NoError(t, parseErr, "Should be able to parse report JSON")
+
+			runNames := make([]string, 0, len(runs))
+			for _, r := range runs {
+				runNames = append(runNames, filepath.Base(r.Name))
+			}
+
+			for _, expected := range tc.expectedUnits {
+				found := false
+
+				for _, r := range runs {
+					if filepath.Base(r.Name) != expected || r.Ref != "HEAD" {
+						continue
+					}
+
+					found = true
+					assert.NotEqual(t, "excluded", r.Result,
+						"expected HEAD-side unit %q should not be excluded. %s", expected, tc.description)
+				}
+
+				assert.True(t, found,
+					"Expected HEAD-side unit %q should be in report (got: %v). %s",
+					expected, runNames, tc.description)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description

Fixes #6420.

Handle deleted files tracked by `mark_glob_as_read(...)` in Git-filtered `run --all` discovery.

When a tracked file is deleted, Terragrunt was discovering the affected unit on the `from` worktree and then excluding it as if the unit itself had been removed. The fix re-discovers reading-affected units in the `to` worktree so surviving units keep `HEAD`-side identity and are not incorrectly treated as destroy candidates.

Also adds regression coverage for:
- deleted-only tracked file
- modified tracked file
- added tracked file
- deleted + modified tracked file
- deleted + added tracked file

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] This change is backwards compatible.
- [X] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed worktree-based discovery to correctly rediscover units when their `read`-tracked files are deleted between git revisions.
  * Ensured those units are attributed to the current (to-worktree) revision side and not marked as deleted/excluded.
  * Improved `terragrunt run --all` behavior with git filters combined with `mark_glob_as_read`, ensuring glob deletion scenarios select the correct units.
* **Tests**
  * Added integration and unit tests covering glob-deletion and affected rediscovery cases, including validation of rediscovery behavior and execution context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->