### PR TITLE
chore: Removing `source` from `version` attribute error

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -952,11 +952,11 @@ func (cfg *TerraformConfig) ValidateVersion(experiments experiment.Experiments, 
 
 	sourceURL, err := url.Parse(source)
 	if err != nil || sourceURL.Scheme != "tfr" {
-		return VersionAttributeNonRegistrySourceError{Source: source, ConfigPath: configPath}
+		return VersionAttributeNonRegistrySourceError{ConfigPath: configPath}
 	}
 
 	if sourceURL.Query().Has("version") {
-		return VersionAttributeSourceConstraintConflictError{Source: source, ConfigPath: configPath}
+		return VersionAttributeSourceConstraintConflictError{ConfigPath: configPath}
 	}
 
 	return nil

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -367,29 +367,25 @@ func (err VersionAttributeRequiresExperimentError) Error() string {
 // version attribute but its source is not a tfr:// registry URL, where a version
 // constraint has no meaning.
 type VersionAttributeNonRegistrySourceError struct {
-	Source     string
 	ConfigPath string
 }
 
 func (err VersionAttributeNonRegistrySourceError) Error() string {
 	return fmt.Sprintf(
-		"the terraform block in %s sets version but its source %q is not a tfr:// registry URL; the version attribute only applies to registry (tfr://) sources",
+		"the terraform block in %s sets version but its source is not a tfr:// registry URL; the version attribute only applies to registry (tfr://) sources",
 		err.ConfigPath,
-		err.Source,
 	)
 }
 
 // VersionAttributeSourceConstraintConflictError is returned when the terraform block sets
 // both the version attribute and an inline ?version= constraint on its tfr:// source.
 type VersionAttributeSourceConstraintConflictError struct {
-	Source     string
 	ConfigPath string
 }
 
 func (err VersionAttributeSourceConstraintConflictError) Error() string {
 	return fmt.Sprintf(
-		"the terraform block in %s sets both the version attribute and an inline ?version= on its source %q; specify the version in only one place",
+		"the terraform block in %s sets both the version attribute and an inline ?version= on its source; specify the version in only one place",
 		err.ConfigPath,
-		err.Source,
 	)
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Drops `source` attribute in version error.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation errors for module version configuration.
  - Error messages now provide clearer guidance when a module uses a non-registry source or when both version settings conflict.
  - Validation details are presented consistently with the relevant configuration path, making configuration issues easier to locate and resolve.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->