### PR TITLE
fix: Preserving SemVer build metadata in tfr:// module versions (#6345)

### DIFF
--- a/internal/getter/resolver_tfr.go
+++ b/internal/getter/resolver_tfr.go
@@ -90,8 +90,8 @@ func (r *TFRResolver) Probe(ctx context.Context, rawURL string) (string, error) 
 		registryDomain = tfimpl.DefaultRegistryDomain(r.TofuImplementation)
 	}
 
-	versionList, hasVersion := srcURL.Query()[versionQueryKey]
-	if !hasVersion || len(versionList) != 1 || versionList[0] == "" {
+	versionList, err := QueryValues(srcURL.RawQuery, versionQueryKey)
+	if err != nil || len(versionList) != 1 || versionList[0] == "" {
 		return "", cas.ErrNoVersionMetadata
 	}
 

--- a/internal/getter/resolver_tfr_test.go
+++ b/internal/getter/resolver_tfr_test.go
@@ -31,6 +31,24 @@ func TestTFRResolver_ProbeReturnsContentKey(t *testing.T) {
 	assert.Equal(t, expected, key)
 }
 
+func TestTFRResolver_ProbePreserveSemverMetadata(t *testing.T) {
+	t.Parallel()
+
+	server := newRegistryTestServer(t)
+
+	r := getter.NewTFRResolver().
+		WithHTTPClient(server.Client()).
+		WithLogger(logger.CreateLogger())
+
+	src := "tfr://" + server.Listener.Addr().String() + "/terraform-aws-modules/vpc/aws?version=1.2.3+build.5"
+
+	key, err := r.Probe(t.Context(), src)
+	require.NoError(t, err)
+
+	expected := cas.ContentKey("tfr-xtg", "https://"+server.Listener.Addr().String()+"/download/terraform-aws-vpc.zip")
+	assert.Equal(t, expected, key)
+}
+
 // TestTFRResolver_ProbeIsStable pins that two probes of the same URL
 // produce the same key, so the CAS hit path on a repeated run is
 // deterministic.

--- a/internal/getter/tfr.go
+++ b/internal/getter/tfr.go
@@ -126,7 +126,10 @@ func (r *RegistryGetter) Get(ctx context.Context, req *getter.Request) error {
 		registryDomain = tfimpl.DefaultRegistryDomain(r.TofuImplementation)
 	}
 
-	queryValues := srcURL.Query()
+	versionList, err := QueryValues(srcURL.RawQuery, versionQueryKey)
+	if err != nil {
+		return err
+	}
 	modulePath, moduleSubDir := SourceDirSubdir(srcURL.Path)
 
 	moduleRegistryBasePath, err := GetModuleRegistryURLBasePath(ctx, r.Logger, r.HTTPClient, registryDomain)
@@ -134,7 +137,7 @@ func (r *RegistryGetter) Get(ctx context.Context, req *getter.Request) error {
 		return err
 	}
 
-	version, err := r.resolveVersion(ctx, queryValues, registryDomain, moduleRegistryBasePath, modulePath)
+	version, err := r.resolveVersion(ctx, versionList, registryDomain, moduleRegistryBasePath, modulePath)
 	if err != nil {
 		return err
 	}
@@ -251,10 +254,10 @@ func (r *RegistryGetter) getSubdir(ctx context.Context, l log.Logger, dstPath, s
 // latest stable version is resolved from the registry's list-versions endpoint.
 func (r *RegistryGetter) resolveVersion(
 	ctx context.Context,
-	queryValues url.Values,
+	versionList []string,
 	registryDomain, moduleRegistryBasePath, modulePath string,
 ) (string, error) {
-	versionList, hasVersion := queryValues[versionQueryKey]
+	hasVersion := len(versionList) > 0
 
 	if hasVersion && len(versionList) != 1 {
 		return "", MalformedRegistryURLErr{reason: "more than one version query"}

--- a/internal/getter/tfr_test.go
+++ b/internal/getter/tfr_test.go
@@ -181,6 +181,29 @@ func TestRegistryGetterEmptyVersion(t *testing.T) {
 	require.ErrorAs(t, err, &typed)
 }
 
+// TestRegistryGetterBuildMetadataVersion verifies that SemVer build metadata
+// is resolved correctly (e.g. ?version=1.2.3+build.5)
+func TestRegistryGetterBuildMetadataVersion(t *testing.T) {
+	t.Parallel()
+
+	server := newRegistryTestServer(t)
+
+	dstPath := helpers.TmpDirWOSymlinks(t)
+	moduleDestPath := filepath.Join(dstPath, "terraform-aws-vpc")
+	require.False(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+
+	client := newRegistryTestClient(t, server.Client(), tfimpl.Terraform)
+
+	_, err := client.Get(t.Context(), &getter.Request{
+		Src:     "tfr://" + server.Listener.Addr().String() + "/terraform-aws-modules/vpc/aws?version=1.2.3+build.5",
+		Dst:     moduleDestPath,
+		GetMode: getter.ModeDir,
+	})
+
+	require.NoError(t, err)
+	assert.True(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+}
+
 // newRegistryTestClient builds a Client wired to the supplied http.Client so
 // it trusts the test server's self-signed TLS certificate, both for the
 // registry-protocol calls (via RegistryGetter.HTTPClient) and for the module

--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -250,6 +250,41 @@ func GetLatestModuleVersion(
 	return latest.Original(), nil
 }
 
+// QueryValues returns the decoded value(s) for key in a raw query string.
+// Unlike url.ParseQuery, it treats '+' as a literal character rather than
+// an encoded space, so SemVer build metadata like ?version=1.2.3+build.4
+// survives.
+// Returns nil if key is absent.
+func QueryValues(rawQuery, key string) ([]string, error) {
+	var values []string
+
+	for _, pair := range strings.Split(rawQuery, "&") {
+		if pair == "" {
+			continue
+		}
+
+		k, v, _ := strings.Cut(pair, "=")
+
+		k, err := url.PathUnescape(k)
+		if err != nil {
+			return nil, err
+		}
+
+		if k != key {
+			continue
+		}
+
+		v, err = url.PathUnescape(v)
+		if err != nil {
+			return nil, err
+		}
+
+		values = append(values, v)
+	}
+
+	return values, nil
+}
+
 // moduleVersionsResponse is the registry API response for the list-versions endpoint.
 type moduleVersionsResponse struct {
 	Modules []moduleVersionsEntry `json:"modules"`

--- a/internal/getter/tfrhelpers_test.go
+++ b/internal/getter/tfrhelpers_test.go
@@ -231,6 +231,14 @@ func newRegistryTestServer(t *testing.T) *httptest.Server {
 	})
 
 	mux.HandleFunc(
+		"/v1/modules/terraform-aws-modules/vpc/aws/1.2.3+build.5/download",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Terraform-Get", "https://"+r.Host+"/download/terraform-aws-vpc.zip")
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+
+	mux.HandleFunc(
 		"/v1/modules/terraform-aws-modules/vpc/aws/3.3.0/download",
 		func(w http.ResponseWriter, r *http.Request) {
 			// Resolve against the request host so the downloader hits the same


### PR DESCRIPTION
## Description

Fixes #6345.

url.Query() decodes '+' in a query string as a literal space. Registry module versions such as `1.2.3+build.5` were silently incorrectly decoded into '1.2.3 build.5' before ever reaching the registry, breaking module resolution for anyone pinning a module to a build-metadata version.

Add QueryValues, a raw-query parser that unescapes percent-sequences via url.PathUnescape without treating '+' as space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version parsing so module versions with build metadata like `1.2.3+build.5` are handled correctly.
  * Version-related errors now consistently fall back to “no version metadata” when the version query is missing or invalid.
  * Module retrieval now works reliably for versions containing `+` metadata, including downloads to the destination directory.

* **Tests**
  * Added coverage for version strings with build metadata and related download behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->