### PR TITLE
fix: Fixing `run --all` with graph expression throwing on missing working dir

### DIFF
--- a/docs/src/data/changelog/v1.1.1/run-all-git-graph-filter-discovery-crash.mdx
+++ b/docs/src/data/changelog/v1.1.1/run-all-git-graph-filter-discovery-crash.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.1"
+category: "bug-fixes"
+---
+
+#### `run --all` no longer crashes on dependency discovery with graph filters
+
+Running `run --all` with a filter that expands a git range through the dependency graph (for example `[HEAD~1...HEAD]...`) could fail during dependency discovery, reporting that a component "is missing its working directory". Whether it happened depended on the size and shape of the changed unit's dependency closure, so the same filter succeeded on smaller branches and `find` was unaffected.
+
+A dependency reached from several units at once could become visible to discovery before its working directory was set, so a concurrent traversal could read it before it was complete. Dependencies now have their working directory set before they become visible, so `run --all` behaves the same regardless of graph size.

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -40,18 +40,23 @@ func (d *Discovery) Discover(
 
 	withWorktree := len(d.gitExpressions) > 0 && d.worktrees != nil
 
-	l.Debugf("Discovery: starting filesystem phase (workers=%d, with_worktree=%t)", d.numWorkers, withWorktree)
+	l.Debugf(
+		"Discovery: starting filesystem phase (workers=%d, with_worktree=%t)",
+		d.numWorkers,
+		withWorktree,
+	)
 
-	err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "discovery_phase_filesystem", map[string]any{
-		"num_workers":   d.numWorkers,
-		"with_worktree": withWorktree,
-	}, func(childCtx context.Context) error {
-		var phaseErr error
+	err = telemetry.TelemeterFromContext(ctx).
+		Collect(ctx, "discovery_phase_filesystem", map[string]any{
+			"num_workers":   d.numWorkers,
+			"with_worktree": withWorktree,
+		}, func(childCtx context.Context) error {
+			var phaseErr error
 
-		results, phaseErr = d.runFilesystemPhase(childCtx, l, v, opts)
+			results, phaseErr = d.runFilesystemPhase(childCtx, l, v, opts)
 
-		return phaseErr
-	})
+			return phaseErr
+		})
 
 	logPhaseComplete(l, "filesystem", results, err)
 
@@ -74,21 +79,22 @@ func (d *Discovery) Discover(
 		l.Debugf("Discovery: starting parse phase (discovered=%d, candidates=%d, reasons=%s)",
 			len(discovered), len(candidates), reasonsStr)
 
-		err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "discovery_phase_parse", map[string]any{
-			"num_workers":       d.numWorkers,
-			"discovered_in":     len(discovered),
-			"candidates_in":     len(candidates),
-			"parse_includes":    d.parseIncludes,
-			"parse_exclude":     d.parseExclude,
-			"read_files":        d.readFiles,
-			"activation_reason": reasonsStr,
-		}, func(childCtx context.Context) error {
-			var phaseErr error
+		err = telemetry.TelemeterFromContext(ctx).
+			Collect(ctx, "discovery_phase_parse", map[string]any{
+				"num_workers":       d.numWorkers,
+				"discovered_in":     len(discovered),
+				"candidates_in":     len(candidates),
+				"parse_includes":    d.parseIncludes,
+				"parse_exclude":     d.parseExclude,
+				"read_files":        d.readFiles,
+				"activation_reason": reasonsStr,
+			}, func(childCtx context.Context) error {
+				var phaseErr error
 
-			results, phaseErr = d.runParsePhase(childCtx, l, v, opts, discovered, candidates)
+				results, phaseErr = d.runParsePhase(childCtx, l, v, opts, discovered, candidates)
 
-			return phaseErr
-		})
+				return phaseErr
+			})
 
 		logPhaseComplete(l, "parse", results, err)
 
@@ -107,22 +113,30 @@ func (d *Discovery) Discover(
 			}
 		}
 
-		l.Debugf("Discovery: starting graph phase (discovered=%d, candidates=%d, max_depth=%d, has_dependent_filters=%t)",
-			len(discovered), len(candidates), d.maxDependencyDepth, d.classifier.HasDependentFilters())
+		l.Debugf(
+			"Discovery: starting graph phase (discovered=%d, candidates=%d, max_depth=%d, has_dependent_filters=%t)",
+			len(
+				discovered,
+			),
+			len(candidates),
+			d.maxDependencyDepth,
+			d.classifier.HasDependentFilters(),
+		)
 
-		err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "discovery_phase_graph", map[string]any{
-			"num_workers":           d.numWorkers,
-			"max_dependency_depth":  d.maxDependencyDepth,
-			"discovered_in":         len(discovered),
-			"candidates_in":         len(candidates),
-			"has_dependent_filters": d.classifier.HasDependentFilters(),
-		}, func(childCtx context.Context) error {
-			var phaseErr error
+		err = telemetry.TelemeterFromContext(ctx).
+			Collect(ctx, "discovery_phase_graph", map[string]any{
+				"num_workers":           d.numWorkers,
+				"max_dependency_depth":  d.maxDependencyDepth,
+				"discovered_in":         len(discovered),
+				"candidates_in":         len(candidates),
+				"has_dependent_filters": d.classifier.HasDependentFilters(),
+			}, func(childCtx context.Context) error {
+				var phaseErr error
 
-			results, phaseErr = d.runGraphPhase(childCtx, l, v, opts, discovered, candidates)
+				results, phaseErr = d.runGraphPhase(childCtx, l, v, opts, discovered, candidates)
 
-			return phaseErr
-		})
+				return phaseErr
+			})
 
 		logPhaseComplete(l, "graph", results, err)
 
@@ -139,19 +153,24 @@ func (d *Discovery) Discover(
 		l.Debugf("Discovery: starting relationship phase (components=%d, max_depth=%d)",
 			len(components), d.maxDependencyDepth)
 
-		err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "discovery_phase_relationship", map[string]any{
-			"num_workers":          d.numWorkers,
-			"max_dependency_depth": d.maxDependencyDepth,
-			"components_in":        len(components),
-		}, func(childCtx context.Context) error {
-			var phaseErr error
+		err = telemetry.TelemeterFromContext(ctx).
+			Collect(ctx, "discovery_phase_relationship", map[string]any{
+				"num_workers":          d.numWorkers,
+				"max_dependency_depth": d.maxDependencyDepth,
+				"components_in":        len(components),
+			}, func(childCtx context.Context) error {
+				var phaseErr error
 
-			components, phaseErr = d.runRelationshipPhase(childCtx, l, v, opts, components)
+				components, phaseErr = d.runRelationshipPhase(childCtx, l, v, opts, components)
 
-			return phaseErr
-		})
+				return phaseErr
+			})
 
-		l.Debugf("Discovery: relationship phase complete (components=%d, err=%v)", len(components), err)
+		l.Debugf(
+			"Discovery: relationship phase complete (components=%d, err=%v)",
+			len(components),
+			err,
+		)
 
 		if err != nil && !d.suppressParseErrors {
 			return components, err
@@ -159,14 +178,22 @@ func (d *Discovery) Discover(
 	}
 
 	if len(d.filters) > 0 {
-		l.Debugf("Discovery: applying %d filter(s) to %d components", len(d.filters), len(components))
+		l.Debugf(
+			"Discovery: applying %d filter(s) to %d components",
+			len(d.filters),
+			len(components),
+		)
 
 		filtered, err := d.filters.Evaluate(l, components)
 		if err != nil {
 			return components, err
 		}
 
-		l.Debugf("Discovery: filter evaluation complete (in=%d, out=%d)", len(components), len(filtered))
+		l.Debugf(
+			"Discovery: filter evaluation complete (in=%d, out=%d)",
+			len(components),
+			len(filtered),
+		)
 
 		components = filtered
 	}
@@ -213,7 +240,13 @@ func logPhaseComplete(l log.Logger, name string, results *PhaseResults, err erro
 		candidates = len(results.Candidates)
 	}
 
-	l.Debugf("Discovery: %s phase complete (discovered=%d, candidates=%d, err=%v)", name, discovered, candidates, err)
+	l.Debugf(
+		"Discovery: %s phase complete (discovered=%d, candidates=%d, err=%v)",
+		name,
+		discovered,
+		candidates,
+		err,
+	)
 }
 
 // runFilesystemPhase runs the filesystem and worktree phases concurrently.
@@ -242,22 +275,23 @@ func (d *Discovery) runFilesystemPhase(
 
 		l.Debugf("Discovery: starting filesystem walk at %s", d.workingDir)
 
-		err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "discovery_filesystem_walk", map[string]any{
-			"num_workers": d.numWorkers,
-			"working_dir": d.workingDir,
-		}, func(childCtx context.Context) error {
-			phase := NewFilesystemPhase(d.numWorkers)
+		err := telemetry.TelemeterFromContext(ctx).
+			Collect(ctx, "discovery_filesystem_walk", map[string]any{
+				"num_workers": d.numWorkers,
+				"working_dir": d.workingDir,
+			}, func(childCtx context.Context) error {
+				phase := NewFilesystemPhase(d.numWorkers)
 
-			var phaseErr error
+				var phaseErr error
 
-			result, phaseErr = phase.Run(childCtx, l, v, &PhaseInput{
-				Opts:       opts,
-				Classifier: d.classifier,
-				Discovery:  d,
+				result, phaseErr = phase.Run(childCtx, l, v, &PhaseInput{
+					Opts:       opts,
+					Classifier: d.classifier,
+					Discovery:  d,
+				})
+
+				return phaseErr
 			})
-
-			return phaseErr
-		})
 
 		logPhaseComplete(l, "filesystem walk", result, err)
 
@@ -281,24 +315,28 @@ func (d *Discovery) runFilesystemPhase(
 		g.Go(func() error {
 			var result *PhaseResults
 
-			l.Debugf("Discovery: starting worktree walk (git_expressions=%d)", len(d.gitExpressions))
+			l.Debugf(
+				"Discovery: starting worktree walk (git_expressions=%d)",
+				len(d.gitExpressions),
+			)
 
-			err := telemetry.TelemeterFromContext(ctx).Collect(ctx, "discovery_worktree_walk", map[string]any{
-				"num_workers":          d.numWorkers,
-				"git_expression_count": len(d.gitExpressions),
-			}, func(childCtx context.Context) error {
-				phase := NewWorktreePhase(d.gitExpressions, d.numWorkers)
+			err := telemetry.TelemeterFromContext(ctx).
+				Collect(ctx, "discovery_worktree_walk", map[string]any{
+					"num_workers":          d.numWorkers,
+					"git_expression_count": len(d.gitExpressions),
+				}, func(childCtx context.Context) error {
+					phase := NewWorktreePhase(d.gitExpressions, d.numWorkers)
 
-				var phaseErr error
+					var phaseErr error
 
-				result, phaseErr = phase.Run(childCtx, l, v, &PhaseInput{
-					Opts:       opts,
-					Classifier: d.classifier,
-					Discovery:  d,
+					result, phaseErr = phase.Run(childCtx, l, v, &PhaseInput{
+						Opts:       opts,
+						Classifier: d.classifier,
+						Discovery:  d,
+					})
+
+					return phaseErr
 				})
-
-				return phaseErr
-			})
 
 			logPhaseComplete(l, "worktree walk", result, err)
 
@@ -555,17 +593,19 @@ func (d *Discovery) buildComponentDependencies(
 	for _, depPath := range depPaths {
 		depComponent := componentFromDependencyPath(depPath, threadSafeComponents)
 
-		if isExternal(parentCtx.WorkingDir, depPath) {
-			if ext, ok := depComponent.(*component.Unit); ok {
-				ext.SetExternal()
+		if dctx := depComponent.DiscoveryContext(); dctx == nil || dctx.WorkingDir == "" {
+			depComponent.SetDiscoveryContext(
+				parentCtx.CopyWithNewOrigin(component.OriginGraphDiscovery),
+			)
+
+			if isExternal(parentCtx.WorkingDir, depPath) {
+				if ext, ok := depComponent.(*component.Unit); ok {
+					ext.SetExternal()
+				}
 			}
 		}
 
-		addedComponent, created := threadSafeComponents.EnsureComponent(depComponent)
-		if created {
-			copiedCtx := parentCtx.CopyWithNewOrigin(component.OriginGraphDiscovery)
-			depComponent.SetDiscoveryContext(copiedCtx)
-		}
+		addedComponent, _ := threadSafeComponents.EnsureComponent(depComponent)
 
 		c.AddDependency(addedComponent)
 	}
@@ -709,7 +749,10 @@ func buildAllowSet(targetPath string, dependentUnits map[string][]string) map[st
 // filterByAllowSet returns only the components whose path exists in the allow set.
 // Paths are resolved to handle symlinks consistently across platforms.
 // The output order matches the input order (no sorting is performed here).
-func filterByAllowSet(components component.Components, allowed map[string]struct{}) component.Components {
+func filterByAllowSet(
+	components component.Components,
+	allowed map[string]struct{},
+) component.Components {
 	filtered := make(component.Components, 0, len(components))
 
 	for _, c := range components {

--- a/internal/discovery/graph_dependency_race_test.go
+++ b/internal/discovery/graph_dependency_race_test.go
@@ -51,7 +51,10 @@ func TestGraphPhase_ConcurrentDependencyDiscoveryWithRacing(t *testing.T) {
 			fmt.Fprintf(&hcl, "dependency \"d%d\" {\n  config_path = %q\n}\n", i, dep)
 		}
 
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "terragrunt.hcl"), []byte(hcl.String()), 0644))
+		require.NoError(
+			t,
+			os.WriteFile(filepath.Join(dir, "terragrunt.hcl"), []byte(hcl.String()), 0644),
+		)
 	}
 
 	// The dependency closure (parents, mid, leaf) lives under ext/, outside the
@@ -90,4 +93,108 @@ func TestGraphPhase_ConcurrentDependencyDiscoveryWithRacing(t *testing.T) {
 	paths := components.Paths()
 	require.Contains(t, paths, filepath.Join(extDir, "mid"))
 	require.Contains(t, paths, filepath.Join(extDir, "leaf"))
+}
+
+// TestGraphPhase_ConcurrentUpstreamDownstreamSharedDependencyWithRacing pins that
+// a dependency reached by both the upstream (dependents) and downstream
+// (dependencies) traversals never becomes visible without a discovery context.
+//
+// Two targets are processed concurrently: one expanded through its dependents
+// (...A) and one through its dependencies (B...). The upstream walk assigns
+// dependency components to the shared set while checking whether each candidate
+// depends on the target, and the downstream walk reaches the same components from
+// the other side. Both sides converge on "shared" at once, so if a component is
+// published before its working directory is set, a downstream reach writes its
+// context while an upstream reach touches it, which the race detector flags.
+//
+// "shared" lives under ext/, outside the working directory, so it is created
+// during traversal rather than pre-discovered with a context by the filesystem
+// walk.
+func TestGraphPhase_ConcurrentUpstreamDownstreamSharedDependencyWithRacing(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	workingDir := filepath.Join(tmpDir, "root")
+	extDir := filepath.Join(tmpDir, "ext")
+
+	const (
+		upFanOut   = 24
+		downFanOut = 24
+	)
+
+	writeUnit := func(baseDir, name string, deps ...string) {
+		dir := filepath.Join(baseDir, name)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+
+		var hcl strings.Builder
+
+		hcl.WriteString("# " + name + "\n")
+
+		for i, dep := range deps {
+			fmt.Fprintf(&hcl, "dependency \"d%d\" {\n  config_path = %q\n}\n", i, dep)
+		}
+
+		require.NoError(
+			t,
+			os.WriteFile(filepath.Join(dir, "terragrunt.hcl"), []byte(hcl.String()), 0644),
+		)
+	}
+
+	// "shared" lives outside the working directory so it is not pre-discovered.
+	writeUnit(extDir, "shared")
+
+	// Target A (dependents side): many units depend on A and also pull in "shared".
+	// The upstream walk publishes "shared" while checking each of these dependents.
+	writeUnit(workingDir, "A")
+
+	for i := range upFanOut {
+		writeUnit(workingDir, fmt.Sprintf("up%02d", i), "../A", "../../ext/shared")
+	}
+
+	// Target B (dependencies side): fans out to many parents that all reach
+	// "shared" from the downstream direction at the same time.
+	downParents := make([]string, 0, downFanOut)
+	for j := range downFanOut {
+		name := fmt.Sprintf("p%02d", j)
+		writeUnit(workingDir, name, "../../ext/shared")
+		downParents = append(downParents, "../"+name)
+	}
+
+	writeUnit(workingDir, "B", downParents...)
+
+	l := logger.CreateLogger()
+	opts := &options.TerragruntOptions{
+		WorkingDir:     workingDir,
+		RootWorkingDir: workingDir,
+	}
+
+	filters, err := filter.ParseFilterQueries(l, []string{
+		"...{" + filepath.Join(workingDir, "A") + "}",
+		"{" + filepath.Join(workingDir, "B") + "}...",
+	})
+	require.NoError(t, err)
+
+	d := discovery.NewDiscovery(workingDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workingDir}).
+		WithGitRoot(workingDir).
+		WithFilters(filters)
+
+	components, err := d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	require.NoError(t, err)
+
+	require.Contains(t, components.Paths(), filepath.Join(extDir, "shared"))
+
+	// Every discovered component must carry a working directory; a component
+	// published before its context was assigned would surface here as empty.
+	for _, c := range components {
+		dctx := c.DiscoveryContext()
+		require.NotNilf(t, dctx, "component %s has no discovery context", c.Path())
+		require.NotEmptyf(
+			t,
+			dctx.WorkingDir,
+			"component %s has an empty working directory",
+			c.Path(),
+		)
+	}
 }

--- a/internal/discovery/graph_dependency_race_test.go
+++ b/internal/discovery/graph_dependency_race_test.go
@@ -198,3 +198,87 @@ func TestGraphPhase_ConcurrentUpstreamDownstreamSharedDependencyWithRacing(t *te
 		)
 	}
 }
+
+// TestGraphPhase_UpstreamCandidatePublishBeforeContextWithRacing pins that graph
+// dependency discovery never publishes an upstream candidate to the shared set
+// before assigning its discovery context. processUpstreamCandidate is the only
+// path that can, and the context accessors are unlocked, so a goroutine reaching
+// the component as a dependency reads the field while the candidate's own
+// goroutine writes it.
+//
+// To collide, nodes must be candidates in the same upstream walk pass and must
+// not be pre-discovered by the working-directory walk, which would reach them
+// through the safe assign-before-publish path first. A clique in the git root,
+// above the working directory, satisfies both: every node is created during the
+// upstream walk and reached as a dependency by every other node at once.
+func TestGraphPhase_UpstreamCandidatePublishBeforeContextWithRacing(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	// Parent of the working dir, so the upstream walk climbs one level into the clique.
+	gitRoot := tmpDir
+	workingDir := filepath.Join(tmpDir, "root")
+
+	const cliqueSize = 16
+
+	writeUnit := func(baseDir, name string, deps ...string) {
+		dir := filepath.Join(baseDir, name)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+
+		var hcl strings.Builder
+
+		hcl.WriteString("# " + name + "\n")
+
+		for i, dep := range deps {
+			fmt.Fprintf(&hcl, "dependency \"d%d\" {\n  config_path = %q\n}\n", i, dep)
+		}
+
+		require.NoError(
+			t,
+			os.WriteFile(filepath.Join(dir, "terragrunt.hcl"), []byte(hcl.String()), 0644),
+		)
+	}
+
+	// The ...A expansion drives the upstream walk, which climbs to the git root
+	// even though A has no dependents.
+	writeUnit(workingDir, "A")
+
+	names := make([]string, cliqueSize)
+	for i := range cliqueSize {
+		names[i] = fmt.Sprintf("node%02d", i)
+	}
+
+	for i, name := range names {
+		deps := make([]string, 0, cliqueSize-1)
+
+		for j, other := range names {
+			if i == j {
+				continue
+			}
+
+			deps = append(deps, "../"+other)
+		}
+
+		writeUnit(gitRoot, name, deps...)
+	}
+
+	l := logger.CreateLogger()
+	opts := &options.TerragruntOptions{
+		WorkingDir:     workingDir,
+		RootWorkingDir: workingDir,
+	}
+
+	filters, err := filter.ParseFilterQueries(l, []string{
+		"...{" + filepath.Join(workingDir, "A") + "}",
+	})
+	require.NoError(t, err)
+
+	d := discovery.NewDiscovery(workingDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workingDir}).
+		WithGitRoot(gitRoot).
+		WithFilters(filters)
+
+	_, err = d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	require.NoError(t, err)
+}

--- a/internal/discovery/graph_dependency_race_test.go
+++ b/internal/discovery/graph_dependency_race_test.go
@@ -1,0 +1,93 @@
+package discovery_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGraphPhase_ConcurrentDependencyDiscoveryWithRacing pins that graph
+// dependency discovery assigns a component's discovery context before the
+// component becomes reachable by other goroutines. The graph phase fans out one
+// goroutine per dependency, and dependencies that resolve outside the discovered
+// set are created during traversal. When a shared dependency is reached along
+// several paths at once, no goroutine should observe it, and recurse into it,
+// until its working directory has been set.
+//
+// The graph fans out from a single target to many parents that all share one
+// intermediate node, rooted outside the working directory so the whole closure
+// is created during traversal rather than pre-discovered. This drives many
+// concurrent reaches at the shared node.
+func TestGraphPhase_ConcurrentDependencyDiscoveryWithRacing(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	workingDir := filepath.Join(tmpDir, "root")
+	extDir := filepath.Join(tmpDir, "ext")
+
+	const fanOut = 24
+
+	writeUnit := func(baseDir, name string, deps ...string) {
+		dir := filepath.Join(baseDir, name)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+
+		var hcl strings.Builder
+
+		hcl.WriteString("# " + name + "\n")
+
+		for i, dep := range deps {
+			fmt.Fprintf(&hcl, "dependency \"d%d\" {\n  config_path = %q\n}\n", i, dep)
+		}
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "terragrunt.hcl"), []byte(hcl.String()), 0644))
+	}
+
+	// The dependency closure (parents, mid, leaf) lives under ext/, outside the
+	// working directory, so it is not pre-discovered by the filesystem walk and
+	// must be created during graph traversal. Every parent shares "mid", which
+	// itself depends on "leaf", so a goroutine that observes mid before its
+	// context is assigned recurses into it.
+	writeUnit(extDir, "leaf")
+	writeUnit(extDir, "mid", "../leaf")
+
+	parents := make([]string, 0, fanOut)
+	for i := range fanOut {
+		name := fmt.Sprintf("parent%02d", i)
+		writeUnit(extDir, name, "../mid")
+		parents = append(parents, "../../ext/"+name)
+	}
+
+	writeUnit(workingDir, "target", parents...)
+
+	l := logger.CreateLogger()
+	opts := &options.TerragruntOptions{
+		WorkingDir:     workingDir,
+		RootWorkingDir: workingDir,
+	}
+
+	filters, err := filter.ParseFilterQueries(l, []string{"target..."})
+	require.NoError(t, err)
+
+	d := discovery.NewDiscovery(workingDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workingDir}).
+		WithFilters(filters)
+
+	components, err := d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	require.NoError(t, err)
+
+	paths := components.Paths()
+	require.Contains(t, paths, filepath.Join(extDir, "mid"))
+	require.Contains(t, paths, filepath.Join(extDir, "leaf"))
+}

--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -62,7 +62,12 @@ func (p *GraphPhase) Kind() PhaseKind {
 }
 
 // Run executes the graph discovery phase.
-func (p *GraphPhase) Run(ctx context.Context, l log.Logger, v venv.Venv, input *PhaseInput) (*PhaseResults, error) {
+func (p *GraphPhase) Run(
+	ctx context.Context,
+	l log.Logger,
+	v venv.Venv,
+	input *PhaseInput,
+) (*PhaseResults, error) {
 	results := NewPhaseResults()
 
 	discovery := input.Discovery
@@ -236,7 +241,17 @@ func (p *GraphPhase) processGraphTarget(
 
 			visitedDirs := newStringSet()
 
-			err := p.discoverDependentsUpstream(ctx, l, v, state, c, visitedDirs, startDir, boundaryRoot, depth)
+			err := p.discoverDependentsUpstream(
+				ctx,
+				l,
+				v,
+				state,
+				c,
+				visitedDirs,
+				startDir,
+				boundaryRoot,
+				depth,
+			)
 			if err != nil {
 				return err
 			}
@@ -325,7 +340,14 @@ func (p *GraphPhase) discoverDependencies(
 					Phase:     PhaseGraph,
 				})
 
-				err = p.discoverDependencies(contextWithIncrementedParseDepth(ctx), l, v, state, depComponent, depthRemaining-1)
+				err = p.discoverDependencies(
+					contextWithIncrementedParseDepth(ctx),
+					l,
+					v,
+					state,
+					depComponent,
+					depthRemaining-1,
+				)
 				if err != nil {
 					errMu.Lock()
 
@@ -455,8 +477,13 @@ func (p *GraphPhase) discoverDependentsUpstream(
 		return nil
 	}
 
-	if boundaryRoot != "" && currentDir != boundaryRoot && !strings.HasPrefix(currentDir, boundaryRoot) {
-		l.Debugf("discoverDependentsUpstream: outside boundary (currentDir=%s, boundaryRoot=%s)", currentDir, boundaryRoot)
+	if boundaryRoot != "" && currentDir != boundaryRoot &&
+		!strings.HasPrefix(currentDir, boundaryRoot) {
+		l.Debugf(
+			"discoverDependentsUpstream: outside boundary (currentDir=%s, boundaryRoot=%s)",
+			currentDir,
+			boundaryRoot,
+		)
 		return nil
 	}
 
@@ -510,7 +537,11 @@ func (p *GraphPhase) discoverDependentsUpstream(
 			return nil
 		}
 
-		candidate := createComponentFromPath(path, state.discovery.configFilenames, state.discovery.discoveryContext)
+		candidate := createComponentFromPath(
+			path,
+			state.discovery.configFilenames,
+			state.discovery.discoveryContext,
+		)
 		if candidate != nil {
 			candidates = append(candidates, candidate)
 		}
@@ -566,7 +597,10 @@ func (p *GraphPhase) discoverDependentsUpstream(
 			continue
 		}
 
-		l.Debugf("Found dependent during upstream walk: %s (depends on target), adding to results", dependent.Path())
+		l.Debugf(
+			"Found dependent during upstream walk: %s (depends on target), adding to results",
+			dependent.Path(),
+		)
 
 		state.results.AddDiscovered(DiscoveryResult{
 			Component: dependent,
@@ -579,7 +613,11 @@ func (p *GraphPhase) discoverDependentsUpstream(
 
 		freshVisitedDirs := newStringSet()
 
-		l.Debugf("Recursively discovering dependents of %s from %s", dependent.Path(), filepath.Dir(dependent.Path()))
+		l.Debugf(
+			"Recursively discovering dependents of %s from %s",
+			dependent.Path(),
+			filepath.Dir(dependent.Path()),
+		)
 
 		err := p.discoverDependentsUpstream(
 			contextWithIncrementedParseDepth(ctx), l, v, state, dependent, freshVisitedDirs,
@@ -642,7 +680,14 @@ func (p *GraphPhase) processUpstreamCandidate(
 	ctx = contextWithParsePhase(ctx, parsePhaseTagGraphDependents)
 	graphState := state.graphTraversalState
 
-	if err := ensureParsed(ctx, l, v, candidate, graphState.opts, graphState.discovery); err != nil {
+	if err := ensureParsed(
+		ctx,
+		l,
+		v,
+		candidate,
+		graphState.opts,
+		graphState.discovery,
+	); err != nil {
 		if !state.graphTraversalState.discovery.suppressParseErrors {
 			state.errMu.Lock()
 
@@ -678,7 +723,9 @@ func (p *GraphPhase) processUpstreamCandidate(
 		return nil
 	}
 
-	canonicalCandidate, created := state.graphTraversalState.threadSafeComponents.EnsureComponent(candidate)
+	canonicalCandidate, created := state.graphTraversalState.threadSafeComponents.EnsureComponent(
+		candidate,
+	)
 	if created {
 		dCtx := state.target.DiscoveryContext()
 		if dCtx != nil {
@@ -698,16 +745,21 @@ func (p *GraphPhase) processUpstreamCandidate(
 
 	dependsOnTarget := false
 
-	for _, dep := range deps {
-		depComponent := componentFromDependencyPath(dep, state.graphTraversalState.threadSafeComponents)
-		depComponent, _ = state.graphTraversalState.threadSafeComponents.EnsureComponent(depComponent)
+	parentCtx := canonicalCandidate.DiscoveryContext()
 
-		parentCtx := canonicalCandidate.DiscoveryContext()
-		if parentCtx != nil && isExternal(parentCtx.WorkingDir, dep) {
-			if ext, ok := depComponent.(*component.Unit); ok {
-				ext.SetExternal()
-			}
+	for _, dep := range deps {
+		depComponent := componentFromDependencyPath(
+			dep,
+			state.graphTraversalState.threadSafeComponents,
+		)
+
+		if parentCtx != nil {
+			assignGraphDiscoveryContext(depComponent, parentCtx, dep)
 		}
+
+		depComponent, _ = state.graphTraversalState.threadSafeComponents.EnsureComponent(
+			depComponent,
+		)
 
 		// Compare paths: first try exact match, then try relative suffix match
 		// for worktree scenarios where target is in a different directory.
@@ -762,29 +814,46 @@ func (p *GraphPhase) resolveDependency(
 
 	depComponent := componentFromDependencyPath(depPath, threadSafeComponents)
 
-	if dctx := depComponent.DiscoveryContext(); dctx == nil || dctx.WorkingDir == "" {
-		copiedCtx := parentCtx.CopyWithNewOrigin(component.OriginGraphDiscovery)
-
-		// Clear the Ref and related args for graph-discovered dependencies.
-		// They shouldn't inherit the git ref from the parent, as this would
-		// cause them to match git filters and become targets themselves.
-		copiedCtx.Ref = ""
-		copiedCtx.Args = slices.DeleteFunc(copiedCtx.Args, func(arg string) bool {
-			return arg == "-destroy"
-		})
-
-		depComponent.SetDiscoveryContext(copiedCtx)
-
-		if isExternal(parentCtx.WorkingDir, depPath) {
-			if ext, ok := depComponent.(*component.Unit); ok {
-				ext.SetExternal()
-			}
-		}
-	}
+	assignGraphDiscoveryContext(depComponent, parentCtx, depPath)
 
 	addedComponent, _ := threadSafeComponents.EnsureComponent(depComponent)
 
 	parent.AddDependency(addedComponent)
 
 	return addedComponent, nil
+}
+
+// assignGraphDiscoveryContext gives a graph-discovered dependency its discovery
+// context, derived from the parent that reached it, before it is published to the
+// shared component set. Assigning the context first is what keeps discovery
+// correct under concurrency: the graph phase fans out one goroutine per
+// dependency and a dependency shared by several parents is reached along many
+// paths at once, so a component must never become visible to another goroutine
+// before its working directory is set.
+//
+// It is a no-op once the component already has a working directory, which keeps
+// the assignment to the first goroutine to reach the component along any path.
+func assignGraphDiscoveryContext(
+	dep component.Component,
+	parentCtx *component.DiscoveryContext,
+	depPath string,
+) {
+	if dctx := dep.DiscoveryContext(); dctx != nil && dctx.WorkingDir != "" {
+		return
+	}
+
+	copiedCtx := parentCtx.CopyWithNewOrigin(component.OriginGraphDiscovery)
+
+	copiedCtx.Ref = ""
+	copiedCtx.Args = slices.DeleteFunc(copiedCtx.Args, func(arg string) bool {
+		return arg == "-destroy"
+	})
+
+	dep.SetDiscoveryContext(copiedCtx)
+
+	if isExternal(parentCtx.WorkingDir, depPath) {
+		if ext, ok := dep.(*component.Unit); ok {
+			ext.SetExternal()
+		}
+	}
 }

--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -723,25 +723,20 @@ func (p *GraphPhase) processUpstreamCandidate(
 		return nil
 	}
 
-	canonicalCandidate, created := state.graphTraversalState.threadSafeComponents.EnsureComponent(
+	if dCtx := state.target.DiscoveryContext(); dCtx != nil {
+		copiedCtx := dCtx.CopyWithNewOrigin(component.OriginGraphDiscovery)
+
+		copiedCtx.Ref = ""
+		copiedCtx.Args = slices.DeleteFunc(copiedCtx.Args, func(arg string) bool {
+			return arg == "-destroy"
+		})
+
+		candidate.SetDiscoveryContext(copiedCtx)
+	}
+
+	canonicalCandidate, _ := state.graphTraversalState.threadSafeComponents.EnsureComponent(
 		candidate,
 	)
-	if created {
-		dCtx := state.target.DiscoveryContext()
-		if dCtx != nil {
-			copiedCtx := dCtx.CopyWithNewOrigin(component.OriginGraphDiscovery)
-
-			// Clear the Ref and related args for graph-discovered components.
-			// They shouldn't inherit the git ref from the target, as this would
-			// cause them to match git filters and become targets themselves.
-			copiedCtx.Ref = ""
-			copiedCtx.Args = slices.DeleteFunc(copiedCtx.Args, func(arg string) bool {
-				return arg == "-destroy"
-			})
-
-			canonicalCandidate.SetDiscoveryContext(copiedCtx)
-		}
-	}
 
 	dependsOnTarget := false
 

--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -762,8 +762,7 @@ func (p *GraphPhase) resolveDependency(
 
 	depComponent := componentFromDependencyPath(depPath, threadSafeComponents)
 
-	addedComponent, created := threadSafeComponents.EnsureComponent(depComponent)
-	if created {
+	if dctx := depComponent.DiscoveryContext(); dctx == nil || dctx.WorkingDir == "" {
 		copiedCtx := parentCtx.CopyWithNewOrigin(component.OriginGraphDiscovery)
 
 		// Clear the Ref and related args for graph-discovered dependencies.
@@ -775,13 +774,15 @@ func (p *GraphPhase) resolveDependency(
 		})
 
 		depComponent.SetDiscoveryContext(copiedCtx)
-	}
 
-	if isExternal(parentCtx.WorkingDir, depPath) {
-		if ext, ok := addedComponent.(*component.Unit); ok {
-			ext.SetExternal()
+		if isExternal(parentCtx.WorkingDir, depPath) {
+			if ext, ok := depComponent.(*component.Unit); ok {
+				ext.SetExternal()
+			}
 		}
 	}
+
+	addedComponent, _ := threadSafeComponents.EnsureComponent(depComponent)
 
 	parent.AddDependency(addedComponent)
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6472.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when running `run --all` with graph filters that expand Git ranges through the dependency graph.
  * Improved dependency discovery correctness so upstream/downstream candidates get their working directory set before they become visible, preventing inconsistent behavior across graph sizes.

* **Tests**
  * Added race-focused coverage for concurrent dependency discovery scenarios, including shared/external dependencies reached from multiple traversal directions.
  * Added assertions that every discovered component ends up with a non-empty discovery working directory, even under racing traversal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->