### PR TITLE
feat(getter): add OCIGetter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/hashicorp/go-getter/s3/v2 v2.2.3
 	github.com/invopop/jsonschema v0.14.0
 	github.com/mattn/go-shellwords v1.0.13
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/rogpeppe/go-internal v1.15.0
 	github.com/spf13/afero v1.15.0
 	github.com/testcontainers/testcontainers-go v0.43.0
@@ -249,7 +250,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/oklog/run v1.2.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/internal/getter/oci.go
+++ b/internal/getter/oci.go
@@ -1,0 +1,83 @@
+package getter
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/url"
+
+	getter "github.com/hashicorp/go-getter/v2"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ErrOCIGetFileUnsupported reports that oci sources always resolve to module
+// directories, so single-file downloads are not supported.
+var ErrOCIGetFileUnsupported = errors.New("GetFile is not supported for the OCI Getter")
+
+// ErrOCIGetNotImplemented reports that the oci download logic has not landed
+// yet; Get is stubbed until then.
+var ErrOCIGetNotImplemented = errors.New("Get is not implemented yet for the OCI Getter")
+
+// OCIRepositoryStore is the narrow seam between the OCI getter and the
+// registry client that serves it. Resolve turns a tag or digest reference
+// into a manifest descriptor; Fetch streams the blob a descriptor points at.
+// The method set intentionally matches oras-go's content.Fetcher signature so
+// manifest and blob helpers work through the seam without adapters, and unit
+// tests can drive the getter with a fake store and no network.
+type OCIRepositoryStore interface {
+	Resolve(ctx context.Context, ref string) (ociv1.Descriptor, error)
+	Fetch(ctx context.Context, desc ociv1.Descriptor) (io.ReadCloser, error)
+}
+
+// OCIGetter is the go-getter v2 implementation of the oci:// protocol.
+//
+// Source URLs take the form:
+//
+//	oci://REGISTRY_DOMAIN/REPOSITORY[//SUBDIR][?tag=TAG|?digest=DIGEST]
+//
+// where REGISTRY_DOMAIN is an OCI Distribution registry host (host:port
+// allowed) and REPOSITORY is the full, possibly multi-segment repository
+// name. The manifest contract the getter enforces is centralized in
+// [ArtifactTypeModulePkg] and [MediaTypeModuleZip].
+//
+// NewStore is the dependency-injection seam: credential resolution and
+// registry transport live entirely behind it, so credential tiers are
+// additive changes and tests inject a fake [OCIRepositoryStore]. The seam
+// rides as a struct field rather than a function parameter only because the
+// go-getter Getter interface fixes the method set, leaving no parameter to
+// thread it through.
+type OCIGetter struct {
+	NewStore func(ctx context.Context, registryDomain, repositoryName string) (OCIRepositoryStore, error)
+}
+
+var _ getter.Getter = (*OCIGetter)(nil)
+
+// Mode reports directory mode for all oci sources, since oci always
+// downloads a module directory.
+func (g *OCIGetter) Mode(_ context.Context, _ *url.URL) (getter.Mode, error) {
+	return getter.ModeDir, nil
+}
+
+// Detect recognizes oci:// sources and oci-forced sources.
+func (g *OCIGetter) Detect(req *getter.Request) (bool, error) {
+	if req.Forced == SchemeOCI {
+		return true, nil
+	}
+
+	u, err := url.Parse(req.Src)
+	if err == nil && u.Scheme == SchemeOCI {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// Get is stubbed until the module download logic lands.
+func (g *OCIGetter) Get(_ context.Context, _ *getter.Request) error {
+	return ErrOCIGetNotImplemented
+}
+
+// GetFile always fails, per [ErrOCIGetFileUnsupported].
+func (g *OCIGetter) GetFile(_ context.Context, _ *getter.Request) error {
+	return ErrOCIGetFileUnsupported
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* Add OCIGetter skeleton (internal/getter/oci.go) 
* Added explicit dependency for image-spec

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added initial support for recognizing OCI image references.
  * OCI resources are identified as directory-based content.

* **Known Limitations**
  * OCI content downloading is not yet available.
  * Individual file retrieval from OCI references is unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->