### PR TITLE
chore: Register the `version` attribute experiment

### DIFF
--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -79,6 +79,9 @@ const (
 	OptionalHooks = "optional-hooks"
 	// OCI gates downloading modules from OCI Distribution registries via oci:// sources.
 	OCI = "oci"
+	// VersionAttribute gates resolving a tfr:// registry module from a version
+	// constraint expressed through the version attribute on the terraform block.
+	VersionAttribute = "version-attribute"
 )
 
 const (
@@ -169,6 +172,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: OCI,
+		},
+		{
+			Name: VersionAttribute,
 		},
 	}
 }

--- a/internal/experiment/experiment_test.go
+++ b/internal/experiment/experiment_test.go
@@ -47,6 +47,19 @@ func TestOptionalHooksIsOngoing(t *testing.T) {
 	assert.False(t, got.Evaluate(), "optional-hooks must be disabled by default")
 }
 
+func TestVersionAttributeIsOngoing(t *testing.T) {
+	t.Parallel()
+
+	exps := experiment.NewExperiments()
+	got := exps.Find(experiment.VersionAttribute)
+	require.NotNil(t, got, "version-attribute experiment must be registered in NewExperiments()")
+	assert.Equal(t, experiment.StatusOngoing, got.Status, "version-attribute must be ongoing")
+	assert.False(t, got.Evaluate(), "version-attribute must be disabled by default")
+
+	require.NoError(t, exps.EnableExperiment(experiment.VersionAttribute))
+	assert.True(t, got.Evaluate(), "version-attribute must be enabled once explicitly requested")
+}
+
 func TestEvaluate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Registers the `version-attribute` experiment as part of addressing #1930.

Will update the docs, etc. in a future PR.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an experimental version attribute when resolving `tfr://` registry modules, allowing version-based selection from the Terraform block.
  * Included the new experiment in the default experiments list so it can be enabled like other experiments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->