### PR TITLE
feat: Add and validate the `version` attribute on the `terraform` block

### DIFF
--- a/internal/runner/runcfg/types.go
+++ b/internal/runner/runcfg/types.go
@@ -54,6 +54,10 @@ type TerraformConfig struct {
 	// Source is the terraform source URL
 	Source string
 
+	// Version is the version constraint used to resolve a tfr:// registry
+	// module (for example "~> 3.3"). Empty when unset.
+	Version string
+
 	// IncludeInCopy lists files to include when copying source
 	IncludeInCopy []string
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -868,6 +868,7 @@ func (conf *ErrorHook) String() string {
 // well.
 type TerraformConfig struct {
 	Source              *string `hcl:"source,attr"`
+	Version             *string `hcl:"version,attr"`
 	UpdateSourceWithCAS *bool   `hcl:"update_source_with_cas,attr"`
 	Mutable             *bool   `hcl:"mutable,attr"`
 
@@ -924,6 +925,32 @@ func (cfg *TerraformConfig) ValidateHooks() error {
 		if len(curHook.Execute) < 1 || curHook.Execute[0] == "" {
 			return InvalidArgError(fmt.Sprintf("Error with hook %s. Need at least one non-empty argument in 'execute'.", curHook.Name))
 		}
+	}
+
+	return nil
+}
+
+// ValidateVersion checks the optional version attribute against the terraform
+// source. A version constraint only has meaning for a tfr:// registry source,
+// and it must not duplicate a constraint already pinned inline via ?version= on
+// that source.
+func (cfg *TerraformConfig) ValidateVersion() error {
+	if cfg == nil || cfg.Version == nil {
+		return nil
+	}
+
+	var source string
+	if cfg.Source != nil {
+		source = *cfg.Source
+	}
+
+	sourceURL, err := url.Parse(source)
+	if err != nil || sourceURL.Scheme != "tfr" {
+		return VersionAttributeNonRegistrySourceError{Source: source}
+	}
+
+	if sourceURL.Query().Has("version") {
+		return VersionAttributeSourceConstraintConflictError{Source: source}
 	}
 
 	return nil
@@ -1720,6 +1747,10 @@ func convertToTerragruntConfig(ctx context.Context, pctx *ParsingContext, config
 	}
 
 	if err := terragruntConfigFromFile.Terraform.ValidateHooks(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := terragruntConfigFromFile.Terraform.ValidateVersion(); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -930,13 +930,17 @@ func (cfg *TerraformConfig) ValidateHooks() error {
 	return nil
 }
 
-// ValidateVersion checks the optional version attribute against the terraform
-// source. A version constraint only has meaning for a tfr:// registry source,
-// and it must not duplicate a constraint already pinned inline via ?version= on
-// that source.
-func (cfg *TerraformConfig) ValidateVersion() error {
+// ValidateVersion checks the optional version attribute. The attribute is
+// gated behind the version-attribute experiment, and once enabled a version
+// constraint only has meaning for a tfr:// registry source and must not
+// duplicate a constraint already pinned inline via ?version= on that source.
+func (cfg *TerraformConfig) ValidateVersion(experiments experiment.Experiments, configPath string) error {
 	if cfg == nil || cfg.Version == nil {
 		return nil
+	}
+
+	if !experiments.Evaluate(experiment.VersionAttribute) {
+		return VersionAttributeRequiresExperimentError{ConfigPath: configPath}
 	}
 
 	var source string
@@ -1750,7 +1754,7 @@ func convertToTerragruntConfig(ctx context.Context, pctx *ParsingContext, config
 		errs = append(errs, err)
 	}
 
-	if err := terragruntConfigFromFile.Terraform.ValidateVersion(); err != nil {
+	if err := terragruntConfigFromFile.Terraform.ValidateVersion(pctx.Experiments, pctx.TerragruntConfigPath); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -930,10 +930,12 @@ func (cfg *TerraformConfig) ValidateHooks() error {
 	return nil
 }
 
-// ValidateVersion checks the optional version attribute. The attribute is
-// gated behind the version-attribute experiment, and once enabled a version
-// constraint only has meaning for a tfr:// registry source and must not
-// duplicate a constraint already pinned inline via ?version= on that source.
+// ValidateVersion checks the optional version attribute. The attribute is gated behind
+// the version-attribute experiment, and once enabled a version constraint only has
+// meaning for a tfr:// registry source and must not duplicate a constraint already
+// pinned inline via ?version= on that source. version and the source it constrains can
+// come from different files via include, so this must run on the merged config rather
+// than per file.
 func (cfg *TerraformConfig) ValidateVersion(experiments experiment.Experiments, configPath string) error {
 	if cfg == nil || cfg.Version == nil {
 		return nil
@@ -950,11 +952,11 @@ func (cfg *TerraformConfig) ValidateVersion(experiments experiment.Experiments, 
 
 	sourceURL, err := url.Parse(source)
 	if err != nil || sourceURL.Scheme != "tfr" {
-		return VersionAttributeNonRegistrySourceError{Source: source}
+		return VersionAttributeNonRegistrySourceError{Source: source, ConfigPath: configPath}
 	}
 
 	if sourceURL.Query().Has("version") {
-		return VersionAttributeSourceConstraintConflictError{Source: source}
+		return VersionAttributeSourceConstraintConflictError{Source: source, ConfigPath: configPath}
 	}
 
 	return nil
@@ -1479,7 +1481,15 @@ func ParseConfig(
 			mergedConfig.Exclude = config.Exclude
 		}
 
-		return mergedConfig, errors.Join(errs...)
+		config = mergedConfig
+	}
+
+	// A non-nil includeFromChild means this parse is itself an included parent, not a
+	// final config; the including child validates the merged result.
+	if includeFromChild == nil && config != nil {
+		if err := config.Terraform.ValidateVersion(pctx.Experiments, file.ConfigPath); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	return config, errors.Join(errs...)
@@ -1751,10 +1761,6 @@ func convertToTerragruntConfig(ctx context.Context, pctx *ParsingContext, config
 	}
 
 	if err := terragruntConfigFromFile.Terraform.ValidateHooks(); err != nil {
-		errs = append(errs, err)
-	}
-
-	if err := terragruntConfigFromFile.Terraform.ValidateVersion(pctx.Experiments, pctx.TerragruntConfigPath); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/pkg/config/config_as_cty.go
+++ b/pkg/config/config_as_cty.go
@@ -574,6 +574,10 @@ func terraformConfigAsCty(config *TerraformConfig) (cty.Value, error) {
 		val = ctyObjectAddField(val, "mutable", goboolToCty(*config.Mutable))
 	}
 
+	if config.Version != nil {
+		val = ctyObjectAddField(val, "version", gostringToCty(*config.Version))
+	}
+
 	return val, nil
 }
 

--- a/pkg/config/config_as_cty_test.go
+++ b/pkg/config/config_as_cty_test.go
@@ -269,6 +269,7 @@ func TestTerraformConfigAsCtyDrift(t *testing.T) {
 	omitWhenNilFields := map[string]bool{
 		"UpdateSourceWithCAS": true,
 		"Mutable":             true,
+		"Version":             true,
 	}
 
 	var terraformConfigFields []string

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -367,12 +367,14 @@ func (err VersionAttributeRequiresExperimentError) Error() string {
 // version attribute but its source is not a tfr:// registry URL, where a version
 // constraint has no meaning.
 type VersionAttributeNonRegistrySourceError struct {
-	Source string
+	Source     string
+	ConfigPath string
 }
 
 func (err VersionAttributeNonRegistrySourceError) Error() string {
 	return fmt.Sprintf(
-		"the terraform block sets version but its source %q is not a tfr:// registry URL; the version attribute only applies to registry (tfr://) sources",
+		"the terraform block in %s sets version but its source %q is not a tfr:// registry URL; the version attribute only applies to registry (tfr://) sources",
+		err.ConfigPath,
 		err.Source,
 	)
 }
@@ -380,12 +382,14 @@ func (err VersionAttributeNonRegistrySourceError) Error() string {
 // VersionAttributeSourceConstraintConflictError is returned when the terraform block sets
 // both the version attribute and an inline ?version= constraint on its tfr:// source.
 type VersionAttributeSourceConstraintConflictError struct {
-	Source string
+	Source     string
+	ConfigPath string
 }
 
 func (err VersionAttributeSourceConstraintConflictError) Error() string {
 	return fmt.Sprintf(
-		"the terraform block sets both the version attribute and an inline ?version= on its source %q; specify the version in only one place",
+		"the terraform block in %s sets both the version attribute and an inline ?version= on its source %q; specify the version in only one place",
+		err.ConfigPath,
 		err.Source,
 	)
 }

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -350,6 +350,19 @@ func (err DeepMergeRequiresExperimentError) Error() string {
 	return fmt.Sprintf("deep_merge in %s requires the 'deep-merge' experiment to be enabled", err.ConfigPath)
 }
 
+// VersionAttributeRequiresExperimentError is returned when the terraform block sets the
+// version attribute without the version-attribute experiment enabled.
+type VersionAttributeRequiresExperimentError struct {
+	ConfigPath string
+}
+
+func (err VersionAttributeRequiresExperimentError) Error() string {
+	return fmt.Sprintf(
+		"the terraform block in %s sets the version attribute, which requires the 'version-attribute' experiment; enable it with --experiment version-attribute",
+		err.ConfigPath,
+	)
+}
+
 // VersionAttributeNonRegistrySourceError is returned when the terraform block sets the
 // version attribute but its source is not a tfr:// registry URL, where a version
 // constraint has no meaning.

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -349,3 +349,30 @@ type DeepMergeRequiresExperimentError struct {
 func (err DeepMergeRequiresExperimentError) Error() string {
 	return fmt.Sprintf("deep_merge in %s requires the 'deep-merge' experiment to be enabled", err.ConfigPath)
 }
+
+// VersionAttributeNonRegistrySourceError is returned when the terraform block sets the
+// version attribute but its source is not a tfr:// registry URL, where a version
+// constraint has no meaning.
+type VersionAttributeNonRegistrySourceError struct {
+	Source string
+}
+
+func (err VersionAttributeNonRegistrySourceError) Error() string {
+	return fmt.Sprintf(
+		"the terraform block sets version but its source %q is not a tfr:// registry URL; the version attribute only applies to registry (tfr://) sources",
+		err.Source,
+	)
+}
+
+// VersionAttributeSourceConstraintConflictError is returned when the terraform block sets
+// both the version attribute and an inline ?version= constraint on its tfr:// source.
+type VersionAttributeSourceConstraintConflictError struct {
+	Source string
+}
+
+func (err VersionAttributeSourceConstraintConflictError) Error() string {
+	return fmt.Sprintf(
+		"the terraform block sets both the version attribute and an inline ?version= on its source %q; specify the version in only one place",
+		err.Source,
+	)
+}

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -331,6 +331,10 @@ func (cfg *TerragruntConfig) Merge(l log.Logger, sourceConfig *TerragruntConfig)
 				cfg.Terraform.Source = sourceConfig.Terraform.Source
 			}
 
+			if sourceConfig.Terraform.Version != nil {
+				cfg.Terraform.Version = sourceConfig.Terraform.Version
+			}
+
 			if sourceConfig.Terraform.CopyTerraformLockFile != nil {
 				cfg.Terraform.CopyTerraformLockFile = sourceConfig.Terraform.CopyTerraformLockFile
 			}
@@ -513,6 +517,10 @@ func (cfg *TerragruntConfig) DeepMerge(l log.Logger, sourceConfig *TerragruntCon
 		} else {
 			if sourceConfig.Terraform.Source != nil {
 				cfg.Terraform.Source = sourceConfig.Terraform.Source
+			}
+
+			if sourceConfig.Terraform.Version != nil {
+				cfg.Terraform.Version = sourceConfig.Terraform.Version
 			}
 
 			if sourceConfig.Terraform.CopyTerraformLockFile != nil {

--- a/pkg/config/include_test.go
+++ b/pkg/config/include_test.go
@@ -150,6 +150,16 @@ func TestMergeConfigIntoIncludedConfig(t *testing.T) {
 			&config.TerragruntConfig{Terraform: &config.TerraformConfig{ExcludeFromCopy: &[]string{"abc"}}},
 			&config.TerragruntConfig{Terraform: &config.TerraformConfig{CopyTerraformLockFile: &[]bool{false}[0], ExcludeFromCopy: &[]string{"abc"}}},
 		},
+		{
+			config:         &config.TerragruntConfig{Terraform: &config.TerraformConfig{Version: new("~> 4.0")}},
+			includedConfig: &config.TerragruntConfig{Terraform: &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"), Version: new("~> 3.3")}},
+			expected:       &config.TerragruntConfig{Terraform: &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"), Version: new("~> 4.0")}},
+		},
+		{
+			config:         &config.TerragruntConfig{Terraform: &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws")}},
+			includedConfig: &config.TerragruntConfig{Terraform: &config.TerraformConfig{Version: new("~> 3.3")}},
+			expected:       &config.TerragruntConfig{Terraform: &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"), Version: new("~> 3.3")}},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -300,6 +310,18 @@ func TestDeepMergeConfigIntoIncludedConfig(t *testing.T) {
 			source:   &config.TerragruntConfig{Terraform: &config.TerraformConfig{CopyTerraformLockFile: &[]bool{false}[0]}},
 			target:   &config.TerragruntConfig{Terraform: &config.TerraformConfig{ExcludeFromCopy: &[]string{"abc"}}},
 			expected: &config.TerragruntConfig{Terraform: &config.TerraformConfig{CopyTerraformLockFile: &[]bool{false}[0], ExcludeFromCopy: &[]string{"abc"}}},
+		},
+		{
+			name:     "terraform version overridden by source config",
+			source:   &config.TerragruntConfig{Terraform: &config.TerraformConfig{Version: new("~> 4.0")}},
+			target:   &config.TerragruntConfig{Terraform: &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"), Version: new("~> 3.3")}},
+			expected: &config.TerragruntConfig{Terraform: &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"), Version: new("~> 4.0")}},
+		},
+		{
+			name:     "terraform version kept from target config",
+			source:   &config.TerragruntConfig{Terraform: &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws")}},
+			target:   &config.TerragruntConfig{Terraform: &config.TerraformConfig{Version: new("~> 3.3")}},
+			expected: &config.TerragruntConfig{Terraform: &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"), Version: new("~> 3.3")}},
 		},
 	}
 

--- a/pkg/config/terraform_version_test.go
+++ b/pkg/config/terraform_version_test.go
@@ -1,6 +1,8 @@
 package config_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
@@ -36,6 +38,120 @@ terraform {
 	runConfig := terragruntConfig.ToRunConfig(l)
 	require.NotNil(t, runConfig)
 	assert.Equal(t, "~> 3.3", runConfig.Terraform.Version)
+}
+
+// TestParseTerraformVersionAttributeWithInclude pins how the version attribute behaves
+// across include merges: it follows the same child-overrides-parent rule as source, and
+// it is validated against the merged config, so version and source may come from
+// different files.
+func TestParseTerraformVersionAttributeWithInclude(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		expectedErr     any
+		name            string
+		rootCfg         string
+		childCfg        string
+		expectedVersion string
+	}{
+		{
+			name: "parent version survives child terraform block",
+			rootCfg: `
+terraform {
+	source  = "tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"
+	version = "~> 3.3"
+}
+`,
+			childCfg: `
+terraform {
+	copy_terraform_lock_file = false
+}
+`,
+			expectedVersion: "~> 3.3",
+		},
+		{
+			name: "child version overrides parent",
+			rootCfg: `
+terraform {
+	source  = "tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"
+	version = "~> 3.3"
+}
+`,
+			childCfg: `
+terraform {
+	version = "~> 4.0"
+}
+`,
+			expectedVersion: "~> 4.0",
+		},
+		{
+			name: "version and source split across parent and child",
+			rootCfg: `
+terraform {
+	version = "~> 3.3"
+}
+`,
+			childCfg: `
+terraform {
+	source = "tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"
+}
+`,
+			expectedVersion: "~> 3.3",
+		},
+		{
+			name: "child source override invalidates parent version",
+			rootCfg: `
+terraform {
+	source  = "tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"
+	version = "~> 3.3"
+}
+`,
+			childCfg: `
+terraform {
+	source = "github.com/terraform-aws-modules/terraform-aws-vpc"
+}
+`,
+			expectedErr: &config.VersionAttributeNonRegistrySourceError{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			rootPath := filepath.Join(tmpDir, "root.hcl")
+			childDir := filepath.Join(tmpDir, "child")
+			childPath := filepath.Join(childDir, config.DefaultTerragruntConfigPath)
+
+			include := `
+include "root" {
+	path = "` + filepath.ToSlash(rootPath) + `"
+}
+`
+
+			require.NoError(t, os.WriteFile(rootPath, []byte(tc.rootCfg), 0644))
+			require.NoError(t, os.MkdirAll(childDir, 0755))
+			require.NoError(t, os.WriteFile(childPath, []byte(include+tc.childCfg), 0644))
+
+			l := logger.CreateLogger()
+
+			ctx, pctx := newTestParsingContext(t, childPath)
+			require.NoError(t, pctx.Experiments.EnableExperiment(experiment.VersionAttribute))
+
+			terragruntConfig, err := config.ParseConfigFile(ctx, pctx, l, childPath, nil)
+
+			if tc.expectedErr != nil {
+				require.ErrorAs(t, err, tc.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, terragruntConfig.Terraform)
+			require.NotNil(t, terragruntConfig.Terraform.Version)
+			assert.Equal(t, tc.expectedVersion, *terragruntConfig.Terraform.Version)
+		})
+	}
 }
 
 // TestTerraformConfigValidateVersionRequiresExperiment pins that the version

--- a/pkg/config/terraform_version_test.go
+++ b/pkg/config/terraform_version_test.go
@@ -1,0 +1,104 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTerraformVersionAttribute(t *testing.T) {
+	t.Parallel()
+
+	cfg := `
+terraform {
+	source  = "tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"
+	version = "~> 3.3"
+}
+`
+
+	l := logger.CreateLogger()
+
+	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+
+	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, terragruntConfig.Terraform)
+	require.NotNil(t, terragruntConfig.Terraform.Version)
+	assert.Equal(t, "~> 3.3", *terragruntConfig.Terraform.Version)
+
+	runConfig := terragruntConfig.ToRunConfig(l)
+	require.NotNil(t, runConfig)
+	assert.Equal(t, "~> 3.3", runConfig.Terraform.Version)
+}
+
+func TestTerraformConfigValidateVersion(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		cfg       *config.TerraformConfig
+		assertErr func(t *testing.T, err error)
+		name      string
+	}{
+		{
+			name: "no version attribute",
+			cfg:  &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws")},
+			assertErr: func(t *testing.T, err error) {
+				t.Helper()
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "tfr source with version constraint",
+			cfg:  &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"), Version: new("~> 3.3")},
+			assertErr: func(t *testing.T, err error) {
+				t.Helper()
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "non-registry source with version",
+			cfg:  &config.TerraformConfig{Source: new("github.com/terraform-aws-modules/terraform-aws-vpc"), Version: new("~> 3.3")},
+			assertErr: func(t *testing.T, err error) {
+				t.Helper()
+
+				var typed config.VersionAttributeNonRegistrySourceError
+
+				require.ErrorAs(t, err, &typed)
+			},
+		},
+		{
+			name: "version without any source",
+			cfg:  &config.TerraformConfig{Version: new("~> 3.3")},
+			assertErr: func(t *testing.T, err error) {
+				t.Helper()
+
+				var typed config.VersionAttributeNonRegistrySourceError
+
+				require.ErrorAs(t, err, &typed)
+			},
+		},
+		{
+			name: "version attribute conflicts with inline version query",
+			cfg:  &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws?version=3.3.0"), Version: new("~> 3.3")},
+			assertErr: func(t *testing.T, err error) {
+				t.Helper()
+
+				var typed config.VersionAttributeSourceConstraintConflictError
+
+				require.ErrorAs(t, err, &typed)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tc.assertErr(t, tc.cfg.ValidateVersion())
+		})
+	}
+}

--- a/pkg/config/terraform_version_test.go
+++ b/pkg/config/terraform_version_test.go
@@ -3,7 +3,9 @@ package config_test
 import (
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,6 +24,7 @@ terraform {
 	l := logger.CreateLogger()
 
 	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.VersionAttribute))
 
 	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.NoError(t, err)
@@ -35,62 +38,59 @@ terraform {
 	assert.Equal(t, "~> 3.3", runConfig.Terraform.Version)
 }
 
+// TestTerraformConfigValidateVersionRequiresExperiment pins that the version
+// attribute is rejected unless the version-attribute experiment is enabled.
+// TG_EXPERIMENT_MODE forces every experiment on, which defeats the
+// disabled-state assertion, so skip it there.
+func TestTerraformConfigValidateVersionRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsExperimentMode(t) {
+		t.Skip("Skipping: TG_EXPERIMENT_MODE forces the version-attribute experiment on, so its disabled-state error can't be verified")
+	}
+
+	cfg := &config.TerraformConfig{
+		Source:  new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"),
+		Version: new("~> 3.3"),
+	}
+
+	err := cfg.ValidateVersion(experiment.NewExperiments(), "terragrunt.hcl")
+
+	var typed config.VersionAttributeRequiresExperimentError
+
+	require.ErrorAs(t, err, &typed)
+}
+
 func TestTerraformConfigValidateVersion(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		cfg       *config.TerraformConfig
-		assertErr func(t *testing.T, err error)
-		name      string
+		cfg         *config.TerraformConfig
+		expectedErr any
+		name        string
 	}{
 		{
 			name: "no version attribute",
 			cfg:  &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws")},
-			assertErr: func(t *testing.T, err error) {
-				t.Helper()
-				require.NoError(t, err)
-			},
 		},
 		{
 			name: "tfr source with version constraint",
 			cfg:  &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws"), Version: new("~> 3.3")},
-			assertErr: func(t *testing.T, err error) {
-				t.Helper()
-				require.NoError(t, err)
-			},
 		},
 		{
-			name: "non-registry source with version",
-			cfg:  &config.TerraformConfig{Source: new("github.com/terraform-aws-modules/terraform-aws-vpc"), Version: new("~> 3.3")},
-			assertErr: func(t *testing.T, err error) {
-				t.Helper()
-
-				var typed config.VersionAttributeNonRegistrySourceError
-
-				require.ErrorAs(t, err, &typed)
-			},
+			name:        "non-registry source with version",
+			cfg:         &config.TerraformConfig{Source: new("github.com/terraform-aws-modules/terraform-aws-vpc"), Version: new("~> 3.3")},
+			expectedErr: &config.VersionAttributeNonRegistrySourceError{},
 		},
 		{
-			name: "version without any source",
-			cfg:  &config.TerraformConfig{Version: new("~> 3.3")},
-			assertErr: func(t *testing.T, err error) {
-				t.Helper()
-
-				var typed config.VersionAttributeNonRegistrySourceError
-
-				require.ErrorAs(t, err, &typed)
-			},
+			name:        "version without any source",
+			cfg:         &config.TerraformConfig{Version: new("~> 3.3")},
+			expectedErr: &config.VersionAttributeNonRegistrySourceError{},
 		},
 		{
-			name: "version attribute conflicts with inline version query",
-			cfg:  &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws?version=3.3.0"), Version: new("~> 3.3")},
-			assertErr: func(t *testing.T, err error) {
-				t.Helper()
-
-				var typed config.VersionAttributeSourceConstraintConflictError
-
-				require.ErrorAs(t, err, &typed)
-			},
+			name:        "version attribute conflicts with inline version query",
+			cfg:         &config.TerraformConfig{Source: new("tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws?version=3.3.0"), Version: new("~> 3.3")},
+			expectedErr: &config.VersionAttributeSourceConstraintConflictError{},
 		},
 	}
 
@@ -98,7 +98,17 @@ func TestTerraformConfigValidateVersion(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			tc.assertErr(t, tc.cfg.ValidateVersion())
+			experiments := experiment.NewExperiments()
+			require.NoError(t, experiments.EnableExperiment(experiment.VersionAttribute))
+
+			err := tc.cfg.ValidateVersion(experiments, "terragrunt.hcl")
+
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorAs(t, err, tc.expectedErr)
 		})
 	}
 }

--- a/pkg/config/translate.go
+++ b/pkg/config/translate.go
@@ -47,6 +47,11 @@ func translateTerraformConfig(tf *TerraformConfig, l log.Logger) runcfg.Terrafor
 		source = *tf.Source
 	}
 
+	var version string
+	if tf.Version != nil {
+		version = *tf.Version
+	}
+
 	var includeInCopy []string
 	if tf.IncludeInCopy != nil {
 		includeInCopy = *tf.IncludeInCopy
@@ -74,6 +79,7 @@ func translateTerraformConfig(tf *TerraformConfig, l log.Logger) runcfg.Terrafor
 
 	return runcfg.TerraformConfig{
 		Source:                  source,
+		Version:                 version,
 		IncludeInCopy:           includeInCopy,
 		ExcludeFromCopy:         excludeFromCopy,
 		NoCopyTerraformLockFile: noCopyTerraformLockFile,


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds support for parsing and validating the `version` attribute on the `terraform` block.

Part of addressing #1930.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an optional Terraform `version` attribute for registry (`tfr://`) modules.
  * Propagates the `version` value through config parsing, runtime translation, and included/merged configurations.

* **Bug Fixes**
  * Added validation for `version` constraints, including experiment gating, rejecting non-registry sources, and detecting conflicts with inline `?version=` constraints.

* **Tests**
  * Expanded unit test coverage for parsing, include behavior, validation rules, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->