### PR TITLE
chore: Downgrading `render` log to a `debug`

### DIFF
--- a/internal/cli/commands/render/render.go
+++ b/internal/cli/commands/render/render.go
@@ -119,7 +119,7 @@ func renderHCL(l log.Logger, opts *Options, cfg *config.TerragruntConfig) error 
 		return writeRendered(l, opts, buf.Bytes())
 	}
 
-	l.Infof("Rendering config %s", opts.TerragruntConfigPath)
+	l.Debugf("Rendering config %s", opts.TerragruntConfigPath)
 
 	_, err := cfg.WriteTo(opts.Writers.Writer)
 	if err != nil {
@@ -157,7 +157,7 @@ func renderJSON(l log.Logger, opts *Options, cfg *config.TerragruntConfig) error
 		return writeRendered(l, opts, jsonBytes)
 	}
 
-	l.Infof("Rendering config %s", opts.TerragruntConfigPath)
+	l.Debugf("Rendering config %s", opts.TerragruntConfigPath)
 
 	_, err = opts.Writers.Writer.Write(jsonBytes)
 	if err != nil {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

This isn't useful by default.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced console noise during config rendering by moving the “Rendering config …” message to debug-level output.
  * Normal render output is now cleaner in both supported rendering formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->