### PR TITLE
feat: Gate and resolve the version constraint at download time

### DIFF
--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -484,6 +484,7 @@ func (p *GraphPhase) discoverDependentsUpstream(
 			currentDir,
 			boundaryRoot,
 		)
+
 		return nil
 	}
 

--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
+	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/go-cleanhttp"
 	goversion "github.com/hashicorp/go-version"
@@ -306,6 +307,73 @@ func GetMatchingModuleVersion(
 	match := slices.MaxFunc(matching, func(a, b *goversion.Version) int { return a.Compare(b) })
 
 	return match.Original(), nil
+}
+
+// PinModuleVersion resolves constraint against the OpenTofu or Terraform module
+// registry addressed by the tfr:// source and returns the source URL rewritten
+// to pin the exact version that satisfies the constraint. tofuImpl selects the
+// default registry host when the source omits it; a nil httpClient uses a
+// default client.
+func PinModuleVersion(
+	ctx context.Context,
+	l log.Logger,
+	httpClient *http.Client,
+	tofuImpl tfimpl.Type,
+	source, constraint string,
+) (string, error) {
+	sourceURL, err := url.Parse(source)
+	if err != nil {
+		return "", err
+	}
+
+	registryDomain := sourceURL.Host
+	if registryDomain == "" {
+		registryDomain = tfimpl.DefaultRegistryDomain(tofuImpl)
+	}
+
+	moduleRegistryBasePath, err := GetModuleRegistryURLBasePath(ctx, l, httpClient, registryDomain)
+	if err != nil {
+		return "", err
+	}
+
+	modulePath, _ := SourceDirSubdir(sourceURL.Path)
+
+	version, err := GetMatchingModuleVersion(
+		ctx,
+		l,
+		httpClient,
+		registryDomain,
+		moduleRegistryBasePath,
+		modulePath,
+		constraint,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	query := sourceURL.Query()
+	query.Set("version", version)
+	sourceURL.RawQuery = query.Encode()
+
+	return sourceURL.String(), nil
+}
+
+// SourceHasVersionConstraint reports whether source is a tfr:// URL whose
+// ?version= query holds a version constraint rather than an exact version.
+func SourceHasVersionConstraint(source string) bool {
+	sourceURL, err := url.Parse(source)
+	if err != nil || sourceURL.Scheme != SchemeTFR {
+		return false
+	}
+
+	version := sourceURL.Query().Get("version")
+	if version == "" {
+		return false
+	}
+
+	_, err = goversion.NewVersion(version)
+
+	return err != nil
 }
 
 // listModuleVersions queries the registry's list-versions endpoint for the

--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 
 	"errors"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 	goversion "github.com/hashicorp/go-version"
 	svchost "github.com/hashicorp/terraform-svchost"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -374,6 +376,75 @@ func SourceHasVersionConstraint(source string) bool {
 	_, err = goversion.NewVersion(version)
 
 	return err != nil
+}
+
+// VersionResolver memoizes constraint resolution so that repeated or concurrent
+// requests for the same module and constraint query the registry once instead
+// of once each. It is safe for concurrent use; construct one with
+// NewVersionResolver and share it for the lifetime of a run.
+type VersionResolver struct {
+	cache  map[string]string
+	flight singleflight.Group
+	mu     sync.Mutex
+}
+
+// NewVersionResolver returns a VersionResolver with an empty cache.
+func NewVersionResolver() *VersionResolver {
+	return &VersionResolver{cache: make(map[string]string)}
+}
+
+// Pin resolves constraint for the tfr:// source and returns the source URL
+// rewritten with an exact ?version= pin, memoizing the result. Concurrent calls
+// for the same source, constraint, and tofuImpl share a single registry query;
+// later calls are served from the cache. See [PinModuleVersion].
+func (r *VersionResolver) Pin(
+	ctx context.Context,
+	l log.Logger,
+	httpClient *http.Client,
+	tofuImpl tfimpl.Type,
+	source, constraint string,
+) (string, error) {
+	key := source + "\x00" + constraint + "\x00" + string(tofuImpl)
+
+	if pinned, ok := r.load(key); ok {
+		return pinned, nil
+	}
+
+	pinned, err, _ := r.flight.Do(key, func() (any, error) {
+		if pinned, ok := r.load(key); ok {
+			return pinned, nil
+		}
+
+		pinned, err := PinModuleVersion(ctx, l, httpClient, tofuImpl, source, constraint)
+		if err != nil {
+			return nil, err
+		}
+
+		r.store(key, pinned)
+
+		return pinned, nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return pinned.(string), nil
+}
+
+func (r *VersionResolver) load(key string) (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	pinned, ok := r.cache[key]
+
+	return pinned, ok
+}
+
+func (r *VersionResolver) store(key, pinned string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.cache[key] = pinned
 }
 
 // listModuleVersions queries the registry's list-versions endpoint for the

--- a/internal/getter/tfrhelpers_test.go
+++ b/internal/getter/tfrhelpers_test.go
@@ -7,10 +7,63 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPinModuleVersion(t *testing.T) {
+	t.Parallel()
+
+	server := newRegistryTestServer(t)
+	source := "tfr://" + server.Listener.Addr().String() + "/terraform-aws-modules/vpc/aws"
+
+	pinned, err := getter.PinModuleVersion(
+		t.Context(), logger.CreateLogger(), server.Client(), tfimpl.OpenTofu, source, "~> 3.0",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, source+"?version=3.3.0", pinned)
+}
+
+func TestSourceHasVersionConstraint(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		source string
+		want   bool
+	}{
+		{
+			name:   "exact pin",
+			source: "tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws?version=3.3.0",
+			want:   false,
+		},
+		{
+			name:   "constraint",
+			source: "tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws?version=~> 3.3",
+			want:   true,
+		},
+		{
+			name:   "no version query",
+			source: "tfr://registry.opentofu.org/terraform-aws-modules/vpc/aws",
+			want:   false,
+		},
+		{
+			name:   "non-tfr source",
+			source: "git::https://github.com/foo/bar.git?ref=v1.0.0",
+			want:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, getter.SourceHasVersionConstraint(tc.source))
+		})
+	}
+}
 
 func TestGetModuleRegistryURLBasePath(t *testing.T) {
 	t.Parallel()

--- a/internal/getter/tfrhelpers_test.go
+++ b/internal/getter/tfrhelpers_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/getter"
@@ -12,6 +14,53 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestVersionResolverMemoizesWithRacing pins that concurrent and repeated
+// resolutions for the same module and constraint query the registry's
+// list-versions endpoint exactly once.
+func TestVersionResolverMemoizesWithRacing(t *testing.T) {
+	t.Parallel()
+
+	var versionsHits atomic.Int64
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/terraform.json", func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`{"modules.v1":"/v1/modules/"}`))
+		assert.NoError(t, err)
+	})
+	mux.HandleFunc("/v1/modules/foo/bar/baz/versions", func(w http.ResponseWriter, _ *http.Request) {
+		versionsHits.Add(1)
+
+		_, err := w.Write([]byte(`{"modules":[{"versions":[{"version":"3.3.0"},{"version":"2.0.0"}]}]}`))
+		assert.NoError(t, err)
+	})
+
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	resolver := getter.NewVersionResolver()
+	source := "tfr://" + server.Listener.Addr().String() + "/foo/bar/baz"
+
+	var wg sync.WaitGroup
+
+	for range 10 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			pinned, err := resolver.Pin(
+				t.Context(), logger.CreateLogger(), server.Client(), tfimpl.OpenTofu, source, "~> 3.0",
+			)
+			assert.NoError(t, err)
+			assert.Equal(t, source+"?version=3.3.0", pinned)
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, int64(1), versionsHits.Load())
+}
 
 func TestPinModuleVersion(t *testing.T) {
 	t.Parallel()

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -168,6 +168,17 @@ func DownloadTerraformSource(
 	return updatedOpts, nil
 }
 
+var (
+	// moduleVersionResolver memoizes tfr:// constraint resolution for the
+	// process so that units sharing a source and constraint query the registry
+	// once instead of once each.
+	moduleVersionResolver = getter.NewVersionResolver()
+
+	// moduleVersionClient is shared across resolutions so they reuse a single
+	// connection pool.
+	moduleVersionClient = cleanhttp.DefaultClient()
+)
+
 // resolveTerraformModuleVersion rewrites a config-provided tfr:// source to pin
 // the exact version that satisfies the terraform block's `version` constraint.
 // A --source / TG_SOURCE override is a bare URL that must carry an exact pin
@@ -207,10 +218,10 @@ func resolveTerraformModuleVersion(
 		return source, nil
 	}
 
-	pinned, err := getter.PinModuleVersion(
+	pinned, err := moduleVersionResolver.Pin(
 		ctx,
 		l,
-		cleanhttp.DefaultClient(),
+		moduleVersionClient,
 		opts.TofuImplementation,
 		source,
 		constraint,

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -22,6 +23,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/hashicorp/go-cleanhttp"
 )
 
 // ErrNonOSFilesystem is returned by DownloadTerraformSource when Options.FS
@@ -66,7 +68,18 @@ func DownloadTerraformSource(
 
 	source = tf.RewriteLegacyGCSPublicSource(ctx, l, source, opts.StrictControls)
 
-	terraformSource, err := tf.NewSource(l, source, opts.DownloadDir, opts.UnitDir, walkWithSymlinks)
+	source, err := resolveTerraformModuleVersion(ctx, l, source, opts, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	terraformSource, err := tf.NewSource(
+		l,
+		source,
+		opts.DownloadDir,
+		opts.UnitDir,
+		walkWithSymlinks,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +115,11 @@ func DownloadTerraformSource(
 		l.Debugf(
 			"Copying files from %s into %s",
 			util.RelPathForLog(opts.UnitDir, opts.UnitDir, opts.LogShowAbsPaths),
-			util.RelPathForLog(opts.RootWorkingDir, terraformSource.WorkingDir, opts.LogShowAbsPaths),
+			util.RelPathForLog(
+				opts.RootWorkingDir,
+				terraformSource.WorkingDir,
+				opts.LogShowAbsPaths,
+			),
 		)
 
 		// Always include the .tflint.hcl file, if it exists
@@ -116,12 +133,18 @@ func DownloadTerraformSource(
 			copyOpts = append(copyOpts, util.WithFastCopy())
 		}
 
-		err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "copy_folder_contents", map[string]any{
-			"src":  opts.UnitDir,
-			"dest": terraformSource.WorkingDir,
-		}, func(_ context.Context) error {
-			return util.CopyFolderContents(l, opts.UnitDir, terraformSource.WorkingDir, ModuleManifestName, copyOpts...)
-		})
+		err = telemetry.TelemeterFromContext(ctx).
+			Collect(ctx, "copy_folder_contents", map[string]any{
+				"src":  opts.UnitDir,
+				"dest": terraformSource.WorkingDir,
+			}, func(_ context.Context) error {
+				return util.CopyFolderContents(
+					l,
+					opts.UnitDir,
+					terraformSource.WorkingDir,
+					ModuleManifestName,
+					copyOpts...)
+			})
 		if err != nil {
 			return nil, err
 		}
@@ -145,6 +168,75 @@ func DownloadTerraformSource(
 	return updatedOpts, nil
 }
 
+// resolveTerraformModuleVersion rewrites a config-provided tfr:// source to pin
+// the exact version that satisfies the terraform block's `version` constraint.
+// A --source / TG_SOURCE override is a bare URL that must carry an exact pin
+// itself, so a constraint there is rejected rather than resolved.
+func resolveTerraformModuleVersion(
+	ctx context.Context,
+	l log.Logger,
+	source string,
+	opts *Options,
+	cfg *runcfg.RunConfig,
+) (string, error) {
+	if getter.SourceHasVersionConstraint(source) {
+		return "", SourceVersionConstraintErr{Source: source}
+	}
+
+	if opts.Source != "" {
+		return source, nil
+	}
+
+	constraint := cfg.Terraform.Version
+	if constraint == "" {
+		return source, nil
+	}
+
+	sourceURL, err := url.Parse(source)
+	if err != nil {
+		return "", err
+	}
+
+	if sourceURL.Scheme != getter.SchemeTFR {
+		l.Debugf(
+			"Ignoring version constraint %q: source %q is not a tfr:// registry URL",
+			constraint,
+			source,
+		)
+
+		return source, nil
+	}
+
+	pinned, err := getter.PinModuleVersion(
+		ctx,
+		l,
+		cleanhttp.DefaultClient(),
+		opts.TofuImplementation,
+		source,
+		constraint,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	l.Debugf("Resolved version constraint %q for source %s to %s", constraint, source, pinned)
+
+	return pinned, nil
+}
+
+// SourceVersionConstraintErr is returned when a tfr:// source pins its module
+// with a version constraint in the ?version= query instead of an exact version.
+type SourceVersionConstraintErr struct {
+	Source string
+}
+
+func (e SourceVersionConstraintErr) Error() string {
+	return fmt.Sprintf(
+		"the source %q sets a version constraint in its ?version= query, which accepts an exact version only; express a constraint with the terraform block's version attribute instead.",
+		e.Source,
+	)
+}
+
 // DownloadTerraformSourceIfNecessary downloads the specified TerraformSource if the latest code hasn't already been
 // downloaded. It returns true if a download was performed, or false if the existing cache was up to date.
 //
@@ -164,7 +256,10 @@ func DownloadTerraformSourceIfNecessary(
 	}
 
 	if opts.SourceUpdate {
-		l.Debugf("The --source-update flag is set, so deleting the temporary folder %s before downloading source.", terraformSource.DownloadDir)
+		l.Debugf(
+			"The --source-update flag is set, so deleting the temporary folder %s before downloading source.",
+			terraformSource.DownloadDir,
+		)
 
 		if err := opts.FS.RemoveAll(terraformSource.DownloadDir); err != nil {
 			return false, err
@@ -229,21 +324,34 @@ func DownloadTerraformSourceIfNecessary(
 		r,
 		func(childCtx context.Context) error {
 			if opts.Experiments.Evaluate(experiment.SlowTaskReporting) {
-				sourceURL := strings.TrimPrefix(terraformSource.CanonicalSourceURL.String(), fileURIScheme)
+				sourceURL := strings.TrimPrefix(
+					terraformSource.CanonicalSourceURL.String(),
+					fileURIScheme,
+				)
 
-				return util.NotifyIfSlow(childCtx, l, util.SpinnerWriter(), time.Second, util.SlowNotifyMsg{
-					Spinner: "Downloading source from " + sourceURL + "...",
-					Done:    "Downloaded source from " + sourceURL,
-				}, func() error {
-					return downloadSource(childCtx, l, v, terraformSource, opts, cfg, r)
-				})
+				return util.NotifyIfSlow(
+					childCtx,
+					l,
+					util.SpinnerWriter(),
+					time.Second,
+					util.SlowNotifyMsg{
+						Spinner: "Downloading source from " + sourceURL + "...",
+						Done:    "Downloaded source from " + sourceURL,
+					},
+					func() error {
+						return downloadSource(childCtx, l, v, terraformSource, opts, cfg, r)
+					},
+				)
 			}
 
 			return downloadSource(childCtx, l, v, terraformSource, opts, cfg, r)
 		},
 	)
 	if downloadErr != nil {
-		return false, DownloadingTerraformSourceErr{ErrMsg: downloadErr, URL: terraformSource.CanonicalSourceURL.String()}
+		return false, DownloadingTerraformSourceErr{
+			ErrMsg: downloadErr,
+			URL:    terraformSource.CanonicalSourceURL.String(),
+		}
 	}
 
 	if err := terraformSource.WriteVersionFile(l); err != nil {
@@ -258,7 +366,11 @@ func DownloadTerraformSourceIfNecessary(
 	// if source versions are different or calculating version failed, create file to run init
 	// https://github.com/gruntwork-io/terragrunt/issues/1921
 	if (previousVersion != "" && previousVersion != currentVersion) || err != nil {
-		l.Debugf("Requesting re-init, source version has changed from %s to %s recently.", previousVersion, currentVersion)
+		l.Debugf(
+			"Requesting re-init, source version has changed from %s to %s recently.",
+			previousVersion,
+			currentVersion,
+		)
 
 		initFile := filepath.Join(terraformSource.WorkingDir, ModuleInitRequiredFile)
 
@@ -296,7 +408,11 @@ func AlreadyHaveLatestCode(l log.Logger, terraformSource *tf.Source, opts *Optio
 	}
 
 	if !hasFiles {
-		l.Debugf("Working dir %s exists but contains no Terraform or OpenTofu files, so assuming code needs to be downloaded again.", terraformSource.WorkingDir)
+		l.Debugf(
+			"Working dir %s exists but contains no Terraform or OpenTofu files, so assuming code needs to be downloaded again.",
+			terraformSource.WorkingDir,
+		)
+
 		return false, nil
 	}
 
@@ -398,10 +514,19 @@ func downloadSource(
 // should fall through to the standard getter.
 // Returns (false, err) for fatal misconfiguration the user must fix
 // (e.g. an invalid CASCloneDepth). Caller must propagate the error.
-func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Options, mutable bool) (bool, error) {
+func tryCASDownload(
+	ctx context.Context,
+	l log.Logger,
+	src *tf.Source,
+	opts *Options,
+	mutable bool,
+) (bool, error) {
 	canonicalSourceURL := src.CanonicalSourceURL.String()
 
-	l.Debugf("CAS enabled: attempting to use Content Addressable Storage for source: %s", canonicalSourceURL)
+	l.Debugf(
+		"CAS enabled: attempting to use Content Addressable Storage for source: %s",
+		canonicalSourceURL,
+	)
 
 	if err := cas.ValidateCASCloneDepth(opts.CASCloneDepth); err != nil {
 		return false, err
@@ -410,7 +535,12 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 	c, err := cas.New(cas.WithCloneDepth(opts.CASCloneDepth))
 	if err != nil {
 		l.Warnf("Failed to initialize CAS: %v. Falling back to standard getter.", err)
-		cas.RecordFallback(ctx, l, cas.FallbackReasonInitError, map[string]any{"url": canonicalSourceURL})
+		cas.RecordFallback(
+			ctx,
+			l,
+			cas.FallbackReasonInitError,
+			map[string]any{"url": canonicalSourceURL},
+		)
 
 		return false, nil
 	}
@@ -418,7 +548,12 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 	venv, err := cas.OSVenv()
 	if err != nil {
 		l.Warnf("Failed to initialize CAS environment: %v. Falling back to standard getter.", err)
-		cas.RecordFallback(ctx, l, cas.FallbackReasonInitError, map[string]any{"url": canonicalSourceURL})
+		cas.RecordFallback(
+			ctx,
+			l,
+			cas.FallbackReasonInitError,
+			map[string]any{"url": canonicalSourceURL},
+		)
 
 		return false, nil
 	}
@@ -451,7 +586,12 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 		Pwd: opts.CacheDir,
 	}); err != nil {
 		l.Warnf("CAS download failed: %v. Falling back to standard getter.", err)
-		cas.RecordFallback(ctx, l, cas.FallbackReasonGetterError, map[string]any{"url": canonicalSourceURL})
+		cas.RecordFallback(
+			ctx,
+			l,
+			cas.FallbackReasonGetterError,
+			map[string]any{"url": canonicalSourceURL},
+		)
 
 		// Clear any partial CAS output before the fallback runs; mixing
 		// leftover CAS files with the standard getter's output leaves the
@@ -479,7 +619,12 @@ func tryCASDownload(ctx context.Context, l log.Logger, src *tf.Source, opts *Opt
 // abstraction. Returns [ErrNonOSFilesystem] otherwise.
 //
 // Exported so tests can assert the protocol set directly.
-func BuildDownloadClient(l log.Logger, v venv.Venv, opts *Options, cfg *runcfg.RunConfig) (*getter.Client, error) {
+func BuildDownloadClient(
+	l log.Logger,
+	v venv.Venv,
+	opts *Options,
+	cfg *runcfg.RunConfig,
+) (*getter.Client, error) {
 	if !vfs.IsOSFS(v.FS) {
 		return nil, ErrNonOSFilesystem
 	}
@@ -498,13 +643,23 @@ func BuildDownloadClient(l log.Logger, v venv.Venv, opts *Options, cfg *runcfg.R
 
 // ValidateWorkingDir checks if working terraformSource.WorkingDir exists and is a directory
 func ValidateWorkingDir(terraformSource *tf.Source) error {
-	workingLocalDir := strings.ReplaceAll(terraformSource.WorkingDir, terraformSource.DownloadDir+filepath.FromSlash("/"), "")
+	workingLocalDir := strings.ReplaceAll(
+		terraformSource.WorkingDir,
+		terraformSource.DownloadDir+filepath.FromSlash("/"),
+		"",
+	)
 	if util.IsFile(terraformSource.WorkingDir) {
-		return WorkingDirNotDir{Dir: workingLocalDir, Source: terraformSource.CanonicalSourceURL.String()}
+		return WorkingDirNotDir{
+			Dir:    workingLocalDir,
+			Source: terraformSource.CanonicalSourceURL.String(),
+		}
 	}
 
 	if !util.IsDir(terraformSource.WorkingDir) {
-		return WorkingDirNotFound{Dir: workingLocalDir, Source: terraformSource.CanonicalSourceURL.String()}
+		return WorkingDirNotFound{
+			Dir:    workingLocalDir,
+			Source: terraformSource.CanonicalSourceURL.String(),
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Uses the newly parsed `version` attribute during fetches.

Part of addressing #1930.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terraform registry module sources (`tfr://`) now pin `?version=` constraints to the highest matching published version before download.
  * Added a reusable, concurrency-safe resolver that memoizes resolved versions to avoid repeated registry lookups.
* **Bug Fixes**
  * Improved validation for unsupported or non-concrete version constraints in module sources.
  * Enhanced download error details, source-update logging, and debug output around initialization and working directories.
  * Added telemetry for file copying and clearer CAS fallback reason reporting.
* **Tests**
  * Added unit tests covering version pinning, constraint detection, and concurrent memoization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->