### PR TITLE
fix(engine): limit engine ZIP archive extraction

### DIFF
--- a/docs/src/content/docs/03-features/01-units/09-engine.mdx
+++ b/docs/src/content/docs/03-features/01-units/09-engine.mdx
@@ -68,6 +68,10 @@ engine {
 >
 </Code>
 
+Direct HTTP(S) sources are downloaded as-is. Use them only for trusted engines.
+
+For checksum and signature verification, use a GitHub release source so Terragrunt can download the engine package, checksum file, and checksum signature together.
+
 ## Local Sources
 
 Specify a local absolute path as the source:
@@ -100,12 +104,12 @@ The cached engines are stored in the following directory by default:
 
 If you need to use a different path, set the environment variable `TG_ENGINE_CACHE_PATH` accordingly.
 
-Downloaded engines are checked for integrity using the SHA256 checksum GPG key.
+Engines downloaded from GitHub releases are checked for integrity using the SHA256 checksum GPG key.
 If the checksum does not match, the engine is not executed.
-To disable this feature, set the environment variable:
+To disable this feature for trusted development or testing engines, set the environment variable:
 
 ```sh
-export TG_ENGINE_SKIP_CHECK=0
+export TG_ENGINE_SKIP_CHECK=1
 ```
 
 To configure a custom log level for the engine, set the `TG_ENGINE_LOG_LEVEL` environment variable to one of `debug`, `info`, `warn`, `error`.

--- a/docs/src/content/docs/03-features/01-units/09-engine.mdx
+++ b/docs/src/content/docs/03-features/01-units/09-engine.mdx
@@ -68,10 +68,6 @@ engine {
 >
 </Code>
 
-Direct HTTP(S) sources are downloaded as-is. Use them only for trusted engines.
-
-For checksum and signature verification, use a GitHub release source so Terragrunt can download the engine package, checksum file, and checksum signature together.
-
 ## Local Sources
 
 Specify a local absolute path as the source:

--- a/docs/src/data/changelog/v1.1.1/engine-archive-extraction-limits.mdx
+++ b/docs/src/data/changelog/v1.1.1/engine-archive-extraction-limits.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.1"
+category: "bug-fixes"
+---
+
+#### Limit IaC engine archive extraction
+
+Terragrunt now protects developer machines and CI runners from engine archives that expand into unexpectedly large amounts of data. If an IaC engine package is unusually large or contains too many files, Terragrunt stops processing it before it can consume excessive disk space.

--- a/docs/src/data/flags/engine-skip-check.mdx
+++ b/docs/src/data/flags/engine-skip-check.mdx
@@ -10,7 +10,7 @@ When enabled, Terragrunt skips checksum validation of engine files.
 
 This can be useful during development or testing with self-developed engines.
 
-Terragrunt currently only supports signature verification for engines downloaded from GitHub releases, though this will change in the future.
+Terragrunt currently only supports checksum validation for engines downloaded from GitHub releases, though this will change in the future.
 
 In the meantime, download custom engines from a trusted source, verify the integrity of the engine manually, and reference the local path to the engine in your Terragrunt configuration when possible.
 

--- a/docs/src/data/flags/engine-skip-check.mdx
+++ b/docs/src/data/flags/engine-skip-check.mdx
@@ -6,12 +6,12 @@ env:
   - TG_ENGINE_SKIP_CHECK
 ---
 
-When enabled, Terragrunt will skip the checksum validation of engine files.
+When enabled, Terragrunt skips checksum validation of engine files.
 
-This can be useful during development or testing, and is currently the only way to use self-developed engines.
+This can be useful during development or testing with self-developed engines.
 
-Terragrunt currently only has support for verifying the signatures of official engines, though this will change in the future.
+Terragrunt currently only supports signature verification for engines downloaded from GitHub releases, though this will change in the future.
 
-In the meantime, you are encouraged to download engines from a trusted source, verify the integrity of the engine manually, and then reference the local path to the engine in your Terragrunt configuration.
+In the meantime, download custom engines from a trusted source, verify the integrity of the engine manually, and reference the local path to the engine in your Terragrunt configuration when possible.
 
 You must also set the [`experimental-engine`](/reference/cli/commands/run#experimental-engine) flag to use engines.

--- a/internal/engine/archive_internal_test.go
+++ b/internal/engine/archive_internal_test.go
@@ -1,0 +1,143 @@
+package engine
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractArchiveWithLimitsAcceptsSmallArchive(t *testing.T) {
+	t.Parallel()
+
+	baseDir := newArchiveTestDir(t)
+	archivePath := filepath.Join(baseDir, "engine.zip")
+	engineFile := filepath.Join(baseDir, "engine-bin")
+
+	writeZipArchive(t, archivePath, []zipArchiveEntry{
+		{
+			name: "engine",
+			body: []byte("engine-content"),
+		},
+	})
+
+	err := extractArchiveWithLimits(logger.CreateLogger(), archivePath, engineFile, 1024, 2)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(engineFile)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("engine-content"), content)
+}
+
+func TestExtractArchiveWithLimitsAcceptsExactSizeLimit(t *testing.T) {
+	t.Parallel()
+
+	baseDir := newArchiveTestDir(t)
+	archivePath := filepath.Join(baseDir, "engine.zip")
+	engineFile := filepath.Join(baseDir, "engine-bin")
+
+	writeZipArchive(t, archivePath, []zipArchiveEntry{
+		{
+			name: "engine",
+			body: []byte("01234567"),
+		},
+	})
+
+	err := extractArchiveWithLimits(logger.CreateLogger(), archivePath, engineFile, 8, 2)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(engineFile)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("01234567"), content)
+}
+
+func TestExtractArchiveWithLimitsRejectsTooManyFiles(t *testing.T) {
+	t.Parallel()
+
+	baseDir := newArchiveTestDir(t)
+	archivePath := filepath.Join(baseDir, "engine.zip")
+	engineFile := filepath.Join(baseDir, "engine-bin")
+
+	writeZipArchive(t, archivePath, []zipArchiveEntry{
+		{
+			name: "one",
+			body: []byte("1"),
+		},
+		{
+			name: "two",
+			body: []byte("2"),
+		},
+		{
+			name: "three",
+			body: []byte("3"),
+		},
+	})
+
+	err := extractArchiveWithLimits(logger.CreateLogger(), archivePath, engineFile, 1024, 2)
+
+	var extractionErr *archiveExtractionError
+	require.ErrorAs(t, err, &extractionErr)
+	assert.Equal(t, archivePath, extractionErr.downloadFile)
+	assert.NoFileExists(t, engineFile)
+	assert.NoFileExists(t, filepath.Join(baseDir, "one"))
+	assert.NoFileExists(t, filepath.Join(baseDir, "two"))
+	assert.NoFileExists(t, filepath.Join(baseDir, "three"))
+}
+
+func TestExtractArchiveWithLimitsRejectsOversizedContent(t *testing.T) {
+	t.Parallel()
+
+	baseDir := newArchiveTestDir(t)
+	archivePath := filepath.Join(baseDir, "engine.zip")
+	engineFile := filepath.Join(baseDir, "engine-bin")
+
+	writeZipArchive(t, archivePath, []zipArchiveEntry{
+		{
+			name: "engine",
+			body: []byte("0123456789abcdef"),
+		},
+	})
+
+	err := extractArchiveWithLimits(logger.CreateLogger(), archivePath, engineFile, 8, 2)
+
+	var extractionErr *archiveExtractionError
+	require.ErrorAs(t, err, &extractionErr)
+	assert.Equal(t, archivePath, extractionErr.downloadFile)
+	assert.NoFileExists(t, engineFile)
+}
+
+type zipArchiveEntry struct {
+	name string
+	body []byte
+}
+
+func newArchiveTestDir(t *testing.T) string {
+	t.Helper()
+
+	// NOTE: extractArchiveWithLimits uses os.Rename, os.MkdirTemp, and vfs.NewOSFS.
+	return t.TempDir()
+}
+
+func writeZipArchive(t *testing.T, archivePath string, entries []zipArchiveEntry) {
+	t.Helper()
+
+	archiveFile, err := os.Create(archivePath)
+	require.NoError(t, err)
+
+	zipWriter := zip.NewWriter(archiveFile)
+
+	for _, entry := range entries {
+		writer, err := zipWriter.Create(entry.name)
+		require.NoError(t, err)
+
+		_, err = writer.Write(entry.body)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, zipWriter.Close())
+	require.NoError(t, archiveFile.Close())
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -65,6 +65,7 @@ const (
 )
 
 const (
+	// Cap extraction so malformed archives fail before they can exhaust disk space.
 	engineArchiveDecompressedSizeLimit int64 = 512 << 20
 	engineArchiveFilesLimit                  = 20
 )

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -64,6 +64,11 @@ const (
 	errMsgVersionsCacheCast  = "failed to cast engine versions cache from context"
 )
 
+const (
+	engineArchiveDecompressedSizeLimit int64 = 512 << 20
+	engineArchiveFilesLimit                  = 20
+)
+
 type (
 	engineClientsKey byte
 	engineLocksKey   byte
@@ -297,7 +302,7 @@ func downloadEngine(ctx context.Context, l log.Logger, execOptions *ExecutionOpt
 
 		// identify engine version if not specified
 		if len(e.Version) == 0 {
-			if !strings.Contains(e.Source, "://") {
+			if !isDirectURL(e.Source) {
 				tag, err := lastReleaseVersion(ctx, execOptions)
 				if err != nil {
 					return err
@@ -344,7 +349,7 @@ func downloadEngine(ctx context.Context, l log.Logger, execOptions *ExecutionOpt
 		var checksumFile, checksumSigFile string
 
 		// Only add checksum files for GitHub releases (not direct URLs)
-		if !strings.Contains(e.Source, "://") {
+		if !isDirectURL(e.Source) {
 			checksumFile = filepath.Join(path, engineChecksumName(e))
 			checksumSigFile = filepath.Join(path, engineChecksumSigName(e))
 			assets.ChecksumFile = checksumFile
@@ -410,6 +415,22 @@ func lastReleaseVersion(ctx context.Context, opts *ExecutionOptions) (string, er
 }
 
 func extractArchive(l log.Logger, downloadFile string, engineFile string) error {
+	return extractArchiveWithLimits(
+		l,
+		downloadFile,
+		engineFile,
+		engineArchiveDecompressedSizeLimit,
+		engineArchiveFilesLimit,
+	)
+}
+
+func extractArchiveWithLimits(
+	l log.Logger,
+	downloadFile string,
+	engineFile string,
+	decompressedSizeLimit int64,
+	filesLimit int,
+) error {
 	if !isArchiveByHeader(l, downloadFile) {
 		l.Info("Downloaded file is not an archive, no extraction needed")
 		// move file directly if it is not an archive
@@ -433,8 +454,11 @@ func extractArchive(l log.Logger, downloadFile string, engineFile string) error 
 		}
 	}()
 	// extract archive
-	if err = vfs.NewZipDecompressor().Unzip(l, vfs.NewOSFS(), tempDir, downloadFile, 0); err != nil {
-		return err
+	if err = vfs.NewZipDecompressor(
+		vfs.WithFileSizeLimit(decompressedSizeLimit),
+		vfs.WithFilesLimit(filesLimit),
+	).Unzip(l, vfs.NewOSFS(), tempDir, downloadFile, 0); err != nil {
+		return newArchiveExtractionError(downloadFile, err)
 	}
 
 	// process files
@@ -539,6 +563,10 @@ func engineChecksumSigName(e *EngineConfig) string {
 // enginePackageName returns the package name for the engine.
 func enginePackageName(e *EngineConfig) string {
 	return engineFileName(e) + ".zip"
+}
+
+func isDirectURL(source string) bool {
+	return strings.Contains(source, "://")
 }
 
 // isArchiveByHeader checks if a file is an archive by examining its header.

--- a/internal/engine/errors.go
+++ b/internal/engine/errors.go
@@ -1,0 +1,23 @@
+package engine
+
+import "fmt"
+
+type archiveExtractionError struct {
+	cause        error
+	downloadFile string
+}
+
+func newArchiveExtractionError(downloadFile string, cause error) *archiveExtractionError {
+	return &archiveExtractionError{
+		cause:        cause,
+		downloadFile: downloadFile,
+	}
+}
+
+func (err archiveExtractionError) Error() string {
+	return fmt.Sprintf("failed to extract engine archive %q: %v", err.downloadFile, err.cause)
+}
+
+func (err archiveExtractionError) Unwrap() error {
+	return err.cause
+}

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -800,18 +800,29 @@ type limitedReader struct {
 }
 
 func (r *limitedReader) Read(p []byte) (int, error) {
-	if r.remaining <= 0 {
+	if r.remaining > 0 {
+		if int64(len(p)) > r.remaining {
+			p = p[:r.remaining]
+		}
+
+		n, err := r.reader.Read(p)
+		r.remaining -= int64(n)
+
+		return n, err
+	}
+
+	var probe [1]byte
+
+	n, err := r.reader.Read(probe[:])
+	if n > 0 {
 		return 0, errors.New("decompressed size exceeds limit")
 	}
 
-	if int64(len(p)) > r.remaining {
-		p = p[:r.remaining]
+	if err == nil {
+		return 0, io.EOF
 	}
 
-	n, err := r.reader.Read(p)
-	r.remaining -= int64(n)
-
-	return n, err
+	return 0, err
 }
 
 // lstatIfPossible calls Lstat if the filesystem supports it, otherwise Stat.

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -739,6 +739,24 @@ func TestUnzipFileSizeLimit(t *testing.T) {
 		assert.Equal(t, []byte("small content"), data)
 	})
 
+	t.Run("allows extraction exactly at size limit", func(t *testing.T) {
+		t.Parallel()
+
+		fs := vfs.NewMemMapFS()
+		zipData := createZipArchive(t, map[string][]byte{
+			"exact.txt": []byte("0123456789"),
+		})
+		require.NoError(t, vfs.WriteFile(fs, "/archive.zip", zipData, 0644))
+
+		err := vfs.NewZipDecompressor(vfs.WithFileSizeLimit(10)).Unzip(l, fs, "/dst", "/archive.zip", 0)
+
+		require.NoError(t, err)
+
+		data, err := vfs.ReadFile(fs, "/dst/exact.txt")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("0123456789"), data)
+	})
+
 	t.Run("rejects extraction exceeding size limit", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* Add engine archive extraction limits: 512 MiB total decompressed size and 20 ZIP entries.
* Add regression coverage for valid archives, exact-size-limit archives, oversized archives, and excessive file counts.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Engine archive extraction now enforces safety limits to stop unusually large or overly complex engine archives before they expand into excessive disk usage.
  * Improved decompressed size-limit enforcement to more accurately detect when extracted output exceeds the configured limit.
* **Documentation**
  * Clarified the “engine skip check” behavior and updated examples/instructions for trusted custom engines and manual verification.
  * Added a changelog entry describing the new engine archive extraction limits behavior.
* **Tests**
  * Expanded archive extraction and file-size limit tests, including the “exactly at the limit” success case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->