### PR TITLE
feat(getter): add OCI digest CAS resolver with tag re-resolution

### DIFF
--- a/docs/src/data/changelog/v1.1.2/oci-module-caching.mdx
+++ b/docs/src/data/changelog/v1.1.2/oci-module-caching.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.2"
+category: "experiments-updated"
+---
+
+#### `oci` - Content-addressable caching for OCI module sources
+
+`oci://` module sources now integrate with Content Addressable Storage. When the `oci` experiment is enabled, downloads are cached by their manifest digest, so a repeated fetch of the same tag or digest is served from the local store instead of re-downloaded from the registry.
+
+Mutable tags stay correct: every fetch re-resolves the tag to its current manifest digest at download time, so re-pushing a module under the same tag invalidates the cache and pulls the new content rather than serving a stale copy. A digest-pinned source (`?digest=sha256:...`) skips registry resolution and keys the cache directly.

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -473,6 +473,18 @@ func (g *CASGetter) buildInnerFetch(bare getter.Getter, scheme, urlStr string) c
 			return "", err
 		}
 
+		// A mutable source can move between the probe and this download (an
+		// oci tag re-push). Re-probe and drop a stale suggested key so the
+		// fetched bytes are never stored under the earlier key.
+		if suggestedKey != "" {
+			if resolver := g.resolvers[scheme]; resolver != nil {
+				key, probeErr := resolver.Probe(ctx, urlStr)
+				if probeErr != nil || key != suggestedKey {
+					suggestedKey = ""
+				}
+			}
+		}
+
 		return g.CAS.IngestDirectory(l, v, tempDir, suggestedKey)
 	}
 }

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -495,7 +495,8 @@ func (g *CASGetter) pinOCIDigest(ctx context.Context, scheme, rawURL, suggestedK
 
 	resolver, ok := g.resolvers[scheme].(ociDigestResolver)
 	if !ok {
-		return rawURL, suggestedKey
+		// No digest contract: content-hash rather than trust a mutable probe key.
+		return rawURL, ""
 	}
 
 	digestValue, err := resolver.ResolveDigest(ctx, rawURL)

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -464,8 +464,10 @@ func (g *CASGetter) buildInnerFetch(bare getter.Getter, scheme, urlStr string) c
 
 		inner := g.innerClient(bare, scheme)
 
+		fetchURL, treeKey := g.pinOCIDigest(ctx, scheme, urlStr, suggestedKey)
+
 		if _, err := inner.Get(ctx, &getter.Request{
-			Src:     urlStr,
+			Src:     fetchURL,
 			Dst:     tempDir,
 			Forced:  scheme,
 			GetMode: getter.ModeAny,
@@ -473,20 +475,51 @@ func (g *CASGetter) buildInnerFetch(bare getter.Getter, scheme, urlStr string) c
 			return "", err
 		}
 
-		// Re-probe after the download and drop a stale suggested key, so a
-		// source that moved mid-fetch (an oci tag re-push) is never stored
-		// under the earlier key.
-		if suggestedKey != "" {
-			if resolver := g.resolvers[scheme]; resolver != nil {
-				key, probeErr := resolver.Probe(ctx, urlStr)
-				if probeErr != nil || key != suggestedKey {
-					suggestedKey = ""
-				}
-			}
-		}
-
-		return g.CAS.IngestDirectory(l, v, tempDir, suggestedKey)
+		return g.CAS.IngestDirectory(l, v, tempDir, treeKey)
 	}
+}
+
+// ociDigestResolver binds a mutable oci reference to the digest it resolves
+// to at download time.
+type ociDigestResolver interface {
+	ResolveDigest(ctx context.Context, rawURL string) (string, error)
+}
+
+// pinOCIDigest rewrites a mutable oci reference to the digest it resolves to
+// right now, so the download and the cache key name one immutable manifest
+// and a tag moving mid-fetch can never be stored under a stale key.
+func (g *CASGetter) pinOCIDigest(ctx context.Context, scheme, rawURL, suggestedKey string) (string, string) {
+	if scheme != SchemeOCI {
+		return rawURL, suggestedKey
+	}
+
+	resolver, ok := g.resolvers[scheme].(ociDigestResolver)
+	if !ok {
+		return rawURL, suggestedKey
+	}
+
+	digestValue, err := resolver.ResolveDigest(ctx, rawURL)
+	if err != nil {
+		// Unresolvable right now: content-hash instead of trusting the probe key.
+		return rawURL, ""
+	}
+
+	return pinnedOCIURL(rawURL, digestValue), cas.ContentKey(ociManifestKeyAlg, digestValue)
+}
+
+// pinnedOCIURL swaps a tag reference for the resolved digest pin.
+func pinnedOCIURL(rawURL, digestValue string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	q := u.Query()
+	q.Del(ociTagQueryKey)
+	q.Set(ociDigestQueryKey, digestValue)
+	u.RawQuery = q.Encode()
+
+	return u.String()
 }
 
 // defaultInnerClientBuilder is the inner-client builder used when none

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -299,7 +299,7 @@ func (g *CASGetter) matchGenericScheme(req *getter.Request) (string, string, boo
 
 	scheme := strings.ToLower(u.Scheme)
 	switch scheme {
-	case SchemeHTTP, SchemeHTTPS, SchemeTFR:
+	case SchemeHTTP, SchemeHTTPS, SchemeTFR, SchemeOCI:
 		if canonical, ok := canonicalAWSS3HTTPSURL(u); ok {
 			if _, fok := g.fetchers[SchemeS3]; fok {
 				return SchemeS3, canonical, true

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -259,12 +259,12 @@ func GitCloneURL(urlStr string) string {
 // source URL. req.Forced (set by the outer client when it stripped a
 // "<scheme>::" prefix) wins; otherwise the URL scheme is consulted.
 //
-// URL-scheme claiming is restricted to http, https, and tfr. The bare
-// go-getter v2 protocol getters for s3, gcs, hg, smb reject
+// URL-scheme claiming is restricted to http, https, tfr, and oci. The
+// bare go-getter v2 protocol getters for s3, gcs, hg, smb reject
 // `<scheme>://...` URLs (they expect canonical HTTPS forms or the
 // forced-prefix syntax), so claiming those schemes here would set up a
-// doomed inner fetch on every cache miss. The tfr fetcher
-// ([RegistryGetter]) accepts tfr:// URLs natively.
+// doomed inner fetch on every cache miss. The tfr ([RegistryGetter]) and
+// oci ([OCIGetter]) fetchers accept their scheme URLs natively.
 //
 // HTTPS URLs against AWS S3 hosts are an exception: virtual-host forms
 // (`<bucket>.s3.amazonaws.com/<key>`) would route through the HTTPS
@@ -473,9 +473,9 @@ func (g *CASGetter) buildInnerFetch(bare getter.Getter, scheme, urlStr string) c
 			return "", err
 		}
 
-		// A mutable source can move between the probe and this download (an
-		// oci tag re-push). Re-probe and drop a stale suggested key so the
-		// fetched bytes are never stored under the earlier key.
+		// Re-probe after the download and drop a stale suggested key, so a
+		// source that moved mid-fetch (an oci tag re-push) is never stored
+		// under the earlier key.
 		if suggestedKey != "" {
 			if resolver := g.resolvers[scheme]; resolver != nil {
 				key, probeErr := resolver.Probe(ctx, urlStr)

--- a/internal/getter/casgetter_oci_test.go
+++ b/internal/getter/casgetter_oci_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	gogetter "github.com/hashicorp/go-getter/v2"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,20 +23,27 @@ import (
 // digest-specific content: the fetch is bound to the digest resolved at
 // download start, so a tag moving A to B and back to A can neither mis-key
 // the cache nor materialize the wrong manifest's bytes.
+// Valid manifest digests the OCI fakes share, satisfying the digest grammar
+// production enforces.
+var (
+	digestA = digest.FromString("manifest-a").String()
+	digestB = digest.FromString("manifest-b").String()
+)
+
 func TestCASGetterOCITagFetchIsDigestPinned(t *testing.T) {
 	t.Parallel()
 
-	resolver := &movingTagResolver{tagDigest: "sha256:aaaa"}
+	resolver := &movingTagResolver{tagDigest: digestA}
 	fetcher := &digestModuleGetter{}
 	// First download: the tag moves A to B mid-fetch. Second download: it
 	// moves back to A, completing the A to B to A sequence.
 	fetcher.onGet = func(call int32) {
 		if call == 1 {
-			resolver.setTag("sha256:bbbb")
+			resolver.setTag(digestB)
 		}
 
 		if call == 2 {
-			resolver.setTag("sha256:aaaa")
+			resolver.setTag(digestA)
 		}
 	}
 
@@ -50,9 +58,12 @@ func TestCASGetterOCITagFetchIsDigestPinned(t *testing.T) {
 	_, err := client.Get(t.Context(), &gogetter.Request{Src: tagSrc, Dst: dstOne, GetMode: gogetter.ModeDir})
 	require.NoError(t, err)
 	require.EqualValues(t, 1, fetcher.gets.Load())
-	assert.Contains(t, fetcher.lastSrc(), "digest=sha256%3Aaaaa", "the download must be pinned to the resolved digest")
+	assert.Contains(
+		t, fetcher.lastSrc(), "digest="+url.QueryEscape(digestA),
+		"the download must be pinned to the resolved digest",
+	)
 	assert.NotContains(t, fetcher.lastSrc(), "tag=", "the mutable tag must not reach the download")
-	assertModuleContent(t, dstOne, "sha256:aaaa")
+	assertModuleContent(t, dstOne, digestA)
 
 	// The tag points at B now: fetch 2 pins digest B and moves the tag back
 	// to A mid-fetch, so B's content lands under B's key.
@@ -61,30 +72,30 @@ func TestCASGetterOCITagFetchIsDigestPinned(t *testing.T) {
 	_, err = client.Get(t.Context(), &gogetter.Request{Src: tagSrc, Dst: dstTwo, GetMode: gogetter.ModeDir})
 	require.NoError(t, err)
 	require.EqualValues(t, 2, fetcher.gets.Load(), "the moved tag must re-fetch")
-	assert.Contains(t, fetcher.lastSrc(), "digest=sha256%3Abbbb", "the re-fetch must pin the moved digest")
-	assertModuleContent(t, dstTwo, "sha256:bbbb")
+	assert.Contains(t, fetcher.lastSrc(), "digest="+url.QueryEscape(digestB), "the re-fetch must pin the moved digest")
+	assertModuleContent(t, dstTwo, digestB)
 
 	// After A to B to A, digest requests hit their own entries with their
 	// own bytes and no further fetches.
 	dstA := filepath.Join(t.TempDir(), "digest-a")
 
 	_, err = client.Get(t.Context(), &gogetter.Request{
-		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?digest=sha256:aaaa",
+		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?digest=" + digestA,
 		Dst:     dstA,
 		GetMode: gogetter.ModeDir,
 	})
 	require.NoError(t, err)
-	assertModuleContent(t, dstA, "sha256:aaaa")
+	assertModuleContent(t, dstA, digestA)
 
 	dstB := filepath.Join(t.TempDir(), "digest-b")
 
 	_, err = client.Get(t.Context(), &gogetter.Request{
-		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?digest=sha256:bbbb",
+		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?digest=" + digestB,
 		Dst:     dstB,
 		GetMode: gogetter.ModeDir,
 	})
 	require.NoError(t, err)
-	assertModuleContent(t, dstB, "sha256:bbbb")
+	assertModuleContent(t, dstB, digestB)
 
 	// The tag is back on A: a tag request hits A's cached entry.
 	dstThree := filepath.Join(t.TempDir(), "three")
@@ -92,7 +103,7 @@ func TestCASGetterOCITagFetchIsDigestPinned(t *testing.T) {
 	_, err = client.Get(t.Context(), &gogetter.Request{Src: tagSrc, Dst: dstThree, GetMode: gogetter.ModeDir})
 	require.NoError(t, err)
 	assert.EqualValues(t, 2, fetcher.gets.Load(), "every request after the two fetches must be a cache hit")
-	assertModuleContent(t, dstThree, "sha256:aaaa")
+	assertModuleContent(t, dstThree, digestA)
 }
 
 // TestCASGetterOCIResolveFailureFallsBackToContentHash pins the pin-failure
@@ -101,7 +112,7 @@ func TestCASGetterOCITagFetchIsDigestPinned(t *testing.T) {
 func TestCASGetterOCIResolveFailureFallsBackToContentHash(t *testing.T) {
 	t.Parallel()
 
-	resolver := &movingTagResolver{tagDigest: "sha256:aaaa", failTagAfter: 1}
+	resolver := &movingTagResolver{tagDigest: digestA, failTagAfter: 1}
 	fetcher := &countingModuleGetter{}
 
 	_, client := newOCICASHarness(t, resolver, fetcher)
@@ -122,7 +133,7 @@ func TestCASGetterOCIResolveFailureFallsBackToContentHash(t *testing.T) {
 	dstTwo := filepath.Join(t.TempDir(), "two")
 
 	_, err = client.Get(t.Context(), &gogetter.Request{
-		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?digest=sha256:aaaa",
+		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?digest=" + digestA,
 		Dst:     dstTwo,
 		GetMode: gogetter.ModeDir,
 	})
@@ -176,7 +187,7 @@ func TestCASGetterOCISubdirSelectionSharesOneEntry(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			resolver := &movingTagResolver{tagDigest: "sha256:aaaa"}
+			resolver := &movingTagResolver{tagDigest: digestA}
 			fetcher := &treeModuleGetter{}
 
 			_, client := newOCICASHarness(t, resolver, fetcher)
@@ -220,7 +231,7 @@ func TestCASGetterOCISubdirSelectionSharesOneEntry(t *testing.T) {
 func TestCASGetterOCIProbeOnlyResolverNeverKeysMutableTags(t *testing.T) {
 	t.Parallel()
 
-	keyA := tgcas.ContentKey("oci-manifest", "sha256:aaaa")
+	keyA := tgcas.ContentKey("oci-manifest", digestA)
 
 	resolver := &probeOnlyResolver{key: keyA}
 	fetcher := &countingModuleGetter{}
@@ -324,12 +335,11 @@ func (r *movingTagResolver) setTag(digestValue string) {
 }
 
 // countingModuleGetter writes a one-file module, records the requested source,
-// and runs onFirstGet during the first download to simulate a mid-fetch re-push.
+// and counts downloads.
 type countingModuleGetter struct {
-	onFirstGet func()
-	src        string
-	srcMu      sync.Mutex
-	gets       atomic.Int32
+	src   string
+	srcMu sync.Mutex
+	gets  atomic.Int32
 }
 
 func (f *countingModuleGetter) Get(_ context.Context, req *gogetter.Request) error {
@@ -337,9 +347,7 @@ func (f *countingModuleGetter) Get(_ context.Context, req *gogetter.Request) err
 	f.src = req.Src
 	f.srcMu.Unlock()
 
-	if f.gets.Add(1) == 1 && f.onFirstGet != nil {
-		f.onFirstGet()
-	}
+	f.gets.Add(1)
 
 	return os.WriteFile(filepath.Join(req.Dst, "main.tf"), []byte(`output "fetched" {}`), 0o644)
 }

--- a/internal/getter/casgetter_oci_test.go
+++ b/internal/getter/casgetter_oci_test.go
@@ -23,16 +23,11 @@ import (
 // digest-specific content: the fetch is bound to the digest resolved at
 // download start, so a tag moving A to B and back to A can neither mis-key
 // the cache nor materialize the wrong manifest's bytes.
-// Valid manifest digests the OCI fakes share, satisfying the digest grammar
-// production enforces.
-var (
-	digestA = digest.FromString("manifest-a").String()
-	digestB = digest.FromString("manifest-b").String()
-)
-
 func TestCASGetterOCITagFetchIsDigestPinned(t *testing.T) {
 	t.Parallel()
 
+	digestA := testManifestDigest("manifest-a")
+	digestB := testManifestDigest("manifest-b")
 	resolver := &movingTagResolver{tagDigest: digestA}
 	fetcher := &digestModuleGetter{}
 	// First download: the tag moves A to B mid-fetch. Second download: it
@@ -112,6 +107,7 @@ func TestCASGetterOCITagFetchIsDigestPinned(t *testing.T) {
 func TestCASGetterOCIResolveFailureFallsBackToContentHash(t *testing.T) {
 	t.Parallel()
 
+	digestA := testManifestDigest("manifest-a")
 	resolver := &movingTagResolver{tagDigest: digestA, failTagAfter: 1}
 	fetcher := &countingModuleGetter{}
 
@@ -187,7 +183,7 @@ func TestCASGetterOCISubdirSelectionSharesOneEntry(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			resolver := &movingTagResolver{tagDigest: digestA}
+			resolver := &movingTagResolver{tagDigest: testManifestDigest("manifest-a")}
 			fetcher := &treeModuleGetter{}
 
 			_, client := newOCICASHarness(t, resolver, fetcher)
@@ -231,7 +227,7 @@ func TestCASGetterOCISubdirSelectionSharesOneEntry(t *testing.T) {
 func TestCASGetterOCIProbeOnlyResolverNeverKeysMutableTags(t *testing.T) {
 	t.Parallel()
 
-	keyA := tgcas.ContentKey("oci-manifest", digestA)
+	keyA := tgcas.ContentKey("oci-manifest", testManifestDigest("manifest-a"))
 
 	resolver := &probeOnlyResolver{key: keyA}
 	fetcher := &countingModuleGetter{}
@@ -469,4 +465,9 @@ func (f *digestModuleGetter) Mode(_ context.Context, _ *url.URL) (gogetter.Mode,
 
 func (f *digestModuleGetter) Detect(_ *gogetter.Request) (bool, error) {
 	return true, nil
+}
+
+// testManifestDigest derives a valid manifest digest from a seed.
+func testManifestDigest(seed string) string {
+	return digest.FromString(seed).String()
 }

--- a/internal/getter/casgetter_oci_test.go
+++ b/internal/getter/casgetter_oci_test.go
@@ -147,9 +147,16 @@ func TestCASGetterDoesNotClaimOCIWithoutFetcher(t *testing.T) {
 
 	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{})
 
-	claimed, err := g.Detect(&gogetter.Request{Src: "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0"})
-	require.NoError(t, err)
-	assert.False(t, claimed, "oci must not be claimed without a registered oci fetcher")
+	req := &gogetter.Request{
+		Src: "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0",
+		Pwd: t.TempDir(),
+	}
+
+	// The URL falls through to the file detector and fails there, which is
+	// exactly what proves the oci scheme was not claimed.
+	_, err = g.Detect(req)
+	require.ErrorContains(t, err, "directory not found")
+	assert.NotEqual(t, getter.SchemeOCI, req.Forced, "oci must not be claimed without a registered oci fetcher")
 }
 
 // movingTagResolver models a mutable tag: digest probes are deterministic,

--- a/internal/getter/casgetter_oci_test.go
+++ b/internal/getter/casgetter_oci_test.go
@@ -1,0 +1,135 @@
+package getter_test
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	tgcas "github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	gogetter "github.com/hashicorp/go-getter/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCASGetterOCIMovedTagNeverPoisonsProbeKey pins the probe/fetch race fix:
+// a tag that moves during the download must not store the fetched bytes under
+// the pre-move probe key, or a digest-pinned request for that key would
+// silently receive the moved content.
+func TestCASGetterOCIMovedTagNeverPoisonsProbeKey(t *testing.T) {
+	t.Parallel()
+
+	keyA := tgcas.ContentKey("oci-manifest", "sha256:aaaa")
+	keyB := tgcas.ContentKey("oci-manifest", "sha256:bbbb")
+
+	resolver := &movingTagResolver{tagKey: keyA, digestKey: keyA}
+	// The first download re-pushes the tag mid-fetch.
+	fetcher := &countingModuleGetter{onFirstGet: func() { resolver.setTag(keyB) }}
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+
+	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	v, err := tgcas.OSVenv()
+	require.NoError(t, err)
+
+	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},
+		getter.WithGenericFetchers(map[string]gogetter.Getter{
+			getter.SchemeOCI: fetcher,
+		}),
+		getter.WithGenericResolvers(map[string]getter.SourceResolver{
+			getter.SchemeOCI: resolver,
+		}),
+	)
+	client := &gogetter.Client{Getters: []gogetter.Getter{g}}
+
+	tagSrc := "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0"
+	digestSrc := "oci://127.0.0.1:5000/terraform-modules/vpc?digest=sha256:aaaa"
+
+	// The tag moves from A to B while this download runs, so the fetched
+	// bytes must not land under key A.
+	dstOne := filepath.Join(t.TempDir(), "one")
+
+	_, err = client.Get(t.Context(), &gogetter.Request{Src: tagSrc, Dst: dstOne, GetMode: gogetter.ModeDir})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, fetcher.gets.Load())
+
+	// A digest-pinned request for A must re-fetch: a hit here would mean the
+	// moved tag poisoned key A with the wrong content.
+	dstTwo := filepath.Join(t.TempDir(), "two")
+
+	_, err = client.Get(t.Context(), &gogetter.Request{Src: digestSrc, Dst: dstTwo, GetMode: gogetter.ModeDir})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, fetcher.gets.Load(), "a hit would mean the moved tag poisoned the digest key")
+
+	// The digest fetch keyed A legitimately, so a repeat is a pure cache hit.
+	dstThree := filepath.Join(t.TempDir(), "three")
+
+	_, err = client.Get(t.Context(), &gogetter.Request{Src: digestSrc, Dst: dstThree, GetMode: gogetter.ModeDir})
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, fetcher.gets.Load(), "a stable digest pin must be served from CAS")
+	assert.FileExists(t, filepath.Join(dstThree, "main.tf"))
+}
+
+// movingTagResolver models a mutable tag: digest probes are deterministic,
+// tag probes follow the current tag position.
+type movingTagResolver struct {
+	tagKey    string
+	digestKey string
+	mu        sync.Mutex
+}
+
+func (r *movingTagResolver) Scheme() string { return getter.SchemeOCI }
+
+func (r *movingTagResolver) Probe(_ context.Context, rawURL string) (string, error) {
+	if strings.Contains(rawURL, "digest=") {
+		return r.digestKey, nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.tagKey, nil
+}
+
+func (r *movingTagResolver) setTag(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.tagKey = key
+}
+
+// countingModuleGetter writes a one-file module, counts downloads, and runs
+// onFirstGet during the first download to simulate a mid-fetch re-push.
+type countingModuleGetter struct {
+	onFirstGet func()
+	gets       atomic.Int32
+}
+
+func (f *countingModuleGetter) Get(_ context.Context, req *gogetter.Request) error {
+	if f.gets.Add(1) == 1 && f.onFirstGet != nil {
+		f.onFirstGet()
+	}
+
+	return os.WriteFile(filepath.Join(req.Dst, "main.tf"), []byte(`output "fetched" {}`), 0o644)
+}
+
+func (f *countingModuleGetter) GetFile(_ context.Context, _ *gogetter.Request) error {
+	return getter.ErrOCIGetFileUnsupported
+}
+
+func (f *countingModuleGetter) Mode(_ context.Context, _ *url.URL) (gogetter.Mode, error) {
+	return gogetter.ModeDir, nil
+}
+
+func (f *countingModuleGetter) Detect(_ *gogetter.Request) (bool, error) {
+	return true, nil
+}

--- a/internal/getter/casgetter_oci_test.go
+++ b/internal/getter/casgetter_oci_test.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -19,108 +18,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCASGetterOCIMovedTagNeverPoisonsProbeKey pins the probe/fetch race fix:
-// a tag that moves during the download must not store the fetched bytes under
-// the pre-move probe key, or a digest-pinned request for that key would
-// silently receive the moved content.
-func TestCASGetterOCIMovedTagNeverPoisonsProbeKey(t *testing.T) {
+// TestCASGetterOCITagFetchIsDigestPinned pins the ABA-proof design: the
+// fetch is bound to the digest resolved at download start, so a tag moving
+// mid-fetch (even A to B and back to A) can never mis-key the cache.
+func TestCASGetterOCITagFetchIsDigestPinned(t *testing.T) {
 	t.Parallel()
 
-	keyA := tgcas.ContentKey("oci-manifest", "sha256:aaaa")
-	keyB := tgcas.ContentKey("oci-manifest", "sha256:bbbb")
-
-	resolver := &movingTagResolver{tagKey: keyA, digestKey: keyA}
+	resolver := &movingTagResolver{tagDigest: "sha256:aaaa"}
 	// The first download re-pushes the tag mid-fetch.
-	fetcher := &countingModuleGetter{onFirstGet: func() { resolver.setTag(keyB) }}
+	fetcher := &countingModuleGetter{onFirstGet: func() { resolver.setTag("sha256:bbbb") }}
 
-	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
-	require.NoError(t, err)
-
-	v, err := tgcas.OSVenv()
-	require.NoError(t, err)
-
-	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},
-		getter.WithGenericFetchers(map[string]gogetter.Getter{
-			getter.SchemeOCI: fetcher,
-		}),
-		getter.WithGenericResolvers(map[string]getter.SourceResolver{
-			getter.SchemeOCI: resolver,
-		}),
-	)
-	client := &gogetter.Client{Getters: []gogetter.Getter{g}}
+	g, client := newOCICASHarness(t, resolver, fetcher)
+	_ = g
 
 	tagSrc := "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0"
-	digestSrc := "oci://127.0.0.1:5000/terraform-modules/vpc?digest=sha256:aaaa"
-
-	// The tag moves from A to B while this download runs, so the fetched
-	// bytes must not land under key A.
-	dstOne := filepath.Join(t.TempDir(), "one")
-
-	_, err = client.Get(t.Context(), &gogetter.Request{Src: tagSrc, Dst: dstOne, GetMode: gogetter.ModeDir})
-	require.NoError(t, err)
-	require.EqualValues(t, 1, fetcher.gets.Load())
-
-	// A digest-pinned request for A must re-fetch: a hit here would mean the
-	// moved tag poisoned key A with the wrong content.
-	dstTwo := filepath.Join(t.TempDir(), "two")
-
-	_, err = client.Get(t.Context(), &gogetter.Request{Src: digestSrc, Dst: dstTwo, GetMode: gogetter.ModeDir})
-	require.NoError(t, err)
-	require.EqualValues(t, 2, fetcher.gets.Load(), "a hit would mean the moved tag poisoned the digest key")
-
-	// The digest fetch keyed A legitimately, so a repeat is a pure cache hit.
-	dstThree := filepath.Join(t.TempDir(), "three")
-
-	_, err = client.Get(t.Context(), &gogetter.Request{Src: digestSrc, Dst: dstThree, GetMode: gogetter.ModeDir})
-	require.NoError(t, err)
-	assert.EqualValues(t, 2, fetcher.gets.Load(), "a stable digest pin must be served from CAS")
-	assert.FileExists(t, filepath.Join(dstThree, "main.tf"))
-}
-
-// TestCASGetterOCIReProbeFailureDropsSuggestedKey pins the guard's error
-// path: when the post-fetch re-probe fails, the fetched bytes must not be
-// stored under the pre-fetch probe key.
-func TestCASGetterOCIReProbeFailureDropsSuggestedKey(t *testing.T) {
-	t.Parallel()
-
-	keyA := tgcas.ContentKey("oci-manifest", "sha256:aaaa")
-
-	resolver := &movingTagResolver{tagKey: keyA, digestKey: keyA}
-	// The first download breaks tag probing mid-fetch.
-	fetcher := &countingModuleGetter{onFirstGet: func() { resolver.setTagFailure() }}
-
-	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
-	require.NoError(t, err)
-
-	v, err := tgcas.OSVenv()
-	require.NoError(t, err)
-
-	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},
-		getter.WithGenericFetchers(map[string]gogetter.Getter{
-			getter.SchemeOCI: fetcher,
-		}),
-		getter.WithGenericResolvers(map[string]getter.SourceResolver{
-			getter.SchemeOCI: resolver,
-		}),
-	)
-	client := &gogetter.Client{Getters: []gogetter.Getter{g}}
 
 	dstOne := filepath.Join(t.TempDir(), "one")
 
-	_, err = client.Get(t.Context(), &gogetter.Request{
-		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0",
-		Dst:     dstOne,
-		GetMode: gogetter.ModeDir,
-	})
+	_, err := client.Get(t.Context(), &gogetter.Request{Src: tagSrc, Dst: dstOne, GetMode: gogetter.ModeDir})
 	require.NoError(t, err)
 	require.EqualValues(t, 1, fetcher.gets.Load())
+	assert.Contains(t, fetcher.lastSrc(), "digest=sha256%3Aaaaa", "the download must be pinned to the resolved digest")
+	assert.NotContains(t, fetcher.lastSrc(), "tag=", "the mutable tag must not reach the download")
 
-	// Key A must be unpopulated after the failed re-probe, so a digest pin
-	// for A has to fetch instead of hitting unverifiable content.
+	// The pinned fetch keyed A with A's content, so a digest request hits.
 	dstTwo := filepath.Join(t.TempDir(), "two")
 
 	_, err = client.Get(t.Context(), &gogetter.Request{
@@ -129,7 +50,50 @@ func TestCASGetterOCIReProbeFailureDropsSuggestedKey(t *testing.T) {
 		GetMode: gogetter.ModeDir,
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, 2, fetcher.gets.Load(), "a hit would mean the failed re-probe kept the stale key")
+	require.EqualValues(t, 1, fetcher.gets.Load(), "digest A must hit the entry the pinned fetch stored")
+
+	// The moved tag resolves to B now, so the tag misses and re-fetches by B.
+	dstThree := filepath.Join(t.TempDir(), "three")
+
+	_, err = client.Get(t.Context(), &gogetter.Request{Src: tagSrc, Dst: dstThree, GetMode: gogetter.ModeDir})
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, fetcher.gets.Load(), "the moved tag must re-fetch")
+	assert.Contains(t, fetcher.lastSrc(), "digest=sha256%3Abbbb", "the re-fetch must pin the moved digest")
+}
+
+// TestCASGetterOCIResolveFailureFallsBackToContentHash pins the pin-failure
+// path: when resolution fails at download time, the earlier probe key must
+// not be trusted.
+func TestCASGetterOCIResolveFailureFallsBackToContentHash(t *testing.T) {
+	t.Parallel()
+
+	resolver := &movingTagResolver{tagDigest: "sha256:aaaa", failTagAfter: 1}
+	fetcher := &countingModuleGetter{}
+
+	_, client := newOCICASHarness(t, resolver, fetcher)
+
+	dstOne := filepath.Join(t.TempDir(), "one")
+
+	// Probe resolves (call 1), the pin resolution fails (call 2), so the
+	// fetched bytes are stored under a content hash, not the probe key.
+	_, err := client.Get(t.Context(), &gogetter.Request{
+		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0",
+		Dst:     dstOne,
+		GetMode: gogetter.ModeDir,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, fetcher.gets.Load())
+
+	// Key A must be unpopulated, so a digest pin for A has to fetch.
+	dstTwo := filepath.Join(t.TempDir(), "two")
+
+	_, err = client.Get(t.Context(), &gogetter.Request{
+		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?digest=sha256:aaaa",
+		Dst:     dstTwo,
+		GetMode: gogetter.ModeDir,
+	})
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, fetcher.gets.Load(), "a hit would mean the failed pin kept the stale probe key")
 }
 
 // TestCASGetterDoesNotClaimOCIWithoutFetcher pins that oci:// stays unclaimed
@@ -159,59 +123,105 @@ func TestCASGetterDoesNotClaimOCIWithoutFetcher(t *testing.T) {
 	assert.NotEqual(t, getter.SchemeOCI, req.Forced, "oci must not be claimed without a registered oci fetcher")
 }
 
-// movingTagResolver models a mutable tag: digest probes are deterministic,
-// tag probes follow the current tag position or fail on demand.
+// newOCICASHarness builds a CASGetter over a fresh store with the fakes wired in.
+func newOCICASHarness(
+	t *testing.T, resolver getter.SourceResolver, fetcher gogetter.Getter,
+) (*getter.CASGetter, *gogetter.Client) {
+	t.Helper()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+
+	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	v, err := tgcas.OSVenv()
+	require.NoError(t, err)
+
+	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},
+		getter.WithGenericFetchers(map[string]gogetter.Getter{
+			getter.SchemeOCI: fetcher,
+		}),
+		getter.WithGenericResolvers(map[string]getter.SourceResolver{
+			getter.SchemeOCI: resolver,
+		}),
+	)
+
+	return g, &gogetter.Client{Getters: []gogetter.Getter{g}}
+}
+
+// movingTagResolver models a mutable tag with real digest-pin semantics.
 type movingTagResolver struct {
-	tagKey    string
-	digestKey string
-	failTag   bool
-	mu        sync.Mutex
+	tagDigest    string
+	tagResolves  int
+	failTagAfter int
+	mu           sync.Mutex
 }
 
 func (r *movingTagResolver) Scheme() string { return getter.SchemeOCI }
 
-func (r *movingTagResolver) Probe(_ context.Context, rawURL string) (string, error) {
-	if strings.Contains(rawURL, "digest=") {
-		return r.digestKey, nil
+func (r *movingTagResolver) Probe(ctx context.Context, rawURL string) (string, error) {
+	digestValue, err := r.ResolveDigest(ctx, rawURL)
+	if err != nil {
+		return "", tgcas.ErrNoVersionMetadata
+	}
+
+	return tgcas.ContentKey("oci-manifest", digestValue), nil
+}
+
+func (r *movingTagResolver) ResolveDigest(_ context.Context, rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+
+	if pinned := u.Query().Get("digest"); pinned != "" {
+		return pinned, nil
 	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.failTag {
+	r.tagResolves++
+	if r.failTagAfter > 0 && r.tagResolves > r.failTagAfter {
 		return "", errUnknownBlob
 	}
 
-	return r.tagKey, nil
+	return r.tagDigest, nil
 }
 
-func (r *movingTagResolver) setTag(key string) {
+func (r *movingTagResolver) setTag(digestValue string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.tagKey = key
+	r.tagDigest = digestValue
 }
 
-func (r *movingTagResolver) setTagFailure() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	r.failTag = true
-}
-
-// countingModuleGetter writes a one-file module, counts downloads, and runs
-// onFirstGet during the first download to simulate a mid-fetch re-push.
+// countingModuleGetter writes a one-file module, records the requested source,
+// and runs onFirstGet during the first download to simulate a mid-fetch re-push.
 type countingModuleGetter struct {
 	onFirstGet func()
+	src        string
+	srcMu      sync.Mutex
 	gets       atomic.Int32
 }
 
 func (f *countingModuleGetter) Get(_ context.Context, req *gogetter.Request) error {
+	f.srcMu.Lock()
+	f.src = req.Src
+	f.srcMu.Unlock()
+
 	if f.gets.Add(1) == 1 && f.onFirstGet != nil {
 		f.onFirstGet()
 	}
 
 	return os.WriteFile(filepath.Join(req.Dst, "main.tf"), []byte(`output "fetched" {}`), 0o644)
+}
+
+func (f *countingModuleGetter) lastSrc() string {
+	f.srcMu.Lock()
+	defer f.srcMu.Unlock()
+
+	return f.src
 }
 
 func (f *countingModuleGetter) GetFile(_ context.Context, _ *gogetter.Request) error {

--- a/internal/getter/casgetter_oci_test.go
+++ b/internal/getter/casgetter_oci_test.go
@@ -123,6 +123,80 @@ func TestCASGetterDoesNotClaimOCIWithoutFetcher(t *testing.T) {
 	assert.NotEqual(t, getter.SchemeOCI, req.Forced, "oci must not be claimed without a registered oci fetcher")
 }
 
+// TestCASGetterOCISubdirSelectionSharesOneEntry proves root and subdir
+// requests can safely share one cache entry: the client strips //subdir
+// before dispatch, the cached tree is always the full root, and the client
+// applies the selector after materialization.
+func TestCASGetterOCISubdirSelectionSharesOneEntry(t *testing.T) {
+	t.Parallel()
+
+	resolver := &movingTagResolver{tagDigest: "sha256:aaaa"}
+	fetcher := &treeModuleGetter{}
+
+	_, client := newOCICASHarness(t, resolver, fetcher)
+
+	dstRoot := filepath.Join(t.TempDir(), "root")
+
+	_, err := client.Get(t.Context(), &gogetter.Request{
+		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0",
+		Dst:     dstRoot,
+		GetMode: gogetter.ModeDir,
+	})
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(dstRoot, "main.tf"))
+	assert.FileExists(t, filepath.Join(dstRoot, "subdir", "sub.tf"))
+
+	// The subdir request hits the same entry yet receives only the subtree.
+	dstSub := filepath.Join(t.TempDir(), "sub")
+
+	_, err = client.Get(t.Context(), &gogetter.Request{
+		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc//subdir?tag=1.0.0",
+		Dst:     dstSub,
+		GetMode: gogetter.ModeDir,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, fetcher.gets.Load(), "the subdir request must be served from the shared entry")
+	assert.FileExists(t, filepath.Join(dstSub, "sub.tf"))
+	assert.NoFileExists(t, filepath.Join(dstSub, "main.tf"), "the root tree must not leak into a subdir request")
+	assert.NoFileExists(t, filepath.Join(dstSub, "subdir"), "the selector must be applied, not the full tree")
+}
+
+// TestCASGetterOCIProbeOnlyResolverNeverKeysMutableTags pins the fallback for
+// custom resolvers without the digest contract: the fetched bytes must be
+// content-hashed, never stored under the mutable probe key.
+func TestCASGetterOCIProbeOnlyResolverNeverKeysMutableTags(t *testing.T) {
+	t.Parallel()
+
+	keyA := tgcas.ContentKey("oci-manifest", "sha256:aaaa")
+
+	resolver := &probeOnlyResolver{key: keyA}
+	fetcher := &countingModuleGetter{}
+
+	_, client := newOCICASHarness(t, resolver, fetcher)
+
+	dstOne := filepath.Join(t.TempDir(), "one")
+
+	_, err := client.Get(t.Context(), &gogetter.Request{
+		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0",
+		Dst:     dstOne,
+		GetMode: gogetter.ModeDir,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, fetcher.gets.Load())
+	assert.Contains(t, fetcher.lastSrc(), "tag=1.0.0", "a probe-only resolver cannot pin the fetch")
+
+	// Key A must be unpopulated, so a request probing the same key re-fetches.
+	dstTwo := filepath.Join(t.TempDir(), "two")
+
+	_, err = client.Get(t.Context(), &gogetter.Request{
+		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0",
+		Dst:     dstTwo,
+		GetMode: gogetter.ModeDir,
+	})
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, fetcher.gets.Load(), "a hit would mean mutable-tag bytes were stored under the probe key")
+}
+
 // newOCICASHarness builds a CASGetter over a fresh store with the fakes wired in.
 func newOCICASHarness(
 	t *testing.T, resolver getter.SourceResolver, fetcher gogetter.Getter,
@@ -233,5 +307,47 @@ func (f *countingModuleGetter) Mode(_ context.Context, _ *url.URL) (gogetter.Mod
 }
 
 func (f *countingModuleGetter) Detect(_ *gogetter.Request) (bool, error) {
+	return true, nil
+}
+
+// probeOnlyResolver implements only the base resolver contract, no digest pinning.
+type probeOnlyResolver struct {
+	key string
+}
+
+func (r *probeOnlyResolver) Scheme() string { return getter.SchemeOCI }
+
+func (r *probeOnlyResolver) Probe(context.Context, string) (string, error) {
+	return r.key, nil
+}
+
+// treeModuleGetter writes a two-level module tree and counts downloads.
+type treeModuleGetter struct {
+	gets atomic.Int32
+}
+
+func (f *treeModuleGetter) Get(_ context.Context, req *gogetter.Request) error {
+	f.gets.Add(1)
+
+	if err := os.MkdirAll(filepath.Join(req.Dst, "subdir"), 0o755); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filepath.Join(req.Dst, "main.tf"), []byte(`output "root" {}`), 0o644); err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(req.Dst, "subdir", "sub.tf"), []byte(`output "sub" {}`), 0o644)
+}
+
+func (f *treeModuleGetter) GetFile(_ context.Context, _ *gogetter.Request) error {
+	return getter.ErrOCIGetFileUnsupported
+}
+
+func (f *treeModuleGetter) Mode(_ context.Context, _ *url.URL) (gogetter.Mode, error) {
+	return gogetter.ModeDir, nil
+}
+
+func (f *treeModuleGetter) Detect(_ *gogetter.Request) (bool, error) {
 	return true, nil
 }

--- a/internal/getter/casgetter_oci_test.go
+++ b/internal/getter/casgetter_oci_test.go
@@ -79,11 +79,85 @@ func TestCASGetterOCIMovedTagNeverPoisonsProbeKey(t *testing.T) {
 	assert.FileExists(t, filepath.Join(dstThree, "main.tf"))
 }
 
+// TestCASGetterOCIReProbeFailureDropsSuggestedKey pins the guard's error
+// path: when the post-fetch re-probe fails, the fetched bytes must not be
+// stored under the pre-fetch probe key.
+func TestCASGetterOCIReProbeFailureDropsSuggestedKey(t *testing.T) {
+	t.Parallel()
+
+	keyA := tgcas.ContentKey("oci-manifest", "sha256:aaaa")
+
+	resolver := &movingTagResolver{tagKey: keyA, digestKey: keyA}
+	// The first download breaks tag probing mid-fetch.
+	fetcher := &countingModuleGetter{onFirstGet: func() { resolver.setTagFailure() }}
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+
+	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	v, err := tgcas.OSVenv()
+	require.NoError(t, err)
+
+	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},
+		getter.WithGenericFetchers(map[string]gogetter.Getter{
+			getter.SchemeOCI: fetcher,
+		}),
+		getter.WithGenericResolvers(map[string]getter.SourceResolver{
+			getter.SchemeOCI: resolver,
+		}),
+	)
+	client := &gogetter.Client{Getters: []gogetter.Getter{g}}
+
+	dstOne := filepath.Join(t.TempDir(), "one")
+
+	_, err = client.Get(t.Context(), &gogetter.Request{
+		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0",
+		Dst:     dstOne,
+		GetMode: gogetter.ModeDir,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, fetcher.gets.Load())
+
+	// Key A must be unpopulated after the failed re-probe, so a digest pin
+	// for A has to fetch instead of hitting unverifiable content.
+	dstTwo := filepath.Join(t.TempDir(), "two")
+
+	_, err = client.Get(t.Context(), &gogetter.Request{
+		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?digest=sha256:aaaa",
+		Dst:     dstTwo,
+		GetMode: gogetter.ModeDir,
+	})
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, fetcher.gets.Load(), "a hit would mean the failed re-probe kept the stale key")
+}
+
+// TestCASGetterDoesNotClaimOCIWithoutFetcher pins that oci:// stays unclaimed
+// when the oci fetcher is not registered.
+func TestCASGetterDoesNotClaimOCIWithoutFetcher(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+
+	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	v, err := tgcas.OSVenv()
+	require.NoError(t, err)
+
+	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{})
+
+	claimed, err := g.Detect(&gogetter.Request{Src: "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0"})
+	require.NoError(t, err)
+	assert.False(t, claimed, "oci must not be claimed without a registered oci fetcher")
+}
+
 // movingTagResolver models a mutable tag: digest probes are deterministic,
-// tag probes follow the current tag position.
+// tag probes follow the current tag position or fail on demand.
 type movingTagResolver struct {
 	tagKey    string
 	digestKey string
+	failTag   bool
 	mu        sync.Mutex
 }
 
@@ -97,6 +171,10 @@ func (r *movingTagResolver) Probe(_ context.Context, rawURL string) (string, err
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	if r.failTag {
+		return "", errUnknownBlob
+	}
+
 	return r.tagKey, nil
 }
 
@@ -105,6 +183,13 @@ func (r *movingTagResolver) setTag(key string) {
 	defer r.mu.Unlock()
 
 	r.tagKey = key
+}
+
+func (r *movingTagResolver) setTagFailure() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.failTag = true
 }
 
 // countingModuleGetter writes a one-file module, counts downloads, and runs

--- a/internal/getter/casgetter_oci_test.go
+++ b/internal/getter/casgetter_oci_test.go
@@ -18,21 +18,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCASGetterOCITagFetchIsDigestPinned pins the ABA-proof design: the
-// fetch is bound to the digest resolved at download start, so a tag moving
-// mid-fetch (even A to B and back to A) can never mis-key the cache.
+// TestCASGetterOCITagFetchIsDigestPinned pins the ABA-proof design with
+// digest-specific content: the fetch is bound to the digest resolved at
+// download start, so a tag moving A to B and back to A can neither mis-key
+// the cache nor materialize the wrong manifest's bytes.
 func TestCASGetterOCITagFetchIsDigestPinned(t *testing.T) {
 	t.Parallel()
 
 	resolver := &movingTagResolver{tagDigest: "sha256:aaaa"}
-	// The first download re-pushes the tag mid-fetch.
-	fetcher := &countingModuleGetter{onFirstGet: func() { resolver.setTag("sha256:bbbb") }}
+	fetcher := &digestModuleGetter{}
+	// First download: the tag moves A to B mid-fetch. Second download: it
+	// moves back to A, completing the A to B to A sequence.
+	fetcher.onGet = func(call int32) {
+		if call == 1 {
+			resolver.setTag("sha256:bbbb")
+		}
 
-	g, client := newOCICASHarness(t, resolver, fetcher)
-	_ = g
+		if call == 2 {
+			resolver.setTag("sha256:aaaa")
+		}
+	}
+
+	_, client := newOCICASHarness(t, resolver, fetcher)
 
 	tagSrc := "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0"
 
+	// Fetch 1 pins digest A before the mid-fetch move, so A's content lands
+	// under A's key.
 	dstOne := filepath.Join(t.TempDir(), "one")
 
 	_, err := client.Get(t.Context(), &gogetter.Request{Src: tagSrc, Dst: dstOne, GetMode: gogetter.ModeDir})
@@ -40,25 +52,47 @@ func TestCASGetterOCITagFetchIsDigestPinned(t *testing.T) {
 	require.EqualValues(t, 1, fetcher.gets.Load())
 	assert.Contains(t, fetcher.lastSrc(), "digest=sha256%3Aaaaa", "the download must be pinned to the resolved digest")
 	assert.NotContains(t, fetcher.lastSrc(), "tag=", "the mutable tag must not reach the download")
+	assertModuleContent(t, dstOne, "sha256:aaaa")
 
-	// The pinned fetch keyed A with A's content, so a digest request hits.
+	// The tag points at B now: fetch 2 pins digest B and moves the tag back
+	// to A mid-fetch, so B's content lands under B's key.
 	dstTwo := filepath.Join(t.TempDir(), "two")
+
+	_, err = client.Get(t.Context(), &gogetter.Request{Src: tagSrc, Dst: dstTwo, GetMode: gogetter.ModeDir})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, fetcher.gets.Load(), "the moved tag must re-fetch")
+	assert.Contains(t, fetcher.lastSrc(), "digest=sha256%3Abbbb", "the re-fetch must pin the moved digest")
+	assertModuleContent(t, dstTwo, "sha256:bbbb")
+
+	// After A to B to A, digest requests hit their own entries with their
+	// own bytes and no further fetches.
+	dstA := filepath.Join(t.TempDir(), "digest-a")
 
 	_, err = client.Get(t.Context(), &gogetter.Request{
 		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?digest=sha256:aaaa",
-		Dst:     dstTwo,
+		Dst:     dstA,
 		GetMode: gogetter.ModeDir,
 	})
 	require.NoError(t, err)
-	require.EqualValues(t, 1, fetcher.gets.Load(), "digest A must hit the entry the pinned fetch stored")
+	assertModuleContent(t, dstA, "sha256:aaaa")
 
-	// The moved tag resolves to B now, so the tag misses and re-fetches by B.
+	dstB := filepath.Join(t.TempDir(), "digest-b")
+
+	_, err = client.Get(t.Context(), &gogetter.Request{
+		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?digest=sha256:bbbb",
+		Dst:     dstB,
+		GetMode: gogetter.ModeDir,
+	})
+	require.NoError(t, err)
+	assertModuleContent(t, dstB, "sha256:bbbb")
+
+	// The tag is back on A: a tag request hits A's cached entry.
 	dstThree := filepath.Join(t.TempDir(), "three")
 
 	_, err = client.Get(t.Context(), &gogetter.Request{Src: tagSrc, Dst: dstThree, GetMode: gogetter.ModeDir})
 	require.NoError(t, err)
-	assert.EqualValues(t, 2, fetcher.gets.Load(), "the moved tag must re-fetch")
-	assert.Contains(t, fetcher.lastSrc(), "digest=sha256%3Abbbb", "the re-fetch must pin the moved digest")
+	assert.EqualValues(t, 2, fetcher.gets.Load(), "every request after the two fetches must be a cache hit")
+	assertModuleContent(t, dstThree, "sha256:aaaa")
 }
 
 // TestCASGetterOCIResolveFailureFallsBackToContentHash pins the pin-failure
@@ -124,41 +158,60 @@ func TestCASGetterDoesNotClaimOCIWithoutFetcher(t *testing.T) {
 }
 
 // TestCASGetterOCISubdirSelectionSharesOneEntry proves root and subdir
-// requests can safely share one cache entry: the client strips //subdir
-// before dispatch, the cached tree is always the full root, and the client
-// applies the selector after materialization.
+// requests share one full-root cache entry in either order: the client strips
+// //subdir before dispatch, so even a subdir-first miss ingests the complete
+// root, and the client applies the selector after materialization.
 func TestCASGetterOCISubdirSelectionSharesOneEntry(t *testing.T) {
 	t.Parallel()
 
-	resolver := &movingTagResolver{tagDigest: "sha256:aaaa"}
-	fetcher := &treeModuleGetter{}
+	testCases := []struct {
+		name        string
+		subdirFirst bool
+	}{
+		{name: "root then subdir", subdirFirst: false},
+		{name: "subdir then root", subdirFirst: true},
+	}
 
-	_, client := newOCICASHarness(t, resolver, fetcher)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	dstRoot := filepath.Join(t.TempDir(), "root")
+			resolver := &movingTagResolver{tagDigest: "sha256:aaaa"}
+			fetcher := &treeModuleGetter{}
 
-	_, err := client.Get(t.Context(), &gogetter.Request{
-		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0",
-		Dst:     dstRoot,
-		GetMode: gogetter.ModeDir,
-	})
-	require.NoError(t, err)
-	assert.FileExists(t, filepath.Join(dstRoot, "main.tf"))
-	assert.FileExists(t, filepath.Join(dstRoot, "subdir", "sub.tf"))
+			_, client := newOCICASHarness(t, resolver, fetcher)
 
-	// The subdir request hits the same entry yet receives only the subtree.
-	dstSub := filepath.Join(t.TempDir(), "sub")
+			rootSrc := "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0"
+			subSrc := "oci://127.0.0.1:5000/terraform-modules/vpc//subdir?tag=1.0.0"
 
-	_, err = client.Get(t.Context(), &gogetter.Request{
-		Src:     "oci://127.0.0.1:5000/terraform-modules/vpc//subdir?tag=1.0.0",
-		Dst:     dstSub,
-		GetMode: gogetter.ModeDir,
-	})
-	require.NoError(t, err)
-	require.EqualValues(t, 1, fetcher.gets.Load(), "the subdir request must be served from the shared entry")
-	assert.FileExists(t, filepath.Join(dstSub, "sub.tf"))
-	assert.NoFileExists(t, filepath.Join(dstSub, "main.tf"), "the root tree must not leak into a subdir request")
-	assert.NoFileExists(t, filepath.Join(dstSub, "subdir"), "the selector must be applied, not the full tree")
+			first, second := rootSrc, subSrc
+			if tc.subdirFirst {
+				first, second = subSrc, rootSrc
+			}
+
+			dstFirst := filepath.Join(t.TempDir(), "first")
+
+			_, err := client.Get(t.Context(), &gogetter.Request{Src: first, Dst: dstFirst, GetMode: gogetter.ModeDir})
+			require.NoError(t, err)
+
+			dstSecond := filepath.Join(t.TempDir(), "second")
+
+			_, err = client.Get(t.Context(), &gogetter.Request{Src: second, Dst: dstSecond, GetMode: gogetter.ModeDir})
+			require.NoError(t, err)
+			require.EqualValues(t, 1, fetcher.gets.Load(), "both orders must share one full-root cache entry")
+
+			dstRoot, dstSub := dstFirst, dstSecond
+			if tc.subdirFirst {
+				dstRoot, dstSub = dstSecond, dstFirst
+			}
+
+			assert.FileExists(t, filepath.Join(dstRoot, "main.tf"))
+			assert.FileExists(t, filepath.Join(dstRoot, "subdir", "sub.tf"))
+			assert.FileExists(t, filepath.Join(dstSub, "sub.tf"))
+			assert.NoFileExists(t, filepath.Join(dstSub, "main.tf"), "the root tree must not leak into a subdir request")
+			assert.NoFileExists(t, filepath.Join(dstSub, "subdir"), "the selector must be applied, not the full tree")
+		})
+	}
 }
 
 // TestCASGetterOCIProbeOnlyResolverNeverKeysMutableTags pins the fallback for
@@ -349,5 +402,63 @@ func (f *treeModuleGetter) Mode(_ context.Context, _ *url.URL) (gogetter.Mode, e
 }
 
 func (f *treeModuleGetter) Detect(_ *gogetter.Request) (bool, error) {
+	return true, nil
+}
+
+// assertModuleContent asserts the materialized module carries the content of
+// the given digest.
+func assertModuleContent(t *testing.T, dst, digestValue string) {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(dst, "main.tf"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), digestValue, "the materialized tree must match the pinned digest")
+}
+
+// digestModuleGetter writes digest-specific content, records the requested
+// source, and runs onGet with the download count for mid-fetch tag moves.
+type digestModuleGetter struct {
+	onGet func(call int32)
+	src   string
+	srcMu sync.Mutex
+	gets  atomic.Int32
+}
+
+func (f *digestModuleGetter) Get(_ context.Context, req *gogetter.Request) error {
+	f.srcMu.Lock()
+	f.src = req.Src
+	f.srcMu.Unlock()
+
+	call := f.gets.Add(1)
+	if f.onGet != nil {
+		f.onGet(call)
+	}
+
+	pinned := "UNPINNED"
+	if u, err := url.Parse(req.Src); err == nil && u.Query().Get("digest") != "" {
+		pinned = u.Query().Get("digest")
+	}
+
+	content := `output "manifest" { value = "` + pinned + `" }`
+
+	return os.WriteFile(filepath.Join(req.Dst, "main.tf"), []byte(content), 0o644)
+}
+
+func (f *digestModuleGetter) lastSrc() string {
+	f.srcMu.Lock()
+	defer f.srcMu.Unlock()
+
+	return f.src
+}
+
+func (f *digestModuleGetter) GetFile(_ context.Context, _ *gogetter.Request) error {
+	return getter.ErrOCIGetFileUnsupported
+}
+
+func (f *digestModuleGetter) Mode(_ context.Context, _ *url.URL) (gogetter.Mode, error) {
+	return gogetter.ModeDir, nil
+}
+
+func (f *digestModuleGetter) Detect(_ *gogetter.Request) (bool, error) {
 	return true, nil
 }

--- a/internal/getter/defaults.go
+++ b/internal/getter/defaults.go
@@ -31,22 +31,27 @@ const (
 type GenericFetcherOption func(*genericFetcherConfig)
 
 type genericFetcherConfig struct {
-	tfrLogger  log.Logger
-	tfrFS      vfs.FS
-	ociLogger  log.Logger
-	ociVenv    venv.Venv
-	httpExtra  http.Header
-	httpsExtra http.Header
-	tfrImpl    tfimpl.Type
+	tfrLogger   log.Logger
+	tfrFS       vfs.FS
+	ociLogger   log.Logger
+	ociVenv     venv.Venv
+	ociNewStore OCINewStoreFunc
+	httpExtra   http.Header
+	httpsExtra  http.Header
+	tfrImpl     tfimpl.Type
 }
 
 // WithOCIConfig registers the dependencies the oci:// fetcher and resolver
 // need for CAS dispatch. When unset, oci is omitted from the generic maps so
-// CASGetter never claims oci:// sources.
+// CASGetter never claims oci:// sources. The store seam is built once here so
+// the fetcher and the resolver share one credential discovery and auth cache.
 func WithOCIConfig(l log.Logger, v venv.Venv) GenericFetcherOption {
+	newStore := NewOCIRepositoryStore(l, v)
+
 	return func(c *genericFetcherConfig) {
 		c.ociLogger = l
 		c.ociVenv = v
+		c.ociNewStore = newStore
 	}
 }
 
@@ -101,7 +106,7 @@ func DefaultGenericFetchers(opts ...GenericFetcherOption) map[string]getter.Gett
 
 	if cfg.ociLogger != nil {
 		m[SchemeOCI] = &OCIGetter{
-			NewStore: NewOCIRepositoryStore(cfg.ociLogger, cfg.ociVenv),
+			NewStore: cfg.ociNewStore,
 			Logger:   cfg.ociLogger,
 			FS:       cfg.ociVenv.FS,
 		}

--- a/internal/getter/defaults.go
+++ b/internal/getter/defaults.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	gcs "github.com/hashicorp/go-getter/gcs/v2"
@@ -32,9 +33,21 @@ type GenericFetcherOption func(*genericFetcherConfig)
 type genericFetcherConfig struct {
 	tfrLogger  log.Logger
 	tfrFS      vfs.FS
+	ociLogger  log.Logger
+	ociVenv    venv.Venv
 	httpExtra  http.Header
 	httpsExtra http.Header
 	tfrImpl    tfimpl.Type
+}
+
+// WithOCIConfig registers the dependencies the oci:// fetcher and resolver
+// need for CAS dispatch. When unset, oci is omitted from the generic maps so
+// CASGetter never claims oci:// sources.
+func WithOCIConfig(l log.Logger, v venv.Venv) GenericFetcherOption {
+	return func(c *genericFetcherConfig) {
+		c.ociLogger = l
+		c.ociVenv = v
+	}
 }
 
 // WithHTTPExtraHeaders attaches header to the bare http getter so
@@ -84,6 +97,14 @@ func DefaultGenericFetchers(opts ...GenericFetcherOption) map[string]getter.Gett
 
 	if cfg.tfrLogger != nil {
 		m[SchemeTFR] = NewRegistryGetter(cfg.tfrLogger, cfg.tfrFS).WithTofuImplementation(cfg.tfrImpl)
+	}
+
+	if cfg.ociLogger != nil {
+		m[SchemeOCI] = &OCIGetter{
+			NewStore: NewOCIRepositoryStore(cfg.ociLogger, cfg.ociVenv),
+			Logger:   cfg.ociLogger,
+			FS:       cfg.ociVenv.FS,
+		}
 	}
 
 	return m

--- a/internal/getter/defaults.go
+++ b/internal/getter/defaults.go
@@ -34,7 +34,7 @@ type genericFetcherConfig struct {
 	tfrLogger   log.Logger
 	tfrFS       vfs.FS
 	ociLogger   log.Logger
-	ociVenv     venv.Venv
+	ociFS       vfs.FS
 	ociNewStore OCINewStoreFunc
 	httpExtra   http.Header
 	httpsExtra  http.Header
@@ -44,13 +44,14 @@ type genericFetcherConfig struct {
 // WithOCIConfig registers the dependencies the oci:// fetcher and resolver
 // need for CAS dispatch. When unset, oci is omitted from the generic maps so
 // CASGetter never claims oci:// sources. The store seam is built once here so
-// the fetcher and the resolver share one credential discovery and auth cache.
-func WithOCIConfig(l log.Logger, v venv.Venv) GenericFetcherOption {
+// the fetcher and the resolver share one credential discovery and auth cache;
+// fs is the extraction filesystem, mirroring [WithTFRConfig].
+func WithOCIConfig(l log.Logger, v venv.Venv, fs vfs.FS) GenericFetcherOption {
 	newStore := NewOCIRepositoryStore(l, v)
 
 	return func(c *genericFetcherConfig) {
 		c.ociLogger = l
-		c.ociVenv = v
+		c.ociFS = fs
 		c.ociNewStore = newStore
 	}
 }
@@ -108,7 +109,7 @@ func DefaultGenericFetchers(opts ...GenericFetcherOption) map[string]getter.Gett
 		m[SchemeOCI] = &OCIGetter{
 			NewStore: cfg.ociNewStore,
 			Logger:   cfg.ociLogger,
-			FS:       cfg.ociVenv.FS,
+			FS:       cfg.ociFS,
 		}
 	}
 

--- a/internal/getter/oci.go
+++ b/internal/getter/oci.go
@@ -280,19 +280,7 @@ func (g *OCIGetter) Get(ctx context.Context, req *getter.Request) error {
 		return ErrOCIGetterNotConfigured
 	}
 
-	srcURL := req.URL()
-
-	registryDomain := srcURL.Host
-	if registryDomain == "" {
-		return ErrOCIMissingRegistryDomain
-	}
-
-	repositoryName, subDir := SourceDirSubdir(strings.TrimPrefix(srcURL.Path, "/"))
-	if repositoryName == "" {
-		return ErrOCIMissingRepositoryName
-	}
-
-	ref, err := ociRefFromQuery(srcURL.Query())
+	registryDomain, repositoryName, subDir, ref, err := parseOCISource(req.URL())
 	if err != nil {
 		return err
 	}
@@ -359,6 +347,27 @@ func validateOCIQueryParams(queryValues url.Values) error {
 	}
 
 	return nil
+}
+
+// parseOCISource splits an oci source URL into registry coordinates, the
+// subdir selector, and the validated reference to resolve.
+func parseOCISource(srcURL *url.URL) (registryDomain, repositoryName, subDir, ref string, err error) {
+	registryDomain = srcURL.Host
+	if registryDomain == "" {
+		return "", "", "", "", ErrOCIMissingRegistryDomain
+	}
+
+	repositoryName, subDir = SourceDirSubdir(strings.TrimPrefix(srcURL.Path, "/"))
+	if repositoryName == "" {
+		return "", "", "", "", ErrOCIMissingRepositoryName
+	}
+
+	ref, err = ociRefFromQuery(srcURL.Query())
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	return registryDomain, repositoryName, subDir, ref, nil
 }
 
 // ociRefFromQuery validates the source query and returns the reference to

--- a/internal/getter/oci_test.go
+++ b/internal/getter/oci_test.go
@@ -841,7 +841,8 @@ func TestDefaultGenericFetchersOCIConfig(t *testing.T) {
 	_, found := getter.DefaultGenericFetchers()[getter.SchemeOCI]
 	assert.False(t, found, "oci fetcher must be absent without WithOCIConfig")
 
-	fetchers := getter.DefaultGenericFetchers(getter.WithOCIConfig(logger.CreateLogger(), venvtest.New()))
+	v := venvtest.New()
+	fetchers := getter.DefaultGenericFetchers(getter.WithOCIConfig(logger.CreateLogger(), v, v.FS))
 
 	g, found := fetchers[getter.SchemeOCI]
 	require.True(t, found, "oci fetcher must be present with WithOCIConfig")
@@ -849,6 +850,8 @@ func TestDefaultGenericFetchersOCIConfig(t *testing.T) {
 	ociGetter, castOK := g.(*getter.OCIGetter)
 	require.True(t, castOK, "oci fetcher must be an OCIGetter")
 	assert.NotNil(t, ociGetter.NewStore, "oci fetcher must carry the default store")
+	assert.NotNil(t, ociGetter.Logger, "oci fetcher must carry the configured logger")
+	assert.NotNil(t, ociGetter.FS, "oci fetcher must carry the extraction filesystem")
 }
 
 // errRenameFailed is the injected fault renameFailFS returns.

--- a/internal/getter/oci_test.go
+++ b/internal/getter/oci_test.go
@@ -10,11 +10,13 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	gogetter "github.com/hashicorp/go-getter/v2"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
@@ -833,11 +835,20 @@ func TestNewClientWithoutOCIRejectsOCISources(t *testing.T) {
 	assert.NotErrorIs(t, err, getter.OCIUnsupportedQueryParamError{Param: "bogus"})
 }
 
-func TestDefaultGenericFetchersExcludeOCI(t *testing.T) {
+func TestDefaultGenericFetchersOCIConfig(t *testing.T) {
 	t.Parallel()
 
 	_, found := getter.DefaultGenericFetchers()[getter.SchemeOCI]
-	assert.False(t, found, "generic dispatch must never route oci sources")
+	assert.False(t, found, "oci fetcher must be absent without WithOCIConfig")
+
+	fetchers := getter.DefaultGenericFetchers(getter.WithOCIConfig(logger.CreateLogger(), venvtest.New()))
+
+	g, found := fetchers[getter.SchemeOCI]
+	require.True(t, found, "oci fetcher must be present with WithOCIConfig")
+
+	ociGetter, castOK := g.(*getter.OCIGetter)
+	require.True(t, castOK, "oci fetcher must be an OCIGetter")
+	assert.NotNil(t, ociGetter.NewStore, "oci fetcher must carry the default store")
 }
 
 // errRenameFailed is the injected fault renameFailFS returns.
@@ -867,6 +878,7 @@ type fakeStore struct {
 	manifestDesc  ociv1.Descriptor
 	manifestBytes []byte
 	gotRefs       []string
+	mu            sync.Mutex
 }
 
 func newFakeStore(
@@ -883,6 +895,9 @@ func newFakeStore(
 }
 
 func (s *fakeStore) Resolve(_ context.Context, ref string) (ociv1.Descriptor, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.gotRefs = append(s.gotRefs, ref)
 
 	return s.manifestDesc, nil

--- a/internal/getter/resolver.go
+++ b/internal/getter/resolver.go
@@ -43,10 +43,10 @@ func DefaultSourceResolvers(opts ...GenericFetcherOption) map[string]SourceResol
 		SchemeTFR:   tfr,
 	}
 
-	// Registered only alongside the oci fetcher, so the probe shares the
-	// getter's credential path and CASGetter claims oci:// consistently.
+	// Registered only alongside the oci fetcher, sharing its store seam so
+	// probe and fetch use one credential discovery and auth cache.
 	if cfg.ociLogger != nil {
-		resolvers[SchemeOCI] = NewOCIResolver(NewOCIRepositoryStore(cfg.ociLogger, cfg.ociVenv))
+		resolvers[SchemeOCI] = NewOCIResolver(cfg.ociNewStore)
 	}
 
 	return resolvers

--- a/internal/getter/resolver.go
+++ b/internal/getter/resolver.go
@@ -34,7 +34,7 @@ func DefaultSourceResolvers(opts ...GenericFetcherOption) map[string]SourceResol
 		tfr.WithTofuImplementation(cfg.tfrImpl)
 	}
 
-	return map[string]SourceResolver{
+	resolvers := map[string]SourceResolver{
 		SchemeHTTP:  NewHTTPResolver(),
 		SchemeHTTPS: NewHTTPSResolver(),
 		SchemeS3:    NewS3Resolver(),
@@ -42,4 +42,12 @@ func DefaultSourceResolvers(opts ...GenericFetcherOption) map[string]SourceResol
 		SchemeHg:    NewHgResolver(),
 		SchemeTFR:   tfr,
 	}
+
+	// Registered only alongside the oci fetcher, so the probe shares the
+	// getter's credential path and CASGetter claims oci:// consistently.
+	if cfg.ociLogger != nil {
+		resolvers[SchemeOCI] = NewOCIResolver(NewOCIRepositoryStore(cfg.ociLogger, cfg.ociVenv))
+	}
+
+	return resolvers
 }

--- a/internal/getter/resolver_oci.go
+++ b/internal/getter/resolver_oci.go
@@ -3,7 +3,6 @@ package getter
 import (
 	"context"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
@@ -44,21 +43,12 @@ func (r *OCIResolver) Probe(ctx context.Context, rawURL string) (string, error) 
 		return "", cas.ErrNoVersionMetadata
 	}
 
-	registryDomain := srcURL.Host
-	if registryDomain == "" {
-		return "", cas.ErrNoVersionMetadata
-	}
-
-	// Strip the //subdir selector so two URLs that only differ in subdir
-	// produce the same probe key.
-	repositoryName, _ := SourceDirSubdir(strings.TrimPrefix(srcURL.Path, "/"))
-	if repositoryName == "" {
-		return "", cas.ErrNoVersionMetadata
-	}
-
 	queryValues := srcURL.Query()
+	// Drop the archive marker the CAS dispatch injects.
+	queryValues.Del("archive")
+	srcURL.RawQuery = queryValues.Encode()
 
-	ref, err := ociRefFromQuery(queryValues)
+	registryDomain, repositoryName, _, ref, err := parseOCISource(srcURL)
 	if err != nil {
 		return "", cas.ErrNoVersionMetadata
 	}

--- a/internal/getter/resolver_oci.go
+++ b/internal/getter/resolver_oci.go
@@ -1,0 +1,91 @@
+package getter
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+)
+
+// ociResolverTimeout caps the registry probe so a slow registry cannot stall CAS dispatch.
+const ociResolverTimeout = 10 * time.Second
+
+// ociManifestKeyAlg namespaces CAS keys derived from OCI manifest digests.
+const ociManifestKeyAlg = "oci-manifest"
+
+// OCIResolver is a [cas.SourceResolver] for oci:// URLs.
+//
+// A digest pin is already a content hash, so it becomes the cache key without
+// touching the registry. A tag is mutable, so Probe re-resolves it to its
+// manifest digest on every call; an unchanged tag therefore hits the same
+// entry while a re-pushed tag misses and re-fetches.
+type OCIResolver struct {
+	NewStore OCINewStoreFunc
+}
+
+// NewOCIResolver returns an [OCIResolver] probing through newStore, so
+// resolution shares the getter's credential path.
+func NewOCIResolver(newStore OCINewStoreFunc) *OCIResolver {
+	return &OCIResolver{NewStore: newStore}
+}
+
+// Scheme returns "oci".
+func (r *OCIResolver) Scheme() string { return SchemeOCI }
+
+// Probe returns the manifest digest of rawURL as a content-addressed cache
+// key. Any failure returns [cas.ErrNoVersionMetadata] so the fetch falls
+// through to the download-then-content-hash path, surfacing the underlying
+// error on the real fetch attempt.
+func (r *OCIResolver) Probe(ctx context.Context, rawURL string) (string, error) {
+	srcURL, err := url.Parse(rawURL)
+	if err != nil || srcURL.Scheme != SchemeOCI {
+		return "", cas.ErrNoVersionMetadata
+	}
+
+	registryDomain := srcURL.Host
+	if registryDomain == "" {
+		return "", cas.ErrNoVersionMetadata
+	}
+
+	// Strip the //subdir selector so two URLs that only differ in subdir
+	// produce the same probe key.
+	repositoryName, _ := SourceDirSubdir(strings.TrimPrefix(srcURL.Path, "/"))
+	if repositoryName == "" {
+		return "", cas.ErrNoVersionMetadata
+	}
+
+	queryValues := srcURL.Query()
+
+	ref, err := ociRefFromQuery(queryValues)
+	if err != nil {
+		return "", cas.ErrNoVersionMetadata
+	}
+
+	// A digest pin already names the manifest content; no resolution needed.
+	if queryValues.Has(ociDigestQueryKey) {
+		return cas.ContentKey(ociManifestKeyAlg, ref), nil
+	}
+
+	if r.NewStore == nil {
+		return "", cas.ErrNoVersionMetadata
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, ociResolverTimeout)
+	defer cancel()
+
+	store, err := r.NewStore(ctx, registryDomain, repositoryName)
+	if err != nil {
+		return "", cas.ErrNoVersionMetadata
+	}
+
+	// Tags are mutable: resolve on every probe so a re-pushed tag can never
+	// serve a stale cache entry.
+	desc, err := store.Resolve(ctx, ref)
+	if err != nil {
+		return "", cas.ErrNoVersionMetadata
+	}
+
+	return cas.ContentKey(ociManifestKeyAlg, desc.Digest.String()), nil
+}

--- a/internal/getter/resolver_oci.go
+++ b/internal/getter/resolver_oci.go
@@ -64,6 +64,9 @@ func (r *OCIResolver) ResolveDigest(ctx context.Context, rawURL string) (string,
 	queryValues.Del("archive")
 	srcURL.RawQuery = queryValues.Encode()
 
+	// Discarding the subdir is safe: go-getter clients strip //subdir before
+	// dispatch, so the cached tree is always the full root and the client
+	// applies the selector after materialization.
 	registryDomain, repositoryName, _, ref, err := parseOCISource(srcURL)
 	if err != nil {
 		return "", err

--- a/internal/getter/resolver_oci.go
+++ b/internal/getter/resolver_oci.go
@@ -2,6 +2,7 @@ package getter
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"time"
 
@@ -38,9 +39,24 @@ func (r *OCIResolver) Scheme() string { return SchemeOCI }
 // through to the download-then-content-hash path, surfacing the underlying
 // error on the real fetch attempt.
 func (r *OCIResolver) Probe(ctx context.Context, rawURL string) (string, error) {
-	srcURL, err := url.Parse(rawURL)
-	if err != nil || srcURL.Scheme != SchemeOCI {
+	digestValue, err := r.ResolveDigest(ctx, rawURL)
+	if err != nil {
 		return "", cas.ErrNoVersionMetadata
+	}
+
+	return cas.ContentKey(ociManifestKeyAlg, digestValue), nil
+}
+
+// ResolveDigest returns the manifest digest rawURL points at right now: the
+// pinned digest verbatim, or a fresh tag resolution through the store seam.
+func (r *OCIResolver) ResolveDigest(ctx context.Context, rawURL string) (string, error) {
+	srcURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing oci source %q: %w", rawURL, err)
+	}
+
+	if srcURL.Scheme != SchemeOCI {
+		return "", ErrOCIMissingRegistryDomain
 	}
 
 	queryValues := srcURL.Query()
@@ -50,16 +66,16 @@ func (r *OCIResolver) Probe(ctx context.Context, rawURL string) (string, error) 
 
 	registryDomain, repositoryName, _, ref, err := parseOCISource(srcURL)
 	if err != nil {
-		return "", cas.ErrNoVersionMetadata
+		return "", err
 	}
 
 	// A digest pin already names the manifest content; no resolution needed.
 	if queryValues.Has(ociDigestQueryKey) {
-		return cas.ContentKey(ociManifestKeyAlg, ref), nil
+		return ref, nil
 	}
 
 	if r.NewStore == nil {
-		return "", cas.ErrNoVersionMetadata
+		return "", ErrOCIGetterNotConfigured
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, ociResolverTimeout)
@@ -67,15 +83,13 @@ func (r *OCIResolver) Probe(ctx context.Context, rawURL string) (string, error) 
 
 	store, err := r.NewStore(ctx, registryDomain, repositoryName)
 	if err != nil {
-		return "", cas.ErrNoVersionMetadata
+		return "", err
 	}
 
-	// Tags are mutable: resolve on every probe so a re-pushed tag can never
-	// serve a stale cache entry.
 	desc, err := store.Resolve(ctx, ref)
 	if err != nil {
-		return "", cas.ErrNoVersionMetadata
+		return "", fmt.Errorf("resolving OCI reference %q: %w", ref, err)
 	}
 
-	return cas.ContentKey(ociManifestKeyAlg, desc.Digest.String()), nil
+	return desc.Digest.String(), nil
 }

--- a/internal/getter/resolver_oci_test.go
+++ b/internal/getter/resolver_oci_test.go
@@ -74,7 +74,10 @@ func TestOCIResolverProbeStripsSubdir(t *testing.T) {
 	t.Parallel()
 
 	store := resolverFakeStore(t)
-	r := getter.NewOCIResolver(staticStore(store))
+
+	var gotDomain, gotRepo string
+
+	r := getter.NewOCIResolver(recordingStore(store, &gotDomain, &gotRepo))
 
 	whole, err := r.Probe(t.Context(), "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0")
 	require.NoError(t, err)
@@ -83,6 +86,41 @@ func TestOCIResolverProbeStripsSubdir(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, whole, subdir)
+	assert.Equal(t, "127.0.0.1:5000", gotDomain)
+	assert.Equal(t, "terraform-modules/vpc", gotRepo, "the subdir selector must not reach the repository name")
+}
+
+// TestOCIResolverProbeIgnoresArchiveMarker: the CAS dispatch marker must not defeat the probe.
+func TestOCIResolverProbeIgnoresArchiveMarker(t *testing.T) {
+	t.Parallel()
+
+	store := resolverFakeStore(t)
+	r := getter.NewOCIResolver(staticStore(store))
+
+	plain, err := r.Probe(t.Context(), "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0")
+	require.NoError(t, err)
+
+	marked, err := r.Probe(t.Context(), "oci://127.0.0.1:5000/terraform-modules/vpc?archive=false&tag=1.0.0")
+	require.NoError(t, err)
+
+	assert.Equal(t, plain, marked)
+}
+
+// TestOCIResolverProbeAppliesTimeout: the store must see a bounded context.
+func TestOCIResolverProbeAppliesTimeout(t *testing.T) {
+	t.Parallel()
+
+	var sawDeadline bool
+
+	r := getter.NewOCIResolver(func(ctx context.Context, _, _ string) (getter.OCIRepositoryStore, error) {
+		_, sawDeadline = ctx.Deadline()
+
+		return nil, errUnknownBlob
+	})
+
+	_, err := r.Probe(t.Context(), "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0")
+	require.ErrorIs(t, err, cas.ErrNoVersionMetadata)
+	assert.True(t, sawDeadline, "the probe must bound registry calls with a deadline")
 }
 
 // TestOCIResolverProbeTagAndDigestShareKey: a tag resolving to a digest shares its entry.
@@ -194,11 +232,19 @@ func TestDefaultSourceResolversOCIConfig(t *testing.T) {
 	_, found := getter.DefaultSourceResolvers()[getter.SchemeOCI]
 	assert.False(t, found, "oci resolver must be absent without WithOCIConfig")
 
-	resolvers := getter.DefaultSourceResolvers(getter.WithOCIConfig(logger.CreateLogger(), venvtest.New()))
+	resolvers := func() map[string]getter.SourceResolver {
+		v := venvtest.New()
+
+		return getter.DefaultSourceResolvers(getter.WithOCIConfig(logger.CreateLogger(), v, v.FS))
+	}()
 
 	r, found := resolvers[getter.SchemeOCI]
 	require.True(t, found, "oci resolver must be present with WithOCIConfig")
 	assert.Equal(t, getter.SchemeOCI, r.Scheme())
+
+	ociResolver, castOK := r.(*getter.OCIResolver)
+	require.True(t, castOK, "oci resolver must be an OCIResolver")
+	assert.NotNil(t, ociResolver.NewStore, "resolver must carry the shared store seam")
 }
 
 // resolverFakeStore builds a fake store carrying only a resolvable manifest descriptor.

--- a/internal/getter/resolver_oci_test.go
+++ b/internal/getter/resolver_oci_test.go
@@ -1,0 +1,238 @@
+package getter_test
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/opencontainers/go-digest"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOCIResolverScheme(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, getter.SchemeOCI, getter.NewOCIResolver(nil).Scheme())
+}
+
+// TestOCIResolverProbeDigestPinSkipsResolve: a digest pin is the key, no registry roundtrip.
+func TestOCIResolverProbeDigestPinSkipsResolve(t *testing.T) {
+	t.Parallel()
+
+	pinned := digest.FromString("pinned-manifest").String()
+	r := getter.NewOCIResolver(failingNewStore())
+
+	key, err := r.Probe(t.Context(), "oci://127.0.0.1:5000/terraform-modules/vpc?digest="+pinned)
+	require.NoError(t, err, "a digest pin must not consult the store")
+	assert.Equal(t, cas.ContentKey("oci-manifest", pinned), key)
+}
+
+// TestOCIResolverProbeTagResolvesEveryProbe: tags are mutable, so every probe re-resolves.
+func TestOCIResolverProbeTagResolvesEveryProbe(t *testing.T) {
+	t.Parallel()
+
+	store := resolverFakeStore(t)
+	r := getter.NewOCIResolver(staticStore(store))
+
+	first, err := r.Probe(t.Context(), "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0")
+	require.NoError(t, err)
+
+	second, err := r.Probe(t.Context(), "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0")
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second, "an unchanged tag must produce the same key")
+	assert.Equal(t, []string{"1.0.0", "1.0.0"}, store.gotRefs, "every probe must re-resolve the tag")
+}
+
+// TestOCIResolverProbeMovedTagChangesKey: a re-pushed tag must miss the old cache entry.
+func TestOCIResolverProbeMovedTagChangesKey(t *testing.T) {
+	t.Parallel()
+
+	store := resolverFakeStore(t)
+	r := getter.NewOCIResolver(staticStore(store))
+
+	before, err := r.Probe(t.Context(), "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0")
+	require.NoError(t, err)
+
+	store.manifestDesc.Digest = digest.FromString("re-pushed-manifest")
+
+	after, err := r.Probe(t.Context(), "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, before, after, "a moved tag must produce a new key")
+}
+
+// TestOCIResolverProbeStripsSubdir: subdir selectors must not split the cache entry.
+func TestOCIResolverProbeStripsSubdir(t *testing.T) {
+	t.Parallel()
+
+	store := resolverFakeStore(t)
+	r := getter.NewOCIResolver(staticStore(store))
+
+	whole, err := r.Probe(t.Context(), "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0")
+	require.NoError(t, err)
+
+	subdir, err := r.Probe(t.Context(), "oci://127.0.0.1:5000/terraform-modules/vpc//subdir?tag=1.0.0")
+	require.NoError(t, err)
+
+	assert.Equal(t, whole, subdir)
+}
+
+// TestOCIResolverProbeTagAndDigestShareKey: a tag resolving to a digest shares its entry.
+func TestOCIResolverProbeTagAndDigestShareKey(t *testing.T) {
+	t.Parallel()
+
+	store := resolverFakeStore(t)
+	r := getter.NewOCIResolver(staticStore(store))
+
+	viaTag, err := r.Probe(t.Context(), "oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0")
+	require.NoError(t, err)
+
+	viaDigest, err := r.Probe(
+		t.Context(),
+		"oci://127.0.0.1:5000/terraform-modules/vpc?digest="+store.manifestDesc.Digest.String(),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, viaTag, viaDigest)
+}
+
+func TestOCIResolverProbeErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		newStore getter.OCINewStoreFunc
+		name     string
+		rawURL   string
+	}{
+		{name: "wrong scheme", rawURL: "tfr://registry.example.com/module?version=1.0.0"},
+		{name: "unparseable url", rawURL: "oci://bad\x00url"},
+		{name: "missing registry domain", rawURL: "oci:///terraform-modules/vpc?tag=1.0.0"},
+		{name: "missing repository name", rawURL: "oci://127.0.0.1:5000?tag=1.0.0"},
+		{name: "unsupported query parameter", rawURL: "oci://127.0.0.1:5000/vpc?tag=1.0.0&foo=bar"},
+		{name: "invalid digest value", rawURL: "oci://127.0.0.1:5000/vpc?digest=not-a-digest"},
+		{name: "nil store seam", rawURL: "oci://127.0.0.1:5000/vpc?tag=1.0.0"},
+		{
+			name:     "store construction failure",
+			rawURL:   "oci://127.0.0.1:5000/vpc?tag=1.0.0",
+			newStore: failingNewStore(),
+		},
+		{
+			name:     "resolve failure",
+			rawURL:   "oci://127.0.0.1:5000/vpc?tag=1.0.0",
+			newStore: failingResolveStoreFunc(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := getter.NewOCIResolver(tc.newStore)
+
+			_, err := r.Probe(t.Context(), tc.rawURL)
+			require.ErrorIs(t, err, cas.ErrNoVersionMetadata)
+		})
+	}
+}
+
+// TestOCIResolverProbeConcurrentWithRacing: concurrent probes of the same and
+// different refs must be race-free and key-stable.
+func TestOCIResolverProbeConcurrentWithRacing(t *testing.T) {
+	t.Parallel()
+
+	store := resolverFakeStore(t)
+	r := getter.NewOCIResolver(staticStore(store))
+	pinned := store.manifestDesc.Digest.String()
+
+	const probesPerShape = 8
+
+	keys := make(chan string, 3*probesPerShape)
+
+	var wg sync.WaitGroup
+
+	for range probesPerShape {
+		for _, rawURL := range []string{
+			"oci://127.0.0.1:5000/terraform-modules/vpc?tag=1.0.0",
+			"oci://127.0.0.1:5000/terraform-modules/vpc//subdir?tag=1.0.0",
+			"oci://127.0.0.1:5000/terraform-modules/vpc?digest=" + pinned,
+		} {
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+
+				key, err := r.Probe(t.Context(), rawURL)
+				assert.NoError(t, err)
+
+				keys <- key
+			}()
+		}
+	}
+
+	wg.Wait()
+	close(keys)
+
+	want := cas.ContentKey("oci-manifest", pinned)
+	for key := range keys {
+		assert.Equal(t, want, key, "every probe shape must map to the manifest digest key")
+	}
+
+	assert.Len(t, store.gotRefs, 2*probesPerShape, "every tag probe must resolve, digest probes must not")
+}
+
+func TestDefaultSourceResolversOCIConfig(t *testing.T) {
+	t.Parallel()
+
+	_, found := getter.DefaultSourceResolvers()[getter.SchemeOCI]
+	assert.False(t, found, "oci resolver must be absent without WithOCIConfig")
+
+	resolvers := getter.DefaultSourceResolvers(getter.WithOCIConfig(logger.CreateLogger(), venvtest.New()))
+
+	r, found := resolvers[getter.SchemeOCI]
+	require.True(t, found, "oci resolver must be present with WithOCIConfig")
+	assert.Equal(t, getter.SchemeOCI, r.Scheme())
+}
+
+// resolverFakeStore builds a fake store carrying only a resolvable manifest descriptor.
+func resolverFakeStore(t *testing.T) *fakeStore {
+	t.Helper()
+
+	zipBytes := moduleZipBytes(t, map[string]string{"main.tf": `output "probe" {}`})
+	layer := zipLayerDesc(zipBytes)
+	manifestBytes, manifestDesc := manifestFor(t, getter.ArtifactTypeModulePkg, layer)
+
+	return newFakeStore(manifestBytes, &manifestDesc, zipBytes, &layer)
+}
+
+// failingNewStore returns a seam whose construction always fails.
+func failingNewStore() getter.OCINewStoreFunc {
+	return func(context.Context, string, string) (getter.OCIRepositoryStore, error) {
+		return nil, errUnknownBlob
+	}
+}
+
+// failingResolveStoreFunc returns a seam whose store fails every Resolve.
+func failingResolveStoreFunc() getter.OCINewStoreFunc {
+	return func(context.Context, string, string) (getter.OCIRepositoryStore, error) {
+		return failingResolveStore{}, nil
+	}
+}
+
+// failingResolveStore fails Resolve and Fetch alike.
+type failingResolveStore struct{}
+
+func (failingResolveStore) Resolve(context.Context, string) (ociv1.Descriptor, error) {
+	return ociv1.Descriptor{}, errUnknownBlob
+}
+
+func (failingResolveStore) Fetch(context.Context, *ociv1.Descriptor) (io.ReadCloser, error) {
+	return nil, errUnknownBlob
+}

--- a/internal/getter/resolver_oci_test.go
+++ b/internal/getter/resolver_oci_test.go
@@ -232,11 +232,8 @@ func TestDefaultSourceResolversOCIConfig(t *testing.T) {
 	_, found := getter.DefaultSourceResolvers()[getter.SchemeOCI]
 	assert.False(t, found, "oci resolver must be absent without WithOCIConfig")
 
-	resolvers := func() map[string]getter.SourceResolver {
-		v := venvtest.New()
-
-		return getter.DefaultSourceResolvers(getter.WithOCIConfig(logger.CreateLogger(), v, v.FS))
-	}()
+	v := venvtest.New()
+	resolvers := getter.DefaultSourceResolvers(getter.WithOCIConfig(logger.CreateLogger(), v, v.FS))
 
 	r, found := resolvers[getter.SchemeOCI]
 	require.True(t, found, "oci resolver must be present with WithOCIConfig")

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -520,9 +520,11 @@ func tryCASDownload(
 	opts *Options,
 	mutable bool,
 ) (bool, error) {
+	ociEnabled := opts.Experiments.Evaluate(experiment.OCI)
+
 	// Without the oci experiment the CAS maps carry no oci entries, so skip
 	// the attempt instead of logging a guaranteed fallback on every download.
-	if src.CanonicalSourceURL.Scheme == getter.SchemeOCI && !opts.Experiments.Evaluate(experiment.OCI) {
+	if src.CanonicalSourceURL.Scheme == getter.SchemeOCI && !ociEnabled {
 		return false, nil
 	}
 
@@ -576,8 +578,8 @@ func tryCASDownload(
 		getter.WithTFRConfig(l, opts.TofuImplementation, casVenv.FS),
 	}
 
-	if opts.Experiments.Evaluate(experiment.OCI) {
-		dispatchOpts = append(dispatchOpts, getter.WithOCIConfig(l, v))
+	if ociEnabled {
+		dispatchOpts = append(dispatchOpts, getter.WithOCIConfig(l, v, casVenv.FS))
 	}
 
 	// CAS-only client: CASProtocolGetter handles cas::sha1:<hash> sources

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -478,7 +478,7 @@ func downloadSource(
 	isLocalSource := tf.IsLocalSource(src.CanonicalSourceURL)
 
 	if allowCAS && !isLocalSource {
-		done, err := tryCASDownload(ctx, l, src, opts, cfg.Terraform.Mutable)
+		done, err := tryCASDownload(ctx, l, v, src, opts, cfg.Terraform.Mutable)
 		if err != nil {
 			return err
 		}
@@ -515,13 +515,14 @@ func downloadSource(
 func tryCASDownload(
 	ctx context.Context,
 	l log.Logger,
+	v venv.Venv,
 	src *tf.Source,
 	opts *Options,
 	mutable bool,
 ) (bool, error) {
-	// The CAS matcher cannot claim oci:// sources yet, so skip the attempt
-	// instead of logging a guaranteed fallback on every oci download.
-	if src.CanonicalSourceURL.Scheme == getter.SchemeOCI {
+	// Without the oci experiment the CAS maps carry no oci entries, so skip
+	// the attempt instead of logging a guaranteed fallback on every download.
+	if src.CanonicalSourceURL.Scheme == getter.SchemeOCI && !opts.Experiments.Evaluate(experiment.OCI) {
 		return false, nil
 	}
 
@@ -573,6 +574,10 @@ func tryCASDownload(
 
 	dispatchOpts := []getter.GenericFetcherOption{
 		getter.WithTFRConfig(l, opts.TofuImplementation, casVenv.FS),
+	}
+
+	if opts.Experiments.Evaluate(experiment.OCI) {
+		dispatchOpts = append(dispatchOpts, getter.WithOCIConfig(l, v))
 	}
 
 	// CAS-only client: CASProtocolGetter handles cas::sha1:<hash> sources

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -956,8 +956,15 @@ func TestDownloadSourceOCIThroughCASExperimentGate(t *testing.T) {
 			t.Parallel()
 
 			tmpDir := helpers.TmpDirWOSymlinks(t)
+
+			// A TLS server the test owns: the client rejects its self-signed
+			// cert deterministically, with no assumptions about closed ports.
+			registry := httptest.NewTLSServer(http.NotFoundHandler())
+			t.Cleanup(registry.Close)
+
+			registryAddr := registry.Listener.Addr().String()
 			src := &tf.Source{
-				CanonicalSourceURL: parseURL(t, "oci://127.0.0.1:1/terraform-modules/vpc?tag=1.0.0"),
+				CanonicalSourceURL: parseURL(t, "oci://"+registryAddr+"/terraform-modules/vpc?tag=1.0.0"),
 				DownloadDir:        tmpDir,
 				WorkingDir:         tmpDir,
 				VersionFile:        filepath.Join(tmpDir, "version-file.txt"),
@@ -992,7 +999,7 @@ func TestDownloadSourceOCIThroughCASExperimentGate(t *testing.T) {
 				cfg,
 				report.NewReport(),
 			)
-			require.Error(t, err, "the registry at port 1 is unreachable")
+			require.Error(t, err, "the fake registry's cert is untrusted, so every fetch fails")
 
 			const casAttempt = "CAS enabled: attempting to use Content Addressable Storage"
 

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -1,6 +1,7 @@
 package run_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -934,6 +935,78 @@ func TestDownloadSourceWithCASExperimentEnabled(t *testing.T) {
 
 	expectedFilePath := filepath.Join(tmpDir, "main.tf")
 	assert.FileExists(t, expectedFilePath)
+}
+
+// TestDownloadSourceOCIThroughCASExperimentGate: with the oci experiment on,
+// an oci source enters the CAS path (observed via the CAS attempt log) and
+// reaches the real getter; off, the CAS attempt is skipped up front.
+func TestDownloadSourceOCIThroughCASExperimentGate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		enableOCI bool
+	}{
+		{name: "experiment enabled reaches the oci getter", enableOCI: true},
+		{name: "experiment disabled skips the oci getter", enableOCI: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := helpers.TmpDirWOSymlinks(t)
+			src := &tf.Source{
+				CanonicalSourceURL: parseURL(t, "oci://127.0.0.1:1/terraform-modules/vpc?tag=1.0.0"),
+				DownloadDir:        tmpDir,
+				WorkingDir:         tmpDir,
+				VersionFile:        filepath.Join(tmpDir, "version-file.txt"),
+			}
+
+			opts, err := options.NewTerragruntOptionsForTest("./should-not-be-used")
+			require.NoError(t, err)
+
+			opts.Experiments = experiment.NewExperiments()
+
+			if tc.enableOCI {
+				require.NoError(t, opts.Experiments.EnableExperiment(experiment.OCI))
+			}
+
+			cfg := &runcfg.RunConfig{
+				Terraform: runcfg.TerraformConfig{
+					ExtraArgs: []runcfg.TerraformExtraArguments{},
+				},
+			}
+
+			var logBuf bytes.Buffer
+
+			l := logger.CreateLogger()
+			l.SetOptions(log.WithOutput(&logBuf), log.WithLevel(log.DebugLevel))
+
+			_, err = run.DownloadTerraformSourceIfNecessary(
+				t.Context(),
+				l,
+				venv.OSVenv(),
+				src,
+				configbridge.NewRunOptions(opts),
+				cfg,
+				report.NewReport(),
+			)
+			require.Error(t, err, "the registry at port 1 is unreachable")
+
+			const casAttempt = "CAS enabled: attempting to use Content Addressable Storage"
+
+			if tc.enableOCI {
+				require.ErrorContains(t, err, "resolving OCI reference", "the oci getter must run when the experiment is on")
+				assert.Contains(t, logBuf.String(), casAttempt, "the oci source must enter the CAS path when the experiment is on")
+
+				return
+			}
+
+			assert.NotContains(t, err.Error(), "resolving OCI reference", "no oci getter must run when the experiment is off")
+			assert.NotContains(t, logBuf.String(), casAttempt, "the CAS attempt must be skipped when the experiment is off")
+		})
+	}
 }
 
 // TestDownloadSourceWithCASGitSource tests CAS functionality with a Git source

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -613,7 +613,7 @@ type ZipDecompressedSizeLimitError struct {
 
 func (err ZipDecompressedSizeLimitError) Error() string {
 	return fmt.Sprintf(
-		"file %q of decompressed size %d exceeds the total decompressed size limit of %d",
+		"extracting file %q (decompressed size %d) would exceed the total decompressed size limit of %d",
 		err.Name, err.Size, err.Limit,
 	)
 }

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -613,8 +613,8 @@ type ZipDecompressedSizeLimitError struct {
 
 func (err ZipDecompressedSizeLimitError) Error() string {
 	return fmt.Sprintf(
-		"extracting file %q (decompressed size %d) would exceed the total decompressed size limit of %d",
-		err.Name, err.Size, err.Limit,
+		"extracting file %q exceeded the total decompressed size limit of %d (declared entry size %d)",
+		err.Name, err.Limit, err.Size,
 	)
 }
 

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -613,7 +613,7 @@ type ZipDecompressedSizeLimitError struct {
 
 func (err ZipDecompressedSizeLimitError) Error() string {
 	return fmt.Sprintf(
-		"extracting file %q exceeded the total decompressed size limit of %d (declared entry size %d)",
+		"extracting file %q breached the total decompressed size limit of %d (entry size %d)",
 		err.Name, err.Limit, err.Size,
 	)
 }

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -602,10 +602,20 @@ const defaultZipDirMode os.FileMode = 0755
 const maxSymlinkTargetSize = 4096
 
 // ZipDecompressedSizeLimitError reports an extraction exceeding its configured decompressed size limit.
-type ZipDecompressedSizeLimitError struct{}
+type ZipDecompressedSizeLimitError struct {
+	// Name is the archive entry whose extraction breached the limit.
+	Name string
+	// Size is the entry's declared uncompressed size in bytes.
+	Size uint64
+	// Limit is the configured total decompressed size limit in bytes.
+	Limit int64
+}
 
-func (ZipDecompressedSizeLimitError) Error() string {
-	return "decompressed size exceeds limit"
+func (err ZipDecompressedSizeLimitError) Error() string {
+	return fmt.Sprintf(
+		"file %q of decompressed size %d exceeds the total decompressed size limit of %d",
+		err.Name, err.Size, err.Limit,
+	)
 }
 
 // ZipDecompressor handles zip archive extraction with configurable limits.
@@ -770,6 +780,9 @@ func (z *ZipDecompressor) extractRegularFile(
 		reader = &limitedReader{
 			reader:    rc,
 			remaining: z.FileSizeLimit - *totalSize,
+			name:      zipFile.Name,
+			size:      zipFile.UncompressedSize64,
+			limit:     z.FileSizeLimit,
 		}
 	}
 
@@ -812,7 +825,10 @@ func (d FileInfoDirEntry) Info() (fs.FileInfo, error) { return d.FileInfo, nil }
 // limitedReader wraps a reader and enforces a size limit.
 type limitedReader struct {
 	reader    io.Reader
+	name      string
 	remaining int64
+	size      uint64
+	limit     int64
 }
 
 func (r *limitedReader) Read(p []byte) (int, error) {
@@ -831,7 +847,7 @@ func (r *limitedReader) Read(p []byte) (int, error) {
 
 	n, err := r.reader.Read(probe[:])
 	if n > 0 {
-		return 0, ZipDecompressedSizeLimitError{}
+		return 0, ZipDecompressedSizeLimitError{Name: r.name, Size: r.size, Limit: r.limit}
 	}
 
 	if err == nil {
@@ -1207,7 +1223,11 @@ func (z *ZipDecompressor) extractSymlink(
 
 	if z.FileSizeLimit > 0 {
 		if *totalSize+int64(len(targetBytes)) > z.FileSizeLimit {
-			return ZipDecompressedSizeLimitError{}
+			return ZipDecompressedSizeLimitError{
+				Name:  zipFile.Name,
+				Size:  uint64(len(targetBytes)),
+				Limit: z.FileSizeLimit,
+			}
 		}
 
 		*totalSize += int64(len(targetBytes))

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -811,8 +811,9 @@ func TestUnzipFileSizeLimit(t *testing.T) {
 
 		fs := vfs.NewMemMapFS()
 		// Create content that exceeds 10 bytes
+		content := []byte("this content is definitely more than 10 bytes")
 		zipData := createZipArchive(t, map[string][]byte{
-			"large.txt": []byte("this content is definitely more than 10 bytes"),
+			"large.txt": content,
 		})
 		require.NoError(t, vfs.WriteFile(fs, "/archive.zip", zipData, 0644))
 
@@ -820,6 +821,9 @@ func TestUnzipFileSizeLimit(t *testing.T) {
 
 		var limitErr vfs.ZipDecompressedSizeLimitError
 		require.ErrorAs(t, err, &limitErr)
+		assert.Equal(t, "large.txt", limitErr.Name)
+		assert.Equal(t, uint64(len(content)), limitErr.Size)
+		assert.Equal(t, int64(10), limitErr.Limit)
 	})
 
 	t.Run("cumulative size limit across files", func(t *testing.T) {
@@ -840,7 +844,7 @@ func TestUnzipFileSizeLimit(t *testing.T) {
 		require.ErrorAs(t, err, &limitErr)
 		assert.Equal(t, uint64(10), limitErr.Size, "the breaching entry itself is only 10 bytes")
 		assert.Equal(t, int64(25), limitErr.Limit)
-		assert.Contains(t, limitErr.Error(), "would exceed the total decompressed size limit of 25")
+		assert.Contains(t, limitErr.Error(), "exceeded the total decompressed size limit of 25")
 	})
 
 	t.Run("no limit when FileSizeLimit is zero", func(t *testing.T) {

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -578,6 +578,9 @@ func TestUnzipSymlinkLimits(t *testing.T) {
 
 		var limitErr vfs.ZipDecompressedSizeLimitError
 		require.ErrorAs(t, err, &limitErr)
+		assert.Equal(t, "link", limitErr.Name)
+		assert.Equal(t, uint64(len("target.txt")), limitErr.Size)
+		assert.Equal(t, int64(2), limitErr.Limit)
 	})
 
 	t.Run("symlink target above the hard cap is rejected", func(t *testing.T) {

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -844,7 +844,7 @@ func TestUnzipFileSizeLimit(t *testing.T) {
 		require.ErrorAs(t, err, &limitErr)
 		assert.Equal(t, uint64(10), limitErr.Size, "the breaching entry itself is only 10 bytes")
 		assert.Equal(t, int64(25), limitErr.Limit)
-		assert.Contains(t, limitErr.Error(), "exceeded the total decompressed size limit of 25")
+		assert.Contains(t, limitErr.Error(), "breached the total decompressed size limit of 25")
 	})
 
 	t.Run("no limit when FileSizeLimit is zero", func(t *testing.T) {

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -838,6 +838,9 @@ func TestUnzipFileSizeLimit(t *testing.T) {
 
 		var limitErr vfs.ZipDecompressedSizeLimitError
 		require.ErrorAs(t, err, &limitErr)
+		assert.Equal(t, uint64(10), limitErr.Size, "the breaching entry itself is only 10 bytes")
+		assert.Equal(t, int64(25), limitErr.Limit)
+		assert.Contains(t, limitErr.Error(), "would exceed the total decompressed size limit of 25")
 	})
 
 	t.Run("no limit when FileSizeLimit is zero", func(t *testing.T) {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

- oci:// module sources now integrate with Content Addressable Storage (CAS)

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OCI (`oci://`) source support to generic fetching and resolution when the OCI feature is enabled.
  * Improved caching for OCI tags by pinning downloads to immutable manifest digests.
  * Enhanced zip extraction size-limit errors with the entry name, size, and configured limit.

* **Bug Fixes**
  * Prevented stale cache keys by falling back safely when OCI digest resolution fails.
  * Fixed OCI subdirectory selection so requests share the correct cached content without leaking root results.
  * Ensured OCI sources respect the feature enablement setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->