### PR TITLE
chore: Engine per unit shutdown

### DIFF
--- a/internal/configbridge/bridge.go
+++ b/internal/configbridge/bridge.go
@@ -148,7 +148,8 @@ func NewRunOptions(opts *options.TerragruntOptions) *run.Options {
 	runOpts.LogDisableErrorSummary = opts.LogDisableErrorSummary
 	runOpts.TerragruntConfigPath = opts.TerragruntConfigPath
 	runOpts.OriginalTerragruntConfigPath = opts.OriginalTerragruntConfigPath
-	runOpts.WorkingDir = opts.WorkingDir
+	runOpts.UnitDir = opts.WorkingDir
+	runOpts.CacheDir = opts.WorkingDir
 	runOpts.RootWorkingDir = opts.RootWorkingDir
 	runOpts.DownloadDir = opts.DownloadDir
 	runOpts.TerraformCommand = opts.TerraformCommand

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -93,6 +94,59 @@ type engineInstance struct {
 	execOptions  *ExecutionOptions
 }
 
+// engineClients is the registry of engine plugin instances, keyed by the post-download
+// cache working dir. The lock guards only the map, never the plugin work (create,
+// shutdown RPC, kill), which the caller does outside it.
+type engineClients struct {
+	clients map[string]*engineInstance
+	mu      sync.Mutex
+}
+
+func newEngineClients() *engineClients {
+	return &engineClients{clients: make(map[string]*engineInstance)}
+}
+
+// get returns the instance registered for key.
+func (c *engineClients) get(key string) (*engineInstance, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	inst, ok := c.clients[key]
+
+	return inst, ok
+}
+
+// store registers inst under key.
+func (c *engineClients) store(key string, inst *engineInstance) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.clients[key] = inst
+}
+
+// takeMatching removes the instances whose key satisfies match and returns them, so
+// the caller can shut them down outside the lock. Removing under the lock makes a
+// per-unit ShutdownUnit and the batch Shutdown mutually exclusive: each instance is
+// returned to exactly one caller, so none is shut down twice.
+func (c *engineClients) takeMatching(match func(key string) bool) []*engineInstance {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var taken []*engineInstance
+
+	for key, inst := range c.clients {
+		if !match(key) {
+			continue
+		}
+
+		taken = append(taken, inst)
+
+		delete(c.clients, key)
+	}
+
+	return taken
+}
+
 // Run executes the given command with the experimental engine. The provided
 // vexec.Exec is used to spawn the engine plugin subprocess and must be
 // OS-backed.
@@ -108,7 +162,7 @@ func Run(
 	}
 
 	workingDir := execOptions.WorkingDir
-	instance, found := engineClients.Load(workingDir)
+	instance, found := engineClients.get(workingDir)
 
 	var output *util.CmdOutput
 
@@ -129,25 +183,19 @@ func Run(
 				return createEngineErr
 			}
 
-			engineClients.Store(workingDir, &engineInstance{
+			instance = &engineInstance{
 				engineClient: terragruntEngine,
 				client:       client,
 				execOptions:  execOptions,
-			})
-
-			instance, _ = engineClients.Load(workingDir)
+			}
+			engineClients.store(workingDir, instance)
 
 			if err = initialize(runCtx, l, execOptions, terragruntEngine); err != nil {
 				return err
 			}
 		}
 
-		engInst, ok := instance.(*engineInstance)
-		if !ok {
-			return fmt.Errorf("failed to fetch engine instance %s", workingDir)
-		}
-
-		terragruntEngine := engInst.engineClient
+		terragruntEngine := instance.engineClient
 
 		var invokeErr error
 
@@ -167,7 +215,7 @@ func Run(
 
 // WithEngineValues add to context default values for engine.
 func WithEngineValues(ctx context.Context) context.Context {
-	ctx = context.WithValue(ctx, terraformCommandContextKey, &sync.Map{})
+	ctx = context.WithValue(ctx, terraformCommandContextKey, newEngineClients())
 	ctx = context.WithValue(ctx, locksContextKey, util.NewKeyLocks())
 	ctx = context.WithValue(ctx, latestVersionsContextKey, cache.NewCache[string]("engineVersions"))
 
@@ -451,14 +499,14 @@ func isArchiveByHeader(l log.Logger, filePath string) bool {
 	return err == nil && archiveType != ""
 }
 
-// engineClientsFromContext returns the engine clients map from the context.
-func engineClientsFromContext(ctx context.Context) (*sync.Map, error) {
+// engineClientsFromContext returns the engine clients registry from the context.
+func engineClientsFromContext(ctx context.Context) (*engineClients, error) {
 	val := ctx.Value(terraformCommandContextKey)
 	if val == nil {
 		return nil, errors.New(errMsgEngineClientsFetch)
 	}
 
-	result, ok := val.(*sync.Map)
+	result, ok := val.(*engineClients)
 	if !ok {
 		return nil, errors.New(errMsgEngineClientsCast)
 	}
@@ -506,14 +554,12 @@ func Shutdown(ctx context.Context, l log.Logger, experiments experiment.Experime
 		return nil
 	}
 
-	// iterate over all engine instances and shutdown
 	engineClients, err := engineClientsFromContext(ctx)
 	if err != nil {
 		return err
 	}
 
-	engineClients.Range(func(key, value any) bool {
-		instance := value.(*engineInstance)
+	for _, instance := range engineClients.takeMatching(func(string) bool { return true }) {
 		l.Debugf("Shutting down engine for %s", instance.execOptions.WorkingDir)
 
 		// We use without cancel here to ensure that the shutdown isn't cancelled by the main context,
@@ -535,11 +581,65 @@ func Shutdown(ctx context.Context, l log.Logger, experiments experiment.Experime
 			l.Debugf("Plugin did not exit gracefully within timeout, force killing")
 			instance.client.Kill()
 		}
-
-		return true
-	})
+	}
 
 	return nil
+}
+
+// ShutdownUnit shuts down and removes the engine bound to a single unit's cache root,
+// releasing its plugin subprocess when the unit finishes rather than at the batch
+// Shutdown. It is experiment-gated and never fails the run: shutdown-RPC errors are
+// logged, and the only returned error is a missing engine-clients context.
+//
+// The registry is keyed by the post-download cache working dir, which embeds
+// EncodeBase64Sha1(Clean(workingDir)) as a path segment. Matching on that segment
+// rather than a prefix identifies a unit's engines independently of the download dir.
+func ShutdownUnit(
+	ctx context.Context,
+	l log.Logger,
+	experiments experiment.Experiments,
+	noEngine bool,
+	workingDir string,
+) error {
+	if !experiments.Evaluate(experiment.IacEngine) || noEngine {
+		return nil
+	}
+
+	engineClients, err := engineClientsFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	hashSegment := util.EncodeBase64Sha1(filepath.Clean(workingDir))
+
+	for _, instance := range engineClients.takeMatching(func(key string) bool {
+		return PathHasSegment(key, hashSegment)
+	}) {
+		l.Debugf("Shutting down engine for %s", instance.execOptions.WorkingDir)
+
+		// Shutdown must proceed even if the parent context is already cancelled.
+		if err := shutdown(
+			context.WithoutCancel(ctx),
+			l,
+			instance.execOptions,
+			instance.engineClient,
+		); err != nil {
+			l.Errorf("Error shutting down engine: %v", err)
+		}
+
+		if !waitForPluginExit(instance.client, gracefulExitTimeout) {
+			l.Debugf("Plugin did not exit gracefully within timeout, force killing")
+			instance.client.Kill()
+		}
+	}
+
+	return nil
+}
+
+// PathHasSegment reports whether seg is one of p's path components (between
+// separators), not merely a substring of p.
+func PathHasSegment(p, seg string) bool {
+	return slices.Contains(strings.Split(p, string(os.PathSeparator)), seg)
 }
 
 // waitForPluginExit waits for the plugin process to exit, returning true if it exited

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -94,46 +94,76 @@ type engineInstance struct {
 	execOptions  *ExecutionOptions
 }
 
-// engineClients is the registry of engine plugin instances, keyed by the post-download
-// cache working dir. The lock guards only the map, never the plugin work (create,
-// shutdown RPC, kill), which the caller does outside it. Removing an instance under the
-// lock hands it to exactly one caller, so a batch Shutdown racing a per-unit ShutdownUnit
-// never shuts the same engine down twice.
+// engineEntry single-flights one cache dir's engine creation: the builder writes instance and
+// err, then closes ready, so every other reader must receive on ready first. That close is
+// their sole happens-before edge.
+type engineEntry struct {
+	ready       chan struct{}
+	instance    *engineInstance
+	err         error
+	execOptions *ExecutionOptions
+}
+
+// engineClients is the registry of engine instances, keyed by post-download cache working dir.
+// mu guards only map membership, never the slow create or shutdown work, so distinct cache
+// dirs proceed in parallel. Every removal is under mu, so a batch Shutdown racing a per-unit
+// ShutdownUnit never shuts an engine down twice.
 type engineClients struct {
-	clients map[string]*engineInstance
+	clients map[string]*engineEntry
 	mu      sync.Mutex
 }
 
 func newEngineClients() *engineClients {
-	return &engineClients{clients: make(map[string]*engineInstance)}
+	return &engineClients{clients: make(map[string]*engineEntry)}
 }
 
-// get returns the instance registered for key.
-func (c *engineClients) get(key string) (*engineInstance, bool) {
+// loadOrCreate returns the instance for key, or reserves the key and builds one via create.
+// Concurrent callers for one key share a single build instead of racing to register competing
+// engines. The bool reports whether an existing instance was reused.
+func (c *engineClients) loadOrCreate(
+	key string,
+	execOptions *ExecutionOptions,
+	create func() (*engineInstance, error),
+) (*engineInstance, bool, error) {
+	c.mu.Lock()
+
+	if e, found := c.clients[key]; found {
+		c.mu.Unlock()
+
+		<-e.ready
+
+		return e.instance, true, e.err
+	}
+
+	e := &engineEntry{ready: make(chan struct{}), execOptions: execOptions}
+	c.clients[key] = e
+	c.mu.Unlock()
+
+	e.instance, e.err = create()
+
+	if e.err != nil {
+		// Drop a failed build so the next Run rebuilds instead of serving the cached failure.
+		// The identity guard avoids deleting a different entry that replaced this one.
+		c.mu.Lock()
+		if c.clients[key] == e {
+			delete(c.clients, key)
+		}
+		c.mu.Unlock()
+	}
+
+	close(e.ready)
+
+	return e.instance, false, e.err
+}
+
+// takeAll removes and returns every registered entry.
+func (c *engineClients) takeAll() []*engineEntry {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	inst, ok := c.clients[key]
-
-	return inst, ok
-}
-
-// store registers inst under key.
-func (c *engineClients) store(key string, inst *engineInstance) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.clients[key] = inst
-}
-
-// takeAll removes and returns every registered instance.
-func (c *engineClients) takeAll() []*engineInstance {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	taken := make([]*engineInstance, 0, len(c.clients))
-	for _, inst := range c.clients {
-		taken = append(taken, inst)
+	taken := make([]*engineEntry, 0, len(c.clients))
+	for _, e := range c.clients {
+		taken = append(taken, e)
 	}
 
 	clear(c.clients)
@@ -141,17 +171,17 @@ func (c *engineClients) takeAll() []*engineInstance {
 	return taken
 }
 
-// takeByUnitDir removes and returns the instance belonging to the given unit, or nil if
-// none is registered.
-func (c *engineClients) takeByUnitDir(unitDir string) *engineInstance {
+// takeUnit removes and returns the entry for the given unit, or nil. It matches the
+// entry's execOptions, not the instance's, so it finds a unit whose engine is still building.
+func (c *engineClients) takeUnit(unitDir string) *engineEntry {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for key, inst := range c.clients {
-		if inst.execOptions.UnitDir == unitDir {
+	for key, e := range c.clients {
+		if e.execOptions.UnitDir == unitDir {
 			delete(c.clients, key)
 
-			return inst
+			return e
 		}
 	}
 
@@ -173,7 +203,13 @@ func Run(
 	}
 
 	cacheDir := execOptions.CacheDir
-	instance, found := engineClients.get(cacheDir)
+
+	instance, found, err := engineClients.loadOrCreate(cacheDir, execOptions, func() (*engineInstance, error) {
+		return createInstance(ctx, l, e, execOptions)
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	var output *util.CmdOutput
 
@@ -182,46 +218,48 @@ func Run(
 		"cache_dir":          cacheDir,
 		"engine_initialized": found,
 	}, func(runCtx context.Context) error {
-		// initialize engine for working directory
-		if !found {
-			// download engine if not available
-			if err = downloadEngine(runCtx, l, execOptions); err != nil {
-				return err
-			}
-
-			terragruntEngine, client, createEngineErr := createEngine(runCtx, l, e, execOptions)
-			if createEngineErr != nil {
-				return createEngineErr
-			}
-
-			instance = &engineInstance{
-				engineClient: terragruntEngine,
-				client:       client,
-				execOptions:  execOptions,
-			}
-			engineClients.store(cacheDir, instance)
-
-			if err = initialize(runCtx, l, execOptions, terragruntEngine); err != nil {
-				return err
-			}
-		}
-
-		terragruntEngine := instance.engineClient
-
 		var invokeErr error
 
-		output, invokeErr = invoke(runCtx, l, execOptions, terragruntEngine)
-		if invokeErr != nil {
-			return invokeErr
-		}
+		output, invokeErr = invoke(runCtx, l, execOptions, instance.engineClient)
 
-		return nil
+		return invokeErr
 	})
 	if runErr != nil {
 		return nil, runErr
 	}
 
 	return output, nil
+}
+
+// createInstance downloads, starts, and initializes an engine for execOptions. A plugin
+// that starts but fails to initialize is killed rather than leaked, since it is never
+// registered for a later Shutdown to reach.
+func createInstance(
+	ctx context.Context,
+	l log.Logger,
+	e vexec.Exec,
+	execOptions *ExecutionOptions,
+) (*engineInstance, error) {
+	if err := downloadEngine(ctx, l, execOptions); err != nil {
+		return nil, err
+	}
+
+	terragruntEngine, client, err := createEngine(ctx, l, e, execOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := initialize(ctx, l, execOptions, terragruntEngine); err != nil {
+		client.Kill()
+
+		return nil, err
+	}
+
+	return &engineInstance{
+		engineClient: terragruntEngine,
+		client:       client,
+		execOptions:  execOptions,
+	}, nil
 }
 
 // WithEngineValues add to context default values for engine.
@@ -570,8 +608,8 @@ func Shutdown(ctx context.Context, l log.Logger, experiments experiment.Experime
 		return err
 	}
 
-	for _, instance := range engineClients.takeAll() {
-		shutdownInstance(ctx, l, instance)
+	for _, entry := range engineClients.takeAll() {
+		drainEntry(ctx, l, entry)
 	}
 
 	return nil
@@ -596,18 +634,28 @@ func ShutdownUnit(
 		return err
 	}
 
-	if instance := engineClients.takeByUnitDir(filepath.Clean(unitDir)); instance != nil {
-		shutdownInstance(ctx, l, instance)
+	if entry := engineClients.takeUnit(filepath.Clean(unitDir)); entry != nil {
+		drainEntry(ctx, l, entry)
 	}
 
 	return nil
 }
 
-// shutdownInstance shuts down the instance's engine and releases its plugin subprocess,
-// force-killing it if it does not exit gracefully within the timeout. Failures are
-// logged, never returned: engine shutdown is best-effort and must not fail the run. The
-// context is detached from cancellation so an already-cancelled run still tears the
-// engine down.
+// drainEntry shuts down the entry's engine after its build settles. A failed build leaves a
+// nil instance and nothing to release: createInstance already killed any half-built plugin.
+func drainEntry(ctx context.Context, l log.Logger, e *engineEntry) {
+	<-e.ready
+
+	if e.instance == nil {
+		return
+	}
+
+	shutdownInstance(ctx, l, e.instance)
+}
+
+// shutdownInstance tears down one engine, force-killing a plugin that will not exit in time.
+// Errors are logged, not returned: shutdown is best-effort and must not fail the run. The
+// context is detached from cancellation so an already-cancelled run still shuts engines down.
 func shutdownInstance(ctx context.Context, l log.Logger, instance *engineInstance) {
 	ctx = context.WithoutCancel(ctx)
 
@@ -781,7 +829,11 @@ func createEngine(
 			return err
 		}
 
-		terragruntEngine := rawClient.(proto.EngineClient)
+		terragruntEngine, ok := rawClient.(proto.EngineClient)
+		if !ok {
+			return fmt.Errorf("engine plugin returned unexpected client type %T", rawClient)
+		}
+
 		engineClient = &terragruntEngine
 		pluginClient = client
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -673,31 +673,30 @@ func shutdownInstance(ctx context.Context, l log.Logger, instance *engineInstanc
 	}
 
 	// The shutdown RPC already told the plugin to exit, so wait before force-killing it.
-	if !waitForPluginExit(instance.client, gracefulExitTimeout) {
+	if !WaitForPluginExit(instance.client.Exited, gracefulExitTimeout) {
 		l.Debugf("Plugin did not exit gracefully within timeout, force killing")
 		instance.client.Kill()
 	}
 }
 
-// waitForPluginExit waits for the plugin process to exit, returning true if it exited
-// within the timeout, false otherwise.
-func waitForPluginExit(client *plugin.Client, timeout time.Duration) bool {
-	done := make(chan struct{})
+// WaitForPluginExit reports whether the plugin exited within the timeout, polling at
+// pluginExitPollInterval.
+func WaitForPluginExit(exited func() bool, timeout time.Duration) bool {
+	deadline := time.After(timeout)
 
-	go func() {
-		// Client.Exited() returns true when the plugin process has exited
-		for !client.Exited() {
-			time.Sleep(pluginExitPollInterval)
+	ticker := time.NewTicker(pluginExitPollInterval)
+	defer ticker.Stop()
+
+	for {
+		if exited() {
+			return true
 		}
 
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		return true
-	case <-time.After(timeout):
-		return false
+		select {
+		case <-deadline:
+			return false
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -593,8 +593,12 @@ func engineVersionsCacheFromContext(ctx context.Context) (*cache.Cache[string], 
 }
 
 const (
-	gracefulExitTimeout    = 5 * time.Second
+	// gracefulExitTimeout is the grace period for a plugin to exit on its own.
+	gracefulExitTimeout = 5 * time.Second
+	// pluginExitPollInterval is the cadence for polling whether the plugin has exited.
 	pluginExitPollInterval = 50 * time.Millisecond
+	// shutdownRPCTimeout bounds the Shutdown RPC stream.
+	shutdownRPCTimeout = 30 * time.Second
 )
 
 // Shutdown shuts down the experimental engine.
@@ -655,9 +659,12 @@ func drainEntry(ctx context.Context, l log.Logger, e *engineEntry) {
 
 // shutdownInstance tears down one engine, force-killing a plugin that will not exit in time.
 // Errors are logged, not returned: shutdown is best-effort and must not fail the run. The
-// context is detached from cancellation so an already-cancelled run still shuts engines down.
+// context is detached from cancellation so an already-cancelled run still shuts engines down,
+// then bounded by shutdownRPCTimeout so a hung Shutdown stream falls through to the force-kill
+// below instead of blocking the worker.
 func shutdownInstance(ctx context.Context, l log.Logger, instance *engineInstance) {
-	ctx = context.WithoutCancel(ctx)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownRPCTimeout)
+	defer cancel()
 
 	l.Debugf("Shutting down engine for %s", instance.execOptions.CacheDir)
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -75,7 +74,8 @@ type ExecutionOptions struct {
 	EngineOptions     *EngineOptions
 	EngineConfig      *EngineConfig
 	Env               map[string]string
-	WorkingDir        string
+	UnitDir           string
+	CacheDir          string
 	RootWorkingDir    string
 	Command           string
 	Args              []string
@@ -96,7 +96,9 @@ type engineInstance struct {
 
 // engineClients is the registry of engine plugin instances, keyed by the post-download
 // cache working dir. The lock guards only the map, never the plugin work (create,
-// shutdown RPC, kill), which the caller does outside it.
+// shutdown RPC, kill), which the caller does outside it. Removing an instance under the
+// lock hands it to exactly one caller, so a batch Shutdown racing a per-unit ShutdownUnit
+// never shuts the same engine down twice.
 type engineClients struct {
 	clients map[string]*engineInstance
 	mu      sync.Mutex
@@ -124,27 +126,36 @@ func (c *engineClients) store(key string, inst *engineInstance) {
 	c.clients[key] = inst
 }
 
-// takeMatching removes the instances whose key satisfies match and returns them, so
-// the caller can shut them down outside the lock. Removing under the lock makes a
-// per-unit ShutdownUnit and the batch Shutdown mutually exclusive: each instance is
-// returned to exactly one caller, so none is shut down twice.
-func (c *engineClients) takeMatching(match func(key string) bool) []*engineInstance {
+// takeAll removes and returns every registered instance.
+func (c *engineClients) takeAll() []*engineInstance {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var taken []*engineInstance
-
-	for key, inst := range c.clients {
-		if !match(key) {
-			continue
-		}
-
+	taken := make([]*engineInstance, 0, len(c.clients))
+	for _, inst := range c.clients {
 		taken = append(taken, inst)
-
-		delete(c.clients, key)
 	}
 
+	clear(c.clients)
+
 	return taken
+}
+
+// takeByUnitDir removes and returns the instance belonging to the given unit, or nil if
+// none is registered.
+func (c *engineClients) takeByUnitDir(unitDir string) *engineInstance {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for key, inst := range c.clients {
+		if inst.execOptions.UnitDir == unitDir {
+			delete(c.clients, key)
+
+			return inst
+		}
+	}
+
+	return nil
 }
 
 // Run executes the given command with the experimental engine. The provided
@@ -161,14 +172,14 @@ func Run(
 		return nil, err
 	}
 
-	workingDir := execOptions.WorkingDir
-	instance, found := engineClients.get(workingDir)
+	cacheDir := execOptions.CacheDir
+	instance, found := engineClients.get(cacheDir)
 
 	var output *util.CmdOutput
 
 	runErr := telemetry.TelemeterFromContext(ctx).Collect(ctx, "engine_run", map[string]any{
 		"command":            execOptions.Command,
-		"working_dir":        workingDir,
+		"cache_dir":          cacheDir,
 		"engine_initialized": found,
 	}, func(runCtx context.Context) error {
 		// initialize engine for working directory
@@ -188,7 +199,7 @@ func Run(
 				client:       client,
 				execOptions:  execOptions,
 			}
-			engineClients.store(workingDir, instance)
+			engineClients.store(cacheDir, instance)
 
 			if err = initialize(runCtx, l, execOptions, terragruntEngine); err != nil {
 				return err
@@ -559,47 +570,22 @@ func Shutdown(ctx context.Context, l log.Logger, experiments experiment.Experime
 		return err
 	}
 
-	for _, instance := range engineClients.takeMatching(func(string) bool { return true }) {
-		l.Debugf("Shutting down engine for %s", instance.execOptions.WorkingDir)
-
-		// We use without cancel here to ensure that the shutdown isn't cancelled by the main context,
-		// like it is in the RunCommandWithOutput function. This ensures that we don't cancel the shutdown
-		// when the command is cancelled.
-		if err := shutdown(
-			context.WithoutCancel(ctx),
-			l,
-			instance.execOptions,
-			instance.engineClient,
-		); err != nil {
-			l.Errorf("Error shutting down engine: %v", err)
-		}
-
-		// Wait for plugin to exit gracefully before force-killing.
-		// The shutdown RPC has already told the plugin to exit, so it should
-		// be cleaning up and exiting on its own. Give it time to finish.
-		if !waitForPluginExit(instance.client, gracefulExitTimeout) {
-			l.Debugf("Plugin did not exit gracefully within timeout, force killing")
-			instance.client.Kill()
-		}
+	for _, instance := range engineClients.takeAll() {
+		shutdownInstance(ctx, l, instance)
 	}
 
 	return nil
 }
 
-// ShutdownUnit shuts down and removes the engine bound to a single unit's cache root,
-// releasing its plugin subprocess when the unit finishes rather than at the batch
-// Shutdown. It is experiment-gated and never fails the run: shutdown-RPC errors are
-// logged, and the only returned error is a missing engine-clients context.
-//
-// The registry is keyed by the post-download cache working dir, which embeds
-// EncodeBase64Sha1(Clean(workingDir)) as a path segment. Matching on that segment
-// rather than a prefix identifies a unit's engines independently of the download dir.
+// ShutdownUnit shuts down and removes the engine bound to a single unit, releasing its
+// plugin subprocess when the unit finishes rather than at the batch Shutdown. It is
+// experiment-gated; the only error it returns is a missing engine-clients context.
 func ShutdownUnit(
 	ctx context.Context,
 	l log.Logger,
 	experiments experiment.Experiments,
 	noEngine bool,
-	workingDir string,
+	unitDir string,
 ) error {
 	if !experiments.Evaluate(experiment.IacEngine) || noEngine {
 		return nil
@@ -610,36 +596,32 @@ func ShutdownUnit(
 		return err
 	}
 
-	hashSegment := util.EncodeBase64Sha1(filepath.Clean(workingDir))
-
-	for _, instance := range engineClients.takeMatching(func(key string) bool {
-		return PathHasSegment(key, hashSegment)
-	}) {
-		l.Debugf("Shutting down engine for %s", instance.execOptions.WorkingDir)
-
-		// Shutdown must proceed even if the parent context is already cancelled.
-		if err := shutdown(
-			context.WithoutCancel(ctx),
-			l,
-			instance.execOptions,
-			instance.engineClient,
-		); err != nil {
-			l.Errorf("Error shutting down engine: %v", err)
-		}
-
-		if !waitForPluginExit(instance.client, gracefulExitTimeout) {
-			l.Debugf("Plugin did not exit gracefully within timeout, force killing")
-			instance.client.Kill()
-		}
+	if instance := engineClients.takeByUnitDir(filepath.Clean(unitDir)); instance != nil {
+		shutdownInstance(ctx, l, instance)
 	}
 
 	return nil
 }
 
-// PathHasSegment reports whether seg is one of p's path components (between
-// separators), not merely a substring of p.
-func PathHasSegment(p, seg string) bool {
-	return slices.Contains(strings.Split(p, string(os.PathSeparator)), seg)
+// shutdownInstance shuts down the instance's engine and releases its plugin subprocess,
+// force-killing it if it does not exit gracefully within the timeout. Failures are
+// logged, never returned: engine shutdown is best-effort and must not fail the run. The
+// context is detached from cancellation so an already-cancelled run still tears the
+// engine down.
+func shutdownInstance(ctx context.Context, l log.Logger, instance *engineInstance) {
+	ctx = context.WithoutCancel(ctx)
+
+	l.Debugf("Shutting down engine for %s", instance.execOptions.CacheDir)
+
+	if err := shutdown(ctx, l, instance.execOptions, instance.engineClient); err != nil {
+		l.Errorf("Error shutting down engine: %v", err)
+	}
+
+	// The shutdown RPC already told the plugin to exit, so wait before force-killing it.
+	if !waitForPluginExit(instance.client, gracefulExitTimeout) {
+		l.Debugf("Plugin did not exit gracefully within timeout, force killing")
+		instance.client.Kill()
+	}
 }
 
 // waitForPluginExit waits for the plugin process to exit, returning true if it exited
@@ -703,9 +685,9 @@ func createEngine(
 	)
 
 	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "engine_create", map[string]any{
-		"source":      execOptions.EngineConfig.Source,
-		"version":     execOptions.EngineConfig.Version,
-		"working_dir": execOptions.WorkingDir,
+		"source":    execOptions.EngineConfig.Source,
+		"version":   execOptions.EngineConfig.Version,
+		"cache_dir": execOptions.CacheDir,
 	}, func(ctx context.Context) error {
 		path, err := engineDir(execOptions)
 		if err != nil {
@@ -822,8 +804,8 @@ func invoke(
 	var result *util.CmdOutput
 
 	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "engine_invoke", map[string]any{
-		"command":     runOptions.Command,
-		"working_dir": runOptions.WorkingDir,
+		"command":   runOptions.Command,
+		"cache_dir": runOptions.CacheDir,
 	}, func(ctx context.Context) error {
 		l = l.WithField(placeholders.TFPathKeyName, "engine")
 
@@ -836,7 +818,7 @@ func invoke(
 			Command:           runOptions.Command,
 			Args:              runOptions.Args,
 			AllocatePseudoTty: runOptions.AllocatePseudoTty,
-			WorkingDir:        runOptions.WorkingDir,
+			WorkingDir:        runOptions.CacheDir,
 			Meta:              meta,
 			EnvVars:           runOptions.Env,
 		})
@@ -927,13 +909,13 @@ func invoke(
 			return err
 		}
 
-		l.Debugf("Engine execution done in %v", runOptions.WorkingDir)
+		l.Debugf("Engine execution done in %v", runOptions.CacheDir)
 
 		if resultCode != 0 {
 			err = util.ProcessExecutionError{
 				Err:             fmt.Errorf("command failed with exit code %d", resultCode),
 				Output:          output,
-				WorkingDir:      runOptions.WorkingDir,
+				WorkingDir:      runOptions.CacheDir,
 				RootWorkingDir:  runOptions.RootWorkingDir,
 				LogShowAbsPaths: runOptions.LogShowAbsPaths,
 				Command:         runOptions.Command,
@@ -988,25 +970,25 @@ var ErrEngineInitFailed = errors.New("engine init failed")
 // initialize engine for working directory
 func initialize(ctx context.Context, l log.Logger, runOptions *ExecutionOptions, client *proto.EngineClient) error {
 	return telemetry.TelemeterFromContext(ctx).Collect(ctx, "engine_initialize", map[string]any{
-		"working_dir": runOptions.WorkingDir,
+		"cache_dir": runOptions.CacheDir,
 	}, func(ctx context.Context) error {
 		meta, err := ConvertMetaToProtobuf(runOptions.EngineConfig.Meta)
 		if err != nil {
 			return err
 		}
 
-		l.Debugf("Running init for engine in %s", runOptions.WorkingDir)
+		l.Debugf("Running init for engine in %s", runOptions.CacheDir)
 
 		request, err := (*client).Init(ctx, &proto.InitRequest{
 			EnvVars:    runOptions.Env,
-			WorkingDir: runOptions.WorkingDir,
+			WorkingDir: runOptions.CacheDir,
 			Meta:       meta,
 		})
 		if err != nil {
 			return err
 		}
 
-		l.Debugf("Reading init output for engine in %s", runOptions.WorkingDir)
+		l.Debugf("Reading init output for engine in %s", runOptions.CacheDir)
 
 		return ReadEngineOutput(runOptions, true, func() (*OutputLine, error) {
 			output, err := request.Recv()
@@ -1061,7 +1043,7 @@ func shutdown(
 	terragruntEngine *proto.EngineClient,
 ) error {
 	return telemetry.TelemeterFromContext(ctx).Collect(ctx, "engine_shutdown", map[string]any{
-		"working_dir": runOptions.WorkingDir,
+		"cache_dir": runOptions.CacheDir,
 	}, func(ctx context.Context) error {
 		meta, err := ConvertMetaToProtobuf(runOptions.EngineConfig.Meta)
 		if err != nil {
@@ -1069,7 +1051,7 @@ func shutdown(
 		}
 
 		request, err := (*terragruntEngine).Shutdown(ctx, &proto.ShutdownRequest{
-			WorkingDir: runOptions.WorkingDir,
+			WorkingDir: runOptions.CacheDir,
 			Meta:       meta,
 			EnvVars:    runOptions.Env,
 		})
@@ -1077,7 +1059,7 @@ func shutdown(
 			return err
 		}
 
-		l.Debugf("Reading shutdown output for engine in %s", runOptions.WorkingDir)
+		l.Debugf("Reading shutdown output for engine in %s", runOptions.CacheDir)
 
 		return ReadEngineOutput(runOptions, true, func() (*OutputLine, error) {
 			output, err := request.Recv()

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -77,7 +77,7 @@ func TestRun_NonOSBackedExecReturnsSentinel(t *testing.T) {
 			Version: "v0.0.0",
 			Type:    "test",
 		},
-		WorkingDir: t.TempDir(),
+		CacheDir: t.TempDir(),
 	}
 
 	_, err := engine.Run(ctx, log.New(), memExec, opts)

--- a/internal/engine/engineclients_internal_test.go
+++ b/internal/engine/engineclients_internal_test.go
@@ -1,0 +1,149 @@
+package engine
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errBuildFailed = errors.New("build failed")
+
+// TestEngineClients_LoadOrCreateIsSingleFlightWithRacing verifies that racing callers on one
+// key build exactly one engine and reuse it (the destroy-diamond read at its core).
+func TestEngineClients_LoadOrCreateIsSingleFlightWithRacing(t *testing.T) {
+	t.Parallel()
+
+	c := newEngineClients()
+
+	const key = "/cache/single-flight"
+
+	execOpts := &ExecutionOptions{UnitDir: "/unit/sf", CacheDir: key}
+	inst := &engineInstance{execOptions: execOpts}
+
+	var builds atomic.Int64
+
+	create := func() (*engineInstance, error) {
+		builds.Add(1)
+
+		return inst, nil
+	}
+
+	const n = 64
+
+	var (
+		wg       sync.WaitGroup
+		start    = make(chan struct{})
+		gotInst  = make([]*engineInstance, n)
+		gotReuse = make([]bool, n)
+		gotErr   = make([]error, n)
+	)
+
+	for i := range n {
+		wg.Go(func() {
+			<-start
+
+			got, reused, err := c.loadOrCreate(key, execOpts, create)
+			gotInst[i], gotReuse[i], gotErr[i] = got, reused, err
+		})
+	}
+
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int64(1), builds.Load(), "create must run exactly once across racing callers")
+
+	fresh := 0
+
+	for i := range n {
+		require.NoError(t, gotErr[i])
+		assert.Same(t, inst, gotInst[i], "every caller gets the single built instance")
+
+		if !gotReuse[i] {
+			fresh++
+		}
+	}
+
+	assert.Equal(t, 1, fresh, "exactly one caller built the engine; the rest reused it")
+}
+
+// TestEngineClients_LoadOrCreateRetriesAfterFailedBuild verifies a failed build is dropped, so
+// the next call builds fresh instead of being served the stale failure.
+func TestEngineClients_LoadOrCreateRetriesAfterFailedBuild(t *testing.T) {
+	t.Parallel()
+
+	c := newEngineClients()
+
+	const key = "/cache/retry"
+
+	execOpts := &ExecutionOptions{UnitDir: "/unit/retry", CacheDir: key}
+
+	_, _, err := c.loadOrCreate(key, execOpts, func() (*engineInstance, error) {
+		return nil, errBuildFailed
+	})
+	require.ErrorIs(t, err, errBuildFailed)
+
+	inst := &engineInstance{execOptions: execOpts}
+
+	got, reused, err := c.loadOrCreate(key, execOpts, func() (*engineInstance, error) {
+		return inst, nil
+	})
+	require.NoError(t, err)
+	assert.False(t, reused, "a failed build is dropped, so the next call builds fresh")
+	assert.Same(t, inst, got)
+}
+
+// TestEngineClients_LoadOrCreateGuardsReplacementOnFailedBuildWithRacing checks the ABA guard:
+// after a drain removes a still-building entry and a replacement takes its key, the original
+// build's failure must not delete the replacement.
+func TestEngineClients_LoadOrCreateGuardsReplacementOnFailedBuildWithRacing(t *testing.T) {
+	t.Parallel()
+
+	c := newEngineClients()
+
+	const key = "/cache/aba"
+
+	execOpts := &ExecutionOptions{UnitDir: "/unit/aba", CacheDir: key}
+
+	reserved := make(chan struct{})
+	release := make(chan struct{})
+
+	var (
+		first    sync.WaitGroup
+		firstErr error
+	)
+
+	first.Go(func() {
+		_, _, firstErr = c.loadOrCreate(key, execOpts, func() (*engineInstance, error) {
+			close(reserved)
+			<-release
+
+			return nil, errBuildFailed
+		})
+	})
+
+	<-reserved // first build is parked in create() with its entry reserved
+
+	require.NotNil(t, c.takeUnit("/unit/aba"))
+
+	replacement := &engineInstance{execOptions: execOpts}
+
+	got, reused, err := c.loadOrCreate(key, execOpts, func() (*engineInstance, error) {
+		return replacement, nil
+	})
+	require.NoError(t, err)
+	require.False(t, reused)
+	require.Same(t, replacement, got)
+
+	// Now let the first build fail; its cleanup must not delete the replacement.
+	close(release)
+	first.Wait()
+	require.ErrorIs(t, firstErr, errBuildFailed)
+
+	survivor := c.takeUnit("/unit/aba")
+	require.NotNil(t, survivor, "the replacement must survive the failed build's cleanup")
+	assert.Same(t, replacement, survivor.instance)
+}

--- a/internal/engine/shutdown_unit_test.go
+++ b/internal/engine/shutdown_unit_test.go
@@ -2,22 +2,13 @@ package engine_test
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/engine"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// unitCacheKey mimics the engine registry key that tf.NewSource produces for a unit:
-// filepath.Join(downloadDir, EncodeBase64Sha1(Clean(workingDir)), rootPath, modulePath).
-func unitCacheKey(downloadDir, workingDir string) string {
-	return filepath.Join(downloadDir, util.EncodeBase64Sha1(filepath.Clean(workingDir)), "github.com/acme/mod", ".")
-}
 
 func iacEngineEnabled(t *testing.T) experiment.Experiments {
 	t.Helper()
@@ -28,26 +19,6 @@ func iacEngineEnabled(t *testing.T) experiment.Experiments {
 	return exps
 }
 
-// TestPathHasSegment verifies a unit's engine is identified by the hashed-workingDir
-// segment of its cache key: matched independently of the download dir, isolated from
-// other units, and never on a bare substring.
-func TestPathHasSegment(t *testing.T) {
-	t.Parallel()
-
-	const unitA, unitB = "/repo/unitA", "/repo/unitB"
-
-	segA := util.EncodeBase64Sha1(filepath.Clean(unitA))
-
-	assert.True(t, engine.PathHasSegment(unitCacheKey("/tmp/dl", unitA), segA),
-		"the target unit's cache key contains its own hash segment")
-	assert.True(t, engine.PathHasSegment(unitCacheKey("/some/custom/download-dir", unitA), segA),
-		"the match is download-dir-independent")
-	assert.False(t, engine.PathHasSegment(unitCacheKey("/tmp/dl", unitB), segA),
-		"another unit's cache key must not match unit A's hash segment")
-	assert.False(t, engine.PathHasSegment("/a/foobar/c", "foo"),
-		"a substring that is not a whole path component must not match")
-}
-
 // TestShutdownUnit_NoOpWhenGated asserts ShutdownUnit returns nil without touching the
 // registry when the iac-engine experiment is disabled or NoEngine is set.
 func TestShutdownUnit_NoOpWhenGated(t *testing.T) {
@@ -55,10 +26,20 @@ func TestShutdownUnit_NoOpWhenGated(t *testing.T) {
 
 	ctx := engine.WithEngineValues(context.Background())
 
-	const unit = "/repo/unit"
+	const unitDir = "/repo/unit"
 
-	require.NoError(t, engine.ShutdownUnit(ctx, log.New(), experiment.NewExperiments(), false, unit),
+	require.NoError(t, engine.ShutdownUnit(ctx, log.New(), experiment.NewExperiments(), false, unitDir),
 		"a disabled iac-engine experiment must be a no-op")
-	require.NoError(t, engine.ShutdownUnit(ctx, log.New(), iacEngineEnabled(t), true, unit),
+	require.NoError(t, engine.ShutdownUnit(ctx, log.New(), iacEngineEnabled(t), true, unitDir),
 		"NoEngine must be a no-op")
+}
+
+// TestShutdownUnit_NoMatchingEngineIsNoOp asserts that, with the experiment enabled and
+// no engine registered for the unit, ShutdownUnit is a safe no-op rather than erroring.
+func TestShutdownUnit_NoMatchingEngineIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx := engine.WithEngineValues(context.Background())
+
+	require.NoError(t, engine.ShutdownUnit(ctx, log.New(), iacEngineEnabled(t), false, "/repo/unit-without-engine"))
 }

--- a/internal/engine/shutdown_unit_test.go
+++ b/internal/engine/shutdown_unit_test.go
@@ -1,0 +1,64 @@
+package engine_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/engine"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// unitCacheKey mimics the engine registry key that tf.NewSource produces for a unit:
+// filepath.Join(downloadDir, EncodeBase64Sha1(Clean(workingDir)), rootPath, modulePath).
+func unitCacheKey(downloadDir, workingDir string) string {
+	return filepath.Join(downloadDir, util.EncodeBase64Sha1(filepath.Clean(workingDir)), "github.com/acme/mod", ".")
+}
+
+func iacEngineEnabled(t *testing.T) experiment.Experiments {
+	t.Helper()
+
+	exps := experiment.NewExperiments()
+	require.NoError(t, exps.EnableExperiment(experiment.IacEngine))
+
+	return exps
+}
+
+// TestPathHasSegment verifies a unit's engine is identified by the hashed-workingDir
+// segment of its cache key: matched independently of the download dir, isolated from
+// other units, and never on a bare substring.
+func TestPathHasSegment(t *testing.T) {
+	t.Parallel()
+
+	const unitA, unitB = "/repo/unitA", "/repo/unitB"
+
+	segA := util.EncodeBase64Sha1(filepath.Clean(unitA))
+
+	assert.True(t, engine.PathHasSegment(unitCacheKey("/tmp/dl", unitA), segA),
+		"the target unit's cache key contains its own hash segment")
+	assert.True(t, engine.PathHasSegment(unitCacheKey("/some/custom/download-dir", unitA), segA),
+		"the match is download-dir-independent")
+	assert.False(t, engine.PathHasSegment(unitCacheKey("/tmp/dl", unitB), segA),
+		"another unit's cache key must not match unit A's hash segment")
+	assert.False(t, engine.PathHasSegment("/a/foobar/c", "foo"),
+		"a substring that is not a whole path component must not match")
+}
+
+// TestShutdownUnit_NoOpWhenGated asserts ShutdownUnit returns nil without touching the
+// registry when the iac-engine experiment is disabled or NoEngine is set.
+func TestShutdownUnit_NoOpWhenGated(t *testing.T) {
+	t.Parallel()
+
+	ctx := engine.WithEngineValues(context.Background())
+
+	const unit = "/repo/unit"
+
+	require.NoError(t, engine.ShutdownUnit(ctx, log.New(), experiment.NewExperiments(), false, unit),
+		"a disabled iac-engine experiment must be a no-op")
+	require.NoError(t, engine.ShutdownUnit(ctx, log.New(), iacEngineEnabled(t), true, unit),
+		"NoEngine must be a no-op")
+}

--- a/internal/engine/waitforpluginexit_test.go
+++ b/internal/engine/waitforpluginexit_test.go
@@ -1,0 +1,39 @@
+package engine_test
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/engine"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestWaitForPluginExit drives the graceful-exit window on synctest's fake clock: a plugin that
+// exits inside it is awaited, one that outlives it falls through to the caller's force-kill.
+func TestWaitForPluginExit(t *testing.T) {
+	t.Parallel()
+
+	const window = time.Second
+
+	t.Run("plugin exits within the grace window", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			start := time.Now()
+			exited := func() bool { return time.Since(start) >= window/2 }
+
+			assert.True(t, engine.WaitForPluginExit(exited, window))
+		})
+	})
+
+	t.Run("plugin outlives the grace window", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			neverExits := func() bool { return false }
+
+			assert.False(t, engine.WaitForPluginExit(neverExits, window))
+		})
+	})
+}

--- a/internal/prepare/prepare.go
+++ b/internal/prepare/prepare.go
@@ -162,7 +162,7 @@ func PrepareSource(
 		return nil, err
 	}
 
-	updatedTerragruntOptions.WorkingDir = updatedRunOpts.WorkingDir
+	updatedTerragruntOptions.WorkingDir = updatedRunOpts.CacheDir
 
 	return updatedTerragruntOptions, nil
 }

--- a/internal/runner/run/debug.go
+++ b/internal/runner/run/debug.go
@@ -23,10 +23,10 @@ func WriteTerragruntDebugFile(l log.Logger, opts *Options, cfg *runcfg.RunConfig
 	l.Infof(
 		"Debug mode requested: generating debug file %s in working dir %s",
 		TerragruntTFVarsFile,
-		opts.WorkingDir,
+		opts.CacheDir,
 	)
 
-	required, optional, err := tf.ModuleVariables(opts.WorkingDir)
+	required, optional, err := tf.ModuleVariables(opts.CacheDir)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func WriteTerragruntDebugFile(l log.Logger, opts *Options, cfg *runcfg.RunConfig
 	l.Debugf(
 		"\t%s -chdir=\"%s\" %s -var-file=\"%s\" ",
 		tofuImpl,
-		opts.WorkingDir,
+		opts.CacheDir,
 		strings.Join(opts.TerraformCliArgs.Slice(), " "),
 		fileName,
 	)

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -43,8 +43,8 @@ const (
 // DownloadTerraformSource downloads the given source URL, which should use Terraform's module source syntax,
 // into a temporary folder, then:
 // 1. Check if module directory exists in temporary folder
-// 2. Copy the contents of opts.WorkingDir into the temporary folder.
-// 3. Set opts.WorkingDir to the temporary folder.
+// 2. Copy the contents of opts.UnitDir into the temporary folder.
+// 3. Return a clone whose CacheDir points at the temporary folder.
 //
 // See the NewTerraformSource method for how we determine the temporary folder so we can reuse it across multiple
 // runs of Terragrunt to avoid downloading everything from scratch every time.
@@ -65,7 +65,7 @@ func DownloadTerraformSource(
 
 	source = tf.RewriteLegacyGCSPublicSource(ctx, l, source, opts.StrictControls)
 
-	terraformSource, err := tf.NewSource(l, source, opts.DownloadDir, opts.WorkingDir, walkWithSymlinks)
+	terraformSource, err := tf.NewSource(l, source, opts.DownloadDir, opts.UnitDir, walkWithSymlinks)
 	if err != nil {
 		return nil, err
 	}
@@ -94,13 +94,13 @@ func DownloadTerraformSource(
 	// overlays working-dir files on top of the downloaded source. These files may
 	// change independently of the source version hash, so the copy must always run.
 	sourceIsWorkingDir := tf.IsLocalSource(terraformSource.CanonicalSourceURL) &&
-		filepath.Clean(terraformSource.CanonicalSourceURL.Path) == filepath.Clean(opts.WorkingDir)
+		filepath.Clean(terraformSource.CanonicalSourceURL.Path) == filepath.Clean(opts.UnitDir)
 	needsModuleCopy := downloaded || !sourceIsWorkingDir
 
 	if needsModuleCopy {
 		l.Debugf(
 			"Copying files from %s into %s",
-			util.RelPathForLog(opts.WorkingDir, opts.WorkingDir, opts.LogShowAbsPaths),
+			util.RelPathForLog(opts.UnitDir, opts.UnitDir, opts.LogShowAbsPaths),
 			util.RelPathForLog(opts.RootWorkingDir, terraformSource.WorkingDir, opts.LogShowAbsPaths),
 		)
 
@@ -116,10 +116,10 @@ func DownloadTerraformSource(
 		}
 
 		err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "copy_folder_contents", map[string]any{
-			"src":  opts.WorkingDir,
+			"src":  opts.UnitDir,
 			"dest": terraformSource.WorkingDir,
 		}, func(_ context.Context) error {
-			return util.CopyFolderContents(l, opts.WorkingDir, terraformSource.WorkingDir, ModuleManifestName, copyOpts...)
+			return util.CopyFolderContents(l, opts.UnitDir, terraformSource.WorkingDir, ModuleManifestName, copyOpts...)
 		})
 		if err != nil {
 			return nil, err
@@ -139,7 +139,7 @@ func DownloadTerraformSource(
 			opts.LogShowAbsPaths,
 		),
 	)
-	updatedOpts.WorkingDir = terraformSource.WorkingDir
+	updatedOpts.CacheDir = terraformSource.WorkingDir
 
 	return updatedOpts, nil
 }
@@ -447,7 +447,7 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 	if _, err := client.Get(ctx, &getter.Request{
 		Src: canonicalSourceURL,
 		Dst: src.DownloadDir,
-		Pwd: opts.WorkingDir,
+		Pwd: opts.CacheDir,
 	}); err != nil {
 		l.Warnf("CAS download failed: %v. Falling back to standard getter.", err)
 		cas.RecordFallback(ctx, l, cas.FallbackReasonGetterError, map[string]any{"url": canonicalSourceURL})

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -809,11 +809,11 @@ func TestDownloadWithNoSourceCreatesCache(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that the working directory was changed to the cache directory (inside downloadDir)
-	assert.NotEqual(t, sourceDir, updatedOpts.WorkingDir, "Working dir should be changed to cache")
-	assert.True(t, strings.HasPrefix(updatedOpts.WorkingDir, downloadDir), "Working dir should be under download dir")
+	assert.NotEqual(t, sourceDir, updatedOpts.CacheDir, "Working dir should be changed to cache")
+	assert.True(t, strings.HasPrefix(updatedOpts.CacheDir, downloadDir), "Working dir should be under download dir")
 
 	// Verify that the main.tf file was copied to the cache
-	cachedMainTf := filepath.Join(updatedOpts.WorkingDir, "main.tf")
+	cachedMainTf := filepath.Join(updatedOpts.CacheDir, "main.tf")
 	assert.FileExists(t, cachedMainTf, "main.tf should exist in cache directory")
 
 	// Verify the contents were copied correctly

--- a/internal/runner/run/hook_lifecycle_test.go
+++ b/internal/runner/run/hook_lifecycle_test.go
@@ -104,7 +104,7 @@ func TestProcessHooks_PropagatesWorkingDir(t *testing.T) {
 	l := logger.CreateLogger()
 
 	opts := newHookOpts()
-	opts.WorkingDir = "/work/unit"
+	opts.CacheDir = "/work/unit"
 
 	hooks := []runcfg.Hook{
 		{

--- a/internal/runner/run/hook_test.go
+++ b/internal/runner/run/hook_test.go
@@ -369,7 +369,7 @@ func (r *recorder) snapshot() []vexec.Invocation {
 func newHookOpts() *run.Options {
 	return &run.Options{
 		Env:               map[string]string{},
-		WorkingDir:        "/work",
+		CacheDir:          "/work",
 		RootWorkingDir:    "/work",
 		TerraformCommand:  "plan",
 		TFPath:            "/fake/tofu",

--- a/internal/runner/run/options.go
+++ b/internal/runner/run/options.go
@@ -63,7 +63,8 @@ type Options struct {
 	TofuImplementation           tfimpl.Type
 	TerragruntConfigPath         string
 	OriginalTerragruntConfigPath string
-	WorkingDir                   string
+	UnitDir                      string
+	CacheDir                     string
 	DownloadDir                  string
 	RootWorkingDir               string
 	OriginalTerraformCommand     string
@@ -113,12 +114,13 @@ func (o *Options) CloneWithConfigPath(l log.Logger, configPath string) (log.Logg
 
 	workingDir := filepath.Dir(configPath)
 
-	if workingDir != o.WorkingDir {
+	if workingDir != o.CacheDir {
 		l = l.WithField(placeholders.WorkDirKeyName, workingDir)
 	}
 
 	newOpts.TerragruntConfigPath = configPath
-	newOpts.WorkingDir = workingDir
+	newOpts.UnitDir = workingDir
+	newOpts.CacheDir = workingDir
 
 	return l, newOpts, nil
 }
@@ -189,13 +191,14 @@ func (o *Options) DataDir() string {
 		return tfDataDir
 	}
 
-	return filepath.Join(o.WorkingDir, tfDataDir)
+	return filepath.Join(o.CacheDir, tfDataDir)
 }
 
 // shellRunOptions builds a *shell.ShellOptions from this Options.
 func (o *Options) shellRunOptions() *shell.ShellOptions {
 	s := shell.NewShellOptions().
-		WithWorkingDir(o.WorkingDir).
+		WithWorkingDir(o.CacheDir).
+		WithUnitDir(o.UnitDir).
 		WithEnv(o.Env).
 		WithWriters(o.Writers).
 		WithTelemetry(o.Telemetry).
@@ -244,7 +247,7 @@ func (o *Options) tflintRunOptions() *tflint.TFLintOptions {
 		ShellOptions:         o.shellRunOptions(),
 		Writers:              o.Writers,
 		LogShowAbsPaths:      o.LogShowAbsPaths,
-		WorkingDir:           o.WorkingDir,
+		WorkingDir:           o.CacheDir,
 		RootWorkingDir:       o.RootWorkingDir,
 		TerragruntConfigPath: o.TerragruntConfigPath,
 		MaxFoldersToCheck:    o.MaxFoldersToCheck,
@@ -264,7 +267,7 @@ func (o *Options) RunWithErrorHandling(
 
 	currentAttempt := 1
 
-	reportWorkingDir := o.WorkingDir
+	reportWorkingDir := o.CacheDir
 	if o.OriginalTerragruntConfigPath != "" {
 		reportWorkingDir = filepath.Dir(o.OriginalTerragruntConfigPath)
 	}
@@ -362,7 +365,7 @@ func (o *Options) RunWithErrorHandling(
 }
 
 func (o *Options) handleIgnoreSignals(l log.Logger, signals map[string]any) error {
-	signalsFile := filepath.Join(o.WorkingDir, defaultSignalsFile)
+	signalsFile := filepath.Join(o.CacheDir, defaultSignalsFile)
 
 	signalsJSON, err := json.MarshalIndent(signals, "", "  ")
 	if err != nil {

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -200,13 +200,13 @@ func GenerateConfig(l log.Logger, fs vfs.FS, opts *Options, cfg *runcfg.RunConfi
 	defer actualLock.Unlock()
 
 	for _, genCfg := range cfg.GenerateConfigs {
-		if err := codegen.WriteToFile(l, opts.WorkingDir, &genCfg); err != nil {
+		if err := codegen.WriteToFile(l, opts.CacheDir, &genCfg); err != nil {
 			return err
 		}
 	}
 
 	if cfg.RemoteState.Config != nil && cfg.RemoteState.Generate != nil {
-		if err := cfg.RemoteState.GenerateOpenTofuCode(l, opts.WorkingDir); err != nil {
+		if err := cfg.RemoteState.GenerateOpenTofuCode(l, opts.CacheDir); err != nil {
 			return err
 		}
 	} else if cfg.RemoteState.Config != nil {
@@ -235,7 +235,7 @@ func runTerragruntWithConfig(
 	r *report.Report,
 ) error {
 	if cfg.Exclude.ShouldPreventRun(opts.TerraformCommand) {
-		l.Infof("Early exit in terragrunt unit %s due to exclude block with no_run = true", opts.WorkingDir)
+		l.Infof("Early exit in terragrunt unit %s due to exclude block with no_run = true", opts.CacheDir)
 
 		return nil
 	}
@@ -295,13 +295,13 @@ func runTerragruntWithConfig(
 			// terragrunt.hcl. However, the default value for the user's working dir, set in options.go, IS just the
 			// parent dir of terragrunt.hcl, so these will likely always be the same.
 			// Use directory from OriginalTerragruntConfigPath to copy locks since WorkingDir point to cache directory
-			lockFileError = runcfg.CopyLockFile(l, opts.RootWorkingDir, opts.LogShowAbsPaths, opts.WorkingDir, filepath.Dir(opts.OriginalTerragruntConfigPath))
+			lockFileError = runcfg.CopyLockFile(l, opts.RootWorkingDir, opts.LogShowAbsPaths, opts.CacheDir, filepath.Dir(opts.OriginalTerragruntConfigPath))
 		}
 
 		// If command failed, log a helpful message
 		if runTerraformError != nil {
 			if out == nil {
-				l.Errorf("%s invocation failed in %s", opts.TofuImplementation, opts.WorkingDir)
+				l.Errorf("%s invocation failed in %s", opts.TofuImplementation, opts.CacheDir)
 			}
 		}
 
@@ -416,13 +416,13 @@ func SetTerragruntInputsAsEnvVars(l log.Logger, opts *Options, cfg *runcfg.RunCo
 
 // CheckFolderContainsTerraformCode checks if the folder contains Terraform/OpenTofu code
 func CheckFolderContainsTerraformCode(opts *Options) error {
-	found, err := util.DirContainsTFFiles(opts.WorkingDir)
+	found, err := util.DirContainsTFFiles(opts.CacheDir)
 	if err != nil {
 		return err
 	}
 
 	if !found {
-		return NoTerraformFilesFound(opts.WorkingDir)
+		return NoTerraformFilesFound(opts.CacheDir)
 	}
 
 	return nil
@@ -436,7 +436,7 @@ func checkTerraformCodeDefinesBackend(fs vfs.FS, opts *Options, backendType stri
 	}
 
 	// Check for backend definitions in .tf and .tofu files using WalkDir
-	definesBackend, err := util.RegexFoundInTFFiles(opts.WorkingDir, terraformBackendRegexp)
+	definesBackend, err := util.RegexFoundInTFFiles(opts.CacheDir, terraformBackendRegexp)
 	if err != nil {
 		return err
 	}
@@ -450,7 +450,7 @@ func checkTerraformCodeDefinesBackend(fs vfs.FS, opts *Options, backendType stri
 		return err
 	}
 
-	definesJSONBackend, err := util.GrepFilesWithSuffix(fs, terraformJSONBackendRegexp, opts.WorkingDir, ".tf.json")
+	definesJSONBackend, err := util.GrepFilesWithSuffix(fs, terraformJSONBackendRegexp, opts.CacheDir, ".tf.json")
 	if err != nil {
 		return err
 	}
@@ -459,14 +459,14 @@ func checkTerraformCodeDefinesBackend(fs vfs.FS, opts *Options, backendType stri
 		return nil
 	}
 
-	return BackendNotDefined{ConfigPath: opts.TerragruntConfigPath, WorkingDir: opts.WorkingDir, BackendType: backendType}
+	return BackendNotDefined{ConfigPath: opts.TerragruntConfigPath, WorkingDir: opts.CacheDir, BackendType: backendType}
 }
 
 // Returns true if we need to run `terraform init` to download providers
 func providersNeedInit(opts *Options) bool {
 	pluginsPath := filepath.Join(opts.DataDir(), "plugins")
 	providersPath := filepath.Join(opts.DataDir(), "providers")
-	terraformLockPath := filepath.Join(opts.WorkingDir, tf.TerraformLockFile)
+	terraformLockPath := filepath.Join(opts.CacheDir, tf.TerraformLockFile)
 
 	return (!util.FileExists(pluginsPath) && !util.FileExists(providersPath)) || !util.FileExists(terraformLockPath)
 }
@@ -479,7 +479,7 @@ func prepareInitOptions(l log.Logger, opts *Options) (log.Logger, *Options, erro
 	}
 
 	initOptions.TerraformCliArgs = iacargs.New().SetCommand(tf.CommandNameInit)
-	initOptions.WorkingDir = opts.WorkingDir
+	initOptions.CacheDir = opts.CacheDir
 	initOptions.TerraformCommand = tf.CommandNameInit
 	initOptions.Headless = true
 
@@ -509,7 +509,7 @@ func modulesNeedInit(opts *Options) (bool, error) {
 	}
 
 	// Check for module definitions in .tf and .tofu files using WalkDir
-	hasModuleDefinition, err := util.RegexFoundInTFFiles(opts.WorkingDir, ModuleRegex)
+	hasModuleDefinition, err := util.RegexFoundInTFFiles(opts.CacheDir, ModuleRegex)
 	if err != nil {
 		return false, err
 	}
@@ -684,7 +684,7 @@ func needsInitRunCfg(ctx context.Context, l log.Logger, opts *Options, cfg *runc
 
 	// Marker check lives here, not in modulesNeedInit, so a populated .terraform/modules/
 	// can't short-circuit past it. Refs: #1921, #6058.
-	if util.FileExists(filepath.Join(opts.WorkingDir, ModuleInitRequiredFile)) {
+	if util.FileExists(filepath.Join(opts.CacheDir, ModuleInitRequiredFile)) {
 		return true, nil
 	}
 
@@ -732,7 +732,7 @@ func runTerraformInitRunCfg(
 		return err
 	}
 
-	moduleNeedInit := filepath.Join(opts.WorkingDir, ModuleInitRequiredFile)
+	moduleNeedInit := filepath.Join(opts.CacheDir, ModuleInitRequiredFile)
 	if util.FileExists(moduleNeedInit) {
 		return os.Remove(moduleNeedInit)
 	}
@@ -784,7 +784,7 @@ func setTerragruntNullValuesRunCfg(opts *Options, cfg *runcfg.RunConfig) (string
 		return "", err
 	}
 
-	varFile := filepath.Join(opts.WorkingDir, NullTFVarsFile)
+	varFile := filepath.Join(opts.CacheDir, NullTFVarsFile)
 
 	const ownerReadWritePermissions = 0600
 

--- a/internal/runner/run/run_e2e_test.go
+++ b/internal/runner/run/run_e2e_test.go
@@ -204,6 +204,7 @@ func newRunE2EOpts(t *testing.T, s runE2EScaffold, command string, extraArgs ...
 
 	return &run.Options{
 		FS:                           vfs.NewOSFS(),
+		UnitDir:                      s.dir,
 		CacheDir:                     s.dir,
 		RootWorkingDir:               s.dir,
 		DownloadDir:                  filepath.Join(s.dir, ".terragrunt-cache"),

--- a/internal/runner/run/run_e2e_test.go
+++ b/internal/runner/run/run_e2e_test.go
@@ -204,7 +204,7 @@ func newRunE2EOpts(t *testing.T, s runE2EScaffold, command string, extraArgs ...
 
 	return &run.Options{
 		FS:                           vfs.NewOSFS(),
-		WorkingDir:                   s.dir,
+		CacheDir:                     s.dir,
 		RootWorkingDir:               s.dir,
 		DownloadDir:                  filepath.Join(s.dir, ".terragrunt-cache"),
 		TerragruntConfigPath:         s.configPath,

--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/util"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/engine"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/os/stdout"
 	"github.com/gruntwork-io/terragrunt/internal/queue"
@@ -311,6 +312,23 @@ func filterUnitsToComponents(units []*component.Unit) component.Components {
 	return result
 }
 
+// UnitsWithDependents returns the set of unit paths that at least one other unit in q
+// depends on. Run uses it to decide which units may have their engine shut down early.
+func UnitsWithDependents(q *queue.Queue) map[string]bool {
+	withDependents := make(map[string]bool)
+	if q == nil {
+		return withDependents
+	}
+
+	for _, entry := range q.Entries {
+		for _, dep := range entry.Component.Dependencies() {
+			withDependents[dep.Path()] = true
+		}
+	}
+
+	return withDependents
+}
+
 // Run executes the stack according to TerragruntOptions and returns the first
 // error (or a joined error) once execution is finished.
 func (rnr *Runner) Run(ctx context.Context, l log.Logger, v run.Venv, stackOpts *options.TerragruntOptions, r *report.Report) error {
@@ -410,6 +428,8 @@ func (rnr *Runner) Run(ctx context.Context, l log.Logger, v run.Venv, stackOpts 
 		}
 	}
 
+	withDependents := UnitsWithDependents(rnr.queue)
+
 	task := func(ctx context.Context, u *component.Unit) error {
 		// Build per-unit opts and logger on demand
 		unitOpts, unitLogger, err := BuildUnitOpts(l, stackOpts, u)
@@ -505,6 +525,21 @@ func (rnr *Runner) Run(ctx context.Context, l log.Logger, v run.Venv, stackOpts 
 					credsGetter,
 				)
 			})
+
+			// This unit's terraform commands are all done, so release its engine now
+			// instead of holding it until the batch Shutdown. Skip units that another
+			// in-run unit depends on: that dependent re-reads this unit's outputs through
+			// engine.Run after this task ends, which would just re-spawn the engine we
+			// tore down.
+			if !withDependents[unitPath] {
+				noEngine := unitOpts.EngineOptions != nil && unitOpts.EngineOptions.NoEngine
+				if sErr := engine.ShutdownUnit(
+					childCtx, unitLogger, unitOpts.Experiments, noEngine,
+					unitOpts.WorkingDir,
+				); sErr != nil {
+					unitLogger.Errorf("Error shutting down engine for unit %s: %v", unitPath, sErr)
+				}
+			}
 
 			// Flush any remaining buffered output
 			if flushErr := unitWriter.Flush(); flushErr != nil && err == nil {

--- a/internal/runner/runnerpool/shutdown_gate_test.go
+++ b/internal/runner/runnerpool/shutdown_gate_test.go
@@ -1,0 +1,44 @@
+package runnerpool_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/queue"
+	"github.com/gruntwork-io/terragrunt/internal/runner/runnerpool"
+)
+
+// TestUnitsWithDependents verifies a unit is flagged iff another in-run unit depends on
+// it. Flagged units must not have their engine shut down early, since a dependent
+// re-reads their outputs through engine.Run, which would re-spawn the engine.
+func TestUnitsWithDependents(t *testing.T) {
+	t.Parallel()
+
+	d := component.NewUnit("/tmp/test/d")
+	y := component.NewUnit("/tmp/test/y")
+	leaf := component.NewUnit("/tmp/test/leaf")
+
+	y.AddDependency(d) // y depends on d, so d has a dependent
+
+	q := &queue.Queue{Entries: queue.Entries{
+		{Component: d},
+		{Component: y},
+		{Component: leaf},
+	}}
+
+	got := runnerpool.UnitsWithDependents(q)
+
+	assert.True(t, got[d.Path()], "d has a dependent (y) → must be kept alive, not shut down early")
+	assert.False(t, got[y.Path()], "y has no dependents → safe to shut down early")
+	assert.False(t, got[leaf.Path()], "an independent unit → safe to shut down early")
+}
+
+// TestUnitsWithDependents_NilQueue is defensive: a nil queue yields an empty set
+// (every unit then treated as having no dependents).
+func TestUnitsWithDependents_NilQueue(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, runnerpool.UnitsWithDependents(nil))
+}

--- a/internal/shell/run_cmd.go
+++ b/internal/shell/run_cmd.go
@@ -44,6 +44,7 @@ type ShellOptions struct {
 
 	RootWorkingDir         string
 	WorkingDir             string
+	UnitDir                string
 	TFPath                 string
 	Experiments            experiment.Experiments
 	Headless               bool
@@ -77,6 +78,13 @@ func NewShellOptions() *ShellOptions {
 // WithWorkingDir sets the working directory for command execution.
 func (o *ShellOptions) WithWorkingDir(dir string) *ShellOptions {
 	o.WorkingDir = dir
+
+	return o
+}
+
+// WithUnitDir sets the logical unit directory the command belongs to.
+func (o *ShellOptions) WithUnitDir(dir string) *ShellOptions {
+	o.UnitDir = dir
 
 	return o
 }
@@ -292,7 +300,8 @@ func runCommand(
 				EngineOptions:          runOpts.EngineOptions,
 				EngineConfig:           runOpts.EngineConfig,
 				Env:                    runOpts.Env,
-				WorkingDir:             cmdOpts.CommandDir,
+				UnitDir:                runOpts.UnitDir,
+				CacheDir:               cmdOpts.CommandDir,
 				RootWorkingDir:         runOpts.RootWorkingDir,
 				Command:                cmdOpts.Command,
 				Args:                   cmdOpts.Args,

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1528,6 +1528,7 @@ func runTerragruntOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Lo
 	runOpts.LogDisableErrorSummary = pctx.LogDisableErrorSummary
 	runOpts.TerragruntConfigPath = pctx.TerragruntConfigPath
 	runOpts.OriginalTerragruntConfigPath = pctx.OriginalTerragruntConfigPath
+	runOpts.UnitDir = pctx.WorkingDir
 	runOpts.CacheDir = pctx.WorkingDir
 	runOpts.RootWorkingDir = pctx.RootWorkingDir
 	runOpts.DownloadDir = pctx.DownloadDir

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1528,7 +1528,7 @@ func runTerragruntOutputJSON(ctx context.Context, pctx *ParsingContext, l log.Lo
 	runOpts.LogDisableErrorSummary = pctx.LogDisableErrorSummary
 	runOpts.TerragruntConfigPath = pctx.TerragruntConfigPath
 	runOpts.OriginalTerragruntConfigPath = pctx.OriginalTerragruntConfigPath
-	runOpts.WorkingDir = pctx.WorkingDir
+	runOpts.CacheDir = pctx.WorkingDir
 	runOpts.RootWorkingDir = pctx.RootWorkingDir
 	runOpts.DownloadDir = pctx.DownloadDir
 	runOpts.Source = pctx.Source


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Updates engine management so that engines are init and shutdown with the lifecycle of their unit runs, rather than being done in batch. As part of this, the UnitDir and CacheDir were split from WorkingDir so that we don't overload the meaning of the field.

This is important, as it allows for resource exhaustion prevention on init and improved resource reclamation on shutdown.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for separate unit and cache directories, improving consistency of generated outputs and execution behavior.
  * Introduced safer, earlier per-unit engine shutdown using dependency-aware gating.
* **Bug Fixes**
  * Corrected directory handling across source download, config generation, init/module detection, hooks, debug output, and error reporting to use the appropriate unit/cache locations.
  * Improved engine reuse/recovery under concurrent startups and build failures by keying and managing engine instances per cache directory.
* **Tests**
  * Added/updated coverage for single-flight engine creation, retry-after-failure behavior, shutdown no-op cases, and plugin-exit waiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->