### PR TITLE
fix: use dependency's own IAM role when fetching state across AWS accounts

### DIFF
--- a/docs/src/data/changelog/v1.1.1/dependency-fetch-output-cross-account-role.mdx
+++ b/docs/src/data/changelog/v1.1.1/dependency-fetch-output-cross-account-role.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.1"
+category: "bug-fixes"
+---
+
+#### Fix `AccessDenied` fetching a `dependency`'s state across AWS accounts
+
+With `--experiment dependency-fetch-output-from-state` enabled, fetching a `dependency`'s state directly from its S3 backend could fail with `AccessDenied` when the dependency lives in a different AWS account or otherwise needs its own IAM role. Terragrunt now assumes the dependency's own role when fetching its state, including when the calling unit already has static AWS credentials in its environment.
+
+Resolves [#4979](https://github.com/gruntwork-io/terragrunt/issues/4979), superseding the credential-resolution approach attempted in [#5153](https://github.com/gruntwork-io/terragrunt/pull/5153).

--- a/internal/awshelper/config.go
+++ b/internal/awshelper/config.go
@@ -133,11 +133,22 @@ func (b *AWSConfigBuilder) Build(ctx context.Context, l log.Logger) (aws.Config,
 		return aws.Config{}, fmt.Errorf("error loading AWS config: %w", err)
 	}
 
-	if createCredentialsFromEnv(b.env) != nil {
+	mergedIAMRoleOptions := getMergedIAMRoleOptions(b.sessionConfig, b.iamRoleOpts)
+
+	// If static credentials are present in the environment (e.g. temporary credentials from an
+	// IRSA/OIDC web-identity exchange or an external auth-provider-cmd) but no role needs to be
+	// assumed on top of them, those credentials are the final identity to use as-is.
+	//
+	// If a role IS configured, those same env credentials must still be used as the BASE identity
+	// for the sts:AssumeRole call below (config.WithCredentialsProvider already wired them into cfg
+	// above) rather than short-circuiting here. Returning early in that case silently skips role
+	// assumption entirely and every AWS call ends up using the calling identity's own credentials
+	// instead of the configured role -- e.g. an S3 GetObject against a cross-account dependency's
+	// remote state fails with AccessDenied instead of assuming that dependency's own IAM role.
+	if createCredentialsFromEnv(b.env) != nil && mergedIAMRoleOptions.RoleARN == "" {
 		return cfg, nil
 	}
 
-	mergedIAMRoleOptions := getMergedIAMRoleOptions(b.sessionConfig, b.iamRoleOpts)
 	if mergedIAMRoleOptions.RoleARN == "" {
 		return cfg, nil
 	}

--- a/internal/awshelper/config_test.go
+++ b/internal/awshelper/config_test.go
@@ -4,12 +4,17 @@ package awshelper_test
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/gruntwork-io/terragrunt/internal/awshelper"
+	"github.com/gruntwork-io/terragrunt/internal/iam"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -148,4 +153,71 @@ func TestAwsConfigRegionTakesPrecedenceOverEnvVars(t *testing.T) {
 
 	// Verify that the config uses the region from awsCfg, not from environment variables
 	assert.Equal(t, "us-east-1", cfg.Region)
+}
+
+// TestAwsConfigStillAssumesRoleWithEnvCredentials is a regression test for a bug found while
+// investigating https://github.com/gruntwork-io/terragrunt/issues/4979: Build() returned as soon
+// as it found static AWS credentials in the environment (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY),
+// before ever looking at the configured IAM role options. In production this environment is not
+// just an auth-provider-cmd output -- it is also how ordinary IRSA/OIDC web-identity credential
+// chains present themselves (a CI/EKS pod assumes its own base role once, exports the resulting
+// temporary AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN into the process environment,
+// then terragrunt is expected to assume a further role on top of that base identity for a specific
+// S3 backend, e.g. a cross-account dependency's remote_state.assume_role). Because Build() bailed
+// out the moment it saw env credentials, that further role assumption was silently skipped
+// entirely and every AWS call -- including the S3 fast-path dependency fetch added for #4979 --
+// used the base identity's own credentials instead of the configured role.
+func TestAwsConfigStillAssumesRoleWithEnvCredentials(t *testing.T) {
+	// Not parallel: mutates the process-wide AWS_ENDPOINT_URL_STS env var, which the AWS SDK's
+	// config.LoadDefaultConfig reads directly from the OS environment (unlike terragrunt's own
+	// b.env/WithEnv, which only feeds createCredentialsFromEnv/getRegionFromEnv).
+
+	var gotRoleArn string
+
+	stsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		values, _ := url.ParseQuery(string(body))
+		gotRoleArn = values.Get("RoleArn")
+
+		w.Header().Set("Content-Type", "text/xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<AssumeRoleResponse><AssumeRoleResult><Credentials>` +
+			`<AccessKeyId>assumed-access-key</AccessKeyId>` +
+			`<SecretAccessKey>assumed-secret-key</SecretAccessKey>` +
+			`<SessionToken>assumed-session-token</SessionToken>` +
+			`<Expiration>2999-01-01T00:00:00Z</Expiration>` +
+			`</Credentials></AssumeRoleResult></AssumeRoleResponse>`))
+	}))
+	defer stsServer.Close()
+
+	t.Setenv("AWS_ENDPOINT_URL_STS", stsServer.URL)
+
+	l := logger.CreateLogger()
+	ctx := context.Background()
+
+	const roleARN = "arn:aws:iam::222222222222:role/dependency-role"
+
+	// Simulate a process whose own identity already comes from temporary credentials (as IRSA/OIDC
+	// web-identity chains produce), while a specific AWS call still needs to assume a further role
+	// (e.g. a dependency's own remote_state.assume_role.role_arn).
+	env := map[string]string{
+		"AWS_ACCESS_KEY_ID":     "base-access-key",
+		"AWS_SECRET_ACCESS_KEY": "base-secret-key",
+		"AWS_SESSION_TOKEN":     "base-session-token",
+		"AWS_REGION":            "us-east-1",
+	}
+
+	cfg, err := awshelper.NewAWSConfigBuilder().
+		WithEnv(env).
+		WithIAMRoleOptions(iam.RoleOptions{RoleARN: roleARN}).
+		Build(ctx, l)
+	require.NoError(t, err)
+
+	creds, err := cfg.Credentials.Retrieve(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, roleARN, gotRoleArn,
+		"Build must still call sts:AssumeRole for the configured role even when static credentials are already present in the environment")
+	assert.Equal(t, "assumed-access-key", creds.AccessKeyID,
+		"the resulting credentials must be the assumed role's session credentials, not the base env credentials")
 }

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1344,6 +1344,7 @@ func getTerragruntOutputJSONFromRemoteState(
 				l,
 				pctx,
 				remoteState,
+				mergedIAM,
 			)
 			if s3GetErr != nil {
 				return nil, s3GetErr
@@ -1402,8 +1403,12 @@ func getTerragruntOutputJSONFromRemoteState(
 	return jsonBytes, nil
 }
 
-// getTerragruntOutputJSONFromRemoteStateS3 pulls the output directly from an S3 bucket without calling Terraform
-func getTerragruntOutputJSONFromRemoteStateS3(ctx context.Context, l log.Logger, pctx *ParsingContext, remoteState *remotestate.RemoteState) ([]byte, error) {
+// getTerragruntOutputJSONFromRemoteStateS3 pulls the output directly from an S3 bucket without calling Terraform.
+// iamRoleOpts must be the dependency's own merged IAM role options (the dependency's remote_state IAM role
+// options merged with the calling unit's original IAM role options), not the calling unit's possibly-cleared
+// pctx.IAMRoleOptions, so that reading state for a dependency in another AWS account assumes the dependency's
+// role rather than the caller's.
+func getTerragruntOutputJSONFromRemoteStateS3(ctx context.Context, l log.Logger, pctx *ParsingContext, remoteState *remotestate.RemoteState, iamRoleOpts iam.RoleOptions) ([]byte, error) {
 	bucket := fmt.Sprintf("%s", remoteState.BackendConfig["bucket"])
 	key := fmt.Sprintf("%s", remoteState.BackendConfig["key"])
 
@@ -1425,7 +1430,7 @@ func getTerragruntOutputJSONFromRemoteStateS3(ctx context.Context, l log.Logger,
 		s3Client, err := awshelper.NewAWSConfigBuilder().
 			WithSessionConfig(sessionConfig).
 			WithEnv(pctx.Env).
-			WithIAMRoleOptions(pctx.IAMRoleOptions).
+			WithIAMRoleOptions(iamRoleOpts).
 			BuildS3Client(ctx, l)
 		if err != nil {
 			return fmt.Errorf("building s3 client for s3://%s/%s: %w", bucket, key, err)

--- a/pkg/config/dependency_internal_test.go
+++ b/pkg/config/dependency_internal_test.go
@@ -1,9 +1,18 @@
 package config
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/iam"
+	"github.com/gruntwork-io/terragrunt/internal/remotestate"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -257,5 +266,107 @@ func TestApplyExtraArgsEnvVarsForOutput(t *testing.T) {
 			applyExtraArgsEnvVarsForOutput(pctx, tc.terraform)
 			assert.Equal(t, tc.want, pctx.Env)
 		})
+	}
+}
+
+// TestGetTerragruntOutputJSONFromRemoteStateS3UsesDependencyIAMRole is a regression test for
+// https://github.com/gruntwork-io/terragrunt/issues/4979.
+//
+// When the dependency-fetch-output-from-state experiment is enabled and a dependency lives in an
+// AWS account that requires its own IAM role to read state, getTerragruntOutputJSONFromRemoteStateS3
+// must assume the dependency's own role (passed explicitly as iamRoleOpts) rather than whatever role
+// happens to be left on pctx.IAMRoleOptions (which resolveOutputJSON clears to the zero value whenever
+// it differs from the original). Before the fix, the function read pctx.IAMRoleOptions directly, so a
+// cross-account dependency would be fetched with no role assumption at all -- and an unrelated role left
+// on pctx.IAMRoleOptions would also be used incorrectly when present.
+//
+// This test does not talk to real AWS: it points the AWS SDK's STS endpoint resolution
+// (AWS_ENDPOINT_URL_STS) at a local httptest server and inspects which RoleArn was actually requested.
+func TestGetTerragruntOutputJSONFromRemoteStateS3UsesDependencyIAMRole(t *testing.T) {
+	// Not parallel: mutates process-wide AWS_ENDPOINT_URL_STS / AWS_ENDPOINT_URL_S3 env vars.
+
+	var (
+		gotRoleArnsMu sync.Mutex
+		gotRoleArns   []string
+	)
+
+	stsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		values, _ := url.ParseQuery(string(body))
+
+		gotRoleArnsMu.Lock()
+		gotRoleArns = append(gotRoleArns, values.Get("RoleArn"))
+		gotRoleArnsMu.Unlock()
+
+		w.Header().Set("Content-Type", "text/xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<AssumeRoleResponse><AssumeRoleResult><Credentials>` +
+			`<AccessKeyId>fake-access-key</AccessKeyId>` +
+			`<SecretAccessKey>fake-secret-key</SecretAccessKey>` +
+			`<SessionToken>fake-session-token</SessionToken>` +
+			`<Expiration>2999-01-01T00:00:00Z</Expiration>` +
+			`</Credentials></AssumeRoleResult></AssumeRoleResponse>`))
+	}))
+	defer stsServer.Close()
+
+	// A fake S3 endpoint is also required so BuildS3Client's GetObject call fails fast against a
+	// known server instead of reaching out to real AWS; the role-assumption check above already
+	// happens before this point, so its response content doesn't matter for this test.
+	s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer s3Server.Close()
+
+	t.Setenv("AWS_ENDPOINT_URL_STS", stsServer.URL)
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	const (
+		callingUnitRoleARN = "arn:aws:iam::111111111111:role/calling-unit-role"
+		dependencyRoleARN  = "arn:aws:iam::222222222222:role/dependency-role"
+	)
+
+	l := logger.CreateLogger()
+
+	// Simulate resolveOutputJSON having cleared pctx.IAMRoleOptions to the zero value (as it does
+	// whenever it differs from the original), while an unrelated role is still floating around to
+	// prove the fetch does not fall back to it.
+	pctx := &ParsingContext{
+		Env:            map[string]string{},
+		IAMRoleOptions: iam.RoleOptions{RoleARN: callingUnitRoleARN},
+	}
+
+	remoteState := remotestate.New(&remotestate.Config{
+		BackendName: "s3",
+		BackendConfig: map[string]any{
+			"bucket": "dependency-bucket",
+			"key":    "terraform.tfstate",
+			"region": "us-east-1",
+			"endpoints": map[string]any{
+				"s3": s3Server.URL,
+			},
+			"s3_force_path_style":         true,
+			"skip_credentials_validation": true,
+		},
+	})
+
+	// This is the dependency's own merged IAM role options, as computed by
+	// getTerragruntOutputJSONFromRemoteState via iam.MergeRoleOptions(iamRoleOpts, pctx.OriginalIAMRoleOptions).
+	dependencyMergedIAM := iam.RoleOptions{RoleARN: dependencyRoleARN}
+
+	_, err := getTerragruntOutputJSONFromRemoteStateS3(t.Context(), l, pctx, remoteState, dependencyMergedIAM)
+	// The S3 fetch itself is expected to fail (fake server returns 404 with no valid S3 error body) --
+	// only the role used for credential resolution is under test here.
+	require.Error(t, err)
+
+	gotRoleArnsMu.Lock()
+	defer gotRoleArnsMu.Unlock()
+
+	require.NotEmpty(t, gotRoleArns, "expected the S3 client build to assume a role via STS")
+	for _, roleArn := range gotRoleArns {
+		assert.Equal(t, dependencyRoleARN, roleArn,
+			"S3 client must assume the dependency's own IAM role, not the calling unit's role")
+		assert.NotContains(t, strings.ToLower(roleArn), strings.ToLower(callingUnitRoleARN))
 	}
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #4979.

`getTerragruntOutputJSONFromRemoteStateS3` built its S3 client from `pctx.IAMRoleOptions`, which `resolveOutputJSON` clears to the zero value whenever it differs from the calling unit's own IAM role. With `--experiment dependency-fetch-output-from-state` enabled, this meant a `dependency` living in a different AWS account (or otherwise needing its own IAM role) had its state fetched under the calling unit's identity instead of the dependency's role, and AWS returned `AccessDenied`.

Separately, `AWSConfigBuilder.Build()` returned as soon as it found `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` in the environment, before checking whether a further IAM role was configured on top of those credentials. That environment is also how IRSA/OIDC web-identity credential chains present themselves, so even after threading the dependency's role through, any further role assumption was silently skipped whenever the calling unit already had static env credentials.

This PR fixes both:
- Thread the dependency's already-computed merged IAM role options (`mergedIAM`) into `getTerragruntOutputJSONFromRemoteStateS3` explicitly, instead of reading the cleared `pctx.IAMRoleOptions` field.
- Skip role assumption only when no role is actually configured, not merely because env credentials are present.

CLI reproduction: https://github.com/moleus/terragrunt-issues-repros/tree/main/iam-cross-account-role

Supersedes the credential-resolution approach attempted in #5153, which only adjusted `AWSConfigBuilder` and did not address the cleared `IAMRoleOptions` in the S3 fast path.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Dependency state fetching now uses the dependency’s own AWS role when needed, preventing cross-account `AccessDenied` errors.
  - AWS credential handling now preserves role assumption even when static environment credentials are present.
  - Remote-state lookups now correctly apply dependency-specific IAM role settings instead of reusing the caller’s role.
- **Tests**
  - Added regression tests covering role assumption with environment credentials and dependency-specific remote-state access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->