### PR TITLE
fix: Fixing empty locals block for `stack generate`

### DIFF
--- a/docs/src/data/changelog/v1.1.1/stack-empty-locals-block.mdx
+++ b/docs/src/data/changelog/v1.1.1/stack-empty-locals-block.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.1"
+category: "bug-fixes"
+---
+
+#### Allow empty `locals` blocks in `terragrunt.stack.hcl`
+
+Fixed a bug where an empty `locals {}` block in a stack configuration could break `stack generate`.

--- a/internal/hclparse/parse.go
+++ b/internal/hclparse/parse.go
@@ -250,12 +250,12 @@ func evaluateLocals(body hcl.Body, evalCtx *hcl.EvalContext) error {
 	remaining := maps.Clone(attrs)
 
 	for range maxLocalsIterations {
-		if !attemptEvaluateLocals(remaining, evaluated, evalCtx) {
-			return reportUnresolvedLocals(remaining, evalCtx)
-		}
-
 		if len(remaining) == 0 {
 			return nil
+		}
+
+		if !attemptEvaluateLocals(remaining, evaluated, evalCtx) {
+			return reportUnresolvedLocals(remaining, evalCtx)
 		}
 	}
 

--- a/internal/hclparse/parse_test.go
+++ b/internal/hclparse/parse_test.go
@@ -891,6 +891,23 @@ unit "vpc" {
 	assert.Len(t, cycleErr.Names, 2)
 }
 
+func TestParseStackFile_EmptyLocalsBlock(t *testing.T) {
+	t.Parallel()
+
+	src := `
+locals {}
+
+unit "vpc" {
+  source = "../catalog/units/vpc"
+  path   = "vpc"
+}
+`
+
+	result, err := hclparse.ParseStackFile(vfs.NewMemMapFS(), &hclparse.ParseStackFileInput{Src: []byte(src), Filename: "terragrunt.stack.hcl", StackDir: testStackDir})
+	require.NoError(t, err)
+	require.Len(t, result.Units, 1)
+}
+
 func TestParseStackFile_LocalsCannotReferenceUnit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6467.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where `stack generate` could fail when a stack configuration included an empty `locals {}` block.
  * Improved handling of local values during stack configuration parsing, including edge cases at the evaluation limit.

* **Documentation**
  * Added a changelog entry describing the empty `locals` block fix in version 1.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->