### PR TITLE
fix(catalog): harden temporary clone paths

### DIFF
--- a/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
+++ b/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
@@ -23,12 +23,6 @@ If `<repo-url>` is provided, the repository will be cloned into a temporary dire
 1. The repository list are searched in the config file `terragrunt.hcl`. if `terragrunt.hcl` does not exist in the current directory, the config are searched in the parent directories.
 1. If the repository list is not found in the configuration file, the modules are looked for in the current directory.
 
-## Temporary clone directories
-
-When loading remote repositories, Terragrunt creates a fresh temporary clone directory for each repository under the system temp directory. The temp root is resolved through symlinks before discovery so component paths stay inside the clone on systems where the temp directory itself is reported through a symlink.
-
-Terragrunt does not use a predictable temp path for catalog loads. It refuses to use or clean up clone roots that are symlinks, so local temp-dir entries cannot redirect catalog cleanup outside the directory Terragrunt is preparing. Each clone remains available while the TUI session is running because unit and stack copy actions read files from it, then Terragrunt removes the temporary clone when the session exits.
-
 An example of how to define the optional default template and the list of repositories for the `catalog` command in the `terragrunt.hcl` configuration file:
 
 ``` hcl

--- a/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
+++ b/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
@@ -25,9 +25,9 @@ If `<repo-url>` is provided, the repository will be cloned into a temporary dire
 
 ## Temporary clone directories
 
-When loading a remote repository, Terragrunt creates a fresh temporary clone directory under the system temp directory. The temp root is resolved through symlinks before discovery so component paths stay inside the clone on systems where the temp directory itself is reported through a symlink.
+When loading remote repositories, Terragrunt creates a fresh temporary clone directory for each repository under the system temp directory. The temp root is resolved through symlinks before discovery so component paths stay inside the clone on systems where the temp directory itself is reported through a symlink.
 
-Terragrunt does not use a deterministic URL-derived temp path for catalog loads. It refuses to use or clean up clone roots that are symlinks, so local temp-dir entries cannot redirect catalog cleanup outside the directory Terragrunt is preparing. The clone remains available while the TUI session is running because unit and stack copy actions read files from it, then Terragrunt removes the temporary clone when the session exits.
+Terragrunt does not use a deterministic URL-derived temp path for catalog loads. It refuses to use or clean up clone roots that are symlinks, so local temp-dir entries cannot redirect catalog cleanup outside the directory Terragrunt is preparing. Each clone remains available while the TUI session is running because unit and stack copy actions read files from it, then Terragrunt removes the temporary clone when the session exits.
 
 An example of how to define the optional default template and the list of repositories for the `catalog` command in the `terragrunt.hcl` configuration file:
 

--- a/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
+++ b/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
@@ -27,7 +27,7 @@ If `<repo-url>` is provided, the repository will be cloned into a temporary dire
 
 When loading remote repositories, Terragrunt creates a fresh temporary clone directory for each repository under the system temp directory. The temp root is resolved through symlinks before discovery so component paths stay inside the clone on systems where the temp directory itself is reported through a symlink.
 
-Terragrunt does not use a deterministic URL-derived temp path for catalog loads. It refuses to use or clean up clone roots that are symlinks, so local temp-dir entries cannot redirect catalog cleanup outside the directory Terragrunt is preparing. Each clone remains available while the TUI session is running because unit and stack copy actions read files from it, then Terragrunt removes the temporary clone when the session exits.
+Terragrunt does not use a predictable temp path for catalog loads. It refuses to use or clean up clone roots that are symlinks, so local temp-dir entries cannot redirect catalog cleanup outside the directory Terragrunt is preparing. Each clone remains available while the TUI session is running because unit and stack copy actions read files from it, then Terragrunt removes the temporary clone when the session exits.
 
 An example of how to define the optional default template and the list of repositories for the `catalog` command in the `terragrunt.hcl` configuration file:
 

--- a/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
+++ b/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
@@ -23,6 +23,12 @@ If `<repo-url>` is provided, the repository will be cloned into a temporary dire
 1. The repository list are searched in the config file `terragrunt.hcl`. if `terragrunt.hcl` does not exist in the current directory, the config are searched in the parent directories.
 1. If the repository list is not found in the configuration file, the modules are looked for in the current directory.
 
+## Temporary clone directories
+
+When `catalog` loads a remote repository, Terragrunt creates a fresh temporary clone directory under the system temp directory. The temp root is resolved through symlinks before discovery so component paths stay inside the clone on systems where the temp directory itself is reported through a symlink.
+
+Terragrunt does not use a deterministic URL-derived temp path for catalog loads. It also rejects symlinked clone roots before removing an incomplete clone, so local temp-dir entries cannot redirect catalog cleanup outside the directory Terragrunt is preparing. The clone remains available while the TUI session is running because unit and stack copy actions read files from it.
+
 An example of how to define the optional default template and the list of repositories for the `catalog` command in the `terragrunt.hcl` configuration file:
 
 ``` hcl

--- a/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
+++ b/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
@@ -25,9 +25,9 @@ If `<repo-url>` is provided, the repository will be cloned into a temporary dire
 
 ## Temporary clone directories
 
-When `catalog` loads a remote repository, Terragrunt creates a fresh temporary clone directory under the system temp directory. The temp root is resolved through symlinks before discovery so component paths stay inside the clone on systems where the temp directory itself is reported through a symlink.
+When loading a remote repository, Terragrunt creates a fresh temporary clone directory under the system temp directory. The temp root is resolved through symlinks before discovery so component paths stay inside the clone on systems where the temp directory itself is reported through a symlink.
 
-Terragrunt does not use a deterministic URL-derived temp path for catalog loads. It also rejects symlinked clone roots before removing an incomplete clone, so local temp-dir entries cannot redirect catalog cleanup outside the directory Terragrunt is preparing. The clone remains available while the TUI session is running because unit and stack copy actions read files from it.
+Terragrunt does not use a deterministic URL-derived temp path for catalog loads. It refuses to use or clean up clone roots that are symlinks, so local temp-dir entries cannot redirect catalog cleanup outside the directory Terragrunt is preparing. The clone remains available while the TUI session is running because unit and stack copy actions read files from it, then Terragrunt removes the temporary clone when the session exits.
 
 An example of how to define the optional default template and the list of repositories for the `catalog` command in the `terragrunt.hcl` configuration file:
 

--- a/docs/src/data/changelog/v1.1.1/catalog-temp-clone-hardening.mdx
+++ b/docs/src/data/changelog/v1.1.1/catalog-temp-clone-hardening.mdx
@@ -3,8 +3,6 @@ version: "v1.1.1"
 category: "bug-fixes"
 ---
 
-#### `terragrunt catalog` no longer uses predictable temporary clone paths
+#### Safer temporary clone directories for `terragrunt catalog`
 
-The `catalog` command used to derive its temporary clone directory from the repository URL under the shared system temp directory. On shared machines, a pre-existing symlink at that path could redirect catalog clone cleanup outside the intended temp root.
-
-Terragrunt now creates a fresh temporary clone root for each catalog load and refuses to prepare or clean up a clone root that is a symlink. Catalog browsing and unit/stack copy behavior continue to use the clone for the current TUI session, and Terragrunt removes the temporary clone when the session exits.
+Terragrunt now creates a fresh temporary clone directory for each catalog load, rejects symlinked clone roots, and removes catalog clones when the TUI session exits.

--- a/docs/src/data/changelog/v1.1.1/catalog-temp-clone-hardening.mdx
+++ b/docs/src/data/changelog/v1.1.1/catalog-temp-clone-hardening.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.1"
+category: "bug-fixes"
+---
+
+#### `terragrunt catalog` no longer uses predictable temporary clone paths
+
+The `catalog` command used to derive its temporary clone directory from the repository URL under the shared system temp directory. On shared machines, a pre-existing symlink at that path could redirect catalog clone cleanup outside the intended temp root.
+
+Terragrunt now creates a fresh temporary clone root for each catalog load and refuses to prepare or clean up a clone root that is a symlink. Catalog browsing and unit/stack copy behavior continue to use the clone for the current TUI session, but the path is no longer predictable or reused across runs.

--- a/docs/src/data/changelog/v1.1.1/catalog-temp-clone-hardening.mdx
+++ b/docs/src/data/changelog/v1.1.1/catalog-temp-clone-hardening.mdx
@@ -7,4 +7,4 @@ category: "bug-fixes"
 
 The `catalog` command used to derive its temporary clone directory from the repository URL under the shared system temp directory. On shared machines, a pre-existing symlink at that path could redirect catalog clone cleanup outside the intended temp root.
 
-Terragrunt now creates a fresh temporary clone root for each catalog load and refuses to prepare or clean up a clone root that is a symlink. Catalog browsing and unit/stack copy behavior continue to use the clone for the current TUI session, but the path is no longer predictable or reused across runs.
+Terragrunt now creates a fresh temporary clone root for each catalog load and refuses to prepare or clean up a clone root that is a symlink. Catalog browsing and unit/stack copy behavior continue to use the clone for the current TUI session, and Terragrunt removes the temporary clone when the session exits.

--- a/internal/cli/commands/catalog/catalog.go
+++ b/internal/cli/commands/catalog/catalog.go
@@ -37,6 +37,9 @@ func Run(ctx context.Context, l log.Logger, v venv.Venv, opts *options.Terragrun
 		return err
 	}
 
+	tempDirs := tui.NewTempDirTracker(v.FS)
+	defer tempDirs.Cleanup(l)
+
 	return tui.Run(
 		ctx, l, v, opts, opts.Writers.ErrWriter,
 		func(
@@ -45,10 +48,10 @@ func Run(ctx context.Context, l log.Logger, v venv.Venv, opts *options.Terragrun
 			if repoURL != "" {
 				status("Loading " + repoURL + "...")
 
-				return tui.LoadURL(ctx, l, v, opts, repoURL, componentCh)
+				return tui.LoadURL(ctx, l, v, opts, tempDirs, repoURL, componentCh)
 			}
 
-			return discoverAndLoad(ctx, l, v, opts, status, componentCh)
+			return discoverAndLoad(ctx, l, v, opts, tempDirs, status, componentCh)
 		})
 }
 
@@ -56,6 +59,7 @@ func Run(ctx context.Context, l log.Logger, v venv.Venv, opts *options.Terragrun
 // distinct repo URL they surface into componentCh, bounded by parallelism.
 func discoverAndLoad(
 	ctx context.Context, l log.Logger, v venv.Venv, opts *options.TerragruntOptions,
+	tempDirs *tui.TempDirTracker,
 	status tui.StatusFunc, componentCh chan<- *tui.ComponentEntry,
 ) error {
 	urlCh := make(chan string, urlChannelBufferSize)
@@ -104,7 +108,7 @@ func discoverAndLoad(
 		seen[repoURL] = struct{}{}
 
 		loaders.Go(func() error {
-			err := tui.LoadURL(loadCtx, l, v, opts, repoURL, componentCh)
+			err := tui.LoadURL(loadCtx, l, v, opts, tempDirs, repoURL, componentCh)
 			if err == nil {
 				return nil
 			}

--- a/internal/cli/commands/catalog/tui/load.go
+++ b/internal/cli/commands/catalog/tui/load.go
@@ -14,13 +14,13 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
-const tempDirPattern = "catalog-*"
-
 // CreateCatalogTempPath creates a fresh clone root under the resolved temp dir.
 // Resolving os.TempDir keeps filepath.Rel results inside the clone on systems
 // where the temp dir itself is reported through a symlink.
-func CreateCatalogTempPath(fsys vfs.FS) (string, error) {
-	return vfs.MkdirTemp(fsys, util.ResolvePath(os.TempDir()), tempDirPattern)
+func CreateCatalogTempPath(fsys vfs.FS, repoURL string) (string, error) {
+	pattern := fmt.Sprintf("catalog-%s-*", util.EncodeBase64Sha1(repoURL))
+
+	return vfs.MkdirTemp(fsys, util.ResolvePath(os.TempDir()), pattern)
 }
 
 // LoadURL clones repoURL via module.NewRepo, walks it with a
@@ -45,7 +45,7 @@ func LoadURL(
 	allowCAS := !opts.NoCAS
 	slowReporting := opts.Experiments.Evaluate(experiment.SlowTaskReporting)
 
-	tempPath, err := CreateCatalogTempPath(v.FS)
+	tempPath, err := CreateCatalogTempPath(v.FS, repoURL)
 	if err != nil {
 		return fmt.Errorf("failed to create catalog temporary directory for %s: %w", repoURL, err)
 	}

--- a/internal/cli/commands/catalog/tui/load.go
+++ b/internal/cli/commands/catalog/tui/load.go
@@ -50,9 +50,17 @@ func LoadURL(
 		return fmt.Errorf("failed to create catalog temporary directory for %s: %w", repoURL, err)
 	}
 
-	tempDirs.Track(tempPath)
-
 	keepDir := false
+
+	preserveTempDir := func() {
+		if keepDir {
+			return
+		}
+
+		keepDir = true
+
+		tempDirs.Track(tempPath)
+	}
 
 	defer func() {
 		if keepDir {
@@ -60,7 +68,7 @@ func LoadURL(
 		}
 
 		if err := v.FS.RemoveAll(tempPath); err != nil {
-			l.Debugf("Failed to remove unused catalog temporary directory %q: %v", tempPath, err)
+			l.Warnf("Failed to remove catalog temporary directory %q: %v", tempPath, err)
 		}
 	}()
 
@@ -111,12 +119,11 @@ func LoadURL(
 
 		select {
 		case componentCh <- entry:
+			preserveTempDir()
 		case <-ctx.Done():
 			return nil
 		}
 	}
-
-	keepDir = true
 
 	return nil
 }

--- a/internal/cli/commands/catalog/tui/load.go
+++ b/internal/cli/commands/catalog/tui/load.go
@@ -32,6 +32,7 @@ func LoadURL(
 	l log.Logger,
 	v venv.Venv,
 	opts *options.TerragruntOptions,
+	tempDirs *TempDirTracker,
 	repoURL string,
 	componentCh chan<- *ComponentEntry,
 ) error {
@@ -48,6 +49,20 @@ func LoadURL(
 	if err != nil {
 		return fmt.Errorf("failed to create catalog temporary directory for %s: %w", repoURL, err)
 	}
+
+	tempDirs.Track(tempPath)
+
+	keepDir := false
+
+	defer func() {
+		if keepDir {
+			return
+		}
+
+		if err := v.FS.RemoveAll(tempPath); err != nil {
+			l.Debugf("Failed to remove unused catalog temporary directory %q: %v", tempPath, err)
+		}
+	}()
 
 	l.Debugf("Processing repository %s in temporary path %s", repoURL, tempPath)
 
@@ -100,6 +115,8 @@ func LoadURL(
 			return nil
 		}
 	}
+
+	keepDir = true
 
 	return nil
 }

--- a/internal/cli/commands/catalog/tui/load.go
+++ b/internal/cli/commands/catalog/tui/load.go
@@ -4,35 +4,29 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
-// tempDirFormat mirrors the legacy catalog service's temp-path scheme so
-// repeated runs reuse the same clone on disk.
-const tempDirFormat = "catalog-%s"
+const tempDirPattern = "catalog-*"
 
-// CatalogTempPath returns the local cache directory for repoURL's clone. It
-// resolves os.TempDir() through any symlinks so the subdirectories
-// [ComponentDiscovery] derives via filepath.Rel stay inside the clone. macOS
-// reports os.TempDir() as a /var/folders symlink to /private/var/folders;
-// leaving it unresolved makes Rel emit a "../" traversal that the getter package
-// rejects when scaffolding.
-func CatalogTempPath(repoURL string) string {
-	encodedRepoURL := util.EncodeBase64Sha1(repoURL)
-	return filepath.Join(util.ResolvePath(os.TempDir()), fmt.Sprintf(tempDirFormat, encodedRepoURL))
+// CreateCatalogTempPath creates a fresh clone root under the resolved temp dir.
+// Resolving os.TempDir keeps filepath.Rel results inside the clone on systems
+// where the temp dir itself is reported through a symlink.
+func CreateCatalogTempPath(fsys vfs.FS) (string, error) {
+	return vfs.MkdirTemp(fsys, util.ResolvePath(os.TempDir()), tempDirPattern)
 }
 
 // LoadURL clones repoURL via module.NewRepo, walks it with a
 // [ComponentDiscovery], resolves the latest release tag once, and emits a
-// *ComponentEntry for each discovered component on componentCh. It reuses
-// module.NewRepo for the generic git/clone plumbing.
+// *ComponentEntry for each discovered component on componentCh. Each load uses
+// a fresh temp directory and module.NewRepo for the generic git/clone plumbing.
 func LoadURL(
 	ctx context.Context,
 	l log.Logger,
@@ -50,7 +44,10 @@ func LoadURL(
 	allowCAS := !opts.NoCAS
 	slowReporting := opts.Experiments.Evaluate(experiment.SlowTaskReporting)
 
-	tempPath := CatalogTempPath(repoURL)
+	tempPath, err := CreateCatalogTempPath(v.FS)
+	if err != nil {
+		return fmt.Errorf("failed to create catalog temporary directory for %s: %w", repoURL, err)
+	}
 
 	l.Debugf("Processing repository %s in temporary path %s", repoURL, tempPath)
 

--- a/internal/cli/commands/catalog/tui/load.go
+++ b/internal/cli/commands/catalog/tui/load.go
@@ -18,9 +18,9 @@ import (
 // Resolving os.TempDir keeps filepath.Rel results inside the clone on systems
 // where the temp dir itself is reported through a symlink.
 func CreateCatalogTempPath(fsys vfs.FS, repoURL string) (string, error) {
-	pattern := fmt.Sprintf("catalog-%s-*", util.EncodeBase64Sha1(repoURL))
+	prefix := "catalog-" + util.EncodeBase64Sha1(repoURL) + "-"
 
-	return vfs.MkdirTemp(fsys, util.ResolvePath(os.TempDir()), pattern)
+	return vfs.MkdirTemp(fsys, util.ResolvePath(os.TempDir()), prefix)
 }
 
 // LoadURL clones repoURL via module.NewRepo, walks it with a

--- a/internal/cli/commands/catalog/tui/load_test.go
+++ b/internal/cli/commands/catalog/tui/load_test.go
@@ -6,15 +6,16 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestCatalogTempPathResolvesSymlinkedTmpDir verifies the clone cache dir is
+// TestCreateCatalogTempPathResolvesSymlinkedTmpDir verifies the clone dir is
 // anchored at a symlink-resolved temp dir. macOS reports os.TempDir() as a
 // /var/folders symlink to /private/var/folders; an unresolved root makes
 // discovery's filepath.Rel emit a "../" traversal that go-getter rejects.
-func TestCatalogTempPathResolvesSymlinkedTmpDir(t *testing.T) {
+func TestCreateCatalogTempPathResolvesSymlinkedTmpDir(t *testing.T) {
 	// t.Setenv forbids t.Parallel.
 	base, err := filepath.EvalSymlinks(t.TempDir())
 	require.NoError(t, err)
@@ -28,10 +29,31 @@ func TestCatalogTempPathResolvesSymlinkedTmpDir(t *testing.T) {
 
 	t.Setenv("TMPDIR", linkTmp)
 
-	got := tui.CatalogTempPath("github.com/gruntwork-io/terragrunt-scale-catalog")
+	got, err := tui.CreateCatalogTempPath(vfs.NewOSFS())
+	require.NoError(t, err)
 
 	// The clone dir must sit directly under the resolved temp dir, with no
 	// symlink component left for filepath.Rel to trip over later.
 	assert.Equal(t, realTmp, filepath.Dir(got),
-		"CatalogTempPath should anchor the clone at the symlink-resolved temp dir")
+		"CreateCatalogTempPath should anchor the clone at the symlink-resolved temp dir")
+}
+
+func TestCreateCatalogTempPathUsesFreshDirectory(t *testing.T) {
+	t.Parallel()
+
+	first, err := tui.CreateCatalogTempPath(vfs.NewOSFS())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(first))
+	})
+
+	second, err := tui.CreateCatalogTempPath(vfs.NewOSFS())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(second))
+	})
+
+	assert.NotEqual(t, first, second)
+	assert.DirExists(t, first)
+	assert.DirExists(t, second)
 }

--- a/internal/cli/commands/catalog/tui/load_test.go
+++ b/internal/cli/commands/catalog/tui/load_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -35,7 +36,7 @@ func TestCreateCatalogTempPathResolvesSymlinkedTmpDir(t *testing.T) {
 
 	t.Setenv("TMPDIR", linkTmp)
 
-	got, err := tui.CreateCatalogTempPath(vfs.NewOSFS())
+	got, err := tui.CreateCatalogTempPath(vfs.NewOSFS(), "github.com/gruntwork-io/terragrunt-scale-catalog")
 	require.NoError(t, err)
 
 	// The clone dir must sit directly under the resolved temp dir, with no
@@ -47,19 +48,25 @@ func TestCreateCatalogTempPathResolvesSymlinkedTmpDir(t *testing.T) {
 func TestCreateCatalogTempPathUsesFreshDirectory(t *testing.T) {
 	t.Parallel()
 
-	first, err := tui.CreateCatalogTempPath(vfs.NewOSFS())
+	repoURL := "github.com/gruntwork-io/terragrunt-scale-catalog"
+
+	first, err := tui.CreateCatalogTempPath(vfs.NewOSFS(), repoURL)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(first))
 	})
 
-	second, err := tui.CreateCatalogTempPath(vfs.NewOSFS())
+	second, err := tui.CreateCatalogTempPath(vfs.NewOSFS(), repoURL)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(second))
 	})
 
 	assert.NotEqual(t, first, second)
+
+	expectedPrefix := "catalog-" + util.EncodeBase64Sha1(repoURL) + "-"
+	assert.True(t, strings.HasPrefix(filepath.Base(first), expectedPrefix))
+	assert.True(t, strings.HasPrefix(filepath.Base(second), expectedPrefix))
 	assert.DirExists(t, first)
 	assert.DirExists(t, second)
 }

--- a/internal/cli/commands/catalog/tui/load_test.go
+++ b/internal/cli/commands/catalog/tui/load_test.go
@@ -48,27 +48,28 @@ func TestCreateCatalogTempPathResolvesSymlinkedTmpDir(t *testing.T) {
 func TestCreateCatalogTempPathUsesFreshDirectory(t *testing.T) {
 	t.Parallel()
 
+	fsys := vfs.NewMemMapFS()
 	repoURL := "github.com/gruntwork-io/terragrunt-scale-catalog"
 
-	first, err := tui.CreateCatalogTempPath(vfs.NewOSFS(), repoURL)
+	first, err := tui.CreateCatalogTempPath(fsys, repoURL)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(first))
-	})
 
-	second, err := tui.CreateCatalogTempPath(vfs.NewOSFS(), repoURL)
+	second, err := tui.CreateCatalogTempPath(fsys, repoURL)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(second))
-	})
 
 	assert.NotEqual(t, first, second)
 
 	expectedPrefix := "catalog-" + util.EncodeBase64Sha1(repoURL) + "-"
 	assert.True(t, strings.HasPrefix(filepath.Base(first), expectedPrefix))
 	assert.True(t, strings.HasPrefix(filepath.Base(second), expectedPrefix))
-	assert.DirExists(t, first)
-	assert.DirExists(t, second)
+
+	firstExists, err := vfs.FileExists(fsys, first)
+	require.NoError(t, err)
+	assert.True(t, firstExists, "first temp dir should exist on the vfs")
+
+	secondExists, err := vfs.FileExists(fsys, second)
+	require.NoError(t, err)
+	assert.True(t, secondExists, "second temp dir should exist on the vfs")
 }
 
 func TestLoadURLKeepsTempDirAfterEmittingComponentOnCancel(t *testing.T) {

--- a/internal/cli/commands/catalog/tui/load_test.go
+++ b/internal/cli/commands/catalog/tui/load_test.go
@@ -1,12 +1,18 @@
 package tui_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -56,4 +62,86 @@ func TestCreateCatalogTempPathUsesFreshDirectory(t *testing.T) {
 	assert.NotEqual(t, first, second)
 	assert.DirExists(t, first)
 	assert.DirExists(t, second)
+}
+
+func TestLoadURLKeepsTempDirAfterEmittingComponentOnCancel(t *testing.T) {
+	// t.Setenv forbids t.Parallel.
+	base := t.TempDir()
+	tempRoot := filepath.Join(base, "tmp")
+	require.NoError(t, os.Mkdir(tempRoot, 0o755))
+	t.Setenv("TMPDIR", tempRoot)
+
+	repoDir := filepath.Join(base, "repo")
+	writeCatalogRepo(t, repoDir)
+
+	opts, err := options.NewTerragruntOptionsForTest("")
+	require.NoError(t, err)
+
+	v := venv.OSVenv()
+	tracker := tui.NewTempDirTracker(v.FS)
+	ctx, cancel := context.WithCancel(t.Context())
+	componentCh := make(chan *tui.ComponentEntry)
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- tui.LoadURL(ctx, logger.CreateLogger(), v, opts, tracker, repoDir, componentCh)
+	}()
+
+	select {
+	case <-componentCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first component")
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for LoadURL to return")
+	}
+
+	catalogDirs := catalogTempDirs(t, tempRoot)
+	require.Len(t, catalogDirs, 1)
+	assert.DirExists(t, catalogDirs[0])
+
+	tracker.Cleanup(logger.CreateLogger())
+	assert.NoDirExists(t, catalogDirs[0])
+}
+
+func writeCatalogRepo(t *testing.T, repoDir string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".git", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".git", "config"), []byte(`[core]
+	repositoryformatversion = 0
+[remote "origin"]
+	url = github.com/gruntwork-io/fake-repo
+`), 0o644))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "alpha"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "alpha", "main.tf"), []byte("# alpha\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "bravo"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "bravo", "main.tf"), []byte("# bravo\n"), 0o644))
+}
+
+func catalogTempDirs(t *testing.T, tempRoot string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(tempRoot)
+	require.NoError(t, err)
+
+	var dirs []string
+
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "catalog-") {
+			continue
+		}
+
+		dirs = append(dirs, filepath.Join(tempRoot, entry.Name()))
+	}
+
+	return dirs
 }

--- a/internal/cli/commands/catalog/tui/temp_dirs.go
+++ b/internal/cli/commands/catalog/tui/temp_dirs.go
@@ -1,0 +1,66 @@
+package tui
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+)
+
+// TempDirTracker records catalog clone roots that must survive until the TUI
+// exits because unit and stack actions read files from the cloned repository.
+type TempDirTracker struct {
+	fsys vfs.FS
+	dirs map[string]struct{}
+	mu   sync.Mutex
+}
+
+// NewTempDirTracker creates a tracker for temporary catalog clone roots.
+func NewTempDirTracker(fsys vfs.FS) *TempDirTracker {
+	return &TempDirTracker{
+		fsys: fsys,
+		dirs: make(map[string]struct{}),
+	}
+}
+
+// Track records path for cleanup when the catalog session exits.
+func (t *TempDirTracker) Track(path string) {
+	if t == nil || path == "" {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.dirs[path] = struct{}{}
+}
+
+// Cleanup removes tracked paths. Cleanup errors are logged but do not change
+// the catalog command result because they happen after the user action ended.
+func (t *TempDirTracker) Cleanup(l log.Logger) {
+	if t == nil {
+		return
+	}
+
+	for _, dir := range t.dirsSnapshot() {
+		if err := t.fsys.RemoveAll(dir); err != nil {
+			l.Warnf("Failed to remove catalog temporary directory %q: %v", dir, err)
+		}
+	}
+}
+
+func (t *TempDirTracker) dirsSnapshot() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	dirs := make([]string, 0, len(t.dirs))
+	for dir := range t.dirs {
+		dirs = append(dirs, dir)
+	}
+
+	clear(t.dirs)
+	sort.Strings(dirs)
+
+	return dirs
+}

--- a/internal/cli/commands/catalog/tui/temp_dirs_test.go
+++ b/internal/cli/commands/catalog/tui/temp_dirs_test.go
@@ -1,0 +1,29 @@
+package tui_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTempDirTrackerCleanupRemovesTrackedDirs(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "catalog-cleanup")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	tracker := tui.NewTempDirTracker(vfs.NewOSFS())
+	tracker.Track(dir)
+	tracker.Cleanup(logger.CreateLogger())
+
+	_, err := os.Stat(dir)
+	assert.True(t, os.IsNotExist(err), "tracked catalog temp dir should be removed")
+
+	tracker.Cleanup(logger.CreateLogger())
+}

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -2,6 +2,7 @@ package module
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -322,23 +323,76 @@ func (repo *Repo) handleLocalDir(l log.Logger, repoPath string) error {
 }
 
 func (repo *Repo) prepareCloneDirectory(l log.Logger, fsys vfs.FS) error {
-	if err := fsys.MkdirAll(repo.path, os.ModePerm); err != nil {
+	cloneRoot := repo.path
+
+	if err := prepareCloneRoot(fsys, cloneRoot); err != nil {
 		return err
 	}
 
 	repoName := repo.extractRepoName()
-	repo.path = filepath.Join(repo.path, repoName)
+	repo.path = filepath.Join(cloneRoot, repoName)
 
 	// Clean up incomplete clones
 	if repo.shouldCleanupIncompleteClone(fsys) {
 		l.Debugf("The repo dir exists but %q does not. Removing the repo dir for cloning from the remote source.", cloneCompleteSentinel)
 
-		if err := fsys.RemoveAll(repo.path); err != nil {
+		if err := removeIncompleteClone(fsys, cloneRoot, repo.path); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func prepareCloneRoot(fsys vfs.FS, cloneRoot string) error {
+	if err := fsys.MkdirAll(cloneRoot, os.ModePerm); err != nil {
+		return err
+	}
+
+	return validateCloneRoot(fsys, cloneRoot)
+}
+
+func validateCloneRoot(fsys vfs.FS, cloneRoot string) error {
+	if cloneRoot == "" {
+		return nil
+	}
+
+	info, err := vfs.Lstat(fsys, cloneRoot)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to use clone root %q because it is a symlink", cloneRoot)
+	}
+
+	return nil
+}
+
+func removeIncompleteClone(fsys vfs.FS, cloneRoot, clonePath string) error {
+	if err := validateCloneRoot(fsys, cloneRoot); err != nil {
+		return err
+	}
+
+	rel, err := filepath.Rel(filepath.Clean(cloneRoot), filepath.Clean(clonePath))
+	if err != nil {
+		return err
+	}
+
+	parentHasSymlink, err := vfs.ParentPathHasSymlink(fsys, cloneRoot, rel)
+	if err != nil {
+		return err
+	}
+
+	if parentHasSymlink {
+		return fmt.Errorf("refusing to remove clone path %q outside clone root %q", clonePath, cloneRoot)
+	}
+
+	return fsys.RemoveAll(clonePath)
 }
 
 func (repo *Repo) extractRepoName() string {

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -278,15 +278,15 @@ func (repo *Repo) clone(ctx context.Context, l log.Logger, fsys vfs.FS) error {
 		return repo.handleLocalDir(l, cloneURL)
 	}
 
+	if err := repo.prepareCloneDirectory(l, fsys); err != nil {
+		return err
+	}
+
 	// Prepare clone options
 	opts := CloneOptions{
 		SourceURL:  cloneURL,
 		TargetPath: repo.path,
 		Context:    ctx,
-	}
-
-	if err := repo.prepareCloneDirectory(l, fsys); err != nil {
-		return err
 	}
 
 	if repo.cloneCompleted(fsys) {

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -345,6 +345,10 @@ func (repo *Repo) prepareCloneDirectory(l log.Logger, fsys vfs.FS) error {
 }
 
 func prepareCloneRoot(fsys vfs.FS, cloneRoot string) error {
+	if err := validateCloneRoot(fsys, cloneRoot); err != nil {
+		return err
+	}
+
 	if err := fsys.MkdirAll(cloneRoot, os.ModePerm); err != nil {
 		return err
 	}

--- a/internal/services/catalog/module/repo_security_test.go
+++ b/internal/services/catalog/module/repo_security_test.go
@@ -1,0 +1,37 @@
+package module_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRepoRejectsSymlinkRootBeforeCleanup(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	cloneURL := "https://example.com/org/target.git"
+	predictableRoot := filepath.Join(base, "catalog-predictable")
+	repoName := "target"
+	attackerParent := filepath.Join(base, "attacker-parent")
+	outsideRepoPath := filepath.Join(attackerParent, repoName)
+	require.NoError(t, os.MkdirAll(outsideRepoPath, 0o755))
+
+	sentinel := filepath.Join(outsideRepoPath, "sentinel.txt")
+	require.NoError(t, os.WriteFile(sentinel, []byte("do not remove\n"), 0o644))
+	require.NoError(t, os.Symlink(attackerParent, predictableRoot))
+
+	_, err := module.NewRepo(t.Context(), logger.CreateLogger(), vfs.NewOSFS(), &module.RepoOpts{
+		CloneURL: cloneURL,
+		Path:     predictableRoot,
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "symlink")
+	assert.FileExists(t, sentinel)
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* Fixes terragrunt catalog so it no longer uses predictable temp clone paths that could be pre-created as symlinks.
* Adds checks to reject symlinked clone roots before cleanup, plus tests, docs, and a v1.1.1 changelog entry.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Catalog temp directories are now created fresh for each load, rejected when the clone root is a symlink, and cleaned up when the TUI session ends.
  * Clone handling now validates paths more safely to avoid removing files outside the intended location.

* **Tests**
  * Added coverage for fresh temp directory creation, symlink handling, session cancellation cleanup, and safe clone-root validation.

* **Documentation**
  * Added a changelog entry for the catalog hardening update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->