### PR TITLE
fix: Prevent `terraform_binary` from being ignored in `run --all`

### DIFF
--- a/docs/src/data/changelog/v1.1.1/run-all-terraform-binary-ignored.mdx
+++ b/docs/src/data/changelog/v1.1.1/run-all-terraform-binary-ignored.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.1"
+category: "bug-fixes"
+---
+
+#### `terraform_binary` respected by `run --all` when both `tofu` and `terraform` are on `PATH`
+
+`run --all` ignored a unit's `terraform_binary` setting and fell back to the auto-detected default (OpenTofu when both binaries are on `PATH`). The per-unit options used to execute each unit are cloned from the stack options, whose binary path is the auto-detected default, and the configured value was never applied to them.
+
+Each unit now honors its own `terraform_binary`, matching the behavior of a single `run`. Setting `--tf-path` or `TG_TF_PATH` still takes precedence over the config value.

--- a/internal/runner/run/version_check_internal_test.go
+++ b/internal/runner/run/version_check_internal_test.go
@@ -24,8 +24,8 @@ func Test_computeVersionFilesCacheKey(t *testing.T) {
 			want:         "H2PcpB8dh-BE5Dz-LiSD1hykSfk", // "tofu|no-version-files"
 		},
 		{
-			// Same inputs as the previous case except for the binary. The key
-			// must differ. That is the property issue #6147 turned on.
+			// Same inputs as the previous case except for the binary, so the
+			// cache key must differ: the binary is part of what the key scopes.
 			name:         "no version files, terraform binary",
 			workingDir:   "",
 			tfPath:       "terraform",

--- a/internal/runner/run/version_check_test.go
+++ b/internal/runner/run/version_check_test.go
@@ -169,17 +169,13 @@ func TestCheckTerragruntVersionMeetsConstraintPrerelease(t *testing.T) {
 	testCheckTerragruntVersionMeetsConstraint(t, "v0.23.18-alpha202409013", ">= v0.23.18", true)
 }
 
-// TestPopulateTFVersionRespectsTFPath is a regression test for issue #6147:
-// when both tofu and terraform are installed and `terraform_binary = "terraform"`
-// is set in HCL, the default `tofu` binary was selected anyway. The root cause
-// was that the run-scoped version cache keyed only by workingDir and the
-// contents of any version-pinning files, so an early call (e.g. from
-// setupAutoProviderCacheDir) that resolved against `tofu` would poison the
-// cache for the later call made after `terraform_binary` had taken effect.
-//
-// The fix folds the resolved binary path into the cache key. This test feeds
-// distinct --version stdout per binary through a vexec.MemExec handler and
-// asserts the second call resolves Terraform, not the cached OpenTofu entry.
+// TestPopulateTFVersionRespectsTFPath verifies that the run-scoped version
+// cache is keyed by the resolved binary path. Two calls with the same working
+// directory but different binaries must resolve independently: an early call
+// that resolves against `tofu` must not poison the entry a later call reads
+// after `terraform_binary` has taken effect. The test feeds distinct --version
+// stdout per binary through a vexec.MemExec handler and asserts the second call
+// resolves Terraform, not the cached OpenTofu entry.
 func TestPopulateTFVersionRespectsTFPath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -508,6 +508,10 @@ func (rnr *Runner) Run(ctx context.Context, l log.Logger, v run.Venv, stackOpts 
 				return err
 			}
 
+			if !unitOpts.TFPathExplicitlySet && cfg.TerraformBinary != "" {
+				unitOpts.TFPath = cfg.TerraformBinary
+			}
+
 			runCfg := cfg.ToRunConfig(unitLogger)
 
 			err = telemetry.TelemeterFromContext(childCtx).Collect(childCtx, "unit_run", map[string]any{

--- a/test/integration_run_test.go
+++ b/test/integration_run_test.go
@@ -196,3 +196,105 @@ func TestRunVersionFilesCacheKey(t *testing.T) {
 		})
 	}
 }
+
+// TestRunAllHonorsTerraformBinaryWithBothOnPath verifies which binary `run --all`
+// executes for each unit when both tofu and terraform are on PATH:
+//   - terraform_binary selects the binary, overriding what auto-detection picks
+//     (tofu when both are present).
+//   - an explicit --tf-path still wins over terraform_binary.
+//
+// Both tofu and terraform are mocked on PATH so the test is hermetic: it does
+// not depend on which real binary is installed, and each expected binary is
+// checked against the other so the wrong binary is caught regardless of which
+// one auto-detection would otherwise pick.
+//
+//nolint:paralleltest // Mutates PATH via t.Setenv, which is incompatible with t.Parallel.
+func TestRunAllHonorsTerraformBinaryWithBothOnPath(t *testing.T) {
+	binDir := t.TempDir()
+	writeMockTFBinary(t, filepath.Join(binDir, helpers.TofuBinary), "OpenTofu v1.99.9", helpers.TofuBinary)
+	writeMockTFBinary(t, filepath.Join(binDir, helpers.TerraformBinary), "Terraform v1.99.9", helpers.TerraformBinary)
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// A TG_TF_PATH inherited from the environment would override the config
+	// value under test, so clear it.
+	t.Setenv("TG_TF_PATH", "")
+	os.Unsetenv("TG_TF_PATH")
+
+	testCases := []struct {
+		name         string
+		configBinary string
+		tfPathFlag   string
+		expected     string
+	}{
+		{name: "config terraform", configBinary: helpers.TerraformBinary, expected: helpers.TerraformBinary},
+		{name: "config tofu", configBinary: helpers.TofuBinary, expected: helpers.TofuBinary},
+		{name: "tf-path overrides config tofu", configBinary: helpers.TofuBinary, tfPathFlag: helpers.TerraformBinary, expected: helpers.TerraformBinary},
+		{name: "tf-path overrides config terraform", configBinary: helpers.TerraformBinary, tfPathFlag: helpers.TofuBinary, expected: helpers.TofuBinary},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// run --all resolves the binary per unit in the runner pool, the
+			// path where terraform_binary was ignored.
+			workingDir := t.TempDir()
+			for _, unit := range []string{"first", "second"} {
+				unitDir := filepath.Join(workingDir, unit)
+				require.NoError(t, os.MkdirAll(unitDir, 0755))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(unitDir, "terragrunt.hcl"),
+					[]byte("terraform_binary = \""+tc.configBinary+"\"\n"),
+					0644,
+				))
+				require.NoError(t, os.WriteFile(filepath.Join(unitDir, "main.tf"), []byte{}, 0644))
+			}
+
+			cmd := "terragrunt run --all init --non-interactive --working-dir " + workingDir
+			if tc.tfPathFlag != "" {
+				cmd += " --tf-path " + tc.tfPathFlag
+			}
+
+			stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+			require.NoError(t, err)
+
+			output := stdout + stderr
+
+			other := helpers.TofuBinary
+			if tc.expected == helpers.TofuBinary {
+				other = helpers.TerraformBinary
+			}
+
+			assert.Contains(t, output, mockTFMarker(tc.expected),
+				"terragrunt should have invoked the %q binary", tc.expected)
+			assert.NotContains(t, output, mockTFMarker(other),
+				"terragrunt should not have invoked the %q binary", other)
+		})
+	}
+}
+
+// mockTFMarker is the line a mock binary prints when it is invoked for a real
+// command (i.e. anything other than a version probe).
+func mockTFMarker(impl string) string {
+	return "MOCK-TF-IMPL=" + impl
+}
+
+// writeMockTFBinary writes an executable bash script that stands in for tofu or
+// terraform. It answers `-version` with a parseable version line so Terragrunt's
+// version detection succeeds, and prints a distinctive marker for any other
+// command so tests can tell which binary was actually invoked.
+func writeMockTFBinary(t *testing.T, path, versionLine, impl string) {
+	t.Helper()
+
+	script := "#!/usr/bin/env bash\n" +
+		"case \"$1\" in\n" +
+		"  -version|--version|version)\n" +
+		"    echo \"" + versionLine + "\"\n" +
+		"    ;;\n" +
+		"  *)\n" +
+		"    echo \"" + mockTFMarker(impl) + "\"\n" +
+		"    ;;\n" +
+		"esac\n" +
+		"exit 0\n"
+
+	require.NoError(t, os.WriteFile(path, []byte(script), 0755))
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6459

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `run --all` now respects each unit’s configured Terraform/OpenTofu binary instead of always using the auto-detected default.
  * When both binaries are available, the configured one is used for each unit, while an explicit path setting still takes priority.
  * Added coverage for mixed binary setups to verify the correct executable is run in each case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->