### PR TITLE
feat: Adding earlier catalog bail

### DIFF
--- a/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
+++ b/docs/src/content/docs/03-features/06-catalog/02-tui.mdx
@@ -295,6 +295,7 @@ Active after pressing `enter` on a component.
 | `shift+tab` | Focus the previous button in the footer |
 | `enter` | Activate the focused button |
 | `s` | Scaffold the selected component (interactive form) |
+| `ctrl+d` | Scaffold immediately, skipping the form; every input is left as a `# TODO` placeholder |
 | `w` | Toggle soft-wrapping of long README lines |
 | `?` | Toggle the expanded help view |
 | `q`, `esc` | Back to the list |

--- a/docs/src/data/changelog/v1.1.2/catalog-pager-immediate-scaffold.mdx
+++ b/docs/src/data/changelog/v1.1.2/catalog-pager-immediate-scaffold.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.2"
+category: "new-features"
+---
+
+#### Scaffold straight from the catalog README view with `ctrl+d`
+
+In the `terragrunt catalog` TUI, pressing `ctrl+d` while reading a component's README now scaffolds it immediately, skipping the interactive form. Module and template inputs are written as `# TODO` placeholders, and unit/stack copies get a fully placeholder `terragrunt.values.hcl`. The hint bar at the bottom of the README view advertises the new key.

--- a/internal/cli/commands/catalog/tui/keys.go
+++ b/internal/cli/commands/catalog/tui/keys.go
@@ -75,7 +75,8 @@ func NewListKeyMap() list.KeyMap {
 
 // DelegateKeyMap defines the list-row keybindings. `s` opens the
 // interactive scaffold form; the placeholder-only flow is reachable from
-// inside that form via ctrl+d when required values are still unfilled.
+// inside that form via ctrl+d when required values are still unfilled,
+// or directly from the pager via ctrl+d.
 type DelegateKeyMap struct {
 	Choose              key.Binding
 	ScaffoldInteractive key.Binding
@@ -122,17 +123,18 @@ type PagerKeyMap struct {
 
 	HelpModel help.Model
 
-	// Button navigation
+	// Button navigation (tab forward, shift+tab back). The buttonbar
+	// consumes the keypresses; this binding exists for the help line.
 	Navigation key.Binding
-
-	// Button navigation
-	NavigationBack key.Binding
 
 	// Select button
 	Choose key.Binding
 
 	// Run the interactive scaffold flow (s).
 	ScaffoldInteractive key.Binding
+
+	// Scaffold immediately with placeholder values, skipping the form (ctrl+d).
+	ScaffoldImmediate key.Binding
 
 	// Toggle soft-wrapping of long README lines (w).
 	ToggleWrap key.Binding
@@ -148,18 +150,16 @@ type PagerKeyMap struct {
 }
 
 // ShortHelp returns keybindings to be shown in the mini help view. It's part
-// of the key.Map interface.
+// of the key.Map interface. Paging and wrap keys are omitted so the line
+// fits a 120-column terminal; they stay discoverable via `?`.
 func (keys PagerKeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		keys.Up,
 		keys.Down,
-		keys.PageUp,
-		keys.PageDown,
 		keys.Navigation,
-		keys.NavigationBack,
 		keys.Choose,
 		keys.ScaffoldInteractive,
-		keys.ToggleWrap,
+		keys.ScaffoldImmediate,
 		keys.Help,
 		keys.Quit,
 	}
@@ -169,24 +169,9 @@ func (keys PagerKeyMap) ShortHelp() []key.Binding {
 // key.Map interface.
 func (keys PagerKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{
-			keys.Up,
-			keys.Down,
-			keys.PageDown,
-			keys.PageUp,
-		}, // first column
-		{
-			keys.Navigation,
-			keys.NavigationBack,
-			keys.Choose,
-			keys.ScaffoldInteractive,
-		}, // second column
-		{
-			keys.ToggleWrap,
-			keys.Help,
-			keys.Quit,
-			keys.ForceQuit,
-		}, // third column
+		{keys.Up, keys.Down, keys.PageDown, keys.PageUp},                                 // first column
+		{keys.Navigation, keys.Choose, keys.ScaffoldInteractive, keys.ScaffoldImmediate}, // second column
+		{keys.ToggleWrap, keys.Help, keys.Quit, keys.ForceQuit},                          // third column
 	}
 }
 
@@ -219,12 +204,8 @@ func NewPagerKeyMap() PagerKeyMap {
 		},
 		HelpModel: help.New(),
 		Navigation: key.NewBinding(
-			key.WithKeys("tab"),
-			key.WithHelp("tab", "navigation"),
-		),
-		NavigationBack: key.NewBinding(
-			key.WithKeys("shift+tab"),
-			key.WithHelp("shift+tab", "navigation"),
+			key.WithKeys("tab", "shift+tab"),
+			key.WithHelp("tab/shift+tab", "nav"),
 		),
 		Choose: key.NewBinding(
 			key.WithKeys("enter"),
@@ -234,17 +215,21 @@ func NewPagerKeyMap() PagerKeyMap {
 			key.WithKeys("s"),
 			key.WithHelp("s", "scaffold"),
 		),
+		ScaffoldImmediate: key.NewBinding(
+			key.WithKeys("ctrl+d"),
+			key.WithHelp("ctrl+d", "scaffold now"),
+		),
 		ToggleWrap: key.NewBinding(
 			key.WithKeys("w"),
 			key.WithHelp("w", "wrap"),
 		),
 		Help: key.NewBinding(
 			key.WithKeys("?"),
-			key.WithHelp("?", "toggle help"),
+			key.WithHelp("?", "help"),
 		),
 		Quit: key.NewBinding(
 			key.WithKeys("q", "esc"),
-			key.WithHelp("q", "back to list"),
+			key.WithHelp("q", "back"),
 		),
 		ForceQuit: key.NewBinding(key.WithKeys("ctrl+c")),
 	}

--- a/internal/cli/commands/catalog/tui/keys_test.go
+++ b/internal/cli/commands/catalog/tui/keys_test.go
@@ -57,13 +57,10 @@ func TestKeyPagerKeyMapShortHelp(t *testing.T) {
 	want := []key.Binding{
 		km.Up,
 		km.Down,
-		km.PageUp,
-		km.PageDown,
 		km.Navigation,
-		km.NavigationBack,
 		km.Choose,
 		km.ScaffoldInteractive,
-		km.ToggleWrap,
+		km.ScaffoldImmediate,
 		km.Help,
 		km.Quit,
 	}
@@ -91,9 +88,9 @@ func TestKeyPagerKeyMapFullHelp(t *testing.T) {
 
 	require.Len(t, got[1], 4)
 	assert.Equal(t, km.Navigation, got[1][0])
-	assert.Equal(t, km.NavigationBack, got[1][1])
-	assert.Equal(t, km.Choose, got[1][2])
-	assert.Equal(t, km.ScaffoldInteractive, got[1][3])
+	assert.Equal(t, km.Choose, got[1][1])
+	assert.Equal(t, km.ScaffoldInteractive, got[1][2])
+	assert.Equal(t, km.ScaffoldImmediate, got[1][3])
 
 	require.Len(t, got[2], 4)
 	assert.Equal(t, km.ToggleWrap, got[2][0])
@@ -105,10 +102,11 @@ func TestKeyPagerKeyMapFullHelp(t *testing.T) {
 func TestKeyPagerScaffoldBoundToLowerS(t *testing.T) {
 	t.Parallel()
 
-	// Pager mirrors the list: only the lowercase scaffold entry point;
-	// skip-required lives inside the form on ctrl+d.
+	// The lowercase entry point opens the form; ctrl+d mirrors the form's
+	// force-submit by scaffolding immediately with placeholder values.
 	km := tui.NewPagerKeyMap()
 
 	assert.Equal(t, []string{"s"}, km.ScaffoldInteractive.Keys())
+	assert.Equal(t, []string{"ctrl+d"}, km.ScaffoldImmediate.Keys())
 	assert.Equal(t, []string{"w"}, km.ToggleWrap.Keys())
 }

--- a/internal/cli/commands/catalog/tui/model_test.go
+++ b/internal/cli/commands/catalog/tui/model_test.go
@@ -285,7 +285,7 @@ func TestModelInteractiveScaffoldTransitionsToFormStateWithRacing(t *testing.T) 
 // TestModelEnterOnPagerLaunchesInteractiveFormWithRacing asserts that once the user
 // has opened a component's README (PagerState), pressing enter on the
 // default-focused Scaffold button takes the interactive form path, the
-// same as pressing `s`. The placeholder flow stays reachable via `S`.
+// same as pressing `s`. The placeholder flow stays reachable via ctrl+d.
 func TestModelEnterOnPagerLaunchesInteractiveFormWithRacing(t *testing.T) {
 	t.Parallel()
 
@@ -339,6 +339,54 @@ func TestModelEnterOnPagerLaunchesInteractiveFormWithRacing(t *testing.T) {
 
 		assert.Equal(t, tui.FormState, finalModel.State,
 			"enter on the pager's Scaffold button should transition to FormState")
+	})
+}
+
+// TestModelCtrlDOnPagerScaffoldsImmediatelyWithRacing asserts that ctrl+d on
+// the pager skips the form entirely: the session jumps straight to
+// ScaffoldState so the placeholder flow runs without value collection.
+func TestModelCtrlDOnPagerScaffoldsImmediatelyWithRacing(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		fsys := vfs.NewMemMapFS()
+		repoDir := testRepoDir
+
+		unitBody := `locals {
+  region = values.region
+}
+` + "\n"
+		writeFileFS(t, fsys, filepath.Join(repoDir, "vpc", "terragrunt.hcl"), unitBody)
+
+		repo := newFakeRepo(t, fsys, repoDir)
+
+		components, err := tui.NewComponentDiscovery().WithFS(fsys).Discover(repo)
+		require.NoError(t, err)
+		require.Len(t, components, 1)
+
+		opts, err := options.NewTerragruntOptionsForTest("")
+		require.NoError(t, err)
+
+		opts.WorkingDir = t.TempDir()
+
+		entry := tui.NewComponentEntry(components[0]).WithSource("github.com/gruntwork-io/fake-repo")
+
+		componentCh := make(chan *tui.ComponentEntry)
+		close(componentCh)
+
+		m := tui.NewModelStreaming(t.Context(), logger.CreateLogger(), venv.OSVenv(), opts, entry, componentCh, nil)
+
+		// First enter: list → pager. Then ctrl+d: pager → immediate
+		// placeholder scaffold, no form in between.
+		msgs := []tea.Msg{
+			tea.KeyPressMsg{Code: tea.KeyEnter},
+			tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl},
+		}
+
+		finalModel := driveModel(t, m, 120, 40, msgs).(tui.Model)
+
+		assert.Equal(t, tui.ScaffoldState, finalModel.State,
+			"ctrl+d on the pager should skip the form and enter ScaffoldState")
 	})
 }
 

--- a/internal/cli/commands/catalog/tui/update.go
+++ b/internal/cli/commands/catalog/tui/update.go
@@ -150,6 +150,8 @@ func updatePager(msg tea.Msg, m Model) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, m.pagerKeys.ScaffoldInteractive):
 			return enterFormState(m, m.selectedComponent, PagerState)
+		case key.Matches(msg, m.pagerKeys.ScaffoldImmediate):
+			return startPlaceholderScaffold(m, m.selectedComponent)
 		case key.Matches(msg, m.pagerKeys.ToggleWrap):
 			m.softWrap = !m.softWrap
 			m.mdRenderer = nil
@@ -233,6 +235,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		m.width = msg.Width
 		m.height = msg.Height
+
+		// Without a width the help line overflows and the terminal clips
+		// it mid-entry; with one, help truncates whole entries with "…".
+		m.pagerKeys.HelpModel.SetWidth(msg.Width - h)
 
 		viewportHeight := msg.Height - v - lipgloss.Height(m.footerView())
 
@@ -775,6 +781,39 @@ func (m *Model) abandonForm() {
 
 	m.form = nil
 	m.valuesRefs = nil
+}
+
+// startPlaceholderScaffold transitions straight from the pager to
+// ScaffoldState, skipping the form: module and template inputs all land as
+// `# TODO` lines, and unit/stack values stubs get the full TODO treatment.
+func startPlaceholderScaffold(m Model, c *Component) (tea.Model, tea.Cmd) {
+	m.State = ScaffoldState
+
+	if c.Kind.IsCopyable() {
+		return m, copyComponentPlaceholderCmd(m.logger, m, c)
+	}
+
+	return m, scaffoldComponentPlaceholderCmd(m.logger, m, c)
+}
+
+// scaffoldComponentPlaceholderCmd schedules a planless scaffold run, which
+// downloads the source itself and emits TODO placeholders for every input.
+func scaffoldComponentPlaceholderCmd(l log.Logger, m Model, c *Component) tea.Cmd {
+	cmd := newScaffoldCmd(l, m.venv, m.terragruntOptions, c)
+
+	return tea.Exec(cmd, func(err error) tea.Msg {
+		return ScaffoldFinishedMsg{Err: err, Interactive: false}
+	})
+}
+
+// copyComponentPlaceholderCmd schedules the unit/stack copy without any
+// user-supplied values, so the values stub falls back to TODO placeholders.
+func copyComponentPlaceholderCmd(l log.Logger, m Model, c *Component) tea.Cmd {
+	cmd := NewCopyCmd(l, m.terragruntOptions, c)
+
+	return tea.Exec(cmd, func(err error) tea.Msg {
+		return CopyFinishedMsg{Err: err, Result: cmd.Result(), Interactive: false}
+	})
 }
 
 // scaffoldComponentWithPlanCmd schedules the prepared plan's Generate


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6494.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `ctrl+d` shortcut in the Catalog TUI component detail view to scaffold immediately without completing the interactive form.
  * Immediate scaffolding uses `# TODO` placeholders for required inputs and placeholder values files where applicable.
  * Updated on-screen keybinding help and changelog documentation to reflect the new shortcut.

* **Bug Fixes**
  * Improved pager help layout to prevent keybinding text from being clipped in narrow or newly sized terminals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->