### PR TITLE
feat(getter): centralize OCI manifest-contract constants

### DIFF
--- a/internal/getter/defaults.go
+++ b/internal/getter/defaults.go
@@ -22,6 +22,7 @@ const (
 	SchemeHg    = "hg"
 	SchemeSMB   = "smb"
 	SchemeTFR   = "tfr"
+	SchemeOCI   = "oci"
 )
 
 // GenericFetcherOption configures the generic-dispatch defaults consumed

--- a/internal/getter/oci_contract.go
+++ b/internal/getter/oci_contract.go
@@ -1,0 +1,10 @@
+package getter
+
+// OCI manifest-contract constants that must match OpenTofu's OCI module
+// implementation exactly so a single oci:// source string stays portable
+// between tofu and Terragrunt, making them a compatibility contract rather
+// than implementation details to change freely.
+const (
+	ArtifactTypeModulePkg = "application/vnd.opentofu.modulepkg"
+	MediaTypeModuleZip    = "archive/zip"
+)


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* Add OCI manifest-contract constants (ArtifactTypeModulePkg, MediaTypeModuleZip, SchemeOCI) matching OpenTofu

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing OCI-based module sources using the `oci://` scheme.
  - Standardized OCI module package and ZIP artifact types to improve portability and compatibility across supported tooling.
  - Existing source protocols and fetching behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->