### PR TITLE
chore: Adding some integration testing for the `version` attribute

### DIFF
--- a/internal/getter/tfr_test.go
+++ b/internal/getter/tfr_test.go
@@ -149,7 +149,8 @@ func TestRegistryGetterWithoutVersion(t *testing.T) {
 	moduleDestPath := filepath.Join(dstPath, "terraform-aws-vpc")
 	require.False(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
 
-	// No ?version= — getter resolves latest (3.3.0) via the versions endpoint.
+	// With no ?version= query, the getter resolves the latest version (4.0.0)
+	// via the versions endpoint.
 	src := "tfr://" + server.Listener.Addr().String() + "/terraform-aws-modules/vpc/aws"
 	client := newRegistryTestClient(t, server.Client(), tfimpl.Terraform)
 

--- a/internal/getter/tfrhelpers_test.go
+++ b/internal/getter/tfrhelpers_test.go
@@ -65,14 +65,34 @@ func TestVersionResolverMemoizesWithRacing(t *testing.T) {
 func TestPinModuleVersion(t *testing.T) {
 	t.Parallel()
 
-	server := newRegistryTestServer(t)
-	source := "tfr://" + server.Listener.Addr().String() + "/terraform-aws-modules/vpc/aws"
+	testCases := []struct {
+		name       string
+		constraint string
+		want       string
+	}{
+		{name: "pessimistic major", constraint: "~> 3.0", want: "3.4.0"},
+		{name: "pessimistic minor", constraint: "~> 3.3", want: "3.4.0"},
+		{name: "pessimistic patch", constraint: "~> 3.3.0", want: "3.3.1"},
+		{name: "range", constraint: ">= 3.2.0, < 3.4.0", want: "3.3.1"},
+		{name: "exact as constraint", constraint: "3.2.0", want: "3.2.0"},
+		{name: "prerelease excluded", constraint: ">= 4.0.0", want: "4.0.0"},
+		{name: "prerelease opt-in", constraint: ">= 4.1.0-rc1", want: "4.1.0-rc1"},
+	}
 
-	pinned, err := getter.PinModuleVersion(
-		t.Context(), logger.CreateLogger(), server.Client(), tfimpl.OpenTofu, source, "~> 3.0",
-	)
-	require.NoError(t, err)
-	assert.Equal(t, source+"?version=3.3.0", pinned)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newRegistryTestServer(t)
+			source := "tfr://" + server.Listener.Addr().String() + "/terraform-aws-modules/vpc/aws"
+
+			pinned, err := getter.PinModuleVersion(
+				t.Context(), logger.CreateLogger(), server.Client(), tfimpl.OpenTofu, source, tc.constraint,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, source+"?version="+tc.want, pinned)
+		})
+	}
 }
 
 func TestSourceHasVersionConstraint(t *testing.T) {
@@ -256,7 +276,7 @@ func TestGetLatestModuleVersion(t *testing.T) {
 		server.Listener.Addr().String(), "/v1/modules/", "terraform-aws-modules/vpc/aws",
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "3.3.0", latestVersion)
+	assert.Equal(t, "4.0.0", latestVersion)
 }
 
 // TestGetLatestModuleVersionSkipsPrereleases pins the behavior of the
@@ -433,15 +453,19 @@ func newRegistryTestServer(t *testing.T) *httptest.Server {
 		assert.NoError(t, err)
 	})
 
-	// Serve the list-versions endpoint so TestRegistryGetterWithoutVersion can
-	// resolve the latest version without a ?version= query parameter.
+	// Serve the list-versions endpoint with a realistic spread of minor and
+	// patch lines plus a prerelease, so one server exercises latest-version
+	// resolution (TestRegistryGetterWithoutVersion) and every constraint case
+	// (TestPinModuleVersion).
 	mux.HandleFunc(
 		"/v1/modules/terraform-aws-modules/vpc/aws/versions",
 		func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write(
 				[]byte(
-					`{"modules":[{"versions":[{"version":"3.3.0"},{"version":"2.0.0"},{"version":"1.0.0"}]}]}`,
+					`{"modules":[{"versions":[` +
+						`{"version":"3.2.0"},{"version":"3.3.0"},{"version":"3.3.1"},` +
+						`{"version":"3.4.0"},{"version":"4.0.0"},{"version":"4.1.0-rc1"}]}]}`,
 				),
 			)
 			assert.NoError(t, err)
@@ -449,7 +473,7 @@ func newRegistryTestServer(t *testing.T) *httptest.Server {
 	)
 
 	mux.HandleFunc(
-		"/v1/modules/terraform-aws-modules/vpc/aws/3.3.0/download",
+		"/v1/modules/terraform-aws-modules/vpc/aws/{version}/download",
 		func(w http.ResponseWriter, r *http.Request) {
 			// Resolve against the request host so the downloader hits the same
 			// test server we are about to shut down at end-of-test.

--- a/internal/runner/run/context_test.go
+++ b/internal/runner/run/context_test.go
@@ -1,0 +1,129 @@
+package run_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/runner/run"
+	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestModuleVersionResolverSharedPerRunWithRacing pins the contract behind
+// [run.WithModuleVersionResolver]: every lookup on one run's context hands
+// back the same resolver, so concurrent units resolving the same module and
+// constraint query the registry once, while a second run's context starts
+// with a cold cache instead of inheriting state from the first.
+func TestModuleVersionResolverSharedPerRunWithRacing(t *testing.T) {
+	t.Parallel()
+
+	var versionsHits atomic.Int64
+
+	server := newCountingVersionsServer(t, &versionsHits)
+	source := "tfr://" + server.Listener.Addr().String() + "/foo/bar/baz"
+	l := logger.CreateLogger()
+
+	ctx := run.WithModuleVersionResolver(t.Context())
+	run.ModuleVersionResolverFromContext(ctx).WithHTTPClient(server.Client())
+
+	var wg sync.WaitGroup
+
+	for range 10 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			// Fetch the handle from the context on every use, the way the
+			// download path does. If lookups stopped returning the one shared
+			// resolver, the fresh fallback would not trust the test server's
+			// certificate and Pin would fail.
+			pinned, err := run.ModuleVersionResolverFromContext(ctx).Pin(
+				ctx, l, tfimpl.OpenTofu, source, "~> 3.0",
+			)
+			assert.NoError(t, err)
+			assert.Equal(t, source+"?version=3.3.0", pinned)
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, int64(1), versionsHits.Load())
+
+	// A second installed resolver stands in for a second run: its cache must
+	// start cold, proving memoization lives on the run's context rather than
+	// in package-level state.
+	otherCtx := run.WithModuleVersionResolver(t.Context())
+	run.ModuleVersionResolverFromContext(otherCtx).WithHTTPClient(server.Client())
+
+	pinned, err := run.ModuleVersionResolverFromContext(otherCtx).Pin(
+		otherCtx, l, tfimpl.OpenTofu, source, "~> 3.0",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, source+"?version=3.3.0", pinned)
+	assert.Equal(t, int64(2), versionsHits.Load())
+}
+
+// TestModuleVersionResolverFromContextFallback pins the documented fallback:
+// a context without an installed resolver yields a working resolver whose
+// memoization is scoped to that single handle, so two lookups do not share a
+// cache.
+func TestModuleVersionResolverFromContextFallback(t *testing.T) {
+	t.Parallel()
+
+	var versionsHits atomic.Int64
+
+	server := newCountingVersionsServer(t, &versionsHits)
+	source := "tfr://" + server.Listener.Addr().String() + "/foo/bar/baz"
+	l := logger.CreateLogger()
+
+	first := run.ModuleVersionResolverFromContext(t.Context()).WithHTTPClient(server.Client())
+
+	for range 2 {
+		pinned, err := first.Pin(t.Context(), l, tfimpl.OpenTofu, source, "~> 3.0")
+		require.NoError(t, err)
+		assert.Equal(t, source+"?version=3.3.0", pinned)
+	}
+
+	assert.Equal(t, int64(1), versionsHits.Load())
+
+	second := run.ModuleVersionResolverFromContext(t.Context()).WithHTTPClient(server.Client())
+
+	pinned, err := second.Pin(t.Context(), l, tfimpl.OpenTofu, source, "~> 3.0")
+	require.NoError(t, err)
+	assert.Equal(t, source+"?version=3.3.0", pinned)
+	assert.Equal(t, int64(2), versionsHits.Load())
+}
+
+// newCountingVersionsServer stands up a TLS test server that speaks the
+// service-discovery and list-versions endpoints of the module-registry
+// protocol, recording every list-versions request in versionsHits.
+func newCountingVersionsServer(t *testing.T, versionsHits *atomic.Int64) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/.well-known/terraform.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"modules.v1":"/v1/modules/"}`))
+		assert.NoError(t, err)
+	})
+
+	mux.HandleFunc("/v1/modules/foo/bar/baz/versions", func(w http.ResponseWriter, _ *http.Request) {
+		versionsHits.Add(1)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"modules":[{"versions":[{"version":"3.3.0"},{"version":"2.0.0"}]}]}`))
+		assert.NoError(t, err)
+	})
+
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	return server
+}

--- a/test/fixtures/tfr/version-constraint-in-query/terragrunt.hcl
+++ b/test/fixtures/tfr/version-constraint-in-query/terragrunt.hcl
@@ -1,0 +1,6 @@
+# The ?version= query accepts an exact version only; a constraint there is
+# rejected with a typed error pointing at the terraform block's version
+# attribute instead.
+terraform {
+  source = "tfr://registry.opentofu.org/yorinasub17/terragrunt-registry-test/null?version=~>0.0.1"
+}

--- a/test/fixtures/tfr/version-constraint-multi/unit-a/terragrunt.hcl
+++ b/test/fixtures/tfr/version-constraint-multi/unit-a/terragrunt.hcl
@@ -1,0 +1,6 @@
+# One of several units sharing a module source and version constraint, so a
+# single run resolves the constraint once and reuses the pin for every unit.
+terraform {
+  source  = "tfr://registry.opentofu.org/yorinasub17/terragrunt-registry-test/null"
+  version = "~> 0.0.1"
+}

--- a/test/fixtures/tfr/version-constraint-multi/unit-b/terragrunt.hcl
+++ b/test/fixtures/tfr/version-constraint-multi/unit-b/terragrunt.hcl
@@ -1,0 +1,6 @@
+# One of several units sharing a module source and version constraint, so a
+# single run resolves the constraint once and reuses the pin for every unit.
+terraform {
+  source  = "tfr://registry.opentofu.org/yorinasub17/terragrunt-registry-test/null"
+  version = "~> 0.0.1"
+}

--- a/test/fixtures/tfr/version-constraint-multi/unit-c/terragrunt.hcl
+++ b/test/fixtures/tfr/version-constraint-multi/unit-c/terragrunt.hcl
@@ -1,0 +1,6 @@
+# One of several units sharing a module source and version constraint, so a
+# single run resolves the constraint once and reuses the pin for every unit.
+terraform {
+  source  = "tfr://registry.opentofu.org/yorinasub17/terragrunt-registry-test/null"
+  version = "~> 0.0.1"
+}

--- a/test/fixtures/tfr/version-constraint-no-match/terragrunt.hcl
+++ b/test/fixtures/tfr/version-constraint-no-match/terragrunt.hcl
@@ -1,0 +1,6 @@
+# No published version of this module satisfies the constraint, so resolution
+# must fail with a typed no-matching-version error.
+terraform {
+  source  = "tfr://registry.opentofu.org/yorinasub17/terragrunt-registry-test/null"
+  version = "~> 9.0"
+}

--- a/test/fixtures/tfr/version-constraint/terragrunt.hcl
+++ b/test/fixtures/tfr/version-constraint/terragrunt.hcl
@@ -1,0 +1,6 @@
+# Retrieve a module from the public OpenTofu registry. The version constraint
+# is resolved to the newest matching release at download time.
+terraform {
+  source  = "tfr://registry.opentofu.org/yorinasub17/terragrunt-registry-test/null"
+  version = "~> 0.0.1"
+}

--- a/test/integration_registry_test.go
+++ b/test/integration_registry_test.go
@@ -174,6 +174,10 @@ func TestTerraformRegistryVersionConstraintSharedAcrossUnitsWithRacing(t *testin
 func TestTerraformRegistryVersionConstraintRequiresExperiment(t *testing.T) {
 	t.Parallel()
 
+	if helpers.IsExperimentMode(t) {
+		t.Skip("Skipping: TG_EXPERIMENT_MODE forces all experiments on, so the experiment-disabled error this test pins cannot occur")
+	}
+
 	modPath := filepath.Join(registryFixturePath, registryFixtureVersionConstraintModulePath)
 	helpers.CleanupTerraformFolder(t, modPath)
 	tmpEnvPath := helpers.CopyEnvironment(t, modPath)

--- a/test/integration_registry_test.go
+++ b/test/integration_registry_test.go
@@ -6,17 +6,31 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/runner/run"
+	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 const (
-	registryFixturePath                          = "fixtures/tfr"
-	registryFixtureRootModulePath                = "root"
-	registryFixtureRootShorthandModulePath       = "root-shorthand"
-	registryFixtureSubdirModulePath              = "subdir"
-	registryFixtureSubdirWithReferenceModulePath = "subdir-with-reference"
+	registryFixturePath                               = "fixtures/tfr"
+	registryFixtureRootModulePath                     = "root"
+	registryFixtureRootShorthandModulePath            = "root-shorthand"
+	registryFixtureSubdirModulePath                   = "subdir"
+	registryFixtureSubdirWithReferenceModulePath      = "subdir-with-reference"
+	registryFixtureVersionConstraintModulePath        = "version-constraint"
+	registryFixtureVersionConstraintNoMatchModulePath = "version-constraint-no-match"
+	registryFixtureVersionConstraintInQueryModulePath = "version-constraint-in-query"
+
+	// registryTestModuleSource is the source used by the version-constraint
+	// fixtures. The module has exactly two published versions, 0.0.1 and
+	// 0.0.2, so constraint resolution against it is deterministic.
+	registryTestModuleSource = "tfr://registry.opentofu.org/yorinasub17/terragrunt-registry-test/null"
 )
 
 func TestTerraformRegistryFetchingRootModule(t *testing.T) {
@@ -37,6 +51,158 @@ func TestTerraformRegistryFetchingSubdirModule(t *testing.T) {
 func TestTerraformRegistryFetchingSubdirWithReferenceModule(t *testing.T) {
 	t.Parallel()
 	testTerraformRegistryFetching(t, registryFixtureSubdirWithReferenceModulePath, "two")
+}
+
+// TestTerraformRegistryVersionConstraintPinsResolvedVersion runs a unit whose
+// terraform block carries a bare tfr:// source plus a version constraint and
+// verifies the constraint end-to-end: the unit applies successfully, and the
+// download lands in the cache slot keyed by the exact ?version=0.0.2 pin the
+// resolver must have produced from "~> 0.0.1".
+func TestTerraformRegistryVersionConstraintPinsResolvedVersion(t *testing.T) {
+	t.Parallel()
+
+	modPath := filepath.Join(registryFixturePath, registryFixtureVersionConstraintModulePath)
+	helpers.CleanupTerraformFolder(t, modPath)
+	tmpEnvPath := helpers.CopyEnvironment(t, modPath)
+	rootPath := filepath.Join(tmpEnvPath, modPath)
+
+	helpers.RunTerragrunt(
+		t,
+		"terragrunt run --non-interactive --experiment version-attribute --working-dir "+rootPath+" -- apply -auto-approve",
+	)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := helpers.RunTerragruntCommand(
+		t,
+		"terragrunt run --non-interactive --experiment version-attribute --working-dir "+rootPath+" -- output -no-color -json",
+		&stdout,
+		&stderr,
+	)
+	require.NoError(t, err)
+
+	outputs := map[string]helpers.TerraformOutput{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
+	assert.Contains(t, outputs, "root_null_resource")
+
+	// Reconstruct the cache slot for the pinned URL the same way the download
+	// path does. Its presence, with a version file recording the pinned
+	// query, proves the constraint resolved to 0.0.2 rather than some other
+	// version (whose slot would live under a different query hash).
+	l := logger.CreateLogger()
+
+	pinned, err := tf.NewSource(
+		l,
+		registryTestModuleSource+"?version=0.0.2",
+		filepath.Join(rootPath, ".terragrunt-cache"),
+		rootPath,
+		false,
+	)
+	require.NoError(t, err)
+
+	assert.True(t, util.FileExists(filepath.Join(pinned.WorkingDir, "main.tf")))
+
+	wantVersion, err := pinned.EncodeSourceVersion(l)
+	require.NoError(t, err)
+
+	// Guard against a vacuous comparison: the version encoding must
+	// discriminate between the two published versions, or the assertion
+	// below could not tell 0.0.2 apart from 0.0.1.
+	otherPin, err := tf.NewSource(
+		l,
+		registryTestModuleSource+"?version=0.0.1",
+		filepath.Join(rootPath, ".terragrunt-cache"),
+		rootPath,
+		false,
+	)
+	require.NoError(t, err)
+
+	otherVersion, err := otherPin.EncodeSourceVersion(l)
+	require.NoError(t, err)
+	require.NotEqual(t, wantVersion, otherVersion)
+
+	gotVersion, err := util.ReadFileAsString(pinned.VersionFile)
+	require.NoError(t, err)
+	assert.Equal(t, wantVersion, gotVersion)
+}
+
+// TestTerraformRegistryVersionConstraintRequiresExperiment pins the typed
+// error returned when the terraform block sets the version attribute but the
+// version-attribute experiment is not enabled.
+func TestTerraformRegistryVersionConstraintRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	modPath := filepath.Join(registryFixturePath, registryFixtureVersionConstraintModulePath)
+	helpers.CleanupTerraformFolder(t, modPath)
+	tmpEnvPath := helpers.CopyEnvironment(t, modPath)
+	rootPath := filepath.Join(tmpEnvPath, modPath)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := helpers.RunTerragruntCommand(
+		t,
+		"terragrunt plan --non-interactive --working-dir "+rootPath,
+		&stdout,
+		&stderr,
+	)
+	require.Error(t, err)
+
+	var expectedErr config.VersionAttributeRequiresExperimentError
+
+	assert.ErrorAs(t, err, &expectedErr)
+}
+
+// TestTerraformRegistryVersionConstraintNoMatchingVersion pins the typed
+// error returned at download time when the registry publishes versions but
+// none satisfy the configured constraint.
+func TestTerraformRegistryVersionConstraintNoMatchingVersion(t *testing.T) {
+	t.Parallel()
+
+	modPath := filepath.Join(registryFixturePath, registryFixtureVersionConstraintNoMatchModulePath)
+	helpers.CleanupTerraformFolder(t, modPath)
+	tmpEnvPath := helpers.CopyEnvironment(t, modPath)
+	rootPath := filepath.Join(tmpEnvPath, modPath)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := helpers.RunTerragruntCommand(
+		t,
+		"terragrunt plan --non-interactive --experiment version-attribute --working-dir "+rootPath,
+		&stdout,
+		&stderr,
+	)
+	require.Error(t, err)
+
+	var expectedErr getter.NoMatchingVersionErr
+
+	assert.ErrorAs(t, err, &expectedErr)
+}
+
+// TestTerraformRegistryVersionConstraintInQueryRejected pins the typed error
+// returned when a tfr:// source carries a version constraint in its ?version=
+// query, which accepts an exact version only. The guard is active without the
+// version-attribute experiment, since such a source was never valid.
+func TestTerraformRegistryVersionConstraintInQueryRejected(t *testing.T) {
+	t.Parallel()
+
+	modPath := filepath.Join(registryFixturePath, registryFixtureVersionConstraintInQueryModulePath)
+	helpers.CleanupTerraformFolder(t, modPath)
+	tmpEnvPath := helpers.CopyEnvironment(t, modPath)
+	rootPath := filepath.Join(tmpEnvPath, modPath)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := helpers.RunTerragruntCommand(
+		t,
+		"terragrunt plan --non-interactive --working-dir "+rootPath,
+		&stdout,
+		&stderr,
+	)
+	require.Error(t, err)
+
+	var expectedErr run.SourceVersionConstraintErr
+
+	assert.ErrorAs(t, err, &expectedErr)
 }
 
 func testTerraformRegistryFetching(t *testing.T, modPath, expectedOutputKey string) {

--- a/test/integration_registry_test.go
+++ b/test/integration_registry_test.go
@@ -24,6 +24,7 @@ const (
 	registryFixtureSubdirModulePath                   = "subdir"
 	registryFixtureSubdirWithReferenceModulePath      = "subdir-with-reference"
 	registryFixtureVersionConstraintModulePath        = "version-constraint"
+	registryFixtureVersionConstraintMultiModulePath   = "version-constraint-multi"
 	registryFixtureVersionConstraintNoMatchModulePath = "version-constraint-no-match"
 	registryFixtureVersionConstraintInQueryModulePath = "version-constraint-in-query"
 
@@ -124,6 +125,47 @@ func TestTerraformRegistryVersionConstraintPinsResolvedVersion(t *testing.T) {
 	gotVersion, err := util.ReadFileAsString(pinned.VersionFile)
 	require.NoError(t, err)
 	assert.Equal(t, wantVersion, gotVersion)
+}
+
+// TestTerraformRegistryVersionConstraintSharedAcrossUnitsWithRacing applies
+// several units sharing a module source and version constraint in a single
+// run --all, which resolves them concurrently through the run's shared
+// version resolver. The WithRacing suffix puts the shared resolver under the
+// race detector in CI; every unit must land on the same 0.0.2 pin.
+func TestTerraformRegistryVersionConstraintSharedAcrossUnitsWithRacing(t *testing.T) {
+	t.Parallel()
+
+	modPath := filepath.Join(registryFixturePath, registryFixtureVersionConstraintMultiModulePath)
+	helpers.CleanupTerraformFolder(t, modPath)
+	tmpEnvPath := helpers.CopyEnvironment(t, modPath)
+	rootPath := filepath.Join(tmpEnvPath, modPath)
+
+	helpers.RunTerragrunt(
+		t,
+		"terragrunt run --all --non-interactive --experiment version-attribute --working-dir "+rootPath+" -- apply -auto-approve",
+	)
+
+	l := logger.CreateLogger()
+
+	for _, unit := range []string{"unit-a", "unit-b", "unit-c"} {
+		unitPath := filepath.Join(rootPath, unit)
+
+		pinned, err := tf.NewSource(
+			l,
+			registryTestModuleSource+"?version=0.0.2",
+			filepath.Join(unitPath, ".terragrunt-cache"),
+			unitPath,
+			false,
+		)
+		require.NoError(t, err)
+
+		wantVersion, err := pinned.EncodeSourceVersion(l)
+		require.NoError(t, err)
+
+		gotVersion, err := util.ReadFileAsString(pinned.VersionFile)
+		require.NoError(t, err)
+		assert.Equal(t, wantVersion, gotVersion, unit)
+	}
 }
 
 // TestTerraformRegistryVersionConstraintRequiresExperiment pins the typed


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds some integration testing for the `version` attribute.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for version constraints when selecting Terraform Registry modules.
  - Constraints resolve to the latest matching release and can be reused consistently across multiple units.
  - Added support for prerelease selection when explicitly requested.

- **Bug Fixes**
  - Invalid constraints in `?version=` queries are rejected with clear configuration errors.
  - Added clear errors when no published version satisfies a constraint.
  - Registry modules without a specified version now resolve to the latest available release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->