### PR TITLE
feat: Add --no-dependency-outputs flag to skip dependency output resolution

### DIFF
--- a/docs/src/data/changelog/v1.1.3/no-dependency-outputs-flag.mdx
+++ b/docs/src/data/changelog/v1.1.3/no-dependency-outputs-flag.mdx
@@ -1,0 +1,16 @@
+---
+version: "v1.1.3"
+category: "new-features"
+---
+
+#### Add `--no-dependency-outputs` flag to skip dependency output resolution
+
+Added a `--no-dependency-outputs` flag that skips all dependency output resolution globally, mirroring the existing `skip_outputs = true` attribute on individual `dependency` blocks.
+
+The feature is gated behind the `optional-dependency-outputs` experiment:
+
+```bash
+TG_EXPERIMENT=optional-dependency-outputs terragrunt run --no-dependency-outputs -- init
+```
+
+Using `--no-dependency-outputs` without enabling the `optional-dependency-outputs` experiment will return an error.

--- a/docs/src/data/experiments/optional-dependency-outputs.mdx
+++ b/docs/src/data/experiments/optional-dependency-outputs.mdx
@@ -1,0 +1,35 @@
+---
+name: optional-dependency-outputs
+since: "1.1.3"
+---
+
+Support for skipping all dependency output resolution during a `run`.
+
+### `optional-dependency-outputs` - What it does
+
+When enabled, users can pass `--no-dependency-outputs` to skip all dependency output resolution globally. `dependency` blocks will not call `tofu`/`terraform output`, mirroring the existing `skip_outputs = true` attribute on individual `dependency` blocks.
+
+```bash
+terragrunt run --experiment optional-dependency-outputs --no-dependency-outputs -- init
+```
+
+This is useful when you want to run commands that do not need dependency outputs (such as `init` or `validate`) without paying the cost of resolving them, or when the dependencies have not been applied yet.
+
+### `optional-dependency-outputs` - How to enable it
+
+```bash
+# Via CLI flag
+terragrunt --experiment optional-dependency-outputs run --no-dependency-outputs -- init
+
+# Via environment variable
+export TG_EXPERIMENT=optional-dependency-outputs
+terragrunt run --no-dependency-outputs -- init
+```
+
+### `optional-dependency-outputs` - Criteria for stabilization
+
+To transition the `optional-dependency-outputs` feature to a stable release, the following must be addressed, at a minimum:
+
+- [ ] Validate behavior with single-unit and queue-based runs.
+- [ ] Gather community feedback on the flag name and scope.
+- [ ] Confirm the interaction with commands that require dependency outputs (such as `plan`, `apply`, or `destroy`).

--- a/docs/src/data/flags/no-dependency-outputs.mdx
+++ b/docs/src/data/flags/no-dependency-outputs.mdx
@@ -1,0 +1,18 @@
+---
+name: no-dependency-outputs
+description: Skip all dependency output resolution during a run. Requires the optional-dependency-outputs experiment.
+lookup: true
+type: boolean
+env:
+  - TG_NO_DEPENDENCY_OUTPUTS
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Experimental">
+This flag is gated behind the [`optional-dependency-outputs`](/reference/experiments/active#optional-dependency-outputs) experiment. Enable it with `--experiment=optional-dependency-outputs` or `TG_EXPERIMENT=optional-dependency-outputs`; otherwise setting `--no-dependency-outputs` returns an error.
+</Aside>
+
+Skip all dependency output resolution during a run.
+
+When enabled, Terragrunt does not resolve any `dependency` block outputs and will not call `tofu`/`terraform output`. This mirrors the existing `skip_outputs = true` attribute on individual `dependency` blocks, applied globally to the run.

--- a/internal/cli/commands/run/flags.go
+++ b/internal/cli/commands/run/flags.go
@@ -27,6 +27,7 @@ const (
 	NoEngineFlagName                         = "no-engine"
 	NoDependencyFetchOutputFromStateFlagName = "no-dependency-fetch-output-from-state"
 	NoHooksFlagName                          = "no-hooks"
+	NoDependencyOutputsFlagName              = "no-dependency-outputs"
 	TFForwardStdoutFlagName                  = "tf-forward-stdout"
 	UnitsThatIncludeFlagName                 = "units-that-include"
 	DependencyFetchOutputFromStateFlagName   = "dependency-fetch-output-from-state"
@@ -88,6 +89,10 @@ const (
 
 var ErrNoHooksRequiresExperiment = errors.New(
 	"--no-hooks requires the 'optional-hooks' experiment to be enabled (e.g., --experiment=optional-hooks)",
+)
+
+var ErrNoDependencyOutputsRequiresExperiment = errors.New(
+	"--no-dependency-outputs requires the 'optional-dependency-outputs' experiment to be enabled (e.g., --experiment=optional-dependency-outputs)",
 )
 
 // NewFlags creates and returns global flags.
@@ -202,6 +207,24 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 				}
 
 				return ErrNoHooksRequiresExperiment
+			},
+		}),
+
+		flags.NewFlag(&clihelper.BoolFlag{
+			Name:        NoDependencyOutputsFlagName,
+			EnvVars:     tgPrefix.EnvVars(NoDependencyOutputsFlagName),
+			Destination: &opts.SkipOutput,
+			Usage:       "Skip all dependency output resolution. Dependency blocks will not call tofu/terraform output. Requires the 'optional-dependency-outputs' experiment.",
+			Action: func(_ context.Context, _ *clihelper.Context, value bool) error {
+				if !value {
+					return nil
+				}
+
+				if opts.Experiments.Evaluate(experiment.OptionalDependencyOutputs) {
+					return nil
+				}
+
+				return ErrNoDependencyOutputsRequiresExperiment
 			},
 		}),
 

--- a/internal/cli/commands/run/flags_test.go
+++ b/internal/cli/commands/run/flags_test.go
@@ -38,3 +38,29 @@ func TestNoHooksFlagAllowedWithExperiment(t *testing.T) {
 	require.NoError(t, flags.RunActions(context.Background(), &clihelper.Context{}))
 	assert.True(t, opts.NoRunHooks)
 }
+
+func TestNoDependencyOutputsFlagRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	opts := options.NewTerragruntOptions()
+	flags := runcommand.NewFlags(logger.CreateLogger(), opts, nil)
+
+	require.NoError(t, flags.Parse(clihelper.Args{"--no-dependency-outputs"}))
+
+	err := flags.RunActions(context.Background(), &clihelper.Context{})
+
+	require.ErrorIs(t, err, runcommand.ErrNoDependencyOutputsRequiresExperiment)
+	assert.True(t, opts.SkipOutput)
+}
+
+func TestNoDependencyOutputsFlagAllowedWithExperiment(t *testing.T) {
+	t.Parallel()
+
+	opts := options.NewTerragruntOptions()
+	require.NoError(t, opts.Experiments.EnableExperiment(experiment.OptionalDependencyOutputs))
+	flags := runcommand.NewFlags(logger.CreateLogger(), opts, nil)
+
+	require.NoError(t, flags.Parse(clihelper.Args{"--no-dependency-outputs"}))
+	require.NoError(t, flags.RunActions(context.Background(), &clihelper.Context{}))
+	assert.True(t, opts.SkipOutput)
+}

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -108,6 +108,9 @@ const (
 	// content-addressable storage and hard-linked into each working directory
 	// rather than written per unit.
 	MutableGenerate = "mutable-generate"
+	// OptionalDependencyOutputs gates the --no-dependency-outputs flag that skips
+	// all dependency output resolution during a run.
+	OptionalDependencyOutputs = "optional-dependency-outputs"
 )
 
 const (
@@ -222,6 +225,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: MutableGenerate,
+		},
+		{
+			Name: OptionalDependencyOutputs,
 		},
 	}
 }

--- a/test/fixtures/get-output/integration/skip-dependency-outputs/.terraform.lock.hcl
+++ b/test/fixtures/get-output/integration/skip-dependency-outputs/.terraform.lock.hcl
@@ -1,0 +1,2 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.

--- a/test/fixtures/get-output/integration/skip-dependency-outputs/terragrunt.hcl
+++ b/test/fixtures/get-output/integration/skip-dependency-outputs/terragrunt.hcl
@@ -1,0 +1,7 @@
+dependency "app1" {
+  config_path = "../app1"
+}
+
+inputs = {
+  x = dependency.app1.outputs.x
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -988,3 +988,44 @@ func statGeneratedFile(t *testing.T, unitPath, name string) os.FileInfo {
 
 	return found
 }
+
+func TestDependencyOutputSkipDependencyOutputsFlag(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureGetOutput)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGetOutput)
+	noOutputPath := filepath.Join(tmpEnvPath, testFixtureGetOutput, "integration", "skip-dependency-outputs")
+
+	t.Run("plan without flag fails", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan --non-interactive --working-dir "+noOutputPath)
+		require.ErrorContains(t, err, "resolving dependency \"app1\" outputs")
+	})
+
+	t.Run("flag rejected without experiment", func(t *testing.T) {
+		t.Parallel()
+
+		if helpers.IsExperimentMode(t) {
+			t.Skip("Skipping: TG_EXPERIMENT_MODE forces the optional-dependency-outputs experiment on, so its disabled-state error can't be verified")
+		}
+
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt init --no-dependency-outputs --non-interactive --working-dir "+noOutputPath)
+		require.ErrorContains(t, err, "--no-dependency-outputs requires the 'optional-dependency-outputs' experiment")
+	})
+
+	for _, cmd := range []string{"init", "validate", "plan"} {
+		t.Run(cmd+" succeeds with flag", func(t *testing.T) {
+			t.Parallel()
+			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt "+cmd+" --experiment optional-dependency-outputs --no-dependency-outputs --non-interactive --working-dir "+noOutputPath)
+			require.NoError(t, err)
+		})
+	}
+
+	for _, cmd := range []string{"init", "validate", "plan"} {
+		t.Run("run --all "+cmd+" succeeds with flag", func(t *testing.T) {
+			t.Parallel()
+			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --experiment optional-dependency-outputs "+cmd+" --no-dependency-outputs --non-interactive --working-dir "+noOutputPath)
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes #1078 by introducing a global flag that allows terragrunt init to run without resolving dependency outputs.

This flag provides the same behavior as the existing skip_outputs = true option on individual dependency blocks, but applies it across the entire Terragrunt execution.

To prevent inconsistent behavior, the flag is rejected when used with plan or apply commands. For those commands, dependency output resolution continues to be controlled by the existing skip_outputs attribute on individual dependency blocks.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--skip-dependency-outputs` to globally skip dependency output resolution.
  * Supported only for `init` and `validate`; rejected for `plan`, `apply`, `destroy`, `refresh`, `import` (including `run --all` variants).
* **Bug Fixes**
  * Invalid flag usage now fails early with clearer, command-specific errors.
* **Documentation**
  * Updated changelog with `v1.1.0` flag behavior details.
* **Tests**
  * Added integration tests covering allowed and rejected command combinations, plus `run --all init/validate`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->