### PR TITLE
fix(errors): match retryable_errors against stdout, not just stderr

### DIFF
--- a/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -1660,6 +1660,8 @@ The `errors` block contains all the configurations for handling errors.
 
 It supports different nested configuration blocks like `retry` and `ignore` to define specific error-handling strategies.
 
+When multiple rules are defined, `ignore` rules are evaluated before `retry` rules, and the first rule whose patterns match determines the outcome.
+
 ### Retry Configuration
 
 The `retry` block within the `errors` block defines rules for retrying operations when specific errors occur.
@@ -1685,7 +1687,7 @@ Parameters:
 
   e.g. `".*Error: transient.*"` matches errors containing `Error: transient`.
 
-  Patterns are matched against the failed command's combined `stdout` and `stderr` output, together with the underlying error. Diagnostics that OpenTofu/Terraform emits on `stdout` (for example, remote/cloud-backend runs that stream the remote log to `stdout`) are therefore matched. The command line itself — the binary and its flags — is excluded, so flag names such as `-lock-timeout` do not cause spurious matches.
+  Patterns are matched against the failed command's output and the underlying error. <Before version="1.1.2">Only `stderr` and the underlying error are considered.</Before><Since version="1.1.2">Both `stdout` and `stderr` are considered, so diagnostics that OpenTofu/Terraform emit on `stdout` — for example, remote/cloud-backend runs that stream the remote log to `stdout` — are matched.</Since> The command line itself — the binary and its flags — is excluded, so flag names such as `-lock-timeout` do not cause spurious matches.
 
 - `max_attempts`: The maximum number of retry attempts.
 
@@ -1724,7 +1726,7 @@ Parameters:
 - `ignorable_errors`: A list of regex patterns to define errors to ignore.
   - `"Error: safe-to-ignore.*"`: Ignores errors containing `Error: safe-to-ignore`.
   - `"!Error: critical.*"`: Ensures errors containing `Error: critical` are not ignored.
-  - Patterns are matched against the same content as `retryable_errors`: the failed command's combined `stdout` and `stderr` and the underlying error, excluding the command line and its flags.
+  - Patterns are matched against the same content as `retryable_errors` (see above), excluding the command line and its flags.
 - `message` (Optional): A warning message displayed when an error is ignored.
   - Example: `"Ignoring safe-to-ignore errors"`.
 - `signals` (Optional): Key-value pairs used to emit signals to external systems.

--- a/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -1685,6 +1685,8 @@ Parameters:
 
   e.g. `".*Error: transient.*"` matches errors containing `Error: transient`.
 
+  Patterns are matched against the failed command's combined `stdout` and `stderr` output, together with the underlying error. Diagnostics that OpenTofu/Terraform emits on `stdout` (for example, remote/cloud-backend runs that stream the remote log to `stdout`) are therefore matched. The command line itself — the binary and its flags — is excluded, so flag names such as `-lock-timeout` do not cause spurious matches.
+
 - `max_attempts`: The maximum number of retry attempts.
 
   e.g. `5` retries.
@@ -1722,6 +1724,7 @@ Parameters:
 - `ignorable_errors`: A list of regex patterns to define errors to ignore.
   - `"Error: safe-to-ignore.*"`: Ignores errors containing `Error: safe-to-ignore`.
   - `"!Error: critical.*"`: Ensures errors containing `Error: critical` are not ignored.
+  - Patterns are matched against the same content as `retryable_errors`: the failed command's combined `stdout` and `stderr` and the underlying error, excluding the command line and its flags.
 - `message` (Optional): A warning message displayed when an error is ignored.
   - Example: `"Ignoring safe-to-ignore errors"`.
 - `signals` (Optional): Key-value pairs used to emit signals to external systems.

--- a/docs/src/data/changelog/v1.1.2/retry-match-stdout.mdx
+++ b/docs/src/data/changelog/v1.1.2/retry-match-stdout.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.2"
+category: "bug-fixes"
+---
+
+#### `retryable_errors` now match diagnostics emitted on stdout
+
+The `errors` block's retry and ignore matching only inspected a failed command's stderr and the underlying error, so `retryable_errors` never matched diagnostics that OpenTofu/Terraform wrote to stdout. This most affected remote/cloud-backend runs (the `cloud {}` block), where the remote run's log — including messages such as `Error: Failed to install provider ...` from a transient registry or TLS failure — is streamed to the local process's stdout while the local error is only `exit status 1`. Such transient failures were never retried, regardless of the configured pattern.
+
+Matching now also considers stdout, consistent with hook matching and error reporting. The command string and its flags remain excluded, so flag names such as `-lock-timeout` still do not cause false matches.

--- a/internal/errorconfig/types.go
+++ b/internal/errorconfig/types.go
@@ -126,11 +126,15 @@ func (c *Config) AttemptErrorRecovery(l log.Logger, err error, currentAttempt in
 func ExtractErrorMessage(err error) string {
 	var errText string
 
-	// For ProcessExecutionError, match only against stderr and the underlying error,
-	// not the full command string with flags.
+	// For ProcessExecutionError, match against stdout, stderr, and the underlying
+	// error. Some invocations (notably remote/cloud-backend runs) stream diagnostics
+	// to stdout rather than stderr, so stdout must be included for retryable_errors to
+	// match (see #6495). The command string and its flags are still intentionally
+	// excluded to avoid false matches on flag names such as -lock-timeout (see #5088).
 	var processErr util.ProcessExecutionError
 	if errors.As(err, &processErr) {
-		errText = processErr.Output.Stderr.String() + "\n" + processErr.Err.Error()
+		errText = processErr.Output.Stdout.String() + "\n" +
+			processErr.Output.Stderr.String() + "\n" + processErr.Err.Error()
 	} else {
 		errText = err.Error()
 	}

--- a/internal/errorconfig/types_test.go
+++ b/internal/errorconfig/types_test.go
@@ -120,6 +120,59 @@ func TestExtractErrorMessage_StillMatchesTimeoutInStderrWithFlags(t *testing.T) 
 		"timeout pattern should match when stderr actually contains 'timeout'; cleaned message: %s", msg)
 }
 
+func TestExtractErrorMessage_IncludesStdout(t *testing.T) {
+	t.Parallel()
+
+	// Some invocations (notably remote/cloud-backend runs) stream diagnostics to
+	// stdout rather than stderr. Those must still be matchable by retryable_errors.
+	// See issue #6495.
+	var stdout bytes.Buffer
+	stdout.WriteString("Error: Failed to install provider")
+
+	err := util.ProcessExecutionError{
+		Err:        errors.New("exit status 1"),
+		Command:    "tofu",
+		Args:       []string{"plan"},
+		WorkingDir: "/some/path",
+		Output:     util.CmdOutput{Stdout: stdout},
+	}
+
+	msg := errorconfig.ExtractErrorMessage(err)
+	assert.Contains(t, msg, "Failed to install provider")
+
+	pattern := regexp.MustCompile(`.*Failed to install provider.*`)
+	patterns := []*errorconfig.Pattern{{Pattern: pattern}}
+	assert.True(t, errorconfig.MatchesAnyRegexpPattern(msg, patterns),
+		"pattern should match diagnostics emitted on stdout; cleaned message: %s", msg)
+}
+
+func TestExtractErrorMessage_StdoutInclusionStillExcludesCommandFlags(t *testing.T) {
+	t.Parallel()
+
+	// Including stdout must not reintroduce #5088: the command string and its flags
+	// are still excluded, so a pattern must not match text that only appears in flags.
+	var stdout bytes.Buffer
+	stdout.WriteString("Plan: 1 to add, 0 to change, 0 to destroy.")
+
+	err := util.ProcessExecutionError{
+		Err:        errors.New("exit status 1"),
+		Command:    "tofu",
+		Args:       []string{"plan", "-lock-timeout=120m", "-input=false"},
+		WorkingDir: "/some/path",
+		Output:     util.CmdOutput{Stdout: stdout},
+	}
+
+	timeoutPattern := regexp.MustCompile(`(?s).*timeout.*`)
+	patterns := []*errorconfig.Pattern{
+		{Pattern: timeoutPattern},
+	}
+
+	msg := errorconfig.ExtractErrorMessage(err)
+	matched := errorconfig.MatchesAnyRegexpPattern(msg, patterns)
+	assert.False(t, matched,
+		"timeout pattern must not match command flags even with stdout included; cleaned message: %s", msg)
+}
+
 func TestExtractErrorMessage_NonProcessError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Fixes #6495.

The `errors` block's retry/ignore matching only inspected a failed command's **stderr** plus the Go error string, ignoring **stdout** — even though Terragrunt captures both streams in `ProcessExecutionError.Output`. As a result, `retryable_errors` never matched diagnostics that the wrapped OpenTofu/Terraform process writes to stdout.

This matters most for remote/cloud-backend runs: with a `cloud {}` block (HCP Terraform / TFE), the *remote* run's log — including messages such as `Error: Failed to install provider ...` from a transient registry/TLS failure — is streamed to the **local** process's stdout, while the local Go error is only `exit status 1`. So transient failures during remote runs were never retried, regardless of the configured pattern.

`ExtractErrorMessage` (`internal/errorconfig/types.go`) now includes `Output.Stdout` alongside `Output.Stderr` and the underlying error. This mirrors what the hook matcher already does (`internal/runner/run/hook.go`, added in #2045) and the error explainer (`internal/shell/error_explainer.go`).

The command string and its flags remain intentionally excluded, so this does **not** reintroduce the false-match issue fixed in #5088 (e.g. a `.*timeout.*` pattern matching a `-lock-timeout` flag). A new test asserts that guarantee explicitly.

### Change
```go
// internal/errorconfig/types.go — ExtractErrorMessage
if errors.As(err, &processErr) {
    errText = processErr.Output.Stdout.String() + "\n" +
        processErr.Output.Stderr.String() + "\n" + processErr.Err.Error()
} else {
    errText = err.Error()
}
```

### Tests
Added to `internal/errorconfig/types_test.go`:
- `TestExtractErrorMessage_IncludesStdout` — a pattern matches text present only on stdout.
- `TestExtractErrorMessage_StdoutInclusionStillExcludesCommandFlags` — command flags are still excluded (guards #5088).

All pre-existing `errorconfig` tests (including the #5088 regression tests) continue to pass:
```
ok  github.com/gruntwork-io/terragrunt/internal/errorconfig
```

### Changelog
Added `docs/src/data/changelog/v1.1.2/retry-match-stdout.mdx` (category `bug-fixes`). The version is a best guess for the next release — happy to move it if you're targeting a different one.

### Reproduction (no cloud account needed)
A mock binary that writes a retryable diagnostic to a selectable stream demonstrates the bug: with the message on stdout the run is not retried (matcher sees only `exit status 1`); with the identical message on stderr it retries as configured. Full steps are in #6495.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Retryable and ignorable error matching now includes diagnostics written to standard output, in addition to standard error and the underlying error.
  - Command names and flags remain excluded from matching, preventing false matches based on flag text.
  - Ignore rules continue to take precedence over retry rules, with the first matching rule determining the outcome.

- **Documentation**
  - Updated error-handling reference and changelog documentation to describe matching behavior and rule evaluation order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->