### PR TITLE
fix: Preventing spurious re-inits

### DIFF
--- a/docs/src/data/changelog/v1.1.2/local-source-spurious-re-inits.mdx
+++ b/docs/src/data/changelog/v1.1.2/local-source-spurious-re-inits.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.2"
+category: "bug-fixes"
+---
+
+#### Local sources no longer re-init when uncopied files change
+
+For units with a local `source`, Terragrunt decides whether the cached copy is stale by hashing the source directory. That hash previously covered every file in the directory, including hidden files and `exclude_from_copy` matches that are never copied into the cache. Creating or touching such a file (an editor swap file, a scratch note) changed the hash, forcing a needless re-copy and auto-init on the next run.
+
+The hash now covers only the files a copy would deliver, honoring the default hidden-file rule along with `include_in_copy` and `exclude_from_copy`. Files that never reach the cache no longer trigger re-initialization.

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -99,10 +99,10 @@ func DownloadTerraformSource(
 
 	// When no download was needed (AlreadyHaveLatestCode=true) and the source
 	// directory IS the working directory (source="."), skip the module copy: the
-	// version hash incorporates all file mod times, so no files have changed and
-	// the cache already has the correct content from a previous run. Skipping
-	// avoids manifest.Clean() deleting files that a concurrent goroutine expects
-	// to exist.
+	// version hash incorporates the mod times of every file the copy would
+	// deliver, so no relevant files have changed and the cache already has the
+	// correct content from a previous run. Skipping avoids manifest.Clean()
+	// deleting files that a concurrent goroutine expects to exist.
 	//
 	// When the source is a different directory (local or remote), the module copy
 	// overlays working-dir files on top of the downloaded source. These files may
@@ -122,16 +122,7 @@ func DownloadTerraformSource(
 			),
 		)
 
-		// Always include the .tflint.hcl file, if it exists
-		includeInCopy := slices.Concat(cfg.Terraform.IncludeInCopy, []string{tfLintConfig})
-
-		copyOpts := []util.CopyOption{
-			util.WithIncludeInCopy(includeInCopy...),
-			util.WithExcludeFromCopy(cfg.Terraform.ExcludeFromCopy...),
-		}
-		if controls.IsFastCopyEnabled(opts.StrictControls) {
-			copyOpts = append(copyOpts, util.WithFastCopy())
-		}
+		copyOpts := moduleCopyOptions(opts, cfg)
 
 		err = telemetry.TelemeterFromContext(ctx).
 			Collect(ctx, l, "copy_folder_contents", map[string]any{
@@ -166,6 +157,26 @@ func DownloadTerraformSource(
 	updatedOpts.CacheDir = terraformSource.WorkingDir
 
 	return updatedOpts, nil
+}
+
+// moduleCopyOptions returns the copy options for the module copy into the
+// cache working directory. The source version hash uses the same options so it
+// covers exactly the files a copy would deliver: when the source directory is
+// the working directory, the module copy is skipped whenever the hash is
+// unchanged, so any file the hash ignored must be one no copy would refresh.
+func moduleCopyOptions(opts *Options, cfg *runcfg.RunConfig) []util.CopyOption {
+	// Always include the .tflint.hcl file, if it exists
+	includeInCopy := slices.Concat(cfg.Terraform.IncludeInCopy, []string{tfLintConfig})
+
+	copyOpts := []util.CopyOption{
+		util.WithIncludeInCopy(includeInCopy...),
+		util.WithExcludeFromCopy(cfg.Terraform.ExcludeFromCopy...),
+	}
+	if controls.IsFastCopyEnabled(opts.StrictControls) {
+		copyOpts = append(copyOpts, util.WithFastCopy())
+	}
+
+	return copyOpts
 }
 
 // resolveTerraformModuleVersion rewrites a config-provided tfr:// source to pin
@@ -254,6 +265,8 @@ func DownloadTerraformSourceIfNecessary(
 		return false, ErrNonOSFilesystem
 	}
 
+	copyOpts := moduleCopyOptions(opts, cfg)
+
 	if opts.SourceUpdate {
 		l.Debugf(
 			"The --source-update flag is set, so deleting the temporary folder %s before downloading source.",
@@ -264,7 +277,7 @@ func DownloadTerraformSourceIfNecessary(
 			return false, err
 		}
 	} else {
-		alreadyLatest, err := AlreadyHaveLatestCode(l, terraformSource, opts)
+		alreadyLatest, err := AlreadyHaveLatestCode(l, terraformSource, opts, copyOpts...)
 		if err != nil {
 			return false, err
 		}
@@ -353,7 +366,7 @@ func DownloadTerraformSourceIfNecessary(
 		}
 	}
 
-	if err := terraformSource.WriteVersionFile(l); err != nil {
+	if err := terraformSource.WriteVersionFile(l, copyOpts...); err != nil {
 		return false, err
 	}
 
@@ -361,7 +374,7 @@ func DownloadTerraformSourceIfNecessary(
 		return false, err
 	}
 
-	currentVersion, err := terraformSource.EncodeSourceVersion(l)
+	currentVersion, err := terraformSource.EncodeSourceVersion(l, copyOpts...)
 	// if source versions are different or calculating version failed, create file to run init
 	// https://github.com/gruntwork-io/terragrunt/issues/1921
 	if (previousVersion != "" && previousVersion != currentVersion) || err != nil {
@@ -388,8 +401,14 @@ func DownloadTerraformSourceIfNecessary(
 
 // AlreadyHaveLatestCode returns true if the specified TerraformSource, of the exact same version, has already been downloaded into the
 // DownloadFolder. This helps avoid downloading the same code multiple times. Note that if the TerraformSource points
-// to a local file path, a hash will be generated from the contents of the source dir. See the ProcessTerraformSource method for more info.
-func AlreadyHaveLatestCode(l log.Logger, terraformSource *tf.Source, opts *Options) (bool, error) {
+// to a local file path, a hash will be generated from the files in the source dir that a copy configured with
+// copyOpts would deliver. See the ProcessTerraformSource method for more info.
+func AlreadyHaveLatestCode(
+	l log.Logger,
+	terraformSource *tf.Source,
+	opts *Options,
+	copyOpts ...util.CopyOption,
+) (bool, error) {
 	for _, path := range []string{terraformSource.DownloadDir, terraformSource.WorkingDir, terraformSource.VersionFile} {
 		exists, err := vfs.FileExists(opts.FS, path)
 		if err != nil {
@@ -415,7 +434,7 @@ func AlreadyHaveLatestCode(l log.Logger, terraformSource *tf.Source, opts *Optio
 		return false, nil
 	}
 
-	currentVersion, err := terraformSource.EncodeSourceVersion(l)
+	currentVersion, err := terraformSource.EncodeSourceVersion(l, copyOpts...)
 	// If we fail to calculate the source version (e.g. because walking the
 	// directory tree failed) use a random version instead, bypassing the cache.
 	if err != nil {

--- a/internal/tf/source.go
+++ b/internal/tf/source.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"io/fs"
 	"net/url"
 	"os"
@@ -112,62 +113,88 @@ func (src Source) EncodeSourceVersion(l log.Logger, copyOpts ...util.CopyOption)
 		return util.EncodeBase64Sha1(src.CanonicalSourceURL.Query().Encode()), nil
 	}
 
+	version, err := src.encodeLocalSourceVersion(l, copyOpts...)
+	if err != nil {
+		l.WithError(err).Warnf("Could not encode version for local source")
+
+		return "", err
+	}
+
+	return version, nil
+}
+
+// encodeLocalSourceVersion hashes the path and modification time of every
+// file under the local source directory that a copy configured with copyOpts
+// would deliver.
+func (src Source) encodeLocalSourceVersion(
+	l log.Logger,
+	copyOpts ...util.CopyOption,
+) (string, error) {
 	sourceHash := sha256.New()
 	sourceDir := filepath.Clean(src.CanonicalSourceURL.Path)
 
 	copied, err := util.NewCopyFilter(l, sourceDir, copyOpts...)
-	if err == nil {
-		walkDir := filepath.WalkDir
-		if src.WalkDirWithSymlinks {
-			walkDir = util.WalkDirWithSymlinks
+	if err != nil {
+		return "", err
+	}
+
+	walkDir := filepath.WalkDir
+	if src.WalkDirWithSymlinks {
+		walkDir = util.WalkDirWithSymlinks
+	}
+
+	err = walkDir(sourceDir, func(path string, d fs.DirEntry, err error) error {
+		return hashSourceEntry(sourceHash, copied, path, d, err)
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(sourceHash.Sum(nil)), nil
+}
+
+// hashSourceEntry folds one walked entry into sourceHash, pruning directories
+// the copy filter rejects and skipping files it would not deliver.
+func hashSourceEntry(
+	sourceHash hash.Hash,
+	copied util.CopyFilter,
+	path string,
+	d fs.DirEntry,
+	err error,
+) error {
+	if err != nil {
+		// If we've encountered an error while walking the tree, give up
+		return err
+	}
+
+	if d.IsDir() {
+		// We don't use any info from directories to calculate our hash
+		if !copied(path, true) {
+			return filepath.SkipDir
 		}
 
-		err = walkDir(sourceDir, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				// If we've encountered an error while walking the tree, give up
-				return err
-			}
-
-			if d.IsDir() {
-				// We don't use any info from directories to calculate our hash
-				if !copied(path, true) {
-					return filepath.SkipDir
-				}
-
-				return nil
-			}
-			// avoid checking .terraform.lock.hcl file since contents is auto-generated
-			if d.Name() == util.TerraformLockFile {
-				return nil
-			}
-
-			if !copied(path, false) {
-				return nil
-			}
-
-			info, err := d.Info()
-			if err != nil {
-				return err
-			}
-
-			fileModified := info.ModTime().UnixMicro()
-
-			hashContents := fmt.Sprintf("%s:%d", path, fileModified)
-			sourceHash.Write([]byte(hashContents))
-
-			return nil
-		})
+		return nil
+	}
+	// avoid checking .terraform.lock.hcl file since contents is auto-generated
+	if d.Name() == util.TerraformLockFile {
+		return nil
 	}
 
-	if err == nil {
-		hash := hex.EncodeToString(sourceHash.Sum(nil))
-
-		return hash, nil
+	if !copied(path, false) {
+		return nil
 	}
 
-	l.WithError(err).Warnf("Could not encode version for local source")
+	info, err := d.Info()
+	if err != nil {
+		return err
+	}
 
-	return "", err
+	fileModified := info.ModTime().UnixMicro()
+
+	hashContents := fmt.Sprintf("%s:%d", path, fileModified)
+	sourceHash.Write([]byte(hashContents))
+
+	return nil
 }
 
 // WriteVersionFile writes a file into the DownloadDir that contains

--- a/internal/tf/source.go
+++ b/internal/tf/source.go
@@ -103,16 +103,20 @@ func (src Source) String() string {
 // string of the source URL, calculate its sha1, and base 64 encode it. For remote URLs (e.g. Git URLs), this is
 // based on the assumption that the scheme/host/path of the URL (e.g. git::github.com/foo/bar) identifies the module
 // name and the query string (e.g. ?ref=v0.0.3) identifies the version. For local file paths, there is no query string,
-// so the same file path (/foo/bar) is always considered the same version. To detect changes the file path will be hashed
-// and returned as version. In case of hash error the default encoded source version will be returned.
-// See also the encodeSourceName and ProcessTerraformSource methods.
-func (src Source) EncodeSourceVersion(l log.Logger) (string, error) {
-	if IsLocalSource(src.CanonicalSourceURL) {
-		sourceHash := sha256.New()
-		sourceDir := filepath.Clean(src.CanonicalSourceURL.Path)
+// so instead the version is a hash of each file's path and modification time, restricted to the files a copy
+// configured with copyOpts would deliver (see [util.NewCopyFilter]). Files that never reach the cache — hidden files
+// not resurrected by include_in_copy, exclude_from_copy matches — cannot change the version, so they don't force a
+// spurious re-download and re-init. See also the encodeSourceName and ProcessTerraformSource methods.
+func (src Source) EncodeSourceVersion(l log.Logger, copyOpts ...util.CopyOption) (string, error) {
+	if !IsLocalSource(src.CanonicalSourceURL) {
+		return util.EncodeBase64Sha1(src.CanonicalSourceURL.Query().Encode()), nil
+	}
 
-		var err error
+	sourceHash := sha256.New()
+	sourceDir := filepath.Clean(src.CanonicalSourceURL.Path)
 
+	copied, err := util.NewCopyFilter(l, sourceDir, copyOpts...)
+	if err == nil {
 		walkDir := filepath.WalkDir
 		if src.WalkDirWithSymlinks {
 			walkDir = util.WalkDirWithSymlinks
@@ -126,10 +130,18 @@ func (src Source) EncodeSourceVersion(l log.Logger) (string, error) {
 
 			if d.IsDir() {
 				// We don't use any info from directories to calculate our hash
-				return util.SkipDirIfIgnorable(d.Name())
+				if !copied(path, true) {
+					return filepath.SkipDir
+				}
+
+				return nil
 			}
 			// avoid checking .terraform.lock.hcl file since contents is auto-generated
 			if d.Name() == util.TerraformLockFile {
+				return nil
+			}
+
+			if !copied(path, false) {
 				return nil
 			}
 
@@ -145,25 +157,24 @@ func (src Source) EncodeSourceVersion(l log.Logger) (string, error) {
 
 			return nil
 		})
-		if err == nil {
-			hash := hex.EncodeToString(sourceHash.Sum(nil))
-
-			return hash, nil
-		}
-
-		l.WithError(err).Warnf("Could not encode version for local source")
-
-		return "", err
 	}
 
-	return util.EncodeBase64Sha1(src.CanonicalSourceURL.Query().Encode()), nil
+	if err == nil {
+		hash := hex.EncodeToString(sourceHash.Sum(nil))
+
+		return hash, nil
+	}
+
+	l.WithError(err).Warnf("Could not encode version for local source")
+
+	return "", err
 }
 
 // WriteVersionFile writes a file into the DownloadDir that contains
 // the version number of this source code. The version number is
-// calculated using the EncodeSourceVersion method.
-func (src Source) WriteVersionFile(l log.Logger) error {
-	version, err := src.EncodeSourceVersion(l)
+// calculated using the EncodeSourceVersion method with the same copyOpts.
+func (src Source) WriteVersionFile(l log.Logger, copyOpts ...util.CopyOption) error {
+	version, err := src.EncodeSourceVersion(l, copyOpts...)
 	if err != nil {
 		// If we failed to calculate a SHA of the downloaded source, write a SHA of
 		// some random data into the version file.

--- a/internal/tf/source_test.go
+++ b/internal/tf/source_test.go
@@ -28,67 +28,98 @@ func TestSplitSourceUrl(t *testing.T) {
 		expectedSo         string
 		expectedModulePath string
 	}{
-		{"root-path-only-no-double-slash", "/foo", "/foo", ""},
-		{"parent-path-one-child-no-double-slash", "/foo/bar", "/foo/bar", ""},
 		{
-			"parent-path-multiple-children-no-double-slash",
-			"/foo/bar/baz/blah",
-			"/foo/bar/baz/blah",
-			"",
-		},
-		{"relative-path-no-children-no-double-slash", "../foo", "../foo", ""},
-		{"relative-path-one-child-no-double-slash", "../foo/bar", "../foo/bar", ""},
-		{
-			"relative-path-multiple-children-no-double-slash",
-			"../foo/bar/baz/blah",
-			"../foo/bar/baz/blah",
-			"",
-		},
-		{"root-path-only-with-double-slash", "/foo//", "/foo", ""},
-		{"parent-path-one-child-with-double-slash", "/foo//bar", "/foo", "bar"},
-		{
-			"parent-path-multiple-children-with-double-slash",
-			"/foo/bar//baz/blah",
-			"/foo/bar",
-			"baz/blah",
-		},
-		{"relative-path-no-children-with-double-slash", "..//foo", "..", "foo"},
-		{"relative-path-one-child-with-double-slash", "../foo//bar", "../foo", "bar"},
-		{
-			"relative-path-multiple-children-with-double-slash",
-			"../foo/bar//baz/blah",
-			"../foo/bar",
-			"baz/blah",
+			name:       "root-path-only-no-double-slash",
+			sourceURL:  "/foo",
+			expectedSo: "/foo",
 		},
 		{
-			"parent-url-one-child-no-double-slash",
-			"ssh://git@github.com/foo/modules.git/foo",
-			"ssh://git@github.com/foo/modules.git/foo",
-			"",
+			name:       "parent-path-one-child-no-double-slash",
+			sourceURL:  "/foo/bar",
+			expectedSo: "/foo/bar",
 		},
 		{
-			"parent-url-multiple-children-no-double-slash",
-			"ssh://git@github.com/foo/modules.git/foo/bar/baz/blah",
-			"ssh://git@github.com/foo/modules.git/foo/bar/baz/blah",
-			"",
+			name:       "parent-path-multiple-children-no-double-slash",
+			sourceURL:  "/foo/bar/baz/blah",
+			expectedSo: "/foo/bar/baz/blah",
 		},
 		{
-			"parent-url-one-child-with-double-slash",
-			"ssh://git@github.com/foo/modules.git//foo",
-			"ssh://git@github.com/foo/modules.git",
-			"foo",
+			name:       "relative-path-no-children-no-double-slash",
+			sourceURL:  "../foo",
+			expectedSo: "../foo",
 		},
 		{
-			"parent-url-multiple-children-with-double-slash",
-			"ssh://git@github.com/foo/modules.git//foo/bar/baz/blah",
-			"ssh://git@github.com/foo/modules.git",
-			"foo/bar/baz/blah",
+			name:       "relative-path-one-child-no-double-slash",
+			sourceURL:  "../foo/bar",
+			expectedSo: "../foo/bar",
 		},
 		{
-			"separate-ref-with-slash",
-			"ssh://git@github.com/foo/modules.git//foo?ref=feature/modules",
-			"ssh://git@github.com/foo/modules.git?ref=feature/modules",
-			"foo",
+			name:       "relative-path-multiple-children-no-double-slash",
+			sourceURL:  "../foo/bar/baz/blah",
+			expectedSo: "../foo/bar/baz/blah",
+		},
+		{
+			name:       "root-path-only-with-double-slash",
+			sourceURL:  "/foo//",
+			expectedSo: "/foo",
+		},
+		{
+			name:               "parent-path-one-child-with-double-slash",
+			sourceURL:          "/foo//bar",
+			expectedSo:         "/foo",
+			expectedModulePath: "bar",
+		},
+		{
+			name:               "parent-path-multiple-children-with-double-slash",
+			sourceURL:          "/foo/bar//baz/blah",
+			expectedSo:         "/foo/bar",
+			expectedModulePath: "baz/blah",
+		},
+		{
+			name:               "relative-path-no-children-with-double-slash",
+			sourceURL:          "..//foo",
+			expectedSo:         "..",
+			expectedModulePath: "foo",
+		},
+		{
+			name:               "relative-path-one-child-with-double-slash",
+			sourceURL:          "../foo//bar",
+			expectedSo:         "../foo",
+			expectedModulePath: "bar",
+		},
+		{
+			name:               "relative-path-multiple-children-with-double-slash",
+			sourceURL:          "../foo/bar//baz/blah",
+			expectedSo:         "../foo/bar",
+			expectedModulePath: "baz/blah",
+		},
+		{
+			name:       "parent-url-one-child-no-double-slash",
+			sourceURL:  "ssh://git@github.com/foo/modules.git/foo",
+			expectedSo: "ssh://git@github.com/foo/modules.git/foo",
+		},
+		{
+			name:       "parent-url-multiple-children-no-double-slash",
+			sourceURL:  "ssh://git@github.com/foo/modules.git/foo/bar/baz/blah",
+			expectedSo: "ssh://git@github.com/foo/modules.git/foo/bar/baz/blah",
+		},
+		{
+			name:               "parent-url-one-child-with-double-slash",
+			sourceURL:          "ssh://git@github.com/foo/modules.git//foo",
+			expectedSo:         "ssh://git@github.com/foo/modules.git",
+			expectedModulePath: "foo",
+		},
+		{
+			name:               "parent-url-multiple-children-with-double-slash",
+			sourceURL:          "ssh://git@github.com/foo/modules.git//foo/bar/baz/blah",
+			expectedSo:         "ssh://git@github.com/foo/modules.git",
+			expectedModulePath: "foo/bar/baz/blah",
+		},
+		{
+			name:               "separate-ref-with-slash",
+			sourceURL:          "ssh://git@github.com/foo/modules.git//foo?ref=feature/modules",
+			expectedSo:         "ssh://git@github.com/foo/modules.git?ref=feature/modules",
+			expectedModulePath: "foo",
 		},
 	}
 
@@ -118,55 +149,55 @@ func TestToSourceUrl(t *testing.T) {
 		expectedSourceURL string
 	}{
 		{
-			"https://github.com/gruntwork-io/repo-name",
-			"git::https://github.com/gruntwork-io/repo-name.git",
+			sourceURL:         "https://github.com/gruntwork-io/repo-name",
+			expectedSourceURL: "git::https://github.com/gruntwork-io/repo-name.git",
 		},
 		{
-			"git::https://github.com/gruntwork-io/repo-name",
-			"git::https://github.com/gruntwork-io/repo-name",
+			sourceURL:         "git::https://github.com/gruntwork-io/repo-name",
+			expectedSourceURL: "git::https://github.com/gruntwork-io/repo-name",
 		},
 		{
-			"https://github.com/gruntwork-io/repo-name//modules/module-name",
-			"git::https://github.com/gruntwork-io/repo-name.git//modules/module-name",
+			sourceURL:         "https://github.com/gruntwork-io/repo-name//modules/module-name",
+			expectedSourceURL: "git::https://github.com/gruntwork-io/repo-name.git//modules/module-name",
 		},
 		{
-			"ssh://github.com/gruntwork-io/repo-name//modules/module-name",
-			"ssh://github.com/gruntwork-io/repo-name//modules/module-name",
+			sourceURL:         "ssh://github.com/gruntwork-io/repo-name//modules/module-name",
+			expectedSourceURL: "ssh://github.com/gruntwork-io/repo-name//modules/module-name",
 		},
 		{
-			"https://gitlab.com/catamphetamine/libphonenumber-js",
-			"git::https://gitlab.com/catamphetamine/libphonenumber-js.git",
+			sourceURL:         "https://gitlab.com/catamphetamine/libphonenumber-js",
+			expectedSourceURL: "git::https://gitlab.com/catamphetamine/libphonenumber-js.git",
 		},
 		{
-			"https://bitbucket.org/atlassian/aws-ecr-push-image",
-			"git::https://bitbucket.org/atlassian/aws-ecr-push-image.git",
+			sourceURL:         "https://bitbucket.org/atlassian/aws-ecr-push-image",
+			expectedSourceURL: "git::https://bitbucket.org/atlassian/aws-ecr-push-image.git",
 		},
 		{
-			"http://bitbucket.org/atlassian/aws-ecr-push-image",
-			"git::https://bitbucket.org/atlassian/aws-ecr-push-image.git",
+			sourceURL:         "http://bitbucket.org/atlassian/aws-ecr-push-image",
+			expectedSourceURL: "git::https://bitbucket.org/atlassian/aws-ecr-push-image.git",
 		},
 		{
-			"https://s3-eu-west-1.amazonaws.com/modules/vpc.zip",
-			"https://s3-eu-west-1.amazonaws.com/modules/vpc.zip",
+			sourceURL:         "https://s3-eu-west-1.amazonaws.com/modules/vpc.zip",
+			expectedSourceURL: "https://s3-eu-west-1.amazonaws.com/modules/vpc.zip",
 		},
 		// Public GCS URLs route through the http(s) getter (no GCP creds), matching
 		// how public S3 URLs are handled. To force the credentialed gcs getter
 		// callers must use the explicit `gcs::` forced-getter prefix.
 		{
-			"https://www.googleapis.com/storage/v1/modules/foomodule.zip",
-			"https://www.googleapis.com/storage/v1/modules/foomodule.zip",
+			sourceURL:         "https://www.googleapis.com/storage/v1/modules/foomodule.zip",
+			expectedSourceURL: "https://www.googleapis.com/storage/v1/modules/foomodule.zip",
 		},
 		{
-			"gcs::https://www.googleapis.com/storage/v1/modules/foomodule.zip",
-			"gcs::https://www.googleapis.com/storage/v1/modules/foomodule.zip",
+			sourceURL:         "gcs::https://www.googleapis.com/storage/v1/modules/foomodule.zip",
+			expectedSourceURL: "gcs::https://www.googleapis.com/storage/v1/modules/foomodule.zip",
 		},
 		{
-			"git::https://name@dev.azure.com/name/project-name/_git/repo-name",
-			"git::https://name@dev.azure.com/name/project-name/_git/repo-name",
+			sourceURL:         "git::https://name@dev.azure.com/name/project-name/_git/repo-name",
+			expectedSourceURL: "git::https://name@dev.azure.com/name/project-name/_git/repo-name",
 		},
 		{
-			"https://repository.rnd.net/artifactory/generic-production-iac/tf-auto-azr-iam.2.6.0.zip",
-			"https://repository.rnd.net/artifactory/generic-production-iac/tf-auto-azr-iam.2.6.0.zip",
+			sourceURL:         "https://repository.rnd.net/artifactory/generic-production-iac/tf-auto-azr-iam.2.6.0.zip",
+			expectedSourceURL: "https://repository.rnd.net/artifactory/generic-production-iac/tf-auto-azr-iam.2.6.0.zip",
 		},
 	}
 

--- a/internal/tf/source_test.go
+++ b/internal/tf/source_test.go
@@ -5,7 +5,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/strict"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
 
@@ -341,4 +344,123 @@ func TestRegressionCASRefNoSubdir(t *testing.T) {
 
 	assert.Equal(t, "cas::sha1:"+hash, src.CanonicalSourceURL.String())
 	assert.Equal(t, src.DownloadDir, src.WorkingDir)
+}
+
+// TestEncodeSourceVersionTracksOnlyCopiedFiles pins the local-source version
+// hash to the files a copy would deliver: changes to files the copy skips
+// (hidden files, exclude_from_copy matches) must not flip the version, while
+// changes to copied files (including include_in_copy resurrections) must.
+func TestEncodeSourceVersionTracksOnlyCopiedFiles(t *testing.T) {
+	t.Parallel()
+
+	past := time.Now().Add(-24 * time.Hour)
+
+	touch := func(name string) func(t *testing.T, sourceDir string) {
+		return func(t *testing.T, sourceDir string) {
+			t.Helper()
+
+			now := time.Now()
+			require.NoError(t, os.Chtimes(filepath.Join(sourceDir, name), now, now))
+		}
+	}
+
+	create := func(name string) func(t *testing.T, sourceDir string) {
+		return func(t *testing.T, sourceDir string) {
+			t.Helper()
+
+			path := filepath.Join(sourceDir, name)
+			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+			require.NoError(t, os.WriteFile(path, []byte(name), 0644))
+		}
+	}
+
+	testCases := []struct {
+		mutate   func(t *testing.T, sourceDir string)
+		name     string
+		copyOpts []util.CopyOption
+		wantSame bool
+	}{
+		{
+			name:     "hidden file creation ignored",
+			mutate:   create(".this_file_does_not_matter"),
+			wantSame: true,
+		},
+		{
+			name:     "hidden file touch ignored",
+			mutate:   touch(".hidden.txt"),
+			wantSame: true,
+		},
+		{
+			name:     "file in hidden dir ignored",
+			mutate:   create(".cache/entry.txt"),
+			wantSame: true,
+		},
+		{
+			name:     "tracked file touch detected",
+			mutate:   touch("main.tf"),
+			wantSame: false,
+		},
+		{
+			name:     "tracked file creation detected",
+			mutate:   create("outputs.tf"),
+			wantSame: false,
+		},
+		{
+			name:     "exclude_from_copy touch ignored",
+			copyOpts: []util.CopyOption{util.WithExcludeFromCopy("ignored.txt")},
+			mutate:   touch("ignored.txt"),
+			wantSame: true,
+		},
+		{
+			name:     "include_in_copy hidden file touch detected",
+			copyOpts: []util.CopyOption{util.WithIncludeInCopy(".hidden.txt")},
+			mutate:   touch(".hidden.txt"),
+			wantSame: false,
+		},
+	}
+
+	for _, fastCopy := range []bool{false, true} {
+		for _, tc := range testCases {
+			name := tc.name
+			if fastCopy {
+				name += " with fast-copy"
+			}
+
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				l := logger.CreateLogger()
+				sourceDir := t.TempDir()
+
+				for _, name := range []string{"main.tf", "ignored.txt", ".hidden.txt"} {
+					path := filepath.Join(sourceDir, name)
+					require.NoError(t, os.WriteFile(path, []byte(name), 0644))
+					require.NoError(t, os.Chtimes(path, past, past))
+				}
+
+				copyOpts := tc.copyOpts
+				if fastCopy {
+					copyOpts = slices.Concat(copyOpts, []util.CopyOption{util.WithFastCopy()})
+				}
+
+				src, err := tf.NewSource(l, sourceDir, t.TempDir(), sourceDir, false)
+				require.NoError(t, err)
+
+				before, err := src.EncodeSourceVersion(l, copyOpts...)
+				require.NoError(t, err)
+
+				tc.mutate(t, sourceDir)
+
+				after, err := src.EncodeSourceVersion(l, copyOpts...)
+				require.NoError(t, err)
+
+				if tc.wantSame {
+					assert.Equal(t, before, after)
+					return
+				}
+
+				assert.NotEqual(t, before, after)
+			})
+		}
+	}
 }

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -404,7 +404,14 @@ func CopyFolderContents(
 	}
 
 	if cfg.fastCopy {
-		return copyFolderContentsFast(l, source, destination, manifestFile, cfg.includeInCopy, cfg.excludeFromCopy)
+		return copyFolderContentsFast(
+			l,
+			source,
+			destination,
+			manifestFile,
+			cfg.includeInCopy,
+			cfg.excludeFromCopy,
+		)
 	}
 
 	return CopyFolderContentsWithFilter(l, source, destination, manifestFile, filter)

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -394,16 +394,21 @@ func CopyFolderContents(
 	source = filepath.ToSlash(source)
 	destination = filepath.ToSlash(destination)
 
-	filter, err := newLegacyCopyFilter(l, source, cfg.includeInCopy, cfg.excludeFromCopy)
-	if err != nil {
-		return err
-	}
-
-	if err := assertCopyPathsSafe(source, destination, filter); err != nil {
-		return err
-	}
-
 	if cfg.fastCopy {
+		filter, err := newFastCopyFilter(l, source, cfg.includeInCopy, cfg.excludeFromCopy)
+		if err != nil {
+			return err
+		}
+
+		// The dest-inside-source assertion probes each destination path
+		// segment, and every segment is a directory on the way to the
+		// destination, so ask the filter with isDir=true.
+		if err := assertCopyPathsSafe(source, destination, func(absolutePath string) bool {
+			return filter(absolutePath, true)
+		}); err != nil {
+			return err
+		}
+
 		return copyFolderContentsFast(
 			l,
 			source,
@@ -412,6 +417,11 @@ func CopyFolderContents(
 			cfg.includeInCopy,
 			cfg.excludeFromCopy,
 		)
+	}
+
+	filter, err := newLegacyCopyFilter(l, source, cfg.includeInCopy, cfg.excludeFromCopy)
+	if err != nil {
+		return err
 	}
 
 	return CopyFolderContentsWithFilter(l, source, destination, manifestFile, filter)
@@ -536,34 +546,44 @@ func newFastCopyFilter(
 			return false
 		}
 
-		rel = filepath.ToSlash(rel)
-		if rel == "." {
-			return true
-		}
-
-		// Skip .terragrunt-cache before include matching. A user include
-		// like "**" would otherwise pull it back in.
-		if slices.Contains(strings.Split(rel, "/"), TerragruntCacheDir) {
-			return false
-		}
-
-		if exclude != nil && exclude.Match(rel) {
-			return false
-		}
-
-		if include.matches(rel) {
-			return true
-		}
-
-		if TerragruntExcludes(filepath.FromSlash(rel)) {
-			// A directory on the way to a potential include match must
-			// still be descended into even when TerragruntExcludes
-			// would reject it.
-			return isDir && include.isAncestor(rel)
-		}
-
-		return true
+		return fastCopyIncludesEntry(filepath.ToSlash(rel), isDir, include, exclude)
 	}, nil
+}
+
+// fastCopyIncludesEntry applies the fast copy inclusion rules to a
+// source-relative slash-separated path.
+func fastCopyIncludesEntry(
+	rel string,
+	isDir bool,
+	include includePatterns,
+	exclude glob.Matcher,
+) bool {
+	if rel == "." {
+		return true
+	}
+
+	// Skip .terragrunt-cache before include matching. A user include
+	// like "**" would otherwise pull it back in.
+	if slices.Contains(strings.Split(rel, "/"), TerragruntCacheDir) {
+		return false
+	}
+
+	if exclude != nil && exclude.Match(rel) {
+		return false
+	}
+
+	if include.matches(rel) {
+		return true
+	}
+
+	if TerragruntExcludes(filepath.FromSlash(rel)) {
+		// A directory on the way to a potential include match must
+		// still be descended into even when TerragruntExcludes
+		// would reject it.
+		return isDir && include.isAncestor(rel)
+	}
+
+	return true
 }
 
 // copyFolderContentsFast is the [CopyFolderContents] path used when the

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -394,17 +394,73 @@ func CopyFolderContents(
 	source = filepath.ToSlash(source)
 	destination = filepath.ToSlash(destination)
 
-	// Expand all the includeInCopy glob paths, converting the globbed results to relative paths so that they work in
-	// the copy filter. The expanded globs feed both the dest-inside-source
-	// assertion below and the filter passed to the slow-path implementation.
+	filter, err := newLegacyCopyFilter(l, source, cfg.includeInCopy, cfg.excludeFromCopy)
+	if err != nil {
+		return err
+	}
+
+	if err := assertCopyPathsSafe(source, destination, filter); err != nil {
+		return err
+	}
+
+	if cfg.fastCopy {
+		return copyFolderContentsFast(l, source, destination, manifestFile, cfg.includeInCopy, cfg.excludeFromCopy)
+	}
+
+	return CopyFolderContentsWithFilter(l, source, destination, manifestFile, filter)
+}
+
+// CopyFilter reports whether a copy configured with the same [CopyOption]
+// values would deliver the entry at absolutePath. isDir lets the fast-copy
+// variant keep descending through dot-prefixed directories that may hold
+// include_in_copy matches; the legacy variant ignores it.
+type CopyFilter func(absolutePath string, isDir bool) bool
+
+// NewCopyFilter builds the inclusion predicate that [CopyFolderContents]
+// applies with the same options, without performing a copy. It lets callers
+// reason about which files a copy would deliver — for example, hashing only
+// those files when computing a source version.
+func NewCopyFilter(l log.Logger, source string, opts ...CopyOption) (CopyFilter, error) {
+	var cfg copyConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	source = filepath.ToSlash(source)
+
+	if cfg.fastCopy {
+		return newFastCopyFilter(l, source, cfg.includeInCopy, cfg.excludeFromCopy)
+	}
+
+	filter, err := newLegacyCopyFilter(l, source, cfg.includeInCopy, cfg.excludeFromCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(absolutePath string, _ bool) bool {
+		return filter(absolutePath)
+	}, nil
+}
+
+// newLegacyCopyFilter expands the include/exclude globs against the current
+// contents of source and returns the filter applied by the legacy copy path.
+// The expanded globs feed both the dest-inside-source assertion in
+// [CopyFolderContents] and the filter passed to the slow-path implementation.
+func newLegacyCopyFilter(
+	l log.Logger,
+	source string,
+	includeInCopy, excludeFromCopy []string,
+) (func(absolutePath string) bool, error) {
+	// Expand all the includeInCopy glob paths, converting the globbed results
+	// to relative paths so that they work in the copy filter.
 	includeExpandedGlobs := []string{}
 
-	for _, includeGlob := range cfg.includeInCopy {
+	for _, includeGlob := range includeInCopy {
 		globPath := filepath.Join(source, includeGlob)
 
 		expandGlob, err := expandGlobPath(source, globPath)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		includeExpandedGlobs = append(includeExpandedGlobs, expandGlob...)
@@ -412,18 +468,18 @@ func CopyFolderContents(
 
 	excludeExpandedGlobs := []string{}
 
-	for _, excludeGlob := range cfg.excludeFromCopy {
+	for _, excludeGlob := range excludeFromCopy {
 		globPath := filepath.Join(source, excludeGlob)
 
 		expandGlob, err := expandGlobPath(source, globPath)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		excludeExpandedGlobs = append(excludeExpandedGlobs, expandGlob...)
 	}
 
-	filter := func(absolutePath string) bool {
+	return func(absolutePath string) bool {
 		relativePath, err := filepath.Rel(source, absolutePath)
 		if err != nil {
 			l.Warnf("Failed to compute relative path from %s to %s: %v", source, absolutePath, err)
@@ -446,24 +502,61 @@ func CopyFolderContents(
 		}
 
 		return !TerragruntExcludes(filepath.FromSlash(relativePath))
+	}, nil
+}
+
+// newFastCopyFilter mirrors the per-entry decisions of the fast copy walk in
+// copyFolderContentsFast, using the same compiled matchers.
+func newFastCopyFilter(
+	l log.Logger,
+	source string,
+	includeInCopy, excludeFromCopy []string,
+) (CopyFilter, error) {
+	include, err := compileIncludePatterns(includeInCopy)
+	if err != nil {
+		return nil, err
 	}
 
-	if err := assertCopyPathsSafe(source, destination, filter); err != nil {
-		return err
+	exclude, err := compileExcludePattern(excludeFromCopy)
+	if err != nil {
+		return nil, err
 	}
 
-	if cfg.fastCopy {
-		return copyFolderContentsFast(
-			l,
-			source,
-			destination,
-			manifestFile,
-			cfg.includeInCopy,
-			cfg.excludeFromCopy,
-		)
-	}
+	return func(absolutePath string, isDir bool) bool {
+		rel, err := filepath.Rel(source, absolutePath)
+		if err != nil {
+			l.Warnf("Failed to compute relative path from %s to %s: %v", source, absolutePath, err)
+			return false
+		}
 
-	return CopyFolderContentsWithFilter(l, source, destination, manifestFile, filter)
+		rel = filepath.ToSlash(rel)
+		if rel == "." {
+			return true
+		}
+
+		// Skip .terragrunt-cache before include matching. A user include
+		// like "**" would otherwise pull it back in.
+		if slices.Contains(strings.Split(rel, "/"), TerragruntCacheDir) {
+			return false
+		}
+
+		if exclude != nil && exclude.Match(rel) {
+			return false
+		}
+
+		if include.matches(rel) {
+			return true
+		}
+
+		if TerragruntExcludes(filepath.FromSlash(rel)) {
+			// A directory on the way to a potential include match must
+			// still be descended into even when TerragruntExcludes
+			// would reject it.
+			return isDir && include.isAncestor(rel)
+		}
+
+		return true
+	}, nil
 }
 
 // copyFolderContentsFast is the [CopyFolderContents] path used when the

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -1574,6 +1574,30 @@ func TestCopyFolderContentsRejectsDestinationInsideSource(t *testing.T) {
 		},
 	)
 
+	// include_in_copy can resurrect a hidden destination that does not exist
+	// yet: legacy glob expansion finds nothing on disk and treats the segment
+	// as excluded, while the fast walk matches the pattern itself. The guard
+	// must probe the same filter the fast copy uses, or the copy recurses
+	// into its own destination.
+	t.Run(
+		"destination resurrected by include_in_copy is rejected on fast-copy path",
+		func(t *testing.T) {
+			t.Parallel()
+
+			err := util.CopyFolderContents(
+				l,
+				source,
+				filepath.Join(source, ".generated", "dest"),
+				".terragrunt-test",
+				util.WithFastCopy(),
+				util.WithIncludeInCopy(".generated/**"),
+			)
+
+			var insideErr util.CopyDestinationInsideSourceError
+			require.ErrorAs(t, err, &insideErr)
+		},
+	)
+
 	t.Run("relative source is rejected", func(t *testing.T) {
 		t.Parallel()
 

--- a/test/integration_regressions_test.go
+++ b/test/integration_regressions_test.go
@@ -116,6 +116,30 @@ func TestAutoInitHonorsMarkerWhenModulesCached(t *testing.T) {
 	assert.NotContains(t, stderr.String(), "Required plugins are not installed")
 }
 
+func TestAutoInitSkippedWhenOnlyUncopiedFilesChange(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAutoInitMarkerCachedModules)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureAutoInitMarkerCachedModules)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	err := helpers.RunTerragruntCommand(t, "terragrunt plan --non-interactive --tf-forward-stdout --working-dir "+rootPath, &stdout, &stderr)
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"), "first plan should run init")
+
+	// Hidden files are never copied into the cache, so appearing or changing
+	// ones must not alter the computed source version.
+	hiddenFile := filepath.Join(rootPath, "src", ".this_file_does_not_matter")
+	require.NoError(t, os.WriteFile(hiddenFile, []byte("ignored"), 0644))
+
+	stdout = bytes.Buffer{}
+	stderr = bytes.Buffer{}
+	err = helpers.RunTerragruntCommand(t, "terragrunt plan --non-interactive --tf-forward-stdout --working-dir "+rootPath, &stdout, &stderr)
+	require.NoError(t, err)
+	assert.NotContains(t, stdout.String(), "has been successfully initialized!", "second plan should not re-run init when only a file the copy skips changed")
+}
+
 // Test case for yamldecode bug: https://github.com/gruntwork-io/terragrunt/issues/834
 func TestYamlDecodeRegressions(t *testing.T) {
 	t.Parallel()

--- a/test/integration_regressions_test.go
+++ b/test/integration_regressions_test.go
@@ -124,9 +124,19 @@ func TestAutoInitSkippedWhenOnlyUncopiedFilesChange(t *testing.T) {
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
-	err := helpers.RunTerragruntCommand(t, "terragrunt plan --non-interactive --tf-forward-stdout --working-dir "+rootPath, &stdout, &stderr)
+	err := helpers.RunTerragruntCommand(
+		t,
+		"terragrunt plan --non-interactive --tf-forward-stdout --working-dir "+rootPath,
+		&stdout,
+		&stderr,
+	)
 	require.NoError(t, err)
-	assert.Equal(t, 1, strings.Count(stdout.String(), "has been successfully initialized!"), "first plan should run init")
+	assert.Equal(
+		t,
+		1,
+		strings.Count(stdout.String(), "has been successfully initialized!"),
+		"first plan should run init",
+	)
 
 	// Hidden files are never copied into the cache, so appearing or changing
 	// ones must not alter the computed source version.
@@ -135,9 +145,19 @@ func TestAutoInitSkippedWhenOnlyUncopiedFilesChange(t *testing.T) {
 
 	stdout = bytes.Buffer{}
 	stderr = bytes.Buffer{}
-	err = helpers.RunTerragruntCommand(t, "terragrunt plan --non-interactive --tf-forward-stdout --working-dir "+rootPath, &stdout, &stderr)
+	err = helpers.RunTerragruntCommand(
+		t,
+		"terragrunt plan --non-interactive --tf-forward-stdout --working-dir "+rootPath,
+		&stdout,
+		&stderr,
+	)
 	require.NoError(t, err)
-	assert.NotContains(t, stdout.String(), "has been successfully initialized!", "second plan should not re-run init when only a file the copy skips changed")
+	assert.NotContains(
+		t,
+		stdout.String(),
+		"has been successfully initialized!",
+		"second plan should not re-run init when only a file the copy skips changed",
+	)
 }
 
 // Test case for yamldecode bug: https://github.com/gruntwork-io/terragrunt/issues/834


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6443.

The final two commits are golines and switching to using named fields. Might want to ignore them on first pass to review fewer lines.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary auto re-initialization when only hidden, hidden-but-excluded, or `exclude_from_copy`-matched local-source files change.
  - Updated local-source version/hash tracking to consider only the exact subset of files that would be copied into the cache (including correct fast-copy and `include_in_copy` behavior).

- **Tests**
  - Added an integration regression test ensuring init is skipped when only uncopied files change.
  - Added unit tests verifying encoded source versions change only when copy-delivered files change.

- **Documentation**
  - Refined the v1.1.2 changelog entry describing the auto-init fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->