### PR TITLE
fix(git): pass repository and ref as positionals in git fetch, clone, and ls-remote

### DIFF
--- a/docs/src/data/changelog/v1.1.1/git-source-ref-option-handling.mdx
+++ b/docs/src/data/changelog/v1.1.1/git-source-ref-option-handling.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.1"
+category: "bug-fixes"
+---
+
+#### Treat Git source `ref` values strictly as references
+
+Terragrunt now passes the `ref` from a Git module source to git strictly as a reference when downloading through content-addressable storage. Previously a source whose `ref` began with a git option (for example a value starting with `--`) could be interpreted by git as an option rather than a reference while fetching the source.
+
+Terragrunt now terminates git option parsing before the repository and reference arguments in its `fetch`, `clone`, and `ls-remote` invocations, so these values can only ever be read as the repository and reference they are meant to be. Normal refs, branches, tags, and commit SHAs continue to work unchanged.

--- a/internal/cas/getter_injection_test.go
+++ b/internal/cas/getter_injection_test.go
@@ -3,9 +3,7 @@
 package cas_test
 
 import (
-	"context"
 	"net/url"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -28,7 +26,9 @@ func TestCASGetterRefOptionInjection(t *testing.T) {
 	// ${IFS} avoids a literal space, which git rejects in a ref name.
 	injectedRef := "--upload-pack=touch${IFS}" + marker
 
-	repoDir := setupInjectionRepo(t, injectedRef)
+	repoDir := helpers.TmpDirWOSymlinks(t)
+	helpers.CreateFile(t, repoDir, "main.tf")
+	helpers.InitGitRepoWithBranchRef(t, repoDir, injectedRef)
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
 
@@ -52,36 +52,4 @@ func TestCASGetterRefOptionInjection(t *testing.T) {
 	require.NoError(t, err)
 	require.FileExists(t, filepath.Join(dst, "main.tf"))
 	assert.NoFileExists(t, marker)
-}
-
-// setupInjectionRepo creates a file:// repo with one commit and a branch named injectedRef.
-func setupInjectionRepo(t *testing.T, injectedRef string) string {
-	t.Helper()
-
-	ctx := t.Context()
-
-	dir := helpers.TmpDirWOSymlinks(t)
-
-	runGit(t, ctx, dir, "init", "-b", "main")
-	runGit(t, ctx, dir, "config", "user.email", "test@example.com")
-	runGit(t, ctx, dir, "config", "user.name", "Terragrunt Test")
-	runGit(t, ctx, dir, "config", "commit.gpgsign", "false")
-
-	helpers.CreateFile(t, dir, "main.tf")
-
-	runGit(t, ctx, dir, "add", "-A")
-	runGit(t, ctx, dir, "commit", "-m", "initial commit")
-	runGit(t, ctx, dir, "update-ref", "refs/heads/"+injectedRef, "HEAD")
-
-	return dir
-}
-
-func runGit(t *testing.T, ctx context.Context, dir string, args ...string) {
-	t.Helper()
-
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = dir
-
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "git %v failed: %s", args, string(out))
 }

--- a/internal/cas/getter_injection_test.go
+++ b/internal/cas/getter_injection_test.go
@@ -1,0 +1,82 @@
+package cas_test
+
+import (
+	"context"
+	"net/url"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCASGetterRefOptionInjection checks the CAS git source path never runs a command from a crafted ref.
+func TestCASGetterRefOptionInjection(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	marker := filepath.Join(helpers.TmpDirWOSymlinks(t), "injected")
+
+	// ${IFS} avoids a literal space, which git rejects in a ref name.
+	injectedRef := "--upload-pack=touch${IFS}" + marker
+
+	repoDir := setupInjectionRepo(t, injectedRef)
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+
+	c, err := cas.New(cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	v, err := cas.OSVenv()
+	require.NoError(t, err)
+
+	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &cas.CloneOptions{Depth: 1})
+	client := getter.Client{Getters: []getter.Getter{g}}
+
+	src := "git::file://" + repoDir + "?ref=" + url.QueryEscape(injectedRef)
+
+	dst := helpers.TmpDirWOSymlinks(t)
+
+	// The injected command must never run, whether the fetch succeeds or fails.
+	_, _ = client.Get(ctx, &getter.Request{Src: src, Dst: dst})
+
+	assert.NoFileExists(t, marker)
+}
+
+// setupInjectionRepo creates a file:// repo with one commit and a branch named injectedRef.
+func setupInjectionRepo(t *testing.T, injectedRef string) string {
+	t.Helper()
+
+	ctx := t.Context()
+
+	dir := helpers.TmpDirWOSymlinks(t)
+
+	runGit(t, ctx, dir, "init", "-b", "main")
+	runGit(t, ctx, dir, "config", "user.email", "test@example.com")
+	runGit(t, ctx, dir, "config", "user.name", "Terragrunt Test")
+	runGit(t, ctx, dir, "config", "commit.gpgsign", "false")
+
+	helpers.CreateFile(t, dir, "main.tf")
+
+	runGit(t, ctx, dir, "add", "-A")
+	runGit(t, ctx, dir, "commit", "-m", "initial commit")
+	runGit(t, ctx, dir, "update-ref", "refs/heads/"+injectedRef, "HEAD")
+
+	return dir
+}
+
+func runGit(t *testing.T, ctx context.Context, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, string(out))
+}

--- a/internal/cas/getter_injection_test.go
+++ b/internal/cas/getter_injection_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cas_test
 
 import (
@@ -43,9 +45,12 @@ func TestCASGetterRefOptionInjection(t *testing.T) {
 
 	dst := helpers.TmpDirWOSymlinks(t)
 
-	// The injected command must never run, whether the fetch succeeds or fails.
-	_, _ = client.Get(ctx, &getter.Request{Src: src, Dst: dst})
+	_, err = client.Get(ctx, &getter.Request{Src: src, Dst: dst})
 
+	// The crafted ref is a real branch, so the download still succeeds and
+	// materializes the module, but the injected command must never run.
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(dst, "main.tf"))
 	assert.NoFileExists(t, marker)
 }
 

--- a/internal/cas/resolver_git_test.go
+++ b/internal/cas/resolver_git_test.go
@@ -186,7 +186,7 @@ func TestGitResolver_ProbeSCPURLWithBranchUsesSeparateArgs(t *testing.T) {
 	_, err := r.Probe(t.Context(), "git@github.com:org/repo.git")
 	require.NoError(t, err)
 	assert.Equal(t,
-		[]string{"ls-remote", "git@github.com:org/repo.git", "main"},
+		[]string{"ls-remote", "--", "git@github.com:org/repo.git", "main"},
 		capturedArgs,
 		"SCP URL must reach git as-is with branch passed as a separate ls-remote argument",
 	)
@@ -211,7 +211,7 @@ func TestGitResolver_ProbeHTTPURLWithBranchUsesSeparateArgs(t *testing.T) {
 	_, err := r.Probe(t.Context(), "https://example.com/org/repo.git")
 	require.NoError(t, err)
 	assert.Equal(t,
-		[]string{"ls-remote", "https://example.com/org/repo.git", "main"},
+		[]string{"ls-remote", "--", "https://example.com/org/repo.git", "main"},
 		capturedArgs,
 		"HTTP URL must reach git without ?ref= glued on; branch is a separate argument",
 	)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -138,7 +138,7 @@ func (g *GitRunner) LsRemote(ctx context.Context, repo, ref string) ([]LsRemoteR
 		ref = "HEAD"
 	}
 
-	args := []string{repo, ref}
+	args := []string{"--", repo, ref}
 
 	cmd := g.prepareCommand(ctx, "ls-remote", args...)
 
@@ -250,7 +250,7 @@ func (g *GitRunner) Clone(ctx context.Context, repo string, bare bool, depth int
 		args = append(args, "--branch", branch)
 	}
 
-	args = append(args, repo, g.WorkDir)
+	args = append(args, "--", repo, g.WorkDir)
 
 	cmd := g.prepareCommand(ctx, "clone", args...)
 
@@ -308,7 +308,7 @@ func (g *GitRunner) Fetch(ctx context.Context, repo, ref string, depth int) erro
 		args = append(args, "--depth", strconv.Itoa(depth), "--no-tags")
 	}
 
-	args = append(args, repo, ref)
+	args = append(args, "--", repo, ref)
 
 	cmd := g.prepareCommand(ctx, "fetch", args...)
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -317,6 +317,57 @@ func TestGitRunner_FetchAndHasObject(t *testing.T) {
 	assert.True(t, has)
 }
 
+func TestGitRunner_FetchRejectsOptionInjectionRef(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	src := newCommittedRepo(t)
+
+	bareDir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(bareDir)
+	require.NoError(t, runner.InitBare(ctx))
+
+	marker := filepath.Join(helpers.TmpDirWOSymlinks(t), "injected")
+
+	// A ref beginning with a git option must not be parsed as one.
+	injectedRef := "--upload-pack=touch " + marker
+
+	err = runner.Fetch(ctx, "file://"+src, injectedRef, 1)
+	require.Error(t, err)
+
+	var wrappedErr *git.WrappedError
+	require.ErrorAs(t, err, &wrappedErr)
+	require.ErrorIs(t, wrappedErr.Err, git.ErrGitFetch)
+
+	assert.NoFileExists(t, marker)
+}
+
+func TestGitRunner_LsRemoteRejectsOptionInjectionRepo(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	src := newCommittedRepo(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	marker := filepath.Join(helpers.TmpDirWOSymlinks(t), "injected")
+
+	// A repo beginning with a git option must be treated as a positional.
+	injectedRepo := "--upload-pack=touch " + marker
+
+	_, err = runner.LsRemote(ctx, injectedRepo, "file://"+src)
+	require.Error(t, err)
+
+	assert.NoFileExists(t, marker)
+}
+
 func TestGitRunner_HasObjectSurfacesNonMissingFailures(t *testing.T) {
 	t.Parallel()
 
@@ -404,4 +455,27 @@ func TestGitRunner_AddCommitCheckoutConfig(t *testing.T) {
 	email, err := runner.Config(ctx, "user.email")
 	require.NoError(t, err)
 	assert.Equal(t, "test@example.com", email)
+}
+
+// newCommittedRepo creates a local repo with one commit for use as a file:// remote.
+func newCommittedRepo(t *testing.T) string {
+	t.Helper()
+
+	ctx := t.Context()
+
+	dir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(dir)
+
+	require.NoError(t, runner.Init(ctx))
+	require.NoError(t, runner.ConfigSet(ctx, "user.email", "test@example.com"))
+	require.NoError(t, runner.ConfigSet(ctx, "user.name", "Terragrunt Test"))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(""), 0o600))
+	require.NoError(t, runner.Add(ctx, "main.tf"))
+	require.NoError(t, runner.Commit(ctx, "initial commit"))
+
+	return dir
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -334,7 +335,7 @@ func TestGitRunner_FetchRejectsOptionInjectionRef(t *testing.T) {
 
 	marker := filepath.Join(helpers.TmpDirWOSymlinks(t), "injected")
 
-	// A ref beginning with a git option must not be parsed as one.
+	// A literal space is fine here since the ref is passed straight to git, not created as a branch name.
 	injectedRef := "--upload-pack=touch " + marker
 
 	err = runner.Fetch(ctx, "file://"+src, injectedRef, 1)
@@ -352,8 +353,6 @@ func TestGitRunner_LsRemoteRejectsOptionInjectionRepo(t *testing.T) {
 
 	ctx := t.Context()
 
-	src := newCommittedRepo(t)
-
 	runner, err := git.NewGitRunner(vexec.NewOSExec())
 	require.NoError(t, err)
 
@@ -362,10 +361,51 @@ func TestGitRunner_LsRemoteRejectsOptionInjectionRepo(t *testing.T) {
 	// A repo beginning with a git option must be treated as a positional.
 	injectedRepo := "--upload-pack=touch " + marker
 
-	_, err = runner.LsRemote(ctx, injectedRepo, "file://"+src)
+	_, err = runner.LsRemote(ctx, injectedRepo, "HEAD")
 	require.Error(t, err)
 
 	assert.NoFileExists(t, marker)
+}
+
+func TestGitRunner_FetchInsertsOptionTerminator(t *testing.T) {
+	t.Parallel()
+
+	var got []string
+
+	runner := newArgvCapturingRunner(t, &got, nil).WithWorkDir(helpers.TmpDirWOSymlinks(t))
+
+	require.NoError(t, runner.Fetch(t.Context(), "file:///repo", "somebranch", 1))
+	assert.Equal(t,
+		[]string{"fetch", "--depth", "1", "--no-tags", "--", "file:///repo", "somebranch"},
+		got,
+	)
+}
+
+func TestGitRunner_CloneInsertsOptionTerminator(t *testing.T) {
+	t.Parallel()
+
+	var got []string
+
+	workDir := helpers.TmpDirWOSymlinks(t)
+	runner := newArgvCapturingRunner(t, &got, nil).WithWorkDir(workDir)
+
+	require.NoError(t, runner.Clone(t.Context(), "file:///repo", true, 1, "main"))
+	assert.Equal(t,
+		[]string{"clone", "--bare", "--depth", "1", "--single-branch", "--branch", "main", "--", "file:///repo", workDir},
+		got,
+	)
+}
+
+func TestGitRunner_LsRemoteInsertsOptionTerminator(t *testing.T) {
+	t.Parallel()
+
+	var got []string
+
+	runner := newArgvCapturingRunner(t, &got, []byte("deadbeefcafefacedeadbeefcafefacedeadbeef\trefs/heads/main\n"))
+
+	_, err := runner.LsRemote(t.Context(), "file:///repo", "main")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ls-remote", "--", "file:///repo", "main"}, got)
 }
 
 func TestGitRunner_HasObjectSurfacesNonMissingFailures(t *testing.T) {
@@ -455,6 +495,25 @@ func TestGitRunner_AddCommitCheckoutConfig(t *testing.T) {
 	email, err := runner.Config(ctx, "user.email")
 	require.NoError(t, err)
 	assert.Equal(t, "test@example.com", email)
+}
+
+// newArgvCapturingRunner returns a runner backed by an in-memory exec that
+// records the argv passed to git into captured and replies with stdout.
+func newArgvCapturingRunner(t *testing.T, captured *[]string, stdout []byte) *git.GitRunner {
+	t.Helper()
+
+	e := vexec.NewMemExec(
+		func(_ context.Context, inv vexec.Invocation) vexec.Result {
+			*captured = inv.Args
+			return vexec.Result{Stdout: stdout}
+		},
+		vexec.WithLookPath(func(string) (string, error) { return "git", nil }),
+	)
+
+	r, err := git.NewGitRunner(e)
+	require.NoError(t, err)
+
+	return r
 }
 
 // newCommittedRepo creates a local repo with one commit for use as a file:// remote.

--- a/test/helpers/test_helpers.go
+++ b/test/helpers/test_helpers.go
@@ -140,7 +140,10 @@ func InitGitRepoWithBranchRef(t *testing.T, dir, ref string) {
 func runGitCmd(t *testing.T, dir string, args ...string) {
 	t.Helper()
 
-	cmd := exec.CommandContext(t.Context(), "git", args...)
+	gitPath, err := exec.LookPath("git")
+	require.NoError(t, err)
+
+	cmd := exec.CommandContext(t.Context(), gitPath, args...)
 	cmd.Dir = dir
 
 	out, err := cmd.CombinedOutput()

--- a/test/helpers/test_helpers.go
+++ b/test/helpers/test_helpers.go
@@ -122,6 +122,31 @@ func CreateGitRepo(t *testing.T, path string) {
 	require.NoError(t, err, "git commit failed")
 }
 
+// InitGitRepoWithBranchRef initializes a git repo at dir, commits every file
+// already present, and creates a branch named ref pointing at the commit.
+// Callers write their fixture files into dir before calling this.
+func InitGitRepoWithBranchRef(t *testing.T, dir, ref string) {
+	t.Helper()
+
+	runGitCmd(t, dir, "init", "-b", "main")
+	runGitCmd(t, dir, "config", "user.email", "test@example.com")
+	runGitCmd(t, dir, "config", "user.name", "Terragrunt Test")
+	runGitCmd(t, dir, "config", "commit.gpgsign", "false")
+	runGitCmd(t, dir, "add", "-A")
+	runGitCmd(t, dir, "commit", "-m", "initial commit")
+	runGitCmd(t, dir, "update-ref", "refs/heads/"+ref, "HEAD")
+}
+
+func runGitCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	cmd.Dir = dir
+
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, string(out))
+}
+
 // CloneGitRepo creates an isolated git clone for parallel testing.
 // Uses git clone --local --no-hardlinks to preserve file modes, symlinks,
 // and avoid worktree race conditions when multiple tests operate on same repo.

--- a/test/integration_cas_git_injection_test.go
+++ b/test/integration_cas_git_injection_test.go
@@ -3,10 +3,8 @@
 package test_test
 
 import (
-	"context"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -24,7 +22,10 @@ func TestCASGitSourceRefOptionInjection(t *testing.T) {
 	// ${IFS} avoids a literal space, which git rejects in a ref name.
 	injectedRef := "--upload-pack=touch${IFS}" + marker
 
-	repoDir := buildInjectionSourceRepo(t, injectedRef)
+	repoDir := helpers.TmpDirWOSymlinks(t)
+	mainTF := "terraform {\n  required_version = \">= 1.0.0\"\n}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte(mainTF), 0o644))
+	helpers.InitGitRepoWithBranchRef(t, repoDir, injectedRef)
 
 	liveDir := helpers.TmpDirWOSymlinks(t)
 	source := "git::file://" + repoDir + "?ref=" + url.QueryEscape(injectedRef)
@@ -41,36 +42,4 @@ func TestCASGitSourceRefOptionInjection(t *testing.T) {
 	// the injected command must never run.
 	require.NoError(t, err)
 	assert.NoFileExists(t, marker)
-}
-
-// buildInjectionSourceRepo creates a file:// repo with one commit and a branch named injectedRef.
-func buildInjectionSourceRepo(t *testing.T, injectedRef string) string {
-	t.Helper()
-
-	ctx := t.Context()
-
-	dir := helpers.TmpDirWOSymlinks(t)
-
-	mainTF := "terraform {\n  required_version = \">= 1.0.0\"\n}\n"
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(mainTF), 0o644))
-
-	runInjectionGit(t, ctx, dir, "init", "-b", "main")
-	runInjectionGit(t, ctx, dir, "config", "user.email", "test@example.com")
-	runInjectionGit(t, ctx, dir, "config", "user.name", "Terragrunt Test")
-	runInjectionGit(t, ctx, dir, "config", "commit.gpgsign", "false")
-	runInjectionGit(t, ctx, dir, "add", "-A")
-	runInjectionGit(t, ctx, dir, "commit", "-m", "initial commit")
-	runInjectionGit(t, ctx, dir, "update-ref", "refs/heads/"+injectedRef, "HEAD")
-
-	return dir
-}
-
-func runInjectionGit(t *testing.T, ctx context.Context, dir string, args ...string) {
-	t.Helper()
-
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = dir
-
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "git %v failed: %s", args, string(out))
 }

--- a/test/integration_cas_git_injection_test.go
+++ b/test/integration_cas_git_injection_test.go
@@ -1,0 +1,71 @@
+package test_test
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCASGitSourceRefOptionInjection checks a git source ?ref= never runs a command during download.
+func TestCASGitSourceRefOptionInjection(t *testing.T) {
+	t.Parallel()
+
+	marker := filepath.Join(helpers.TmpDirWOSymlinks(t), "injected")
+
+	// ${IFS} avoids a literal space, which git rejects in a ref name.
+	injectedRef := "--upload-pack=touch${IFS}" + marker
+
+	repoDir := buildInjectionSourceRepo(t, injectedRef)
+
+	liveDir := helpers.TmpDirWOSymlinks(t)
+	source := "git::file://" + repoDir + "?ref=" + url.QueryEscape(injectedRef)
+
+	config := "terraform {\n  source = \"" + source + "\"\n}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(liveDir, "terragrunt.hcl"), []byte(config), 0o644))
+
+	// The injected command must never run, even if the download itself fails.
+	_, _, _ = helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt plan --source-update --non-interactive --working-dir "+liveDir,
+	)
+
+	assert.NoFileExists(t, marker)
+}
+
+// buildInjectionSourceRepo creates a file:// repo with one commit and a branch named injectedRef.
+func buildInjectionSourceRepo(t *testing.T, injectedRef string) string {
+	t.Helper()
+
+	ctx := t.Context()
+
+	dir := helpers.TmpDirWOSymlinks(t)
+
+	helpers.CreateFile(t, dir, "main.tf")
+
+	runInjectionGit(t, ctx, dir, "init", "-b", "main")
+	runInjectionGit(t, ctx, dir, "config", "user.email", "test@example.com")
+	runInjectionGit(t, ctx, dir, "config", "user.name", "Terragrunt Test")
+	runInjectionGit(t, ctx, dir, "config", "commit.gpgsign", "false")
+	runInjectionGit(t, ctx, dir, "add", "-A")
+	runInjectionGit(t, ctx, dir, "commit", "-m", "initial commit")
+	runInjectionGit(t, ctx, dir, "update-ref", "refs/heads/"+injectedRef, "HEAD")
+
+	return dir
+}
+
+func runInjectionGit(t *testing.T, ctx context.Context, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, string(out))
+}

--- a/test/integration_cas_git_injection_test.go
+++ b/test/integration_cas_git_injection_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package test_test
 
 import (
@@ -30,12 +32,14 @@ func TestCASGitSourceRefOptionInjection(t *testing.T) {
 	config := "terraform {\n  source = \"" + source + "\"\n}\n"
 	require.NoError(t, os.WriteFile(filepath.Join(liveDir, "terragrunt.hcl"), []byte(config), 0o644))
 
-	// The injected command must never run, even if the download itself fails.
-	_, _, _ = helpers.RunTerragruntCommandWithOutput(
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
 		t,
 		"terragrunt plan --source-update --non-interactive --working-dir "+liveDir,
 	)
 
+	// The crafted ref is a real branch, so the source downloads and plans, but
+	// the injected command must never run.
+	require.NoError(t, err)
 	assert.NoFileExists(t, marker)
 }
 
@@ -47,7 +51,8 @@ func buildInjectionSourceRepo(t *testing.T, injectedRef string) string {
 
 	dir := helpers.TmpDirWOSymlinks(t)
 
-	helpers.CreateFile(t, dir, "main.tf")
+	mainTF := "terraform {\n  required_version = \">= 1.0.0\"\n}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(mainTF), 0o644))
 
 	runInjectionGit(t, ctx, dir, "init", "-b", "main")
 	runInjectionGit(t, ctx, dir, "config", "user.email", "test@example.com")


### PR DESCRIPTION

<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

- Add `--` before the repo and ref in git fetch, clone, and ls-remote so a ref like `--upload-pack=...` is treated as a ref, not a git option.
- Add unit tests for Fetch and LsRemote.
- Add integration and end-to-end tests that download a git source with such a ref and check no command runs.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Git module references so values that look like command options are treated as plain refs.
  * Added safer Git argument parsing for remote downloads, reducing the chance of malformed input being misread.

* **Tests**
  * Added coverage for Git source ref injection scenarios in both unit and integration tests.
  * Expanded command-argument checks to confirm Git operations pass inputs correctly and do not execute injected commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->