### PR TITLE
chore: Avoid package-level module resolution for `version` attribute

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -116,6 +116,7 @@ func (app *App) RunContext(ctx context.Context, args []string) error {
 	ctx = engine.WithEngineValues(ctx)
 
 	ctx = run.WithRunVersionCache(ctx)
+	ctx = run.WithModuleVersionResolver(ctx)
 
 	defer func(ctx context.Context) {
 		if err := engine.Shutdown(ctx, app.l, app.opts.Experiments, app.opts.EngineOptions.NoEngine); err != nil {

--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -380,17 +380,32 @@ func SourceHasVersionConstraint(source string) bool {
 
 // VersionResolver memoizes constraint resolution so that repeated or concurrent
 // requests for the same module and constraint query the registry once instead
-// of once each. It is safe for concurrent use; construct one with
-// NewVersionResolver and share it for the lifetime of a run.
+// of once each, over a single shared connection pool. It is safe for concurrent
+// use; construct one with NewVersionResolver and share it for the lifetime of
+// a run.
 type VersionResolver struct {
-	cache  map[string]string
-	flight singleflight.Group
-	mu     sync.Mutex
+	httpClient *http.Client
+	cache      map[string]string
+	flight     singleflight.Group
+	mu         sync.Mutex
 }
 
-// NewVersionResolver returns a VersionResolver with an empty cache.
+// NewVersionResolver returns a VersionResolver with an empty cache and a
+// [github.com/hashicorp/go-cleanhttp.DefaultClient] for registry-protocol
+// requests.
 func NewVersionResolver() *VersionResolver {
-	return &VersionResolver{cache: make(map[string]string)}
+	return &VersionResolver{
+		httpClient: cleanhttp.DefaultClient(),
+		cache:      make(map[string]string),
+	}
+}
+
+// WithHTTPClient overrides the HTTP client used for registry-protocol
+// requests. Intended for tests routing through a
+// [net/http/httptest.Server].
+func (r *VersionResolver) WithHTTPClient(c *http.Client) *VersionResolver {
+	r.httpClient = c
+	return r
 }
 
 // Pin resolves constraint for the tfr:// source and returns the source URL
@@ -400,7 +415,6 @@ func NewVersionResolver() *VersionResolver {
 func (r *VersionResolver) Pin(
 	ctx context.Context,
 	l log.Logger,
-	httpClient *http.Client,
 	tofuImpl tfimpl.Type,
 	source, constraint string,
 ) (string, error) {
@@ -415,7 +429,7 @@ func (r *VersionResolver) Pin(
 			return pinned, nil
 		}
 
-		pinned, err := PinModuleVersion(ctx, l, httpClient, tofuImpl, source, constraint)
+		pinned, err := PinModuleVersion(ctx, l, r.httpClient, tofuImpl, source, constraint)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/getter/tfrhelpers_test.go
+++ b/internal/getter/tfrhelpers_test.go
@@ -38,7 +38,7 @@ func TestVersionResolverMemoizesWithRacing(t *testing.T) {
 	server := httptest.NewTLSServer(mux)
 	t.Cleanup(server.Close)
 
-	resolver := getter.NewVersionResolver()
+	resolver := getter.NewVersionResolver().WithHTTPClient(server.Client())
 	source := "tfr://" + server.Listener.Addr().String() + "/foo/bar/baz"
 
 	var wg sync.WaitGroup
@@ -50,7 +50,7 @@ func TestVersionResolverMemoizesWithRacing(t *testing.T) {
 			defer wg.Done()
 
 			pinned, err := resolver.Pin(
-				t.Context(), logger.CreateLogger(), server.Client(), tfimpl.OpenTofu, source, "~> 3.0",
+				t.Context(), logger.CreateLogger(), tfimpl.OpenTofu, source, "~> 3.0",
 			)
 			assert.NoError(t, err)
 			assert.Equal(t, source+"?version=3.3.0", pinned)

--- a/internal/runner/run/context.go
+++ b/internal/runner/run/context.go
@@ -4,13 +4,15 @@ import (
 	"context"
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
+	"github.com/gruntwork-io/terragrunt/internal/getter"
 )
 
 type configKey byte
 
 const (
 	versionCacheContextKey configKey = iota
-	versionCacheName                 = "versionCache"
+	moduleVersionResolverContextKey
+	versionCacheName = "versionCache"
 )
 
 // WithRunVersionCache initializes the version cache in the context for the run package.
@@ -22,4 +24,22 @@ func WithRunVersionCache(ctx context.Context) context.Context {
 // GetRunVersionCache retrieves the version cache from the context for the run package.
 func GetRunVersionCache(ctx context.Context) *cache.Cache[string] {
 	return cache.ContextCache[string](ctx, versionCacheContextKey)
+}
+
+// WithModuleVersionResolver installs a shared tfr:// version-constraint
+// resolver so that units sharing a module source and constraint query the
+// registry once per run instead of once each.
+func WithModuleVersionResolver(ctx context.Context) context.Context {
+	return context.WithValue(ctx, moduleVersionResolverContextKey, getter.NewVersionResolver())
+}
+
+// ModuleVersionResolverFromContext returns the resolver installed by
+// [WithModuleVersionResolver]. If none was installed, it returns a fresh
+// resolver whose memoization is scoped to the caller alone.
+func ModuleVersionResolverFromContext(ctx context.Context) *getter.VersionResolver {
+	if resolver, ok := ctx.Value(moduleVersionResolverContextKey).(*getter.VersionResolver); ok {
+		return resolver
+	}
+
+	return getter.NewVersionResolver()
 }

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/hashicorp/go-cleanhttp"
 )
 
 // ErrNonOSFilesystem is returned by DownloadTerraformSource when Options.FS
@@ -168,17 +167,6 @@ func DownloadTerraformSource(
 	return updatedOpts, nil
 }
 
-var (
-	// moduleVersionResolver memoizes tfr:// constraint resolution for the
-	// process so that units sharing a source and constraint query the registry
-	// once instead of once each.
-	moduleVersionResolver = getter.NewVersionResolver()
-
-	// moduleVersionClient is shared across resolutions so they reuse a single
-	// connection pool.
-	moduleVersionClient = cleanhttp.DefaultClient()
-)
-
 // resolveTerraformModuleVersion rewrites a config-provided tfr:// source to pin
 // the exact version that satisfies the terraform block's `version` constraint.
 // A --source / TG_SOURCE override is a bare URL that must carry an exact pin
@@ -218,10 +206,9 @@ func resolveTerraformModuleVersion(
 		return source, nil
 	}
 
-	pinned, err := moduleVersionResolver.Pin(
+	pinned, err := ModuleVersionResolverFromContext(ctx).Pin(
 		ctx,
 		l,
-		moduleVersionClient,
 		opts.TofuImplementation,
 		source,
 		constraint,


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Avoids package-level state for resolution of the `version` attribute constraints. Uses a handle passed explicitly through parameters for synchronization and caching.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Terraform module version resolution during runs.
  * Ensured version lookups consistently use the configured network client.
  * Improved caching and reuse of resolved module versions across a run.

* **Tests**
  * Updated coverage for concurrent version resolution and cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->