### PR TITLE
chore: add separated us-west-2 pass of cloud nuke

### DIFF
--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -47,3 +47,16 @@ jobs:
               --region global \
               --older-than 1h \
               --config .github/cloud-nuke/config.yml
+
+      # cloud-nuke's S3 client only reaches buckets in one region; second pass covers us-west-2
+      - name: Run cloud-nuke (S3 in us-west-2)
+        run: |
+          cloud-nuke aws \
+              --force \
+              --log-level debug \
+              --resource-type s3 \
+              --region global \
+              --older-than 1h \
+              --config .github/cloud-nuke/config.yml
+        env:
+          CLOUD_NUKE_AWS_GLOBAL_REGION: us-west-2


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated cloud resource cleanup to include S3 buckets in the us-west-2 region.
  * S3 cleanup continues to target resources older than one hour using the existing cleanup configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->