### PR TITLE
chore: Resolve registry module versions from a constraint

### DIFF
--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -121,7 +121,9 @@ func GetModuleRegistryURLBasePath(
 
 	var respJSON RegistryServicePath
 	if err := json.Unmarshal(bodyData, &respJSON); err != nil {
-		return "", ServiceDiscoveryErr{reason: fmt.Sprintf("Error parsing response body %s: %s", string(bodyData), err)}
+		return "", ServiceDiscoveryErr{
+			reason: fmt.Sprintf("Error parsing response body %s: %s", string(bodyData), err),
+		}
 	}
 
 	if respJSON.ModulesPath == "" {
@@ -133,7 +135,12 @@ func GetModuleRegistryURLBasePath(
 
 // GetTerraformGetHeader makes a GET against `url` and returns the value of
 // the X-Terraform-Get header (or the body's `location` field as a fallback).
-func GetTerraformGetHeader(ctx context.Context, l log.Logger, httpClient *http.Client, url *url.URL) (string, error) {
+func GetTerraformGetHeader(
+	ctx context.Context,
+	l log.Logger,
+	httpClient *http.Client,
+	url *url.URL,
+) (string, error) {
 	body, header, err := httpGETAndGetResponse(ctx, l, httpClient, url)
 	if err != nil {
 		return "", ModuleDownloadErr{sourceURL: url.String(), details: "error receiving HTTP data"}
@@ -180,7 +187,9 @@ func GetDownloadURLFromHeader(moduleURL *url.URL, terraformGet string) (string, 
 }
 
 // BuildRequestURL constructs the registry download URL for the given module.
-func BuildRequestURL(registryDomain, moduleRegistryBasePath, modulePath, version string) (*url.URL, error) {
+func BuildRequestURL(
+	registryDomain, moduleRegistryBasePath, modulePath, version string,
+) (*url.URL, error) {
 	moduleRegistryBasePath = strings.TrimSuffix(moduleRegistryBasePath, "/")
 	modulePath = strings.TrimSuffix(modulePath, "/")
 	modulePath = strings.TrimPrefix(modulePath, "/")
@@ -211,7 +220,14 @@ func GetLatestModuleVersion(
 	httpClient *http.Client,
 	registryDomain, moduleRegistryBasePath, modulePath string,
 ) (string, error) {
-	versions, err := listModuleVersions(ctx, l, httpClient, registryDomain, moduleRegistryBasePath, modulePath)
+	versions, err := listModuleVersions(
+		ctx,
+		l,
+		httpClient,
+		registryDomain,
+		moduleRegistryBasePath,
+		modulePath,
+	)
 	if err != nil {
 		return "", err
 	}
@@ -259,7 +275,14 @@ func GetMatchingModuleVersion(
 		return "", ConstraintParseErr{constraint: constraint, err: err}
 	}
 
-	versions, err := listModuleVersions(ctx, l, httpClient, registryDomain, moduleRegistryBasePath, modulePath)
+	versions, err := listModuleVersions(
+		ctx,
+		l,
+		httpClient,
+		registryDomain,
+		moduleRegistryBasePath,
+		modulePath,
+	)
 	if err != nil {
 		return "", err
 	}
@@ -273,7 +296,11 @@ func GetMatchingModuleVersion(
 	}
 
 	if len(matching) == 0 {
-		return "", NoMatchingVersionErr{constraint: constraint, modulePath: modulePath, registryDomain: registryDomain}
+		return "", NoMatchingVersionErr{
+			constraint:     constraint,
+			modulePath:     modulePath,
+			registryDomain: registryDomain,
+		}
 	}
 
 	match := slices.MaxFunc(matching, func(a, b *goversion.Version) int { return a.Compare(b) })
@@ -322,11 +349,19 @@ func listModuleVersions(
 
 	var versionsResp moduleVersionsResponse
 	if err := json.Unmarshal(bodyData, &versionsResp); err != nil {
-		return nil, fmt.Errorf("failed to parse module versions response for %s: %w", modulePath, err)
+		return nil, fmt.Errorf(
+			"failed to parse module versions response for %s: %w",
+			modulePath,
+			err,
+		)
 	}
 
 	if len(versionsResp.Modules) == 0 || len(versionsResp.Modules[0].Versions) == 0 {
-		return nil, fmt.Errorf("no versions found for module %s on registry %s", modulePath, registryDomain)
+		return nil, fmt.Errorf(
+			"no versions found for module %s on registry %s",
+			modulePath,
+			registryDomain,
+		)
 	}
 
 	parsed := make([]*goversion.Version, 0, len(versionsResp.Modules[0].Versions))
@@ -367,7 +402,8 @@ func applyHostToken(req *http.Request) (*http.Request, error) {
 		return nil, err
 	}
 
-	if creds := cliCfg.CredentialsSource().ForHost(svchost.Hostname(req.URL.Hostname())); creds != nil {
+	if creds := cliCfg.CredentialsSource().
+		ForHost(svchost.Hostname(req.URL.Hostname())); creds != nil {
 		creds.PrepareRequest(req)
 		return req, nil
 	}

--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -68,6 +68,35 @@ func (e RegistryAPIErr) Error() string {
 	return fmt.Sprintf("Failed to fetch url %s: status code %d", e.url, e.statusCode)
 }
 
+// ConstraintParseErr is returned when a version constraint cannot be parsed.
+type ConstraintParseErr struct {
+	err        error
+	constraint string
+}
+
+func (e ConstraintParseErr) Error() string {
+	return fmt.Sprintf("invalid version constraint %q: %s", e.constraint, e.err)
+}
+
+func (e ConstraintParseErr) Unwrap() error {
+	return e.err
+}
+
+// NoMatchingVersionErr is returned when no published module version satisfies
+// the requested version constraint.
+type NoMatchingVersionErr struct {
+	constraint     string
+	modulePath     string
+	registryDomain string
+}
+
+func (e NoMatchingVersionErr) Error() string {
+	return fmt.Sprintf(
+		"no published version of module %s on registry %s satisfies constraint %q",
+		e.modulePath, e.registryDomain, e.constraint,
+	)
+}
+
 // GetModuleRegistryURLBasePath performs the OpenTofu/Terraform
 // service-discovery protocol against `domain` and returns the base path
 // under which modules are hosted.
@@ -170,20 +199,102 @@ func BuildRequestURL(registryDomain, moduleRegistryBasePath, modulePath, version
 	return &url.URL{Scheme: "https", Host: registryDomain, Path: moduleFullPath}, nil
 }
 
-// GetLatestModuleVersion queries the Terraform module registry to list
-// available versions for the given module and returns the latest stable
+// GetLatestModuleVersion queries the OpenTofu or Terraform module registry to
+// list available versions for the given module and returns the latest stable
 // (non-prerelease) version. Prereleases are excluded to match OpenTofu and
 // Terraform's default behavior when resolving an unconstrained module
 // version; if a user wants a prerelease, they must pin it explicitly via
-// `?version=`. This implements the "List Available Versions for a Specific
-// Module" endpoint of the Terraform Module Registry Protocol.
-// See: https://developer.hashicorp.com/terraform/registry/api-docs#list-available-versions-for-a-specific-module
+// `?version=`.
 func GetLatestModuleVersion(
 	ctx context.Context,
 	l log.Logger,
 	httpClient *http.Client,
 	registryDomain, moduleRegistryBasePath, modulePath string,
 ) (string, error) {
+	versions, err := listModuleVersions(ctx, l, httpClient, registryDomain, moduleRegistryBasePath, modulePath)
+	if err != nil {
+		return "", err
+	}
+
+	stable := make([]*goversion.Version, 0, len(versions))
+
+	for _, v := range versions {
+		if v.Prerelease() != "" {
+			l.Debugf("Skipping prerelease version %q for module %s", v.Original(), modulePath)
+			continue
+		}
+
+		stable = append(stable, v)
+	}
+
+	if len(stable) == 0 {
+		return "", fmt.Errorf(
+			"no stable versions found for module %s on registry %s; pin a version explicitly with ?version=",
+			modulePath,
+			registryDomain,
+		)
+	}
+
+	latest := slices.MaxFunc(stable, func(a, b *goversion.Version) int { return a.Compare(b) })
+
+	return latest.Original(), nil
+}
+
+// GetMatchingModuleVersion queries the OpenTofu or Terraform module registry
+// and returns the highest published version of the module that satisfies
+// constraint (for example "~> 3.3" or ">= 1.0.0, < 2.0.0").
+//
+// Prerelease eligibility follows OpenTofu and Terraform: a prerelease version
+// is a candidate only when the constraint operand itself names a prerelease
+// with the same base version. hashicorp/go-version enforces this in
+// Constraints.Check, so every published version is passed through unfiltered.
+func GetMatchingModuleVersion(
+	ctx context.Context,
+	l log.Logger,
+	httpClient *http.Client,
+	registryDomain, moduleRegistryBasePath, modulePath, constraint string,
+) (string, error) {
+	constraints, err := goversion.NewConstraint(constraint)
+	if err != nil {
+		return "", ConstraintParseErr{constraint: constraint, err: err}
+	}
+
+	versions, err := listModuleVersions(ctx, l, httpClient, registryDomain, moduleRegistryBasePath, modulePath)
+	if err != nil {
+		return "", err
+	}
+
+	matching := make([]*goversion.Version, 0, len(versions))
+
+	for _, v := range versions {
+		if constraints.Check(v) {
+			matching = append(matching, v)
+		}
+	}
+
+	if len(matching) == 0 {
+		return "", NoMatchingVersionErr{constraint: constraint, modulePath: modulePath, registryDomain: registryDomain}
+	}
+
+	match := slices.MaxFunc(matching, func(a, b *goversion.Version) int { return a.Compare(b) })
+
+	return match.Original(), nil
+}
+
+// listModuleVersions queries the registry's list-versions endpoint for the
+// module and returns every published version that parses as semver, preserving
+// the order the registry returned. Unparsable entries are skipped with a debug
+// log so a single malformed row cannot block resolution; prereleases are kept,
+// leaving the prerelease policy to the caller. This implements the "List
+// Available Versions for a Specific Module" endpoint of the Terraform Module
+// Registry Protocol.
+// See: https://developer.hashicorp.com/terraform/registry/api-docs#list-available-versions-for-a-specific-module
+func listModuleVersions(
+	ctx context.Context,
+	l log.Logger,
+	httpClient *http.Client,
+	registryDomain, moduleRegistryBasePath, modulePath string,
+) ([]*goversion.Version, error) {
 	moduleRegistryBasePath = strings.TrimSuffix(moduleRegistryBasePath, "/")
 	modulePath = strings.TrimSuffix(modulePath, "/")
 	modulePath = strings.TrimPrefix(modulePath, "/")
@@ -192,7 +303,7 @@ func GetLatestModuleVersion(
 
 	versionsURL, err := url.Parse(versionsPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse versions URL for %s: %w", modulePath, err)
+		return nil, fmt.Errorf("failed to parse versions URL for %s: %w", modulePath, err)
 	}
 
 	// If the base path is relative (no scheme), construct the full URL using the registry domain.
@@ -206,20 +317,18 @@ func GetLatestModuleVersion(
 
 	bodyData, _, err := httpGETAndGetResponse(ctx, l, httpClient, versionsURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to query module versions for %s: %w", modulePath, err)
+		return nil, fmt.Errorf("failed to query module versions for %s: %w", modulePath, err)
 	}
 
 	var versionsResp moduleVersionsResponse
 	if err := json.Unmarshal(bodyData, &versionsResp); err != nil {
-		return "", fmt.Errorf("failed to parse module versions response for %s: %w", modulePath, err)
+		return nil, fmt.Errorf("failed to parse module versions response for %s: %w", modulePath, err)
 	}
 
 	if len(versionsResp.Modules) == 0 || len(versionsResp.Modules[0].Versions) == 0 {
-		return "", fmt.Errorf("no versions found for module %s on registry %s", modulePath, registryDomain)
+		return nil, fmt.Errorf("no versions found for module %s on registry %s", modulePath, registryDomain)
 	}
 
-	// The registry API does not guarantee version ordering, so parse and pick
-	// the max by semver. Skip prereleases and unparsable entries.
 	parsed := make([]*goversion.Version, 0, len(versionsResp.Modules[0].Versions))
 
 	for _, v := range versionsResp.Modules[0].Versions {
@@ -229,25 +338,10 @@ func GetLatestModuleVersion(
 			continue
 		}
 
-		if pv.Prerelease() != "" {
-			l.Debugf("Skipping prerelease version %q for module %s", v.Version, modulePath)
-			continue
-		}
-
 		parsed = append(parsed, pv)
 	}
 
-	if len(parsed) == 0 {
-		return "", fmt.Errorf(
-			"no stable versions found for module %s on registry %s; pin a version explicitly with ?version=",
-			modulePath,
-			registryDomain,
-		)
-	}
-
-	latest := slices.MaxFunc(parsed, func(a, b *goversion.Version) int { return a.Compare(b) })
-
-	return latest.Original(), nil
+	return parsed, nil
 }
 
 // moduleVersionsResponse is the registry API response for the list-versions endpoint.

--- a/internal/getter/tfrhelpers_test.go
+++ b/internal/getter/tfrhelpers_test.go
@@ -35,7 +35,12 @@ func TestGetTerraformGetHeader(t *testing.T) {
 		Path:   "/v1/modules/terraform-aws-modules/vpc/aws/3.3.0/download",
 	}
 
-	header, err := getter.GetTerraformGetHeader(t.Context(), logger.CreateLogger(), server.Client(), &moduleURL)
+	header, err := getter.GetTerraformGetHeader(
+		t.Context(),
+		logger.CreateLogger(),
+		server.Client(),
+		&moduleURL,
+	)
 	require.NoError(t, err)
 	assert.Contains(t, header, "/download/terraform-aws-vpc.zip")
 }
@@ -179,7 +184,10 @@ func TestGetLatestModuleVersionSkipsPrereleases(t *testing.T) {
 func TestGetLatestModuleVersionAllPrereleases(t *testing.T) {
 	t.Parallel()
 
-	server := newVersionsTestServer(t, `{"modules":[{"versions":[{"version":"1.0.0-alpha"},{"version":"2.0.0-rc1"}]}]}`)
+	server := newVersionsTestServer(
+		t,
+		`{"modules":[{"versions":[{"version":"1.0.0-alpha"},{"version":"2.0.0-rc1"}]}]}`,
+	)
 
 	_, err := getter.GetLatestModuleVersion(
 		t.Context(), logger.CreateLogger(), server.Client(),
@@ -194,7 +202,10 @@ func TestGetLatestModuleVersionAllPrereleases(t *testing.T) {
 func TestGetLatestModuleVersionSkipsUnparsable(t *testing.T) {
 	t.Parallel()
 
-	server := newVersionsTestServer(t, `{"modules":[{"versions":[{"version":"not-a-version"},{"version":"1.0.0"}]}]}`)
+	server := newVersionsTestServer(
+		t,
+		`{"modules":[{"versions":[{"version":"not-a-version"},{"version":"1.0.0"}]}]}`,
+	)
 
 	latest, err := getter.GetLatestModuleVersion(
 		t.Context(), logger.CreateLogger(), server.Client(),
@@ -250,7 +261,10 @@ func TestGetMatchingModuleVersion(t *testing.T) {
 func TestGetMatchingModuleVersionPrereleaseOptIn(t *testing.T) {
 	t.Parallel()
 
-	server := newVersionsTestServer(t, `{"modules":[{"versions":[{"version":"3.4.0"},{"version":"4.0.0-rc1"}]}]}`)
+	server := newVersionsTestServer(
+		t,
+		`{"modules":[{"versions":[{"version":"3.4.0"},{"version":"4.0.0-rc1"}]}]}`,
+	)
 
 	got, err := getter.GetMatchingModuleVersion(
 		t.Context(), logger.CreateLogger(), server.Client(),
@@ -265,7 +279,10 @@ func TestGetMatchingModuleVersionPrereleaseOptIn(t *testing.T) {
 func TestGetMatchingModuleVersionNoMatch(t *testing.T) {
 	t.Parallel()
 
-	server := newVersionsTestServer(t, `{"modules":[{"versions":[{"version":"1.0.0"},{"version":"2.0.0"}]}]}`)
+	server := newVersionsTestServer(
+		t,
+		`{"modules":[{"versions":[{"version":"1.0.0"},{"version":"2.0.0"}]}]}`,
+	)
 
 	_, err := getter.GetMatchingModuleVersion(
 		t.Context(), logger.CreateLogger(), server.Client(),
@@ -316,11 +333,18 @@ func newRegistryTestServer(t *testing.T) *httptest.Server {
 
 	// Serve the list-versions endpoint so TestRegistryGetterWithoutVersion can
 	// resolve the latest version without a ?version= query parameter.
-	mux.HandleFunc("/v1/modules/terraform-aws-modules/vpc/aws/versions", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"modules":[{"versions":[{"version":"3.3.0"},{"version":"2.0.0"},{"version":"1.0.0"}]}]}`))
-		assert.NoError(t, err)
-	})
+	mux.HandleFunc(
+		"/v1/modules/terraform-aws-modules/vpc/aws/versions",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write(
+				[]byte(
+					`{"modules":[{"versions":[{"version":"3.3.0"},{"version":"2.0.0"},{"version":"1.0.0"}]}]}`,
+				),
+			)
+			assert.NoError(t, err)
+		},
+	)
 
 	mux.HandleFunc(
 		"/v1/modules/terraform-aws-modules/vpc/aws/3.3.0/download",
@@ -353,11 +377,14 @@ func newVersionsTestServer(t *testing.T, body string) *httptest.Server {
 	t.Helper()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/modules/foo/bar/baz/versions", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(body))
-		assert.NoError(t, err)
-	})
+	mux.HandleFunc(
+		"/v1/modules/foo/bar/baz/versions",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(body))
+			assert.NoError(t, err)
+		},
+	)
 
 	server := httptest.NewTLSServer(mux)
 	t.Cleanup(server.Close)

--- a/internal/getter/tfrhelpers_test.go
+++ b/internal/getter/tfrhelpers_test.go
@@ -204,6 +204,98 @@ func TestGetLatestModuleVersionSkipsUnparsable(t *testing.T) {
 	assert.Equal(t, "1.0.0", latest)
 }
 
+// matchVersionsBody is a list-versions response spanning several minor and
+// patch lines plus a prerelease, letting the constraint resolver tests exercise
+// pessimistic, range, exact and prerelease-exclusion semantics off one fixture.
+const matchVersionsBody = `{"modules":[{"versions":[` +
+	`{"version":"1.0.0"},{"version":"1.5.0"},{"version":"1.9.0"},` +
+	`{"version":"2.0.0"},{"version":"3.3.0"},{"version":"3.3.5"},` +
+	`{"version":"3.4.0"},{"version":"4.0.0-rc1"}]}]}`
+
+func TestGetMatchingModuleVersion(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		constraint string
+		want       string
+	}{
+		{name: "pessimistic patch", constraint: "~> 3.3.0", want: "3.3.5"},
+		{name: "pessimistic minor", constraint: "~> 3.3", want: "3.4.0"},
+		{name: "range", constraint: ">= 1.0.0, < 2.0.0", want: "1.9.0"},
+		{name: "exact as constraint", constraint: "2.0.0", want: "2.0.0"},
+		{name: "prerelease excluded", constraint: ">= 3.0.0", want: "3.4.0"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newVersionsTestServer(t, matchVersionsBody)
+
+			got, err := getter.GetMatchingModuleVersion(
+				t.Context(), logger.CreateLogger(), server.Client(),
+				server.Listener.Addr().String(), "/v1/modules/", "foo/bar/baz", tc.constraint,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestGetMatchingModuleVersionPrereleaseOptIn pins the opt-in half of the
+// prerelease policy: a constraint naming a prerelease admits prerelease
+// versions sharing its base, so >= 4.0.0-rc1 resolves to 4.0.0-rc1 even though
+// the only other version sorts lower.
+func TestGetMatchingModuleVersionPrereleaseOptIn(t *testing.T) {
+	t.Parallel()
+
+	server := newVersionsTestServer(t, `{"modules":[{"versions":[{"version":"3.4.0"},{"version":"4.0.0-rc1"}]}]}`)
+
+	got, err := getter.GetMatchingModuleVersion(
+		t.Context(), logger.CreateLogger(), server.Client(),
+		server.Listener.Addr().String(), "/v1/modules/", "foo/bar/baz", ">= 4.0.0-rc1",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "4.0.0-rc1", got)
+}
+
+// TestGetMatchingModuleVersionNoMatch pins the typed error returned when the
+// registry publishes versions but none satisfy the constraint.
+func TestGetMatchingModuleVersionNoMatch(t *testing.T) {
+	t.Parallel()
+
+	server := newVersionsTestServer(t, `{"modules":[{"versions":[{"version":"1.0.0"},{"version":"2.0.0"}]}]}`)
+
+	_, err := getter.GetMatchingModuleVersion(
+		t.Context(), logger.CreateLogger(), server.Client(),
+		server.Listener.Addr().String(), "/v1/modules/", "foo/bar/baz", ">= 9.0.0",
+	)
+	require.Error(t, err)
+
+	var typed getter.NoMatchingVersionErr
+
+	require.ErrorAs(t, err, &typed)
+}
+
+// TestGetMatchingModuleVersionUnparsableConstraint pins the typed error
+// returned when the constraint itself does not parse, before any registry call.
+func TestGetMatchingModuleVersionUnparsableConstraint(t *testing.T) {
+	t.Parallel()
+
+	server := newVersionsTestServer(t, `{"modules":[{"versions":[{"version":"1.0.0"}]}]}`)
+
+	_, err := getter.GetMatchingModuleVersion(
+		t.Context(), logger.CreateLogger(), server.Client(),
+		server.Listener.Addr().String(), "/v1/modules/", "foo/bar/baz", "not a constraint",
+	)
+	require.Error(t, err)
+
+	var typed getter.ConstraintParseErr
+
+	require.ErrorAs(t, err, &typed)
+}
+
 // newRegistryTestServer stands up an httptest TLS server that speaks enough of
 // the OpenTofu/Terraform module-registry protocol to satisfy the
 // RegistryGetter: the service-discovery document, a module download endpoint


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds support for matching module version from a registry using a constraint. Nothing is wired into this right now, we're just laying the groundwork for a future update that will add support for this.

Part of addressing #1930.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added constraint-based module version selection, returning the highest compatible version.
  * Added support for exact, range, and prerelease version constraints.

* **Bug Fixes**
  * Latest-version selection now excludes prereleases unless explicitly requested.
  * Improved handling and reporting of invalid constraints, unavailable matches, and malformed registry responses.

* **Tests**
  * Expanded coverage for version matching, prerelease behavior, parsing errors, and missing matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->