### PR TITLE
fix(hcl-validate): set per-unit OriginalTerragruntConfigPath

### DIFF
--- a/docs/src/data/changelog/v1.1.1/hcl-validate-original-terragrunt-dir.mdx
+++ b/docs/src/data/changelog/v1.1.1/hcl-validate-original-terragrunt-dir.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.1"
+category: "bug-fixes"
+---
+
+#### `hcl validate` resolves `get_original_terragrunt_dir()` to the discovered unit
+
+`terragrunt hcl validate` and `terragrunt hcl validate --inputs` now resolve `get_original_terragrunt_dir()` to each discovered unit's own directory instead of the directory the command was launched from. Previously, when the command ran from a parent directory that discovered units in subdirectories, any `read_terragrunt_config()` call that built a path relative to `get_original_terragrunt_dir()` resolved against the wrong directory and failed with "You attempted to run terragrunt in a folder that does not contain a terragrunt.hcl file", even though `plan`, `apply`, and `run validate` worked on the same configuration.
+
+Both commands now set the original config path per discovered unit before parsing, matching the behavior of `run` and `backend bootstrap`, so relative paths resolve against the unit that owns them.

--- a/internal/cli/commands/hcl/validate/validate.go
+++ b/internal/cli/commands/hcl/validate/validate.go
@@ -180,6 +180,7 @@ func RunValidate(ctx context.Context, l log.Logger, v run.Venv, opts *options.Te
 		}
 
 		parseOpts.TerragruntConfigPath = filepath.Join(c.Path(), configFilename)
+		parseOpts.OriginalTerragruntConfigPath = parseOpts.TerragruntConfigPath
 
 		_, pctx := configbridge.NewParsingContext(ctx, l, parseOpts)
 		pctx.Venv = v.ToRoot()
@@ -308,6 +309,7 @@ func RunValidateInputs(ctx context.Context, l log.Logger, v run.Venv, opts *opti
 		}
 
 		unitOpts.TerragruntConfigPath = filepath.Join(c.Path(), configFilename)
+		unitOpts.OriginalTerragruntConfigPath = unitOpts.TerragruntConfigPath
 
 		prepared, err := prepare.PrepareConfig(ctx, l, v, unitOpts)
 		if err != nil {

--- a/pkg/config/config_helpers_test.go
+++ b/pkg/config/config_helpers_test.go
@@ -1177,6 +1177,36 @@ func TestReadTerragruntConfigLocals(t *testing.T) {
 	assert.Equal(t, json.Number("42"), localsMap["number_expression"].(json.Number))
 }
 
+// pins that read_terragrunt_config resolves get_original_terragrunt_dir() relative to OriginalTerragruntConfigPath
+func TestReadTerragruntConfigResolvesRelativeToOriginalTerragruntDir(t *testing.T) {
+	t.Parallel()
+
+	unitFilename, err := filepath.Abs(
+		filepath.Join("..", "..", "test", "fixtures", "hcl-validate-original-dir", "unit", "terragrunt.hcl"),
+	)
+	require.NoError(t, err)
+
+	// correct original path: get_original_terragrunt_dir() resolves to the unit dir
+	ctx, pctx := newTestParsingContext(t, unitFilename)
+	pctx.OriginalTerragruntConfigPath = unitFilename
+	pctx.SkipOutput = true
+
+	cfg, err := config.ParseConfigFile(ctx, pctx, logger.CreateLogger(), unitFilename, nil)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "hello from original terragrunt dir", cfg.Inputs["input"])
+
+	// wrong original path (pre-fix): the relative read escapes the fixture and fails
+	parentFilename := filepath.Join(filepath.Dir(filepath.Dir(unitFilename)), config.DefaultTerragruntConfigPath)
+
+	ctxWrong, pctxWrong := newTestParsingContext(t, unitFilename)
+	pctxWrong.OriginalTerragruntConfigPath = parentFilename
+	pctxWrong.SkipOutput = true
+
+	_, err = config.ParseConfigFile(ctxWrong, pctxWrong, logger.CreateLogger(), unitFilename, nil)
+	require.Error(t, err)
+}
+
 func TestGetTerragruntSourceForModuleHappyPath(t *testing.T) {
 	t.Parallel()
 

--- a/test/fixtures/hcl-validate-original-dir/common.hcl
+++ b/test/fixtures/hcl-validate-original-dir/common.hcl
@@ -1,0 +1,3 @@
+locals {
+  example = "hello from original terragrunt dir"
+}

--- a/test/fixtures/hcl-validate-original-dir/unit/main.tf
+++ b/test/fixtures/hcl-validate-original-dir/unit/main.tf
@@ -1,0 +1,5 @@
+variable "input" {}
+
+output "output" {
+  value = var.input
+}

--- a/test/fixtures/hcl-validate-original-dir/unit/terragrunt.hcl
+++ b/test/fixtures/hcl-validate-original-dir/unit/terragrunt.hcl
@@ -1,0 +1,8 @@
+# get_original_terragrunt_dir() must resolve to this unit, not the parent launch dir
+locals {
+  common = read_terragrunt_config("${get_original_terragrunt_dir()}/../common.hcl")
+}
+
+inputs = {
+  input = local.common.locals.example
+}

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -184,6 +184,38 @@ func TestTerragruntValidateInputsWithStrictModeDisabledAndUnusedInputs(t *testin
 	helpers.RunTerragruntValidateInputs(t, rootPath, args, true)
 }
 
+// pins that hcl validate --inputs resolves get_original_terragrunt_dir() to the discovered unit
+func TestTerragruntHCLValidateInputsResolvesOriginalTerragruntDir(t *testing.T) {
+	t.Parallel()
+
+	fixture := "fixtures/hcl-validate-original-dir"
+	helpers.CleanupTerraformFolder(t, filepath.Join(fixture, "unit"))
+	tmpEnvPath := helpers.CopyEnvironment(t, fixture)
+	rootPath := filepath.Join(tmpEnvPath, fixture)
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt hcl validate --inputs --non-interactive --working-dir "+rootPath,
+	)
+	require.NoError(t, err)
+}
+
+// pins the same for hcl validate without --inputs, which parses units through a separate path
+func TestTerragruntHCLValidateResolvesOriginalTerragruntDir(t *testing.T) {
+	t.Parallel()
+
+	fixture := "fixtures/hcl-validate-original-dir"
+	helpers.CleanupTerraformFolder(t, filepath.Join(fixture, "unit"))
+	tmpEnvPath := helpers.CopyEnvironment(t, fixture)
+	rootPath := filepath.Join(tmpEnvPath, fixture)
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt hcl validate --non-interactive --working-dir "+rootPath,
+	)
+	require.NoError(t, err)
+}
+
 func TestRenderJSONConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* set OriginalTerragruntConfigPath per discovered unit in the hcl validate command

Fixes #6444.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `terragrunt hcl validate` and `terragrunt hcl validate --inputs` now resolve paths correctly from each discovered unit’s original directory.
  * Fixed validation failures when configurations reference files relative to the launch directory’s parent.
  * Validation behavior now matches other Terragrunt commands that preserve the original config location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->