### PR TITLE
feat(experiment): introduce oci experiment flag for OCI module sources

### DIFF
--- a/docs/src/data/changelog/v1.1.1/oci-modules.mdx
+++ b/docs/src/data/changelog/v1.1.1/oci-modules.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.1"
+category: "experiments-added"
+---
+
+#### `oci` - Module sources from OCI registries
+
+The `oci` experiment has been added as the gate for downloading OpenTofu modules from OCI Distribution registries using `oci://` source URLs in a `terraform { source = "..." }` block. This targets the same registries OpenTofu 1.10 supports natively, such as Amazon ECR, GitHub Container Registry, Azure Container Registry, Google Artifact Registry, and self-hosted or air-gapped registries.
+
+In this release the flag is reserved only. Enabling it has no behavioral effect yet, and `oci://` sources still fail to download. The getter that resolves `oci://` sources will land behind this flag in follow-up releases.
+
+Track progress and share feedback in [#4555](https://github.com/gruntwork-io/terragrunt/issues/4555). For setup steps, see the [experiment documentation](/reference/experiments/active#oci).

--- a/docs/src/data/changelog/v1.1.1/oci-modules.mdx
+++ b/docs/src/data/changelog/v1.1.1/oci-modules.mdx
@@ -5,8 +5,8 @@ category: "experiments-added"
 
 #### `oci` - Module sources from OCI registries
 
-The `oci` experiment has been added as the gate for downloading OpenTofu modules from OCI Distribution registries using `oci://` source URLs in a `terraform { source = "..." }` block. This targets the same registries OpenTofu 1.10 supports natively, such as Amazon ECR, GitHub Container Registry, Azure Container Registry, Google Artifact Registry, and self-hosted or air-gapped registries.
+The `oci` experiment has been added as the gate for downloading source code (including OpenTofu modules) from OCI Distribution registries using `oci://` schema URLs in Terragrunt configurations (including `terraform.source` attributes). This targets the same registries OpenTofu 1.10 supports natively, such as Amazon ECR, GitHub Container Registry, Azure Container Registry, Google Artifact Registry, and self-hosted or air-gapped registries.
 
-In this release the flag is reserved only. Enabling it has no behavioral effect yet, and `oci://` sources still fail to download. The getter that resolves `oci://` sources will land behind this flag in follow-up releases.
+In this release, the only change is the reservation of the experiment name. Enabling it has no behavioral effect yet, and `oci://` sources still fail to download. The getter that resolves `oci://` sources will be gated by this experiment in follow-up releases.
 
 For setup steps, see the [experiment documentation](/reference/experiments/active#oci).

--- a/docs/src/data/changelog/v1.1.1/oci-modules.mdx
+++ b/docs/src/data/changelog/v1.1.1/oci-modules.mdx
@@ -8,5 +8,3 @@ category: "experiments-added"
 The `oci` experiment has been added as the gate for downloading OpenTofu modules from OCI Distribution registries using `oci://` source URLs in a `terraform { source = "..." }` block. This targets the same registries OpenTofu 1.10 supports natively, such as Amazon ECR, GitHub Container Registry, Azure Container Registry, Google Artifact Registry, and self-hosted or air-gapped registries.
 
 In this release the flag is reserved only. Enabling it has no behavioral effect yet, and `oci://` sources still fail to download. The getter that resolves `oci://` sources will land behind this flag in follow-up releases.
-
-Track progress and share feedback in [#4555](https://github.com/gruntwork-io/terragrunt/issues/4555). For setup steps, see the [experiment documentation](/reference/experiments/active#oci).

--- a/docs/src/data/changelog/v1.1.1/oci-modules.mdx
+++ b/docs/src/data/changelog/v1.1.1/oci-modules.mdx
@@ -8,3 +8,5 @@ category: "experiments-added"
 The `oci` experiment has been added as the gate for downloading OpenTofu modules from OCI Distribution registries using `oci://` source URLs in a `terraform { source = "..." }` block. This targets the same registries OpenTofu 1.10 supports natively, such as Amazon ECR, GitHub Container Registry, Azure Container Registry, Google Artifact Registry, and self-hosted or air-gapped registries.
 
 In this release the flag is reserved only. Enabling it has no behavioral effect yet, and `oci://` sources still fail to download. The getter that resolves `oci://` sources will land behind this flag in follow-up releases.
+
+For setup steps, see the [experiment documentation](/reference/experiments/active#oci).

--- a/docs/src/data/experiments/oci.mdx
+++ b/docs/src/data/experiments/oci.mdx
@@ -17,9 +17,9 @@ Azure Container Registry, Google Artifact Registry, and self-hosted or air-gappe
 registries.
 
 In its current form (initial registration) the experiment only reserves the
-`oci` experiment name. The flag itself has no behavioral effect yet: there is no
+`oci` experiment name. The experiment has no behavioral effect yet: there is no
 getter for the `oci` scheme, and `oci://` sources still fail to download.
-Functional behavior will land in subsequent releases behind this flag.
+Functional behavior will land in subsequent releases, gated by this experiment.
 
 ### `oci` - How to enable it
 

--- a/docs/src/data/experiments/oci.mdx
+++ b/docs/src/data/experiments/oci.mdx
@@ -1,0 +1,56 @@
+---
+name: oci
+since: "1.1.1"
+---
+
+Experimental support for downloading modules from OCI Distribution registries using `oci://` sources.
+
+### `oci` - What it does
+
+OpenTofu 1.10 can download modules from an OCI Distribution registry using an
+`oci://` source, but Terragrunt currently fails to resolve the same source in a
+`terraform { source = "..." }` block because no getter claims the `oci` scheme.
+This experiment reserves the flag for native Terragrunt support of `oci://`
+module sources, so a single source string works the same way in both `tofu` and
+Terragrunt against registries such as Amazon ECR, GitHub Container Registry,
+Azure Container Registry, Google Artifact Registry, and self-hosted or air-gapped
+registries.
+
+In its current form (initial registration) the experiment only reserves the
+`oci` experiment name. The flag itself has no behavioral effect yet: there is no
+getter for the `oci` scheme, and `oci://` sources still fail to download.
+Functional behavior will land in subsequent releases behind this flag.
+
+### `oci` - How to enable it
+
+```bash
+# Via CLI flag
+terragrunt --experiment oci run -- plan
+
+# Via environment variable
+export TG_EXPERIMENT=oci
+terragrunt run -- plan
+```
+
+### `oci` - How to provide feedback
+
+Track and discuss this experiment in [gruntwork-io/terragrunt#4555](https://github.com/gruntwork-io/terragrunt/issues/4555).
+When reporting issues or providing feedback, please include:
+
+- The registry you are using (ECR, GHCR, ACR, GAR, self-hosted).
+- The authentication method (static credentials, ambient Docker config, or a credential helper such as `ecr-login`).
+- The full `oci://` source string, and whether you pin by `tag` or `digest`.
+- Any errors encountered during module download.
+
+### `oci` - Criteria for stabilization
+
+To transition the `oci` feature to a stable release, the following must be addressed, at a minimum:
+
+- [ ] A getter that resolves `oci://` sources, selecting the `application/vnd.opentofu.modulepkg` artifact and its `archive/zip` layer, with blob digest verification.
+- [ ] Static and ambient Docker-config credential discovery matching OpenTofu's search order.
+- [ ] Credential-helper support (`docker-credential-*`, `ecr-login`) so ECR and other helper-backed registries work with per-run token minting.
+- [ ] Content-addressable caching keyed on the resolved manifest digest, with correct re-resolution of mutable tags.
+- [ ] A portability guarantee that one source string produces an identical module via `tofu` and Terragrunt.
+- [ ] Documentation covering the source syntax, authentication tiers, and publishing contract.
+- [ ] Integration test coverage against a real registry, gated behind a build tag.
+- [ ] Community feedback on real-world usage.

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -77,6 +77,8 @@ const (
 	HookContextEnv = "hook-context-env"
 	// OptionalHooks gates flags that make Terragrunt hooks optional during runs.
 	OptionalHooks = "optional-hooks"
+	// OCI gates downloading modules from OCI Distribution registries via oci:// sources.
+	OCI = "oci"
 )
 
 const (
@@ -164,6 +166,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: OptionalHooks,
+		},
+		{
+			Name: OCI,
 		},
 	}
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

RFC: https://github.com/gruntwork-io/terragrunt/issues/4555

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an `oci` experiment to prepare support for OCI-based module sources (via `oci://`), currently reserved with no functional download behavior yet.
* **Documentation**
  * Added and updated changelog and experiment documentation explaining how to enable the `oci` experiment, current limitations, and what details to include when reporting feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->