### PR TITLE
fix: Fixing deleted changed files

### DIFF
--- a/internal/discovery/phase_worktree.go
+++ b/internal/discovery/phase_worktree.go
@@ -88,11 +88,16 @@ func (p *WorktreePhase) Run(ctx context.Context, l log.Logger, input *PhaseInput
 				return err
 			}
 
+			// Expand routes reading filters for deleted files onto the from side, since a deleted file
+			// only exists in the from worktree where its read relationship can be evaluated. These need
+			// different handling from the path filters for genuinely removed components, so split them.
+			deletedReadFilters, removalFilters := fromFilters.PartitionReadingFilters()
+
 			fromToG, fromToCtx := errgroup.WithContext(discoveryCtx)
 
-			if len(fromFilters) > 0 {
+			if len(removalFilters) > 0 {
 				fromToG.Go(func() error {
-					components, err := p.discoverInWorktree(fromToCtx, l, input, pair.FromWorktree, fromFilters, FromWorktreeKind)
+					components, err := p.discoverInWorktree(fromToCtx, l, input, pair.FromWorktree, removalFilters, FromWorktreeKind)
 					if err != nil {
 						return err
 					}
@@ -105,9 +110,24 @@ func (p *WorktreePhase) Run(ctx context.Context, l log.Logger, input *PhaseInput
 				})
 			}
 
-			if len(toFilters) > 0 {
+			if len(toFilters) > 0 || len(deletedReadFilters) > 0 {
 				fromToG.Go(func() error {
-					components, err := p.discoverInWorktree(fromToCtx, l, input, pair.ToWorktree, toFilters, ToWorktreeKind)
+					finalToFilters := toFilters
+
+					if len(deletedReadFilters) > 0 {
+						translated, err := p.deletedReadingComponentsToFilters(fromToCtx, l, input, pair.FromWorktree, deletedReadFilters)
+						if err != nil {
+							return err
+						}
+
+						finalToFilters = slices.Concat(toFilters, translated)
+					}
+
+					if len(finalToFilters) == 0 {
+						return nil
+					}
+
+					components, err := p.discoverInWorktree(fromToCtx, l, input, pair.ToWorktree, finalToFilters, ToWorktreeKind)
 					if err != nil {
 						return err
 					}
@@ -222,6 +242,42 @@ func (p *WorktreePhase) discoverInWorktree(
 	}
 
 	return components, nil
+}
+
+// deletedReadingComponentsToFilters discovers, in the from worktree, the components that read files
+// deleted in the diff (those files only exist on the from side), then returns a path filter per
+// discovered component aimed at its equivalent path in the to worktree. A component that no longer
+// exists in the to worktree simply matches nothing there, which is the expected outcome for a genuine
+// removal that another filter already covers.
+func (p *WorktreePhase) deletedReadingComponentsToFilters(
+	ctx context.Context,
+	l log.Logger,
+	input *PhaseInput,
+	fromWorktree worktrees.Worktree,
+	readingFilters filter.Filters,
+) (filter.Filters, error) {
+	affected, err := p.discoverInWorktree(ctx, l, input, fromWorktree, readingFilters, FromWorktreeKind)
+	if err != nil {
+		return nil, err
+	}
+
+	toFilters := make(filter.Filters, 0, len(affected))
+
+	for _, c := range affected {
+		relPath, err := filepath.Rel(fromWorktree.Path, c.Path())
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve relative path for reading-affected component %s: %w", c.Path(), err)
+		}
+
+		expr, err := filter.NewPathFilter(relPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create path filter for reading-affected component %s: %w", relPath, err)
+		}
+
+		toFilters = append(toFilters, filter.NewFilter(expr, expr.String()))
+	}
+
+	return toFilters, nil
 }
 
 // discoverChangesInWorktreeStacks discovers changes in worktree stacks.

--- a/internal/discovery/phase_worktree.go
+++ b/internal/discovery/phase_worktree.go
@@ -244,11 +244,13 @@ func (p *WorktreePhase) discoverInWorktree(
 	return components, nil
 }
 
-// deletedReadingComponentsToFilters discovers, in the from worktree, the components that read files
+// deletedReadingComponentsToFilters discovers, in the from worktree, the units that read files
 // deleted in the diff (those files only exist on the from side), then returns a path filter per
-// discovered component aimed at its equivalent path in the to worktree. A component that no longer
-// exists in the to worktree simply matches nothing there, which is the expected outcome for a genuine
-// removal that another filter already covers.
+// discovered unit aimed at its equivalent path in the to worktree. A unit that no longer exists in the
+// to worktree simply matches nothing there, which is the expected outcome for a genuine removal that
+// another filter already covers. Stacks are intentionally skipped: a stack reading a deleted file is
+// routed through ReadingAffectedStacks during generation so its generated units get walked, which a
+// plain path filter (matching only the stack file) would not achieve.
 func (p *WorktreePhase) deletedReadingComponentsToFilters(
 	ctx context.Context,
 	l log.Logger,
@@ -264,6 +266,10 @@ func (p *WorktreePhase) deletedReadingComponentsToFilters(
 	toFilters := make(filter.Filters, 0, len(affected))
 
 	for _, c := range affected {
+		if _, ok := c.(*component.Stack); ok {
+			continue
+		}
+
 		relPath, err := filepath.Rel(fromWorktree.Path, c.Path())
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve relative path for reading-affected component %s: %w", c.Path(), err)

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -85,6 +85,201 @@ func TestWorktreePhase_Integration_UnitLifecycle(t *testing.T) {
 	assert.DirExists(t, expectedUnitToBeUntouched)
 }
 
+// TestWorktreePhase_Integration_DeletedReadingUnitRediscovered verifies that when a file a unit
+// reads via mark_glob_as_read is deleted, the unit is rediscovered in the to-worktree (where it
+// still exists) rather than being left on the from-worktree path and treated as a removal. The
+// deleted file only exists on the from side, so the reading filter lands there, but the surviving
+// unit must keep its HEAD identity and avoid the -destroy treatment.
+func TestWorktreePhase_Integration_DeletedReadingUnitRediscovered(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	createUnit(t, tmpDir, "unit-reads-config", `locals {
+  config_files = mark_glob_as_read("../config/{*.yaml,*.yml}")
+}`)
+
+	configDir := filepath.Join(tmpDir, "config")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "item-a.yml"), []byte("a: 1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "item-b.yml"), []byte("b: 2\n"), 0o644))
+
+	commitChanges(t, runner, "Initial commit")
+
+	// Delete one of the tracked files only; the unit itself is untouched.
+	require.NoError(t, os.Remove(filepath.Join(configDir, "item-a.yml")))
+	commitChanges(t, runner, "Delete tracked config file")
+
+	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
+	components, w := runWorktreeDiscovery(t, tmpDir, gitExpressions, "plan", nil)
+
+	pair := w.WorktreePairs["[HEAD~1...HEAD]"]
+	require.NotEmpty(t, pair)
+
+	fromPath := filepath.Join(pair.FromWorktree.Path, "unit-reads-config")
+	toPath := filepath.Join(pair.ToWorktree.Path, "unit-reads-config")
+
+	units := components.Filter(component.UnitKind)
+	unitPaths := units.Paths()
+
+	assert.Contains(t, unitPaths, toPath, "Surviving reading unit should be rediscovered in the to-worktree")
+	assert.NotContains(t, unitPaths, fromPath, "Surviving reading unit should not remain on the from-worktree path")
+
+	var found bool
+
+	for _, c := range units {
+		if c.Path() != toPath {
+			continue
+		}
+
+		found = true
+
+		dc := c.DiscoveryContext()
+		require.NotNil(t, dc)
+		assert.Equal(t, "HEAD", dc.Ref, "Rediscovered unit should carry the to-worktree ref")
+		assert.NotContains(t, dc.Args, "-destroy", "Rediscovered unit should not be treated as a removal")
+	}
+
+	assert.True(t, found, "Expected the rediscovered unit in the worktree discovery results")
+}
+
+// TestWorktreePhase_Integration_RemovedReadingUnitStaysDestroyed verifies that a unit which both
+// reads a deleted file and is itself removed is still treated as a removal: it is discovered in the
+// from-worktree with -destroy and is not spuriously rediscovered in the to-worktree (where it no
+// longer exists).
+func TestWorktreePhase_Integration_RemovedReadingUnitStaysDestroyed(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	createUnit(t, tmpDir, "unit-removed", `locals {
+  config_files = mark_glob_as_read("../config/{*.yaml,*.yml}")
+}`)
+
+	configDir := filepath.Join(tmpDir, "config")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "item-a.yml"), []byte("a: 1\n"), 0o644))
+
+	commitChanges(t, runner, "Initial commit")
+
+	// Remove the unit and the file it read in the same diff.
+	require.NoError(t, os.RemoveAll(filepath.Join(tmpDir, "unit-removed")))
+	require.NoError(t, os.RemoveAll(configDir))
+	commitChanges(t, runner, "Remove unit and the file it read")
+
+	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
+	components, w := runWorktreeDiscovery(t, tmpDir, gitExpressions, "plan", nil)
+
+	pair := w.WorktreePairs["[HEAD~1...HEAD]"]
+	require.NotEmpty(t, pair)
+
+	fromPath := filepath.Join(pair.FromWorktree.Path, "unit-removed")
+	toPath := filepath.Join(pair.ToWorktree.Path, "unit-removed")
+
+	units := components.Filter(component.UnitKind)
+	unitPaths := units.Paths()
+
+	assert.Contains(t, unitPaths, fromPath, "Removed reading unit should be discovered in the from-worktree")
+	assert.NotContains(t, unitPaths, toPath, "Removed reading unit must not be rediscovered in the to-worktree")
+
+	for _, c := range units {
+		if c.Path() != fromPath {
+			continue
+		}
+
+		dc := c.DiscoveryContext()
+		require.NotNil(t, dc)
+		assert.Equal(t, "HEAD~1", dc.Ref, "Removed unit should carry the from-worktree ref")
+		assert.Contains(t, dc.Args, "-destroy", "Removed unit should retain the -destroy treatment")
+	}
+}
+
+// TestWorktreePhase_Integration_MultipleReadersOfDeletedFile exercises the fan-out when a single
+// deleted file is read by several units at once. Surviving readers must each be rediscovered in the
+// to-worktree, a reader removed in the same diff must keep its from-side -destroy and not be
+// rediscovered, and an unrelated reader of an unchanged file must not be pulled in by the translation.
+func TestWorktreePhase_Integration_MultipleReadersOfDeletedFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	readsShared := `locals {
+  config_files = mark_glob_as_read("../shared/{*.yaml,*.yml}")
+}`
+
+	createUnit(t, tmpDir, "survivor-a", readsShared)
+	createUnit(t, tmpDir, "survivor-b", readsShared)
+	createUnit(t, tmpDir, "removed", readsShared)
+	createUnit(t, tmpDir, "untouched", `locals {
+  config_files = mark_glob_as_read("../other/{*.yaml,*.yml}")
+}`)
+
+	sharedDir := filepath.Join(tmpDir, "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, "item-a.yml"), []byte("a: 1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, "item-b.yml"), []byte("b: 2\n"), 0o644))
+
+	otherDir := filepath.Join(tmpDir, "other")
+	require.NoError(t, os.MkdirAll(otherDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(otherDir, "keep.yml"), []byte("c: 3\n"), 0o644))
+
+	commitChanges(t, runner, "Initial commit")
+
+	// One shared file read by three units is deleted, and one of those three readers is removed.
+	require.NoError(t, os.Remove(filepath.Join(sharedDir, "item-a.yml")))
+	require.NoError(t, os.RemoveAll(filepath.Join(tmpDir, "removed")))
+	commitChanges(t, runner, "Delete a shared read file and remove one of its readers")
+
+	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
+	components, w := runWorktreeDiscovery(t, tmpDir, gitExpressions, "plan", nil)
+
+	pair := w.WorktreePairs["[HEAD~1...HEAD]"]
+	require.NotEmpty(t, pair)
+
+	from := pair.FromWorktree.Path
+	to := pair.ToWorktree.Path
+
+	units := components.Filter(component.UnitKind)
+	unitPaths := units.Paths()
+
+	byPath := make(map[string]component.Component, len(units))
+	for _, c := range units {
+		byPath[c.Path()] = c
+	}
+
+	// Each surviving reader is rediscovered on the to side, with HEAD identity and no destroy.
+	for _, name := range []string{"survivor-a", "survivor-b"} {
+		toUnit := filepath.Join(to, name)
+		assert.Contains(t, unitPaths, toUnit, "surviving reader %s should be rediscovered in to-worktree", name)
+		assert.NotContains(t, unitPaths, filepath.Join(from, name), "surviving reader %s should not stay on from side", name)
+
+		c, ok := byPath[toUnit]
+		require.True(t, ok)
+
+		dc := c.DiscoveryContext()
+		require.NotNil(t, dc)
+		assert.Equal(t, "HEAD", dc.Ref, "surviving reader %s should carry the to-worktree ref", name)
+		assert.NotContains(t, dc.Args, "-destroy", "surviving reader %s should not be a removal", name)
+	}
+
+	// The removed reader keeps its from-side destroy treatment and is not rediscovered in the to side.
+	removedFrom := filepath.Join(from, "removed")
+	assert.Contains(t, unitPaths, removedFrom, "removed reader should be discovered in from-worktree")
+	assert.NotContains(t, unitPaths, filepath.Join(to, "removed"), "removed reader must not reappear in to-worktree")
+
+	removed, ok := byPath[removedFrom]
+	require.True(t, ok)
+
+	removedCtx := removed.DiscoveryContext()
+	require.NotNil(t, removedCtx)
+	assert.Equal(t, "HEAD~1", removedCtx.Ref)
+	assert.Contains(t, removedCtx.Args, "-destroy")
+
+	// The unrelated reader (reads an unchanged directory) is not selected by the translated filters.
+	assert.NotContains(t, unitPaths, filepath.Join(to, "untouched"))
+	assert.NotContains(t, unitPaths, filepath.Join(from, "untouched"))
+}
+
 // TestWorktreePhase_Integration_CommandArgs tests command argument handling for worktrees.
 func TestWorktreePhase_Integration_CommandArgs(t *testing.T) {
 	t.Parallel()

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -2550,6 +2550,103 @@ unit "myapp" {
 			"but got no units. All components: %v", componentPaths)
 }
 
+// TestWorktreePhase_Integration_DeletedReadingStackRecordedAsReadingAffected verifies that when a
+// file a stack reads via mark_glob_as_read is deleted, the stack is recorded in ReadingAffectedStacks
+// during generation so the worktree phase walks it for unit-level diffs. The deleted file only exists
+// on the from side, so the reading filter lands there; the symmetric "to" side detection that covers
+// changed and added files would otherwise miss it, leaving the stack to be rediscovered as a bare
+// stack file with no generated-unit discovery.
+func TestWorktreePhase_Integration_DeletedReadingStackRecordedAsReadingAffected(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	// Catalog unit the stacks instantiate.
+	legacyUnitDir := filepath.Join(tmpDir, "catalog", "units", "legacy")
+	require.NoError(t, os.MkdirAll(legacyUnitDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(legacyUnitDir, "terragrunt.hcl"), []byte(`# Legacy unit`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(legacyUnitDir, "main.tf"), []byte(`# Intentionally empty`), 0o644))
+
+	// Stack that reads a glob of sidecar files via mark_glob_as_read.
+	stackWithRefDir := filepath.Join(tmpDir, "live", "stack-with-ref")
+	configsDir := filepath.Join(stackWithRefDir, "configs")
+	require.NoError(t, os.MkdirAll(configsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(configsDir, "item-a.yml"), []byte("a: 1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(configsDir, "item-b.yml"), []byte("b: 2\n"), 0o644))
+
+	stackWithRefContent := `
+locals {
+  config_files = mark_glob_as_read("configs/*.yml")
+}
+
+unit "app" {
+  source = "${get_repo_root()}/catalog/units/legacy"
+  path   = "app"
+}
+`
+	stackWithRefFile := filepath.Join(stackWithRefDir, "terragrunt.stack.hcl")
+	require.NoError(t, os.WriteFile(stackWithRefFile, []byte(stackWithRefContent), 0o644))
+
+	// Control stack that reads nothing; it must stay untouched.
+	stackNoRefDir := filepath.Join(tmpDir, "live", "stack-no-ref")
+	require.NoError(t, os.MkdirAll(stackNoRefDir, 0o755))
+
+	stackNoRefContent := `
+unit "app" {
+  source = "${get_repo_root()}/catalog/units/legacy"
+  path   = "app"
+}
+`
+	stackNoRefFile := filepath.Join(stackNoRefDir, "terragrunt.stack.hcl")
+	require.NoError(t, os.WriteFile(stackNoRefFile, []byte(stackNoRefContent), 0o644))
+
+	commitChanges(t, runner, "Create stacks")
+
+	// Delete one tracked sidecar file only; the stack file itself is untouched.
+	require.NoError(t, os.Remove(filepath.Join(configsDir, "item-a.yml")))
+	commitChanges(t, runner, "Delete a tracked sidecar file")
+
+	l := logger.CreateLogger()
+	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
+
+	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l))
+	})
+
+	opts := options.NewTerragruntOptions()
+	opts.WorkingDir = tmpDir
+	opts.RootWorkingDir = tmpDir
+
+	parsedFilters, parseErr := filter.ParseFilterQueries(l, []string{"[HEAD~1...HEAD]"})
+	require.NoError(t, parseErr)
+
+	opts.Filters = parsedFilters
+	opts.Experiments = experiment.NewExperiments()
+	require.NoError(t, opts.Experiments.EnableExperiment(experiment.FilterFlag))
+
+	require.NoError(t, generate.NewGenerator().GenerateStacks(t.Context(), l, opts, w))
+
+	readingAffectedDirs := make([]string, 0, len(w.ReadingAffectedStacks))
+
+	for _, pair := range w.ReadingAffectedStacks {
+		rel, relErr := filepath.Rel(pair.ToStack.DiscoveryContext().WorkingDir, pair.ToStack.Path())
+		require.NoError(t, relErr)
+
+		readingAffectedDirs = append(readingAffectedDirs, filepath.ToSlash(rel))
+	}
+
+	assert.Contains(t, readingAffectedDirs, "live/stack-with-ref",
+		"Stack reading the deleted file should be recorded as reading-affected for unit-level walking")
+	assert.NotContains(t, readingAffectedDirs, "live/stack-no-ref",
+		"Stack reading nothing should not be recorded as reading-affected")
+}
+
 // TestWorktreePhase_Integration_NegatedFiltersAppliedInWorktreeSubDiscoveries tests that
 // negated path filters (e.g., from .terragrunt-filters) are applied within worktree
 // sub-discoveries, not just during the final filter evaluation.

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -2561,13 +2561,11 @@ func TestWorktreePhase_Integration_DeletedReadingStackRecordedAsReadingAffected(
 
 	tmpDir, runner := setupGitRepo(t)
 
-	// Catalog unit the stacks instantiate.
 	legacyUnitDir := filepath.Join(tmpDir, "catalog", "units", "legacy")
 	require.NoError(t, os.MkdirAll(legacyUnitDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(legacyUnitDir, "terragrunt.hcl"), []byte(`# Legacy unit`), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(legacyUnitDir, "main.tf"), []byte(`# Intentionally empty`), 0o644))
 
-	// Stack that reads a glob of sidecar files via mark_glob_as_read.
 	stackWithRefDir := filepath.Join(tmpDir, "live", "stack-with-ref")
 	configsDir := filepath.Join(stackWithRefDir, "configs")
 	require.NoError(t, os.MkdirAll(configsDir, 0o755))
@@ -2645,6 +2643,93 @@ unit "app" {
 		"Stack reading the deleted file should be recorded as reading-affected for unit-level walking")
 	assert.NotContains(t, readingAffectedDirs, "live/stack-no-ref",
 		"Stack reading nothing should not be recorded as reading-affected")
+}
+
+// TestWorktreePhase_Integration_MultipleChangedFilesReadByDistinctStacks verifies that when several
+// files change in one diff and each is read by a different stack, every reading stack is recorded as
+// reading-affected. Matching only the first reading filter records just one of them and silently skips
+// the rest, leaving those stacks' units un-walked.
+func TestWorktreePhase_Integration_MultipleChangedFilesReadByDistinctStacks(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	legacyUnitDir := filepath.Join(tmpDir, "catalog", "units", "legacy")
+	require.NoError(t, os.MkdirAll(legacyUnitDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(legacyUnitDir, "terragrunt.hcl"), []byte(`# Legacy unit`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(legacyUnitDir, "main.tf"), []byte(`# Intentionally empty`), 0o644))
+
+	// Each stack reads its own sidecar via read_terragrunt_config, so a stack matches exactly one
+	// reading filter.
+	stackContent := `
+locals {
+  config = read_terragrunt_config("config.hcl")
+}
+
+unit "app" {
+  source = "${get_repo_root()}/catalog/units/legacy"
+  path   = "app"
+}
+`
+
+	stackNames := []string{"stack-a", "stack-b"}
+
+	for _, name := range stackNames {
+		dir := filepath.Join(tmpDir, "live", name)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "config.hcl"), []byte(`inputs = { version = "v1" }`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "terragrunt.stack.hcl"), []byte(stackContent), 0o644))
+	}
+
+	commitChanges(t, runner, "Create stacks")
+
+	// Change every sidecar in one commit; the stack files themselves are untouched.
+	for _, name := range stackNames {
+		dir := filepath.Join(tmpDir, "live", name)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "config.hcl"), []byte(`inputs = { version = "v2" }`), 0o644))
+	}
+
+	commitChanges(t, runner, "Change every sidecar")
+
+	l := logger.CreateLogger()
+	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
+
+	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: gitExpressions,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l))
+	})
+
+	opts := options.NewTerragruntOptions()
+	opts.WorkingDir = tmpDir
+	opts.RootWorkingDir = tmpDir
+
+	parsedFilters, parseErr := filter.ParseFilterQueries(l, []string{"[HEAD~1...HEAD]"})
+	require.NoError(t, parseErr)
+
+	opts.Filters = parsedFilters
+	opts.Experiments = experiment.NewExperiments()
+	require.NoError(t, opts.Experiments.EnableExperiment(experiment.FilterFlag))
+
+	require.NoError(t, generate.NewGenerator().GenerateStacks(t.Context(), l, opts, w))
+
+	readingAffectedDirs := make([]string, 0, len(w.ReadingAffectedStacks))
+
+	for _, pair := range w.ReadingAffectedStacks {
+		rel, relErr := filepath.Rel(pair.ToStack.DiscoveryContext().WorkingDir, pair.ToStack.Path())
+		require.NoError(t, relErr)
+
+		readingAffectedDirs = append(readingAffectedDirs, filepath.ToSlash(rel))
+	}
+
+	assert.Contains(t, readingAffectedDirs, "live/stack-a",
+		"Stack reading one changed file should be recorded as reading-affected: %v", readingAffectedDirs)
+	assert.Contains(t, readingAffectedDirs, "live/stack-b",
+		"Stack reading another changed file should also be recorded as reading-affected: %v", readingAffectedDirs)
 }
 
 // TestWorktreePhase_Integration_NegatedFiltersAppliedInWorktreeSubDiscoveries tests that

--- a/internal/filter/filters.go
+++ b/internal/filter/filters.go
@@ -94,6 +94,24 @@ func (f Filters) RequiresParse() (Expression, bool) {
 	return nil, false
 }
 
+// PartitionReadingFilters splits the filters by whether their top-level expression is a reading
+// attribute filter, preserving the original order within each group. Worktree discovery uses this to
+// separate reading filters (which track files that may be read by other components via a glob) from
+// plain path filters, because a reading relationship can only be evaluated where the read file exists.
+func (f Filters) PartitionReadingFilters() (reading, other Filters) {
+	for _, filter := range f {
+		if attr, ok := filter.expr.(*AttributeExpression); ok && attr.Key == AttributeReading {
+			reading = append(reading, filter)
+
+			continue
+		}
+
+		other = append(other, filter)
+	}
+
+	return reading, other
+}
+
 // ExcludingGitFilters returns all filters that do not contain a git expression.
 // Git expressions are excluded because they are handled by the worktree phase
 // itself and would cause infinite recursion if propagated to sub-discoveries.

--- a/internal/filter/filters_test.go
+++ b/internal/filter/filters_test.go
@@ -629,6 +629,94 @@ func TestFilters_RestrictToStacks(t *testing.T) {
 	})
 }
 
+func TestFilters_PartitionReadingFilters(t *testing.T) {
+	t.Parallel()
+
+	newReading := func(t *testing.T, value string) *filter.Filter {
+		t.Helper()
+
+		expr, err := filter.NewAttributeExpression(filter.AttributeReading, value)
+		require.NoError(t, err)
+
+		return filter.NewFilter(expr, expr.String())
+	}
+
+	newPath := func(t *testing.T, value string) *filter.Filter {
+		t.Helper()
+
+		expr, err := filter.NewPathFilter(value)
+		require.NoError(t, err)
+
+		return filter.NewFilter(expr, expr.String())
+	}
+
+	newName := func(t *testing.T, value string) *filter.Filter {
+		t.Helper()
+
+		expr, err := filter.NewAttributeExpression(filter.AttributeName, value)
+		require.NoError(t, err)
+
+		return filter.NewFilter(expr, expr.String())
+	}
+
+	t.Run("empty filters", func(t *testing.T) {
+		t.Parallel()
+
+		reading, other := filter.Filters{}.PartitionReadingFilters()
+		assert.Empty(t, reading)
+		assert.Empty(t, other)
+	})
+
+	t.Run("only reading filters", func(t *testing.T) {
+		t.Parallel()
+
+		filters := filter.Filters{newReading(t, "config/item-a.yml")}
+
+		reading, other := filters.PartitionReadingFilters()
+		assert.Len(t, reading, 1)
+		assert.Empty(t, other)
+	})
+
+	t.Run("only non-reading filters", func(t *testing.T) {
+		t.Parallel()
+
+		filters := filter.Filters{newPath(t, "app")}
+
+		reading, other := filters.PartitionReadingFilters()
+		assert.Empty(t, reading)
+		assert.Len(t, other, 1)
+	})
+
+	t.Run("mixed filters preserve order within groups", func(t *testing.T) {
+		t.Parallel()
+
+		filters := filter.Filters{
+			newPath(t, "removed-unit"),
+			newReading(t, "config/item-a.yml"),
+			newName(t, "keep"),
+			newReading(t, "config/item-b.yml"),
+			newPath(t, "another-removed"),
+		}
+
+		reading, other := filters.PartitionReadingFilters()
+
+		readingStrs := make([]string, 0, len(reading))
+		for _, f := range reading {
+			readingStrs = append(readingStrs, f.String())
+		}
+
+		otherStrs := make([]string, 0, len(other))
+		for _, f := range other {
+			otherStrs = append(otherStrs, f.String())
+		}
+
+		// Only reading-attribute filters land in the reading group; a non-reading attribute
+		// filter (name=keep) must stay with the path filters in the other group.
+		assert.Equal(t, []string{"reading=config/item-a.yml", "reading=config/item-b.yml"}, readingStrs)
+		assert.Equal(t, []string{"removed-unit", "name=keep", "another-removed"}, otherStrs)
+	})
+}
+
 func TestFilters_ExcludingGitFilters(t *testing.T) {
 	t.Parallel()
 

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -473,9 +473,11 @@ func appendWorktreeStackPaths(
 }
 
 // worktreeStacksToGenerate returns a slice of stacks that need to be generated from the worktree stacks.
-// When reading filters are present (changes to files read by a stack), it also
-// identifies which stacks are affected and records them on the Worktrees object so that the worktree
-// discovery phase can walk them for unit-level changes.
+// When reading filters are present (a stack reads a file that was added, changed, or deleted in the diff),
+// it also identifies which stacks are affected and records them on the Worktrees object so that the worktree
+// discovery phase can walk them for unit-level changes. A changed or added file is matched against the "to"
+// stacks; a deleted file is matched against the "from" stacks, since that is the only side where it still
+// exists.
 func worktreeStacksToGenerate(
 	ctx context.Context,
 	l log.Logger,
@@ -505,18 +507,6 @@ func worktreeStacksToGenerate(
 		stacksToGenerate.EnsureComponent(stack)
 	}
 
-	// Build set of stack dirs already handled by direct changes, so we don't
-	// duplicate them in ReadingAffected.
-	handledStackDirs := make(map[string]struct{}, len(stackDiff.Changed))
-
-	for _, changed := range stackDiff.Changed {
-		if dc := changed.ToStack.DiscoveryContext(); dc != nil {
-			if rel, err := filepath.Rel(dc.WorkingDir, changed.ToStack.Path()); err == nil {
-				handledStackDirs[filepath.Clean(rel)] = struct{}{}
-			}
-		}
-	}
-
 	// When the expanded filter for a given Git expression requires parsing,
 	// we need to generate all the stacks in the given worktree, as units within the generated stack might be affected.
 	// We also identify which specific stacks are affected by reading filters so that the worktree discovery phase
@@ -532,20 +522,56 @@ func worktreeStacksToGenerate(
 		readingAffected []worktrees.StackDiffChangedPair
 	)
 
+	// Seed with stack dirs already covered by direct changes so reading detection doesn't duplicate them.
+	// It is then reused to dedup a stack that reads more than one diffed file (e.g. a changed and a deleted one).
+	recordedDirs := make(map[string]struct{}, len(stackDiff.Changed))
+
+	for _, changed := range stackDiff.Changed {
+		if dc := changed.ToStack.DiscoveryContext(); dc != nil {
+			if rel, err := filepath.Rel(dc.WorkingDir, changed.ToStack.Path()); err == nil {
+				recordedDirs[filepath.Clean(rel)] = struct{}{}
+			}
+		}
+	}
+
+	recordReadingAffected := func(fromStack, toStack *component.Stack, rel string) {
+		key := filepath.Clean(rel)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		if _, ok := recordedDirs[key]; ok {
+			return
+		}
+
+		recordedDirs[key] = struct{}{}
+
+		readingAffected = append(readingAffected, worktrees.StackDiffChangedPair{
+			FromStack: fromStack,
+			ToStack:   toStack,
+		})
+	}
+
 	for _, pair := range w.WorktreePairs {
-		_, toFilters, err := pair.Expand()
+		fromFilters, toFilters, err := pair.Expand()
 		if err != nil {
 			return nil, fmt.Errorf("failed to expand worktree pair: %w", err)
 		}
 
-		parseExpr, requiresParse := toFilters.RequiresParse()
-		if !requiresParse {
+		toParseExpr, toRequiresParse := toFilters.RequiresParse()
+
+		// Deleted-file reading filters live among the from filters (mixed with path filters for genuine
+		// removals), so isolate them before checking whether the from side needs parsing.
+		deletedReadFilters, _ := fromFilters.PartitionReadingFilters()
+		fromParseExpr, fromRequiresParse := deletedReadFilters.RequiresParse()
+
+		if !toRequiresParse && !fromRequiresParse {
 			continue
 		}
 
 		g.Go(func() error {
-			// Discover all stacks in both worktrees for generation.
-			allFromStacks, err := discoverStacks(ctx, l, opts, pair.FromWorktree, false)
+			// Each side only needs Reading() populated when it has reading filters to match against.
+			allFromStacks, err := discoverStacks(ctx, l, opts, pair.FromWorktree, fromRequiresParse)
 			if err != nil {
 				mu.Lock()
 
@@ -555,10 +581,7 @@ func worktreeStacksToGenerate(
 				return nil
 			}
 
-			// The "to" discovery uses readFiles to force all stacks through
-			// the parse phase (populating Reading()), while still returning every stack
-			// (because they all match type=stack).
-			allToStacks, err := discoverStacks(ctx, l, opts, pair.ToWorktree, true)
+			allToStacks, err := discoverStacks(ctx, l, opts, pair.ToWorktree, toRequiresParse)
 			if err != nil {
 				mu.Lock()
 
@@ -576,48 +599,68 @@ func worktreeStacksToGenerate(
 				stacksToGenerate.EnsureComponent(c)
 			}
 
-			// Identify which "to" stacks read the changed files.
-			matchedToStacks, err := filter.Evaluate(l, parseExpr, allToStacks)
-			if err != nil {
-				mu.Lock()
+			if toRequiresParse {
+				matched, err := filter.Evaluate(l, toParseExpr, allToStacks)
+				if err != nil {
+					mu.Lock()
 
-				errs = append(errs, err)
-				mu.Unlock()
+					errs = append(errs, err)
+					mu.Unlock()
 
-				return nil
+					return nil
+				}
+
+				// A stack missing from the "from" side is a fresh addition already covered by stackDiff.Added.
+				for _, toComp := range matched {
+					toStack, ok := toComp.(*component.Stack)
+					if !ok {
+						continue
+					}
+
+					rel, err := filepath.Rel(pair.ToWorktree.Path, toStack.Path())
+					if err != nil {
+						continue
+					}
+
+					fromStack := findStackByRelPath(allFromStacks, pair.FromWorktree.Path, rel)
+					if fromStack == nil {
+						continue
+					}
+
+					recordReadingAffected(fromStack, toStack, rel)
+				}
 			}
 
-			// Record reading-affected stack pairs on the Worktrees object so that
-			// discoverChangesInWorktreeStacks walks them for unit-level diffs.
-			for _, toComp := range matchedToStacks {
-				toStack, ok := toComp.(*component.Stack)
-				if !ok {
-					continue
-				}
-
-				rel, err := filepath.Rel(pair.ToWorktree.Path, toStack.Path())
+			if fromRequiresParse {
+				matched, err := filter.Evaluate(l, fromParseExpr, allFromStacks)
 				if err != nil {
-					continue
+					mu.Lock()
+
+					errs = append(errs, err)
+					mu.Unlock()
+
+					return nil
 				}
 
-				if _, handled := handledStackDirs[filepath.Clean(rel)]; handled {
-					continue
+				// A stack missing from the "to" side is a genuine removal already covered by stackDiff.Removed.
+				for _, fromComp := range matched {
+					fromStack, ok := fromComp.(*component.Stack)
+					if !ok {
+						continue
+					}
+
+					rel, err := filepath.Rel(pair.FromWorktree.Path, fromStack.Path())
+					if err != nil {
+						continue
+					}
+
+					toStack := findStackByRelPath(allToStacks, pair.ToWorktree.Path, rel)
+					if toStack == nil {
+						continue
+					}
+
+					recordReadingAffected(fromStack, toStack, rel)
 				}
-
-				// If the stack only exists in one worktree (e.g. newly added),
-				// it will be handled by stackDiff.Added/Removed instead.
-				fromStack := findStackByRelPath(allFromStacks, pair.FromWorktree.Path, rel)
-				if fromStack == nil {
-					continue
-				}
-
-				mu.Lock()
-
-				readingAffected = append(readingAffected, worktrees.StackDiffChangedPair{
-					FromStack: fromStack,
-					ToStack:   toStack,
-				})
-				mu.Unlock()
 			}
 
 			return nil

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -522,8 +522,8 @@ func worktreeStacksToGenerate(
 		readingAffected []worktrees.StackDiffChangedPair
 	)
 
-	// Seed with stack dirs already covered by direct changes so reading detection doesn't duplicate them.
-	// It is then reused to dedup a stack that reads more than one diffed file (e.g. a changed and a deleted one).
+	// Stacks already covered by a direct change must not be re-recorded, and a stack reading more than one
+	// diffed file must be recorded once; both are guarded by this set of stack dirs.
 	recordedDirs := make(map[string]struct{}, len(stackDiff.Changed))
 
 	for _, changed := range stackDiff.Changed {
@@ -558,35 +558,35 @@ func worktreeStacksToGenerate(
 			return nil, fmt.Errorf("failed to expand worktree pair: %w", err)
 		}
 
-		toParseExpr, toRequiresParse := toFilters.RequiresParse()
-
-		// Deleted-file reading filters live among the from filters (mixed with path filters for genuine
-		// removals), so isolate them before checking whether the from side needs parsing.
+		// Evaluate every reading filter, not just the first: a stack matches one filter per file it reads.
+		// The from filters mix deleted-file reading filters with path filters for genuine removals, so the
+		// partition isolates the reading ones.
+		toReadFilters, _ := toFilters.PartitionReadingFilters()
 		deletedReadFilters, _ := fromFilters.PartitionReadingFilters()
-		fromParseExpr, fromRequiresParse := deletedReadFilters.RequiresParse()
 
-		if !toRequiresParse && !fromRequiresParse {
+		if len(toReadFilters) == 0 && len(deletedReadFilters) == 0 {
 			continue
 		}
 
 		g.Go(func() error {
-			// Each side only needs Reading() populated when it has reading filters to match against.
-			allFromStacks, err := discoverStacks(ctx, l, opts, pair.FromWorktree, fromRequiresParse)
-			if err != nil {
+			recordErr := func(err error) {
 				mu.Lock()
 
 				errs = append(errs, err)
+
 				mu.Unlock()
+			}
+
+			allFromStacks, err := discoverStacks(ctx, l, opts, pair.FromWorktree, len(deletedReadFilters) > 0)
+			if err != nil {
+				recordErr(err)
 
 				return nil
 			}
 
-			allToStacks, err := discoverStacks(ctx, l, opts, pair.ToWorktree, toRequiresParse)
+			allToStacks, err := discoverStacks(ctx, l, opts, pair.ToWorktree, len(toReadFilters) > 0)
 			if err != nil {
-				mu.Lock()
-
-				errs = append(errs, err)
-				mu.Unlock()
+				recordErr(err)
 
 				return nil
 			}
@@ -599,68 +599,48 @@ func worktreeStacksToGenerate(
 				stacksToGenerate.EnsureComponent(c)
 			}
 
-			if toRequiresParse {
-				matched, err := filter.Evaluate(l, toParseExpr, allToStacks)
-				if err != nil {
-					mu.Lock()
+			matchedToStacks, err := stacksReadingFiles(l, toReadFilters, allToStacks)
+			if err != nil {
+				recordErr(err)
 
-					errs = append(errs, err)
-					mu.Unlock()
-
-					return nil
-				}
-
-				// A stack missing from the "from" side is a fresh addition already covered by stackDiff.Added.
-				for _, toComp := range matched {
-					toStack, ok := toComp.(*component.Stack)
-					if !ok {
-						continue
-					}
-
-					rel, err := filepath.Rel(pair.ToWorktree.Path, toStack.Path())
-					if err != nil {
-						continue
-					}
-
-					fromStack := findStackByRelPath(allFromStacks, pair.FromWorktree.Path, rel)
-					if fromStack == nil {
-						continue
-					}
-
-					recordReadingAffected(fromStack, toStack, rel)
-				}
+				return nil
 			}
 
-			if fromRequiresParse {
-				matched, err := filter.Evaluate(l, fromParseExpr, allFromStacks)
+			// A stack missing from the "from" side is a fresh addition already covered by stackDiff.Added.
+			for _, toStack := range matchedToStacks {
+				rel, err := filepath.Rel(pair.ToWorktree.Path, toStack.Path())
 				if err != nil {
-					mu.Lock()
-
-					errs = append(errs, err)
-					mu.Unlock()
-
-					return nil
+					continue
 				}
 
-				// A stack missing from the "to" side is a genuine removal already covered by stackDiff.Removed.
-				for _, fromComp := range matched {
-					fromStack, ok := fromComp.(*component.Stack)
-					if !ok {
-						continue
-					}
-
-					rel, err := filepath.Rel(pair.FromWorktree.Path, fromStack.Path())
-					if err != nil {
-						continue
-					}
-
-					toStack := findStackByRelPath(allToStacks, pair.ToWorktree.Path, rel)
-					if toStack == nil {
-						continue
-					}
-
-					recordReadingAffected(fromStack, toStack, rel)
+				fromStack := findStackByRelPath(allFromStacks, pair.FromWorktree.Path, rel)
+				if fromStack == nil {
+					continue
 				}
+
+				recordReadingAffected(fromStack, toStack, rel)
+			}
+
+			matchedFromStacks, err := stacksReadingFiles(l, deletedReadFilters, allFromStacks)
+			if err != nil {
+				recordErr(err)
+
+				return nil
+			}
+
+			// A stack missing from the "to" side is a genuine removal already covered by stackDiff.Removed.
+			for _, fromStack := range matchedFromStacks {
+				rel, err := filepath.Rel(pair.FromWorktree.Path, fromStack.Path())
+				if err != nil {
+					continue
+				}
+
+				toStack := findStackByRelPath(allToStacks, pair.ToWorktree.Path, rel)
+				if toStack == nil {
+					continue
+				}
+
+				recordReadingAffected(fromStack, toStack, rel)
 			}
 
 			return nil
@@ -741,6 +721,41 @@ func findStackByRelPath(stacks component.Components, worktreePath string, relPat
 	}
 
 	return nil
+}
+
+// stacksReadingFiles returns the stacks among components that read a file targeted by any of the given
+// reading filters, deduplicated by path. The components must have been discovered with readFiles enabled
+// so their Reading attribute is populated.
+func stacksReadingFiles(
+	l log.Logger,
+	readingFilters filter.Filters,
+	components component.Components,
+) ([]*component.Stack, error) {
+	seen := make(map[string]struct{})
+	matched := make([]*component.Stack, 0, len(readingFilters))
+
+	for _, f := range readingFilters {
+		evaluated, err := filter.Evaluate(l, f.Expression(), components)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, c := range evaluated {
+			stack, ok := c.(*component.Stack)
+			if !ok {
+				continue
+			}
+
+			if _, ok := seen[stack.Path()]; ok {
+				continue
+			}
+
+			seen[stack.Path()] = struct{}{}
+			matched = append(matched, stack)
+		}
+	}
+
+	return matched, nil
 }
 
 // stackTypeFilter returns a filter.Filters that restricts to stack components.

--- a/test/integration_filter_test.go
+++ b/test/integration_filter_test.go
@@ -2316,3 +2316,132 @@ func TestFilterFlagWithGitFilterMarkGlobAsRead(t *testing.T) {
 	assert.ElementsMatch(t, []string{"unit-reads-added", "unit-reads-removed"}, results,
 		"units reading added or removed glob files should be selected; untouched unit should not")
 }
+
+// TestRunAllGitFilterMarkGlobAsReadDeleted verifies that `terragrunt run --all -- plan` selects a
+// unit reading a glob-tracked file even when the diff deletes that file, instead of excluding the
+// unit as a removal. In the deletion-only case the unit's only "change" is a file it reads
+// disappearing, so the surviving unit must be planned on the HEAD side rather than excluded by the
+// destroy-protection path. The modified/added cases and the combined cases
+// (where another change could mask the bug) are covered as regressions alongside it.
+func TestRunAllGitFilterMarkGlobAsReadDeleted(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		setupChange func(t *testing.T, configDir string)
+		name        string
+		description string
+	}{
+		{
+			name: "deleted-only tracked file",
+			setupChange: func(t *testing.T, configDir string) {
+				t.Helper()
+				require.NoError(t, os.Remove(filepath.Join(configDir, "item-a.yml")))
+			},
+			description: "deleting the only tracked file must still select the reading unit",
+		},
+		{
+			name: "modified tracked file",
+			setupChange: func(t *testing.T, configDir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(configDir, "item-a.yml"), []byte("a: modified\n"), 0644))
+			},
+			description: "modifying a tracked file must select the reading unit",
+		},
+		{
+			name: "added tracked file",
+			setupChange: func(t *testing.T, configDir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(configDir, "item-c.yml"), []byte("c: 3\n"), 0644))
+			},
+			description: "adding a tracked file must select the reading unit",
+		},
+		{
+			name: "deleted tracked file alongside a modification",
+			setupChange: func(t *testing.T, configDir string) {
+				t.Helper()
+				require.NoError(t, os.Remove(filepath.Join(configDir, "item-a.yml")))
+				require.NoError(t, os.WriteFile(filepath.Join(configDir, "item-b.yml"), []byte("b: modified\n"), 0644))
+			},
+			description: "deleting a tracked file alongside another change must still select the reading unit",
+		},
+		{
+			name: "deleted tracked file alongside an addition",
+			setupChange: func(t *testing.T, configDir string) {
+				t.Helper()
+				require.NoError(t, os.Remove(filepath.Join(configDir, "item-a.yml")))
+				require.NoError(t, os.WriteFile(filepath.Join(configDir, "item-c.yml"), []byte("c: 3\n"), 0644))
+			},
+			description: "deleting a tracked file alongside an addition must still select the reading unit",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := helpers.TmpDirWOSymlinks(t)
+			runner := helpers.InitTestGitRunner(t, tmpDir)
+
+			unitDir := filepath.Join(tmpDir, "unit-reads-config")
+			require.NoError(t, os.MkdirAll(unitDir, 0755))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(unitDir, "terragrunt.hcl"),
+				[]byte(`locals {
+  config_files = mark_glob_as_read("../config/{*.yaml,*.yml}")
+}`), 0644))
+			require.NoError(t, os.WriteFile(filepath.Join(unitDir, "main.tf"), []byte("# minimal"), 0644))
+
+			configDir := filepath.Join(tmpDir, "config")
+			require.NoError(t, os.MkdirAll(configDir, 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(configDir, "item-a.yml"), []byte("a: 1\n"), 0644))
+			require.NoError(t, os.WriteFile(filepath.Join(configDir, "item-b.yml"), []byte("b: 2\n"), 0644))
+
+			require.NoError(t, runner.Add(t.Context(), "."))
+			require.NoError(t, runner.Commit(t.Context(), "Baseline unit and tracked config files"))
+
+			tc.setupChange(t, configDir)
+
+			require.NoError(t, runner.Add(t.Context(), "."))
+			require.NoError(t, runner.Commit(t.Context(), "Apply change to tracked config files"))
+
+			helpers.CleanupTerraformFolder(t, tmpDir)
+
+			reportFilePath := filepath.Join(tmpDir, helpers.ReportFile)
+			cmd := "terragrunt run --all --non-interactive --no-color --working-dir " + tmpDir +
+				" --filter '[HEAD~1...HEAD]' --report-file " + reportFilePath + " -- plan"
+
+			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+			// A missing backend or IaC binary may fail the plan itself, but discovery and the report
+			// still run; only an unrelated failure is unexpected.
+			if err != nil && !strings.Contains(stderr, "terraform") && !strings.Contains(stderr, "tofu") {
+				require.NoError(t, err, "Unexpected error\nstdout: %s\nstderr: %s", stdout, stderr)
+			}
+
+			require.FileExists(t, reportFilePath, "Report file should exist at %s", reportFilePath)
+
+			runs, parseErr := report.ParseJSONRunsFromFile(reportFilePath)
+			require.NoError(t, parseErr, "Should be able to parse report JSON")
+
+			var found bool
+
+			runNames := make([]string, 0, len(runs))
+
+			for i := range runs {
+				run := &runs[i]
+				runNames = append(runNames, filepath.Base(run.Name))
+
+				if filepath.Base(run.Name) != "unit-reads-config" || run.Ref != "HEAD" {
+					continue
+				}
+
+				found = true
+
+				assert.NotEqual(t, "excluded", run.Result,
+					"HEAD-side reading unit should not be excluded: %s", tc.description)
+			}
+
+			assert.True(t, found,
+				"HEAD-side reading unit should be in the report (got: %v): %s", runNames, tc.description)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6420.

Closes #6421

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree diff discovery for `mark_glob_as_read` when referenced files are deleted, ensuring surviving reader units and stacks are rediscovered on the correct side.
  * Correctly handles removal vs. rediscovery when the reader itself is deleted in the same change, preserving expected destroy behavior.
  * Refined stack “reading affected” tracking so all relevant stacks are recorded when multiple reading filters and files change.

* **Tests**
  * Added/extended integration and regression tests covering deleted-file reading for units and stacks, plus filter partitioning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->