### PR TITLE
feat: Optional caching for read_terragrunt_config to improve performance

### DIFF
--- a/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/04-functions.mdx
@@ -944,6 +944,28 @@ Notes:
 
 - `read_terragrunt_config` can be also used to read `terragrunt.stack.hcl` and `terragrunt.values.hcl` files.
 
+### Special Parameters
+
+The `read_terragrunt_config` function accepts special flags that alter how the function evaluates configuration files. Placing these `--terragrunt-` prefixed flags as the first argument of a `read_terragrunt_config` call will adjust its behavior.
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `--terragrunt-with-cache` | Caches the parsed configuration in-memory for the current Terragrunt invocation, keyed by absolute file path. Subsequent reads of the same file return the first parse result. Useful when the same shared configuration file is read many times during `run --all`. | `read_terragrunt_config("--terragrunt-with-cache", find_in_parent_folders("common.hcl"))` |
+
+Unlike `run_cmd`, `read_terragrunt_config` does not cache by default. Pass `--terragrunt-with-cache` only when you want to reuse a previously parsed result.
+
+**Scope and invalidation:** The cache is in-memory and per process — it is not persisted between Terragrunt runs. The first successful parse wins: subsequent reads in the same invocation return that cached value, even if the underlying file changes later during parsing.
+
+**Warning:** When using `--terragrunt-with-cache`, context-dependent functions like [`get_original_terragrunt_dir()`](#get_original_terragrunt_dir) return the value from the first parse, not the current calling context. This can cause issues when the same configuration file is accessed from different modules. If you need `original_terragrunt_dir` to reflect the current parsing context, call `read_terragrunt_config` without the flag.
+
+#### Example
+
+```hcl
+locals {
+  global_accts = read_terragrunt_config("--terragrunt-with-cache", find_in_parent_folders("global-accounts.hcl")).locals
+}
+```
+
 ## sops_decrypt_file
 
 `sops_decrypt_file(file_path)` decrypts a yaml, json, ini, env or "raw text" file encrypted with `sops`.

--- a/docs/src/content/docs/06-troubleshooting/03-performance.mdx
+++ b/docs/src/content/docs/06-troubleshooting/03-performance.mdx
@@ -203,6 +203,8 @@ locals {
 
 The [`read_terragrunt_config`](/reference/hcl/functions/#read_terragrunt_config) HCL function evaluates the target file as HCL each time it's called, including any function calls the file makes. When that file is included by many units, the whole evaluation repeats for each one.
 
+When the shared file must remain HCL (for example, it contains `dependency` blocks or `run_cmd` calls), you can pass [`--terragrunt-with-cache`](/reference/hcl/functions/#special-parameters-1) as the first argument to `read_terragrunt_config` to cache the parsed result for the rest of the Terragrunt invocation. Only use this when the file does not depend on per-module context such as [`get_original_terragrunt_dir()`](/reference/hcl/functions/#get_original_terragrunt_dir).
+
 That cost buys you dynamic behavior, and shared configuration often doesn't need any: region names, tag maps, account IDs, and similar values are just static data. Storing static data as JSON or YAML and decoding it is cheaper than evaluating it as HCL:
 
 ```hcl

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -56,6 +56,8 @@ const (
 	// stringCompParams is the exact number of arguments expected by the
 	// startswith, endswith, and strcontains helpers (haystack + needle).
 	stringCompParams = 2
+
+	terragruntWithCacheFlag = "--terragrunt-with-cache"
 )
 
 // RunCmdCacheEntry stores run_cmd results including output for replay.
@@ -877,7 +879,61 @@ func ParseTerragruntConfig(ctx context.Context, pctx *ParsingContext, l log.Logg
 	return TerragruntConfigAsCty(config)
 }
 
-// Create a cty Function that can be used to for calling read_terragrunt_config.
+// parseReadTerragruntConfigArgs extracts the optional --terragrunt-with-cache flag,
+// config path, and optional default value from read_terragrunt_config call arguments.
+func parseReadTerragruntConfigArgs(args []cty.Value) (useCache bool, configPath string, defaultVal *cty.Value, err error) {
+	if len(args) == 0 {
+		return false, "", nil, WrongNumberOfParamsError{
+			Func:     FuncNameReadTerragruntConfig,
+			Expected: "1 or 2",
+			Actual:   0,
+		}
+	}
+
+	remaining := args
+	if args[0].Type() == cty.String {
+		switch args[0].AsString() {
+		case terragruntWithCacheFlag:
+			useCache = true
+			remaining = args[1:]
+		default:
+			if strings.HasPrefix(args[0].AsString(), "--terragrunt-") {
+				return false, "", nil, UnknownReadTerragruntConfigOptionError{Option: args[0].AsString()}
+			}
+		}
+	}
+
+	numParams := len(remaining)
+	switch {
+	case useCache && (numParams == 0 || numParams > matchedPats):
+		return false, "", nil, WrongNumberOfParamsError{
+			Func:     FuncNameReadTerragruntConfig,
+			Expected: "2 or 3 (with --terragrunt-with-cache)",
+			Actual:   len(args),
+		}
+	case !useCache && (numParams == 0 || numParams > matchedPats):
+		return false, "", nil, WrongNumberOfParamsError{
+			Func:     FuncNameReadTerragruntConfig,
+			Expected: "1 or 2",
+			Actual:   len(args),
+		}
+	}
+
+	strArgs, err := ctySliceToStringSlice(remaining[:1])
+	if err != nil {
+		return false, "", nil, err
+	}
+
+	configPath = strArgs[0]
+
+	if numParams == matchedPats {
+		defaultVal = &remaining[1]
+	}
+
+	return useCache, configPath, defaultVal, nil
+}
+
+// Create a cty Function that can be used to call read_terragrunt_config.
 func readTerragruntConfigAsFuncImpl(ctx context.Context, pctx *ParsingContext, l log.Logger) function.Function {
 	return function.New(&function.Spec{
 		// Takes one required string param
@@ -887,25 +943,50 @@ func readTerragruntConfigAsFuncImpl(ctx context.Context, pctx *ParsingContext, l
 		// We don't know the return type until we parse the terragrunt config, so we use a dynamic type
 		Type: function.StaticReturnType(cty.DynamicPseudoType),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			numParams := len(args)
-
-			if numParams == 0 || numParams > 2 {
-				return cty.NilVal, WrongNumberOfParamsError{Func: "read_terragrunt_config", Expected: "1 or 2", Actual: numParams}
-			}
-
-			strArgs, err := ctySliceToStringSlice(args[:1])
+			useCache, targetConfigPath, defaultVal, err := parseReadTerragruntConfigArgs(args)
 			if err != nil {
 				return cty.NilVal, err
 			}
 
-			var defaultVal *cty.Value = nil
-			if numParams == matchedPats {
-				defaultVal = &args[1]
+			if !useCache {
+				return ParseTerragruntConfig(ctx, pctx, l, targetConfigPath, defaultVal)
 			}
 
-			targetConfigPath := strArgs[0]
+			targetConfig := getCleanedTargetConfigPath(targetConfigPath, pctx.TerragruntConfigPath)
+			readConfigCache := cache.ContextCache[cty.Value](ctx, ReadTerragruntConfigCacheContextKey)
+			cacheKey := fmt.Sprintf("parse-terragrunt-config-%v-hasDefault=%t", targetConfig, defaultVal != nil)
 
-			return ParseTerragruntConfig(ctx, pctx, l, targetConfigPath, defaultVal)
+			if cachedConfig, found := readConfigCache.Get(ctx, cacheKey); found {
+				l.Debugf("%s: cache hit for %s", FuncNameReadTerragruntConfig, targetConfig)
+
+				return cachedConfig, nil
+			}
+
+			l.Debugf("%s: cache miss for %s", FuncNameReadTerragruntConfig, targetConfig)
+
+			attrs := map[string]any{
+				"config_path":        pctx.TerragruntConfigPath,
+				"working_dir":        pctx.WorkingDir,
+				"target_config_path": targetConfigPath,
+				"has_default":        defaultVal != nil,
+			}
+
+			var result cty.Value
+
+			err = telemetry.TelemeterFromContext(ctx).Collect(ctx, "hcl_fn_read_terragrunt_config_with_cache", attrs, func(childCtx context.Context) error {
+				var innerErr error
+
+				result, innerErr = ParseTerragruntConfig(childCtx, pctx, l, targetConfigPath, defaultVal)
+
+				return innerErr
+			})
+			if err != nil {
+				return cty.NilVal, err
+			}
+
+			readConfigCache.Put(ctx, cacheKey, result)
+
+			return result, nil
 		},
 	})
 }

--- a/pkg/config/config_helpers_test.go
+++ b/pkg/config/config_helpers_test.go
@@ -1635,3 +1635,60 @@ func TestRunCommandOptionsOnlyArityRegression(t *testing.T) {
 		})
 	}
 }
+
+func TestReadTerragruntConfigWithCacheReusesParsedConfig(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx = config.WithConfigValues(ctx)
+
+	fixturePath := "../../test/fixtures/locals/canonical/terragrunt.hcl"
+
+	const hclTemplate = `locals {
+  first = read_terragrunt_config("--terragrunt-with-cache", %q)
+  second = read_terragrunt_config("--terragrunt-with-cache", %q)
+}`
+
+	out, err := config.ParseConfigString(ctx, pctx, l, "test.hcl", fmt.Sprintf(hclTemplate, fixturePath, fixturePath), nil)
+	require.NoError(t, err)
+	require.NotNil(t, out.Locals)
+
+	first, ok := out.Locals["first"]
+	require.True(t, ok)
+	second, ok := out.Locals["second"]
+	require.True(t, ok)
+	assert.Equal(t, first, second)
+}
+
+func TestReadTerragruntConfigWithCacheFlagOnlyReturnsError(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx = config.WithConfigValues(ctx)
+
+	const hcl = `locals {
+  x = read_terragrunt_config("--terragrunt-with-cache")
+}`
+
+	_, err := config.ParseConfigString(ctx, pctx, l, "test.hcl", hcl, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Expected 2 or 3 (with --terragrunt-with-cache) params for function read_terragrunt_config")
+}
+
+func TestReadTerragruntConfigUnknownOptionReturnsError(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx = config.WithConfigValues(ctx)
+
+	const hcl = `locals {
+  x = read_terragrunt_config("--terragrunt-unknown", "common.hcl")
+}`
+
+	_, err := config.ParseConfigString(ctx, pctx, l, "test.hcl", hcl, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `Unknown option "--terragrunt-unknown" for function read_terragrunt_config`)
+}

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -6,32 +6,36 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type configKey byte
 
 const (
-	HclCacheContextKey               configKey = iota
-	TerragruntConfigCacheContextKey  configKey = iota
-	RunCmdCacheContextKey            configKey = iota
-	DependencyOutputCacheContextKey  configKey = iota
-	JSONOutputCacheContextKey        configKey = iota
-	OutputLocksContextKey            configKey = iota
-	SopsCacheContextKey              configKey = iota
-	AutoIncludeSuffixCacheContextKey configKey = iota
+	HclCacheContextKey                  configKey = iota
+	ReadTerragruntConfigCacheContextKey configKey = iota
+	TerragruntConfigCacheContextKey     configKey = iota
+	RunCmdCacheContextKey               configKey = iota
+	DependencyOutputCacheContextKey     configKey = iota
+	JSONOutputCacheContextKey           configKey = iota
+	OutputLocksContextKey               configKey = iota
+	SopsCacheContextKey                 configKey = iota
+	AutoIncludeSuffixCacheContextKey    configKey = iota
 
-	hclCacheName               = "hclCache"
-	configCacheName            = "configCache"
-	runCmdCacheName            = "runCmdCache"
-	dependencyOutputCacheName  = "dependencyOutputCache"
-	jsonOutputCacheName        = "jsonOutputCache"
-	sopsCacheName              = "sopsCache"
-	autoIncludeSuffixCacheName = "autoIncludeSuffixCache"
+	hclCacheName                  = "hclCache"
+	readTerragruntConfigCacheName = "readTerragruntConfigCache"
+	configCacheName               = "configCache"
+	runCmdCacheName               = "runCmdCache"
+	dependencyOutputCacheName     = "dependencyOutputCache"
+	jsonOutputCacheName           = "jsonOutputCache"
+	sopsCacheName                 = "sopsCache"
+	autoIncludeSuffixCacheName    = "autoIncludeSuffixCache"
 )
 
 // WithConfigValues add to context default values for configuration.
 func WithConfigValues(ctx context.Context) context.Context {
 	ctx = context.WithValue(ctx, HclCacheContextKey, cache.NewCache[*hclparse.File](hclCacheName))
+	ctx = context.WithValue(ctx, ReadTerragruntConfigCacheContextKey, cache.NewCache[cty.Value](readTerragruntConfigCacheName))
 	ctx = context.WithValue(ctx, TerragruntConfigCacheContextKey, cache.NewCache[*TerragruntConfig](configCacheName))
 	ctx = context.WithValue(ctx, RunCmdCacheContextKey, cache.NewCache[*RunCmdCacheEntry](runCmdCacheName))
 	ctx = context.WithValue(ctx, DependencyOutputCacheContextKey, cache.NewCache[*dependencyOutputCache](dependencyOutputCacheName))

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -152,6 +152,18 @@ func (err ConflictingRunCmdCacheOptionsError) Error() string {
 	return "The --terragrunt-global-cache and --terragrunt-no-cache options cannot be used together. Choose one caching option for run_cmd."
 }
 
+type UnknownReadTerragruntConfigOptionError struct {
+	Option string
+}
+
+func (err UnknownReadTerragruntConfigOptionError) Error() string {
+	return fmt.Sprintf(
+		"Unknown option %q for function read_terragrunt_config. The only supported option is %q.",
+		err.Option,
+		"--terragrunt-with-cache",
+	)
+}
+
 type TerragruntConfigNotFoundError struct {
 	Path string
 }

--- a/pkg/config/read_terragrunt_config_cache_test.go
+++ b/pkg/config/read_terragrunt_config_cache_test.go
@@ -1,0 +1,113 @@
+package config //nolint:testpackage // needs access to parseReadTerragruntConfigArgs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestParseReadTerragruntConfigArgs(t *testing.T) {
+	t.Parallel()
+
+	defaultVal := cty.ObjectVal(map[string]cty.Value{
+		"data": cty.StringVal("default"),
+	})
+
+	//nolint:govet // fieldalignment is not important for test tables
+	testCases := []struct {
+		args        []cty.Value
+		wantErrType any
+		name        string
+		wantPath    string
+		wantCache   bool
+		wantDefault bool
+		wantErr     bool
+	}{
+		{
+			name:      "path only",
+			args:      []cty.Value{cty.StringVal("common.hcl")},
+			wantCache: false,
+			wantPath:  "common.hcl",
+		},
+		{
+			name:        "path with default",
+			args:        []cty.Value{cty.StringVal("common.hcl"), defaultVal},
+			wantCache:   false,
+			wantPath:    "common.hcl",
+			wantDefault: true,
+		},
+		{
+			name:      "with cache flag and path",
+			args:      []cty.Value{cty.StringVal(terragruntWithCacheFlag), cty.StringVal("common.hcl")},
+			wantCache: true,
+			wantPath:  "common.hcl",
+		},
+		{
+			name:        "with cache flag path and default",
+			args:        []cty.Value{cty.StringVal(terragruntWithCacheFlag), cty.StringVal("common.hcl"), defaultVal},
+			wantCache:   true,
+			wantPath:    "common.hcl",
+			wantDefault: true,
+		},
+		{
+			name:        "no args",
+			args:        []cty.Value{},
+			wantErr:     true,
+			wantErrType: WrongNumberOfParamsError{},
+		},
+		{
+			name:        "cache flag only",
+			args:        []cty.Value{cty.StringVal(terragruntWithCacheFlag)},
+			wantErr:     true,
+			wantErrType: WrongNumberOfParamsError{},
+		},
+		{
+			name:        "too many args",
+			args:        []cty.Value{cty.StringVal("a.hcl"), defaultVal, cty.StringVal("extra")},
+			wantErr:     true,
+			wantErrType: WrongNumberOfParamsError{},
+		},
+		{
+			name:        "too many args with cache flag",
+			args:        []cty.Value{cty.StringVal(terragruntWithCacheFlag), cty.StringVal("a.hcl"), defaultVal, cty.StringVal("extra")},
+			wantErr:     true,
+			wantErrType: WrongNumberOfParamsError{},
+		},
+		{
+			name:        "unknown terragrunt flag",
+			args:        []cty.Value{cty.StringVal("--terragrunt-unknown"), cty.StringVal("common.hcl")},
+			wantErr:     true,
+			wantErrType: UnknownReadTerragruntConfigOptionError{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			useCache, configPath, defaultValOut, err := parseReadTerragruntConfigArgs(tc.args)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				if tc.wantErrType != nil {
+					require.ErrorAs(t, err, &tc.wantErrType)
+				}
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantCache, useCache)
+			assert.Equal(t, tc.wantPath, configPath)
+
+			if tc.wantDefault {
+				require.NotNil(t, defaultValOut)
+				assert.True(t, defaultValOut.RawEquals(defaultVal))
+			} else {
+				assert.Nil(t, defaultValOut)
+			}
+		})
+	}
+}

--- a/test/fixtures/read-config-with-cache/from_dependency/dep/main.tf
+++ b/test/fixtures/read-config-with-cache/from_dependency/dep/main.tf
@@ -1,0 +1,3 @@
+variable "foo" {}
+
+output "foo" { value = var.foo }

--- a/test/fixtures/read-config-with-cache/from_dependency/dep/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/from_dependency/dep/terragrunt.hcl
@@ -1,0 +1,7 @@
+locals {
+  vars = read_terragrunt_config("--terragrunt-with-cache", "vars.hcl")
+}
+
+inputs = {
+  foo = local.vars.locals.foo
+}

--- a/test/fixtures/read-config-with-cache/from_dependency/dep/vars.hcl
+++ b/test/fixtures/read-config-with-cache/from_dependency/dep/vars.hcl
@@ -1,0 +1,3 @@
+locals {
+  foo = "hello world"
+}

--- a/test/fixtures/read-config-with-cache/from_dependency/main.tf
+++ b/test/fixtures/read-config-with-cache/from_dependency/main.tf
@@ -1,0 +1,2 @@
+variable "bar" {}
+output "bar" { value = var.bar }

--- a/test/fixtures/read-config-with-cache/from_dependency/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/from_dependency/terragrunt.hcl
@@ -1,0 +1,7 @@
+dependency "dep" {
+  config_path = "./dep/"
+}
+
+inputs = {
+  bar = dependency.dep.outputs.foo
+}

--- a/test/fixtures/read-config-with-cache/full/main.tf
+++ b/test/fixtures/read-config-with-cache/full/main.tf
@@ -1,0 +1,38 @@
+variable "localstg" {}
+output "localstg" { value = var.localstg }
+
+variable "generate" {}
+output "generate" { value = var.generate }
+
+variable "remote_state" {}
+output "remote_state" { value = var.remote_state }
+
+variable "terraformtg" {}
+output "terraformtg" { value = var.terraformtg }
+
+variable "dependencies" {}
+output "dependencies" { value = var.dependencies }
+
+variable "terraform_binary" {}
+output "terraform_binary" { value = var.terraform_binary }
+
+variable "terraform_version_constraint" {}
+output "terraform_version_constraint" { value = var.terraform_version_constraint }
+
+variable "terragrunt_version_constraint" {}
+output "terragrunt_version_constraint" { value = var.terragrunt_version_constraint }
+
+variable "download_dir" {}
+output "download_dir" { value = var.download_dir }
+
+variable "prevent_destroy" {}
+output "prevent_destroy" { value = var.prevent_destroy }
+
+variable "exclude" {}
+output "exclude" { value = var.exclude }
+
+variable "iam_role" {}
+output "iam_role" { value = var.iam_role }
+
+variable "inputs" {}
+output "inputs" { value = var.inputs }

--- a/test/fixtures/read-config-with-cache/full/source.hcl
+++ b/test/fixtures/read-config-with-cache/full/source.hcl
@@ -1,0 +1,76 @@
+locals {
+  the_answer = 42
+}
+
+generate "provider" {
+  path = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents = <<EOF
+provider "aws" {
+  region = "us-east-1"
+}
+EOF
+}
+
+remote_state {
+  backend = "local"
+  generate = {
+    path = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    path = "foo.tfstate"
+  }
+  encryption = {
+    key_provider = "foo"
+  }
+}
+
+terraform {
+  source                   = "./delorean"
+  include_in_copy          = ["time_machine.*"]
+  exclude_from_copy        = ["excluded_time_machine.*"]
+  copy_terraform_lock_file = true
+
+  extra_arguments "var-files" {
+    commands = ["apply", "plan"]
+    required_var_files = ["extra.tfvars"]
+    optional_var_files = ["optional.tfvars"]
+    env_vars = {
+      TF_VAR_custom_var = "I'm set in extra_arguments env_vars"
+    }
+  }
+
+  before_hook "before_hook_1" {
+    commands = ["apply", "plan"]
+    execute = ["touch", "before.out"]
+    run_on_error = true
+  }
+
+  after_hook "after_hook_1" {
+    commands = ["apply", "plan"]
+    execute = ["touch", "after.out"]
+    run_on_error = true
+  }
+}
+
+dependencies {
+  paths = ["../../terragrunt"]
+}
+
+terraform_binary = "terragrunt"
+terraform_version_constraint = "= 0.12.20"
+terragrunt_version_constraint = "= 0.23.18"
+download_dir = ".terragrunt-cache"
+prevent_destroy = true
+iam_role = "TerragruntIAMRole"
+
+exclude {
+  if = true
+  actions = ["all"]
+  no_run = true
+}
+
+inputs = {
+  doc = "Emmett Brown"
+}

--- a/test/fixtures/read-config-with-cache/full/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/full/terragrunt.hcl
@@ -1,0 +1,19 @@
+locals {
+  config = read_terragrunt_config("--terragrunt-with-cache", "${get_terragrunt_dir()}/source.hcl")
+}
+
+inputs = {
+  localstg                     = local.config.locals
+  generate                     = local.config.generate
+  remote_state                 = local.config.remote_state
+  terraformtg                  = local.config.terraform
+  dependencies                 = local.config.dependencies
+  terraform_binary             = local.config.terraform_binary
+  terraform_version_constraint = local.config.terraform_version_constraint
+  terragrunt_version_constraint = local.config.terragrunt_version_constraint
+  download_dir                 = local.config.download_dir
+  prevent_destroy              = local.config.prevent_destroy
+  exclude                      = local.config.exclude
+  iam_role                     = local.config.iam_role
+  inputs                       = local.config.inputs
+}

--- a/test/fixtures/read-config-with-cache/with_default/main.tf
+++ b/test/fixtures/read-config-with-cache/with_default/main.tf
@@ -1,0 +1,4 @@
+variable "data" {}
+output "data" {
+  value = var.data
+}

--- a/test/fixtures/read-config-with-cache/with_default/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/with_default/terragrunt.hcl
@@ -1,0 +1,5 @@
+locals {
+  config_does_not_exist = read_terragrunt_config("--terragrunt-with-cache", "${get_terragrunt_dir()}/i-dont-exist.hcl", {data = "default value"})
+}
+
+inputs = local.config_does_not_exist

--- a/test/fixtures/read-config-with-cache/with_dependency/dep/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/with_dependency/dep/terragrunt.hcl
@@ -1,0 +1,3 @@
+dependency "inputs" {
+  config_path = "../../../inputs"
+}

--- a/test/fixtures/read-config-with-cache/with_dependency/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/with_dependency/terragrunt.hcl
@@ -1,0 +1,9 @@
+locals {
+  config_with_dependency = read_terragrunt_config("--terragrunt-with-cache", "${get_terragrunt_dir()}/dep/terragrunt.hcl")
+}
+
+terraform {
+  source = "${get_terragrunt_dir()}/../../inputs"
+}
+
+inputs = local.config_with_dependency.dependency.inputs.outputs

--- a/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/dep/main.tf
+++ b/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/dep/main.tf
@@ -1,0 +1,31 @@
+variable "terragrunt_dir" {
+  type = string
+}
+
+variable "original_terragrunt_dir" {
+  type = string
+}
+
+variable "bar_terragrunt_dir" {
+  type = string
+}
+
+variable "bar_original_terragrunt_dir" {
+  type = string
+}
+
+output "terragrunt_dir" {
+  value = var.terragrunt_dir
+}
+
+output "original_terragrunt_dir" {
+  value = var.original_terragrunt_dir
+}
+
+output "bar_terragrunt_dir" {
+  value = var.bar_terragrunt_dir
+}
+
+output "bar_original_terragrunt_dir" {
+  value = var.bar_original_terragrunt_dir
+}

--- a/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/dep/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/dep/terragrunt.hcl
@@ -1,0 +1,11 @@
+locals {
+  bar = read_terragrunt_config("--terragrunt-with-cache", "../foo/bar.hcl")
+}
+
+inputs = {
+  terragrunt_dir          = get_terragrunt_dir()
+  original_terragrunt_dir = get_original_terragrunt_dir()
+
+  bar_terragrunt_dir          = local.bar.locals.terragrunt_dir
+  bar_original_terragrunt_dir = local.bar.locals.original_terragrunt_dir
+}

--- a/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/foo/bar.hcl
+++ b/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/foo/bar.hcl
@@ -1,0 +1,4 @@
+locals {
+  terragrunt_dir          = get_terragrunt_dir()
+  original_terragrunt_dir = get_original_terragrunt_dir()
+}

--- a/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/main.tf
+++ b/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/main.tf
@@ -1,0 +1,47 @@
+variable "terragrunt_dir" {
+  type = string
+}
+
+variable "original_terragrunt_dir" {
+  type = string
+}
+
+variable "dep_terragrunt_dir" {
+  type = string
+}
+
+variable "dep_original_terragrunt_dir" {
+  type = string
+}
+
+variable "dep_bar_terragrunt_dir" {
+  type = string
+}
+
+variable "dep_bar_original_terragrunt_dir" {
+  type = string
+}
+
+output "terragrunt_dir" {
+  value = var.terragrunt_dir
+}
+
+output "original_terragrunt_dir" {
+  value = var.original_terragrunt_dir
+}
+
+output "dep_terragrunt_dir" {
+  value = var.dep_terragrunt_dir
+}
+
+output "dep_original_terragrunt_dir" {
+  value = var.dep_original_terragrunt_dir
+}
+
+output "dep_bar_terragrunt_dir" {
+  value = var.dep_bar_terragrunt_dir
+}
+
+output "dep_bar_original_terragrunt_dir" {
+  value = var.dep_bar_original_terragrunt_dir
+}

--- a/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/terragrunt.hcl
+++ b/test/fixtures/read-config-with-cache/with_original_terragrunt_dir/terragrunt.hcl
@@ -1,0 +1,18 @@
+locals {
+  bar = read_terragrunt_config("--terragrunt-with-cache", "foo/bar.hcl")
+}
+
+dependency "dep" {
+  config_path = "./dep"
+}
+
+inputs = {
+  terragrunt_dir          = local.bar.locals.terragrunt_dir
+  original_terragrunt_dir = local.bar.locals.original_terragrunt_dir
+
+  dep_terragrunt_dir          = dependency.dep.outputs.terragrunt_dir
+  dep_original_terragrunt_dir = dependency.dep.outputs.original_terragrunt_dir
+
+  dep_bar_terragrunt_dir          = dependency.dep.outputs.bar_terragrunt_dir
+  dep_bar_original_terragrunt_dir = dependency.dep.outputs.bar_original_terragrunt_dir
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -101,6 +101,7 @@ const (
 	testFixtureProviderCacheMultiplePlatforms = "fixtures/provider-cache/multiple-platforms"
 	testFixtureProviderCacheNetworkMirror     = "fixtures/provider-cache/network-mirror"
 	testFixtureReadConfig                     = "fixtures/read-config"
+	testFixtureReadConfigWithCache            = "fixtures/read-config-with-cache"
 	testFixtureRefSource                      = "fixtures/download/remote-ref"
 	testFixtureSkip                           = "fixtures/skip/"
 	testFixtureSkipLegacyRoot                 = "fixtures/skip-legacy-root/"
@@ -2748,6 +2749,346 @@ func TestReadTerragruntConfigFull(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, "fixtures")
 	helpers.CleanupTerraformFolder(t, filepath.Join(tmpEnvPath, testFixtureReadConfig))
 	rootPath := filepath.Join(tmpEnvPath, testFixtureReadConfig, "full")
+
+	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+rootPath)
+
+	// check the outputs to make sure they are as expected
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	require.NoError(
+		t,
+		helpers.RunTerragruntCommand(t, "terragrunt output -no-color -json --non-interactive --working-dir "+rootPath, &stdout, &stderr),
+	)
+
+	outputs := map[string]helpers.TerraformOutput{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
+
+	assert.Equal(t, "terragrunt", outputs["terraform_binary"].Value)
+	assert.Equal(t, "= 0.12.20", outputs["terraform_version_constraint"].Value)
+	assert.Equal(t, "= 0.23.18", outputs["terragrunt_version_constraint"].Value)
+	assert.Equal(t, ".terragrunt-cache", outputs["download_dir"].Value)
+	assert.Equal(t, "TerragruntIAMRole", outputs["iam_role"].Value)
+	// exclude is now a block, not a simple boolean - just verify it exists
+	assert.Contains(t, outputs, "exclude")
+	assert.NotEmpty(t, outputs["exclude"].Value)
+	assert.Equal(t, "true", outputs["prevent_destroy"].Value)
+
+	// Simple maps
+	localstgOut := map[string]any{}
+	require.NoError(t, json.Unmarshal([]byte(outputs["localstg"].Value.(string)), &localstgOut))
+	assert.Equal(t, map[string]any{"the_answer": float64(42)}, localstgOut)
+
+	inputsOut := map[string]any{}
+	require.NoError(t, json.Unmarshal([]byte(outputs["inputs"].Value.(string)), &inputsOut))
+	assert.Equal(t, map[string]any{"doc": "Emmett Brown"}, inputsOut)
+
+	// Complex blocks
+	depsOut := map[string]any{}
+	require.NoError(t, json.Unmarshal([]byte(outputs["dependencies"].Value.(string)), &depsOut))
+	assert.Equal(
+		t,
+		map[string]any{
+			"paths": []any{"../../terragrunt"},
+		},
+		depsOut,
+	)
+
+	generateOut := map[string]any{}
+	require.NoError(t, json.Unmarshal([]byte(outputs["generate"].Value.(string)), &generateOut))
+	assert.Equal(
+		t,
+		map[string]any{
+			"provider": map[string]any{
+				"path":              "provider.tf",
+				"if_exists":         "overwrite_terragrunt",
+				"hcl_fmt":           nil,
+				"if_disabled":       "skip",
+				"comment_prefix":    "# ",
+				"disable_signature": false,
+				"disable":           false,
+				"contents": `provider "aws" {
+  region = "us-east-1"
+}
+`,
+			},
+		},
+		generateOut,
+	)
+
+	remoteStateOut := map[string]any{}
+	require.NoError(t, json.Unmarshal([]byte(outputs["remote_state"].Value.(string)), &remoteStateOut))
+	assert.Equal(
+		t,
+		map[string]any{
+			"backend":                         "local",
+			"disable_init":                    false,
+			"disable_dependency_optimization": false,
+			"generate":                        map[string]any{"path": "backend.tf", "if_exists": "overwrite_terragrunt"},
+			"config":                          map[string]any{"path": "foo.tfstate"},
+			"encryption":                      map[string]any{"key_provider": "foo"},
+		},
+		remoteStateOut,
+	)
+
+	terraformOut := map[string]any{}
+	require.NoError(t, json.Unmarshal([]byte(outputs["terraformtg"].Value.(string)), &terraformOut))
+	assert.Equal(
+		t,
+		map[string]any{
+			"source":                   "./delorean",
+			"include_in_copy":          []any{"time_machine.*"},
+			"exclude_from_copy":        []any{"excluded_time_machine.*"},
+			"copy_terraform_lock_file": true,
+			"extra_arguments": map[string]any{
+				"var-files": map[string]any{
+					"name":               "var-files",
+					"commands":           []any{"apply", "plan"},
+					"arguments":          nil,
+					"required_var_files": []any{"extra.tfvars"},
+					"optional_var_files": []any{"optional.tfvars"},
+					"env_vars": map[string]any{
+						"TF_VAR_custom_var": "I'm set in extra_arguments env_vars",
+					},
+				},
+			},
+			"before_hook": map[string]any{
+				"before_hook_1": map[string]any{
+					"name":            "before_hook_1",
+					"commands":        []any{"apply", "plan"},
+					"execute":         []any{"touch", "before.out"},
+					"working_dir":     nil,
+					"run_on_error":    true,
+					"if":              nil,
+					"suppress_stdout": nil,
+				},
+			},
+			"after_hook": map[string]any{
+				"after_hook_1": map[string]any{
+					"name":            "after_hook_1",
+					"commands":        []any{"apply", "plan"},
+					"execute":         []any{"touch", "after.out"},
+					"working_dir":     nil,
+					"run_on_error":    true,
+					"if":              nil,
+					"suppress_stdout": nil,
+				},
+			},
+			"error_hook": map[string]any{},
+		},
+		terraformOut,
+	)
+}
+
+func TestReadTerragruntConfigWithCacheWithDependency(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureReadConfigWithCache)
+	helpers.CleanupTerraformFolder(t, testFixtureInputs)
+	tmpEnvPath := helpers.CopyEnvironment(t, ".")
+
+	inputsPath := filepath.Join(tmpEnvPath, testFixtureInputs)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureReadConfigWithCache, "with_dependency")
+
+	// First apply the inputs module
+	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+inputsPath)
+
+	// Then apply the read config module
+	showStdout := bytes.Buffer{}
+	showStderr := bytes.Buffer{}
+	require.NoError(
+		t,
+		helpers.RunTerragruntCommand(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+rootPath, &showStdout, &showStderr),
+	)
+
+	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
+	helpers.LogBufferContentsLineByLine(t, showStderr, "show stderr")
+
+	// Now check the outputs to make sure they are as expected
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	require.NoError(
+		t,
+		helpers.RunTerragruntCommand(t, "terragrunt output -no-color -json --non-interactive --working-dir "+rootPath, &stdout, &stderr),
+	)
+
+	outputs := map[string]helpers.TerraformOutput{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
+
+	assert.Equal(t, true, outputs["bool"].Value)
+	assert.Equal(t, []any{true, false}, outputs["list_bool"].Value)
+	assert.Equal(t, []any{1.0, 2.0, 3.0}, outputs["list_number"].Value)
+	assert.Equal(t, []any{"a", "b", "c"}, outputs["list_string"].Value)
+	assert.Equal(t, map[string]any{"foo": true, "bar": false, "baz": true}, outputs["map_bool"].Value)
+	assert.Equal(t, map[string]any{"foo": 42.0, "bar": 12345.0}, outputs["map_number"].Value)
+	assert.Equal(t, map[string]any{"foo": "bar"}, outputs["map_string"].Value)
+	numberVal, isNumberFloat64 := outputs["number"].Value.(float64)
+	require.True(t, isNumberFloat64, "number output should be float64")
+	assert.InEpsilon(t, 42.0, numberVal, 0.0000001)
+	assert.Equal(t, map[string]any{"list": []any{1.0, 2.0, 3.0}, "map": map[string]any{"foo": "bar"}, "num": 42.0, "str": "string"}, outputs["object"].Value)
+	assert.Equal(t, "string", outputs["string"].Value)
+	assert.Equal(t, "default", outputs["from_env"].Value)
+}
+
+func TestReadTerragruntConfigWithCacheFromDependency(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureReadConfigWithCache)
+	tmpEnvPath := helpers.CopyEnvironment(t, ".")
+	rootPath := filepath.Join(tmpEnvPath, testFixtureReadConfigWithCache, "from_dependency")
+
+	showStdout := bytes.Buffer{}
+	showStderr := bytes.Buffer{}
+	require.NoError(
+		t,
+		helpers.RunTerragruntCommand(t, "terragrunt run --all apply --non-interactive --working-dir "+rootPath, &showStdout, &showStderr),
+	)
+
+	helpers.LogBufferContentsLineByLine(t, showStdout, "show stdout")
+	helpers.LogBufferContentsLineByLine(t, showStderr, "show stderr")
+
+	// Now check the outputs to make sure they are as expected
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	require.NoError(
+		t,
+		helpers.RunTerragruntCommand(t, "terragrunt output -no-color -json --non-interactive --working-dir "+rootPath, &stdout, &stderr),
+	)
+
+	outputs := map[string]helpers.TerraformOutput{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
+
+	assert.Equal(t, "hello world", outputs["bar"].Value)
+}
+
+func TestReadTerragruntConfigWithCacheWithDefault(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureReadConfigWithCache)
+	helpers.CleanupTerraformFolder(t, filepath.Join(tmpEnvPath, testFixtureReadConfigWithCache))
+	rootPath := filepath.Join(tmpEnvPath, testFixtureReadConfigWithCache, "with_default")
+
+	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+rootPath)
+
+	// check the outputs to make sure they are as expected
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	require.NoError(
+		t,
+		helpers.RunTerragruntCommand(t, "terragrunt output -no-color -json --non-interactive --working-dir "+rootPath, &stdout, &stderr),
+	)
+
+	outputs := map[string]helpers.TerraformOutput{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &outputs))
+
+	assert.Equal(t, "default value", outputs["data"].Value)
+}
+
+//nolint:funlen
+func TestReadTerragruntConfigWithCacheWithOriginalTerragruntDir(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureReadConfigWithCache)
+	helpers.CleanupTerraformFolder(t, filepath.Join(tmpEnvPath, testFixtureReadConfigWithCache))
+	rootPath := filepath.Join(tmpEnvPath, testFixtureReadConfigWithCache, "with_original_terragrunt_dir")
+
+	rootPathAbs := filepath.Clean(rootPath)
+
+	fooPathAbs := filepath.Join(rootPathAbs, "foo")
+	depPathAbs := filepath.Join(rootPathAbs, "dep")
+
+	// Run apply on the dependency module and make sure we get the outputs we expect
+	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+depPathAbs)
+
+	depStdout := bytes.Buffer{}
+	depStderr := bytes.Buffer{}
+
+	require.NoError(
+		t,
+		helpers.RunTerragruntCommand(t, "terragrunt output -no-color -json --non-interactive --working-dir "+depPathAbs, &depStdout, &depStderr),
+	)
+
+	depOutputs := map[string]helpers.TerraformOutput{}
+	require.NoError(t, json.Unmarshal(depStdout.Bytes(), &depOutputs))
+
+	assert.Equal(t, depPathAbs, depOutputs["terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, depOutputs["original_terragrunt_dir"].Value)
+	assert.Equal(t, fooPathAbs, depOutputs["bar_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, depOutputs["bar_original_terragrunt_dir"].Value)
+
+	// Run apply on the root module and make sure we get the expected outputs
+	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+rootPath)
+
+	rootStdout := bytes.Buffer{}
+	rootStderr := bytes.Buffer{}
+
+	require.NoError(
+		t,
+		helpers.RunTerragruntCommand(t, "terragrunt output -no-color -json --non-interactive --working-dir "+rootPath, &rootStdout, &rootStderr),
+	)
+
+	rootOutputs := map[string]helpers.TerraformOutput{}
+	require.NoError(t, json.Unmarshal(rootStdout.Bytes(), &rootOutputs))
+
+	assert.Equal(t, fooPathAbs, rootOutputs["terragrunt_dir"].Value)
+	assert.Equal(t, rootPathAbs, rootOutputs["original_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, rootOutputs["dep_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, rootOutputs["dep_original_terragrunt_dir"].Value)
+	assert.Equal(t, fooPathAbs, rootOutputs["dep_bar_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, rootOutputs["dep_bar_original_terragrunt_dir"].Value)
+
+	// Run 'run --all apply' and make sure all the outputs are identical in the root module and the dependency module
+	helpers.RunTerragrunt(t, "terragrunt run --all  --non-interactive --working-dir "+rootPath+" -- apply -auto-approve")
+
+	runAllRootStdout := bytes.Buffer{}
+	runAllRootStderr := bytes.Buffer{}
+
+	require.NoError(
+		t,
+		helpers.RunTerragruntCommand(t, "terragrunt output -no-color -json --non-interactive --working-dir "+rootPath, &runAllRootStdout, &runAllRootStderr),
+	)
+
+	runAllRootOutputs := map[string]helpers.TerraformOutput{}
+	require.NoError(t, json.Unmarshal(runAllRootStdout.Bytes(), &runAllRootOutputs))
+
+	runAllDepStdout := bytes.Buffer{}
+	runAllDepStderr := bytes.Buffer{}
+
+	require.NoError(
+		t,
+		helpers.RunTerragruntCommand(t, "terragrunt output -no-color -json --non-interactive --working-dir "+depPathAbs, &runAllDepStdout, &runAllDepStderr),
+	)
+
+	runAllDepOutputs := map[string]helpers.TerraformOutput{}
+	require.NoError(t, json.Unmarshal(runAllDepStdout.Bytes(), &runAllDepOutputs))
+
+	assert.Equal(t, fooPathAbs, runAllRootOutputs["terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, runAllRootOutputs["dep_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, runAllRootOutputs["dep_original_terragrunt_dir"].Value)
+	assert.Equal(t, fooPathAbs, runAllRootOutputs["dep_bar_terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, runAllDepOutputs["terragrunt_dir"].Value)
+	assert.Equal(t, depPathAbs, runAllDepOutputs["original_terragrunt_dir"].Value)
+	assert.Equal(t, fooPathAbs, runAllDepOutputs["bar_terragrunt_dir"].Value)
+
+	// With --terragrunt-with-cache, all reads of foo/bar.hcl in a single invocation
+	// share the first parse result. Which module parses first can vary, but every
+	// consumer must see the same cached original_terragrunt_dir value.
+	cachedBarOriginalDir := runAllRootOutputs["original_terragrunt_dir"].Value
+	assert.Equal(t, cachedBarOriginalDir, runAllDepOutputs["bar_original_terragrunt_dir"].Value)
+	assert.Equal(t, cachedBarOriginalDir, runAllRootOutputs["dep_bar_original_terragrunt_dir"].Value)
+	assert.Contains(t, []string{rootPathAbs, depPathAbs}, cachedBarOriginalDir)
+}
+
+//nolint:funlen,forcetypeassert
+func TestReadTerragruntConfigWithCacheFull(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, "fixtures")
+	helpers.CleanupTerraformFolder(t, filepath.Join(tmpEnvPath, testFixtureReadConfigWithCache))
+	rootPath := filepath.Join(tmpEnvPath, testFixtureReadConfigWithCache, "full")
 
 	helpers.RunTerragrunt(t, "terragrunt apply -auto-approve --non-interactive --working-dir "+rootPath)
 


### PR DESCRIPTION
## Description

This PR adds optional, opt-in caching for Terragrunt config parsing via a special parameter on the existing `read_terragrunt_config` function.

In large Terragrunt infrastructures, shared configuration files (e.g. `global-accounts.hcl`, `global-modules.hcl`, `global-vars.hcl`) may be parsed thousands of times during a single `run --all` / `run-all` operation. That causes redundant HCL parsing and increases execution time, especially in complex multi-account environments.

This implements one of the options described in #4896, which outlines the motivation, performance impact, and proposed design for optional caching of repeated config reads.

### What changed vs the previous approach (https://github.com/gruntwork-io/terragrunt/pull/5116)

The earlier design introduced a separate function, `read_terragrunt_config_with_cache(path)`. This PR instead extends `read_terragrunt_config` with an opt-in flag as the first argument:

```hcl
read_terragrunt_config("--terragrunt-with-cache", path [, default_val])
```

This mirrors the existing `run_cmd` pattern of `--terragrunt-` prefixed special parameters, keeps a single function surface, and leaves default `read_terragrunt_config` behavior unchanged.

### Behavior

- When `--terragrunt-with-cache` is passed, the parsed result is stored in an in-memory process cache keyed by cleaned absolute path (and whether a default value was supplied).
- Subsequent calls for the same path reuse the cached `cty.Value` and skip re-parsing.
- Without the flag, behavior is identical to today.
- The cache is **not** persisted between Terragrunt invocations; first successful parse wins for the rest of the process.

### Key points

- **Opt-in:** Existing Terragrunt behavior remains unchanged.
- **Performance:** Real-world project tested — 1956 redundant parses reduced to a single parse, producing a ~35% reduction in pipeline runtime.
- **Safe by default:** Caching is not enabled automatically due to compatibility with context-dependent functions such as `get_original_terragrunt_dir()`.
- **API consistency:** Uses the same special-parameter style as `run_cmd`, rather than introducing a second HCL function.

This feature enables teams with large infrastructures to materially speed up Terragrunt operations without modifying existing configurations.

## Release Notes (draft)

### Added

- Added optional `--terragrunt-with-cache` special parameter to `read_terragrunt_config`, which caches parsed Terragrunt config files in-memory and reuses them across modules within a single Terragrunt invocation.

## Migration Guide

Terragrunt now provides an optional caching mechanism for repeated config parsing via a special parameter on `read_terragrunt_config`:

```hcl
read_terragrunt_config("--terragrunt-with-cache", path [, default_val])
```

Caching is disabled by default to preserve existing behavior and avoid compatibility issues for users relying on evaluation-context-dependent functions.

### Who should migrate?

Users with:

- Large Terragrunt mono-repos
- Many modules reusing shared global configuration files
- Slow `run --all plan` / `run --all apply` (or legacy `run-all`) operations
- High numbers of repeated `read_terragrunt_config` calls

If your infrastructure parses the same `*.hcl` configuration files hundreds or thousands of times, you are likely to benefit.

### How to migrate

Replace:

```hcl
locals {
  global_accts = read_terragrunt_config(find_in_parent_folders("global-accounts.hcl")).locals
}
```

with:

```hcl
locals {
  global_accts = read_terragrunt_config("--terragrunt-with-cache", find_in_parent_folders("global-accounts.hcl")).locals
}
```

No other changes are required.

### Caveat

When using `--terragrunt-with-cache`, context-dependent functions like `get_original_terragrunt_dir()` return the value from the **first** parse, not the current calling module. If you need per-module context, omit the flag.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [ ] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
