### PR TITLE
chore: Adding `vsops`

### DIFF
--- a/internal/venv/venv.go
+++ b/internal/venv/venv.go
@@ -3,8 +3,9 @@
 //
 // A [Venv] bundles the side-effect handles every layer below the CLI needs
 // to do its work: [vfs.FS] for filesystem reads and writes, [vexec.Exec]
-// for spawning subprocesses, the shell environment variables and platform
-// handles read at startup, and the stdout/stderr writers. Production code
+// for spawning subprocesses, [vsops.Decrypter] for SOPS decryption, the
+// shell environment variables and platform handles read at startup, and
+// the stdout/stderr writers. Production code
 // constructs the real bundle once at the top via [OSVenv]; tests construct
 // an in-memory bundle and drive the full CLI through it.
 //
@@ -23,6 +24,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/vsops"
 	"github.com/gruntwork-io/terragrunt/internal/writer"
 )
 
@@ -48,12 +50,14 @@ type Platform struct {
 }
 
 // Venv is the root virtualized environment. It carries the filesystem,
-// process-execution, environment-variable, platform, and writer handles that
-// every Terragrunt operation needs. Env is shared by reference across the run
-// and mutated in place as provider-cache, hook, and inputs contributions resolve.
+// process-execution, SOPS-decryption, environment-variable, platform, and
+// writer handles that every Terragrunt operation needs. Env is shared by
+// reference across the run and mutated in place as provider-cache, hook, and
+// inputs contributions resolve.
 type Venv struct {
 	FS       vfs.FS
 	Exec     vexec.Exec
+	Sops     vsops.Decrypter
 	Env      map[string]string
 	Platform *Platform
 	Writers  *writer.Writers
@@ -96,6 +100,13 @@ func (v Venv) WithExec(exec vexec.Exec) Venv {
 // by h, for the in-memory test bundles this package serves.
 func (v Venv) WithHandler(h vexec.Handler) Venv {
 	v.Exec = vexec.NewMemExec(h)
+
+	return v
+}
+
+// WithSops returns a copy of v whose SOPS decrypter is d.
+func (v Venv) WithSops(d vsops.Decrypter) Venv {
+	v.Sops = d
 
 	return v
 }
@@ -188,6 +199,7 @@ func OSVenv() Venv {
 	return Venv{
 		FS:   vfs.NewOSFS(),
 		Exec: vexec.NewOSExec(),
+		Sops: vsops.NewOSDecrypter(),
 		Env:  ParseEnviron(os.Environ()),
 		Platform: &Platform{
 			UserHomeDir: os.UserHomeDir,

--- a/internal/vsops/vsops.go
+++ b/internal/vsops/vsops.go
@@ -1,0 +1,111 @@
+// Package vsops provides a virtual SOPS decryption abstraction for testing and production use.
+// It wraps the getsops/sops library to provide a consistent, injectable interface for
+// decrypting SOPS-encrypted files.
+package vsops
+
+import (
+	"errors"
+	"reflect"
+
+	"github.com/getsops/sops/v3/cmd/sops/formats"
+	"github.com/getsops/sops/v3/decrypt"
+)
+
+// Decrypter is the SOPS decryption interface used throughout the codebase.
+// It provides an abstraction over the real sops library and in-memory
+// decryption.
+type Decrypter interface {
+	// DecryptFile decrypts the SOPS-encrypted file at path, parsing its
+	// content according to format, and returns the cleartext data.
+	DecryptFile(path, format string) ([]byte, error)
+}
+
+// Handler processes a single decryption request for the in-memory backend and
+// returns the cleartext. It is invoked synchronously by [Decrypter.DecryptFile].
+type Handler func(path, format string) ([]byte, error)
+
+// FormatForPath returns the sops format name implied by the file extension of
+// path: "yaml", "json", "dotenv", or "ini", falling back to "binary" for
+// unrecognized extensions.
+func FormatForPath(path string) string {
+	return formatNames[formats.FormatForPath(path)]
+}
+
+// NewOSDecrypter returns a [Decrypter] backed by the real sops library. It reads
+// the encrypted file from the OS filesystem and resolves data keys through the
+// key services named in the file's sops metadata, which draw credentials from
+// the process environment.
+func NewOSDecrypter() Decrypter {
+	return osDecrypter{}
+}
+
+// NewMemDecrypter returns a [Decrypter] whose [Decrypter.DecryptFile] calls
+// are dispatched to h instead of the sops library. It is intended for tests:
+// h decides how each request should behave.
+//
+// h must not be nil.
+func NewMemDecrypter(h Handler) Decrypter {
+	if h == nil {
+		panic("vsops: NewMemDecrypter requires a non-nil Handler")
+	}
+
+	return memDecrypter{handler: h}
+}
+
+var formatNames = map[formats.Format]string{
+	formats.Binary: "binary",
+	formats.Dotenv: "dotenv",
+	formats.Ini:    "ini",
+	formats.Json:   "json",
+	formats.Yaml:   "yaml",
+}
+
+type osDecrypter struct{}
+
+func (osDecrypter) DecryptFile(path, format string) ([]byte, error) {
+	data, err := decrypt.File(path, format)
+	if err != nil {
+		return nil, extractGroupErrors(err)
+	}
+
+	return data, nil
+}
+
+type memDecrypter struct {
+	handler Handler
+}
+
+func (d memDecrypter) DecryptFile(path, format string) ([]byte, error) {
+	return d.handler(path, format)
+}
+
+// extractGroupErrors pulls the per-group errors out of sops' getDataKeyError via reflection.
+// The sops library doesn't export these, so the field walk may break on future sops versions.
+func extractGroupErrors(err error) error {
+	var errs []error
+
+	errValue := reflect.ValueOf(err)
+	if errValue.Kind() == reflect.Pointer {
+		errValue = errValue.Elem()
+	}
+
+	if errValue.Type().Name() == "getDataKeyError" {
+		groupResultsField := errValue.FieldByName("GroupResults")
+		if groupResultsField.IsValid() && groupResultsField.Kind() == reflect.Slice {
+			for i := range groupResultsField.Len() {
+				groupErr := groupResultsField.Index(i)
+				if groupErr.CanInterface() {
+					if resultErr, ok := groupErr.Interface().(error); ok {
+						errs = append(errs, resultErr)
+					}
+				}
+			}
+		}
+	}
+
+	if len(errs) == 0 {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
+}

--- a/internal/vsops/vsops.go
+++ b/internal/vsops/vsops.go
@@ -65,7 +65,11 @@ type osDecrypter struct{}
 func (osDecrypter) DecryptFile(path, format string) ([]byte, error) {
 	data, err := decrypt.File(path, format)
 	if err != nil {
-		return nil, extractGroupErrors(err)
+		if groupErrs := dataKeyGroupErrors(err); len(groupErrs) > 0 {
+			return nil, errors.Join(groupErrs...)
+		}
+
+		return nil, err
 	}
 
 	return data, nil
@@ -79,33 +83,35 @@ func (d memDecrypter) DecryptFile(path, format string) ([]byte, error) {
 	return d.handler(path, format)
 }
 
-// extractGroupErrors pulls the per-group errors out of sops' getDataKeyError via reflection.
-// The sops library doesn't export these, so the field walk may break on future sops versions.
-func extractGroupErrors(err error) error {
-	var errs []error
-
+// dataKeyGroupErrors returns the per-key-group failures hidden in sops'
+// getDataKeyError, whose own message doesn't explain why each key group
+// failed. The sops library doesn't export the type or its fields, so the
+// field walk is reflective and may break on future sops versions. A nil
+// result means there is nothing to extract: err isn't a getDataKeyError,
+// its shape changed, or no group recorded a failure (successful groups
+// leave nil entries in GroupResults).
+func dataKeyGroupErrors(err error) []error {
 	errValue := reflect.ValueOf(err)
 	if errValue.Kind() == reflect.Pointer {
 		errValue = errValue.Elem()
 	}
 
-	if errValue.Type().Name() == "getDataKeyError" {
-		groupResultsField := errValue.FieldByName("GroupResults")
-		if groupResultsField.IsValid() && groupResultsField.Kind() == reflect.Slice {
-			for i := range groupResultsField.Len() {
-				groupErr := groupResultsField.Index(i)
-				if groupErr.CanInterface() {
-					if resultErr, ok := groupErr.Interface().(error); ok {
-						errs = append(errs, resultErr)
-					}
-				}
-			}
+	if errValue.Type().Name() != "getDataKeyError" {
+		return nil
+	}
+
+	field := errValue.FieldByName("GroupResults")
+	if !field.IsValid() || field.Type() != reflect.TypeFor[[]error]() {
+		return nil
+	}
+
+	var groupErrs []error
+
+	for _, groupErr := range field.Interface().([]error) {
+		if groupErr != nil {
+			groupErrs = append(groupErrs, groupErr)
 		}
 	}
 
-	if len(errs) == 0 {
-		errs = append(errs, err)
-	}
-
-	return errors.Join(errs...)
+	return groupErrs
 }

--- a/internal/vsops/vsops_test.go
+++ b/internal/vsops/vsops_test.go
@@ -1,0 +1,96 @@
+package vsops_test
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/vsops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatForPath(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		path     string
+		expected string
+	}{
+		{path: "secrets.yaml", expected: "yaml"},
+		{path: "secrets.yml", expected: "yaml"},
+		{path: "secrets.json", expected: "json"},
+		{path: "secrets.env", expected: "dotenv"},
+		{path: "secrets.ini", expected: "ini"},
+		{path: "secrets.txt", expected: "binary"},
+		{path: "secrets", expected: "binary"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, vsops.FormatForPath(tc.path))
+		})
+	}
+}
+
+func TestMemDecrypterDispatchesToHandler(t *testing.T) {
+	t.Parallel()
+
+	d := vsops.NewMemDecrypter(func(path, format string) ([]byte, error) {
+		assert.Equal(t, "secrets.env", path)
+		assert.Equal(t, "dotenv", format)
+
+		return []byte("value=cleartext"), nil
+	})
+
+	data, err := d.DecryptFile("secrets.env", "dotenv")
+	require.NoError(t, err)
+	assert.Equal(t, "value=cleartext", string(data))
+}
+
+func TestMemDecrypterReturnsHandlerError(t *testing.T) {
+	t.Parallel()
+
+	handlerErr := errors.New("no data key")
+
+	d := vsops.NewMemDecrypter(func(string, string) ([]byte, error) {
+		return nil, handlerErr
+	})
+
+	data, err := d.DecryptFile("secrets.json", "json")
+	require.ErrorIs(t, err, handlerErr)
+	assert.Nil(t, data)
+}
+
+func TestNewMemDecrypterNilHandlerPanics(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		vsops.NewMemDecrypter(nil)
+	})
+}
+
+func TestOSDecrypterMissingFile(t *testing.T) {
+	t.Parallel()
+
+	d := vsops.NewOSDecrypter()
+
+	_, err := d.DecryptFile(filepath.Join(t.TempDir(), "missing.json"), "json")
+	require.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestOSDecrypterFileWithoutSopsMetadata(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "plain.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"value":"not encrypted"}`), 0600))
+
+	d := vsops.NewOSDecrypter()
+
+	_, err := d.DecryptFile(path, "json")
+	require.Error(t, err)
+}

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"runtime"
 	"slices"
@@ -19,8 +18,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/getsops/sops/v3/cmd/sops/formats"
-	"github.com/getsops/sops/v3/decrypt"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
@@ -45,6 +42,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/vsops"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -979,16 +977,17 @@ func getAWSField(
 
 	var result string
 
-	err = telemetry.TelemeterFromContext(ctx).Collect(ctx, l, "config_get_aws_field", map[string]any{
-		"config_path": pctx.TerragruntConfigPath,
-		"role_arn":    pctx.IAMRoleOptions.RoleARN,
-	}, func(ctx context.Context, l log.Logger) error {
-		var fetchErr error
+	err = telemetry.TelemeterFromContext(ctx).
+		Collect(ctx, l, "config_get_aws_field", map[string]any{
+			"config_path": pctx.TerragruntConfigPath,
+			"role_arn":    pctx.IAMRoleOptions.RoleARN,
+		}, func(ctx context.Context, l log.Logger) error {
+			var fetchErr error
 
-		result, fetchErr = fetchFn(ctx, &awsConfig)
+			result, fetchErr = fetchFn(ctx, &awsConfig)
 
-		return fetchErr
-	})
+			return fetchErr
+		})
 
 	return result, err
 }
@@ -1276,10 +1275,7 @@ func sopsDecryptFile(
 
 	sourceFile := params[0]
 
-	format, err := getSopsFileFormat(sourceFile)
-	if err != nil {
-		return "", fmt.Errorf("determining sops file format: %w", err)
-	}
+	format := vsops.FormatForPath(sourceFile)
 
 	path := sourceFile
 
@@ -1290,7 +1286,7 @@ func sopsDecryptFile(
 
 	pctx.FilesRead.Add(path)
 
-	return sopsDecryptFileImpl(ctx, pctx, l, path, format, decrypt.File)
+	return sopsDecryptFileImpl(ctx, pctx, l, path, format, pctx.Venv.Sops)
 }
 
 // sopsDecryptFileImpl contains the actual implementation of sopsDecryptFile
@@ -1300,7 +1296,7 @@ func sopsDecryptFileImpl(
 	l log.Logger,
 	path string,
 	format string,
-	decryptFn func(string, string) ([]byte, error),
+	d vsops.Decrypter,
 ) (string, error) {
 	sopsCache := cache.ContextCache[string](ctx, SopsCacheContextKey)
 
@@ -1357,18 +1353,19 @@ func sopsDecryptFileImpl(
 
 	var rawData []byte
 
-	err := telemetry.TelemeterFromContext(ctx).Collect(ctx, l, "config_sops_decrypt", map[string]any{
-		"path":   path,
-		"format": format,
-	}, func(ctx context.Context, l log.Logger) error {
-		var decryptErr error
+	err := telemetry.TelemeterFromContext(ctx).
+		Collect(ctx, l, "config_sops_decrypt", map[string]any{
+			"path":   path,
+			"format": format,
+		}, func(ctx context.Context, l log.Logger) error {
+			var decryptErr error
 
-		rawData, decryptErr = decryptFn(path, format)
+			rawData, decryptErr = d.DecryptFile(path, format)
 
-		return decryptErr
-	})
+			return decryptErr
+		})
 	if err != nil {
-		return "", extractSopsErrors(err)
+		return "", err
 	}
 
 	if utf8.Valid(rawData) {
@@ -1379,27 +1376,6 @@ func sopsDecryptFileImpl(
 	}
 
 	return "", InvalidSopsFormatError{SourceFilePath: path}
-}
-
-// Mapping of SOPS format to string
-var sopsFormatToString = map[formats.Format]string{
-	formats.Binary: "binary",
-	formats.Dotenv: "dotenv",
-	formats.Ini:    "ini",
-	formats.Json:   "json",
-	formats.Yaml:   "yaml",
-}
-
-// getSopsFileFormat - Return file format for SOPS library
-func getSopsFileFormat(sourceFile string) (string, error) {
-	fileFormat := formats.FormatForPath(sourceFile)
-
-	format, found := sopsFormatToString[fileFormat]
-	if !found {
-		return "", InvalidSopsFormatError{SourceFilePath: sourceFile}
-	}
-
-	return format, nil
 }
 
 // Return the location of the Terraform files provided via --source
@@ -1813,37 +1789,6 @@ func ParseAndDecodeVarFile(l log.Logger, varFile string, fileContents []byte, ou
 	}
 
 	return gocty.FromCtyValue(ctyVal, out)
-}
-
-// extractSopsErrors pulls the per-group errors out of sops' getDataKeyError via reflection.
-// The sops library doesn't export these, so the field walk may break on future sops versions.
-func extractSopsErrors(err error) error {
-	var errs []error
-
-	errValue := reflect.ValueOf(err)
-	if errValue.Kind() == reflect.Pointer {
-		errValue = errValue.Elem()
-	}
-
-	if errValue.Type().Name() == "getDataKeyError" {
-		groupResultsField := errValue.FieldByName("GroupResults")
-		if groupResultsField.IsValid() && groupResultsField.Kind() == reflect.Slice {
-			for i := range groupResultsField.Len() {
-				groupErr := groupResultsField.Index(i)
-				if groupErr.CanInterface() {
-					if err, ok := groupErr.Interface().(error); ok {
-						errs = append(errs, err)
-					}
-				}
-			}
-		}
-	}
-
-	if len(errs) == 0 {
-		errs = append(errs, err)
-	}
-
-	return errors.Join(errs...)
 }
 
 // ConstraintCheck Implementation of Terraform's StartsWith function

--- a/pkg/config/sops_race_test.go
+++ b/pkg/config/sops_race_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
+	"github.com/gruntwork-io/terragrunt/internal/vsops"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,13 +46,13 @@ func TestSOPSDecryptConcurrencyWithRacing(t *testing.T) {
 		files = append(files, secretFile)
 	}
 
-	// Mock decrypt that reads the env var (creating a read that races with
+	// Mock decrypter that reads the env var (creating a read that races with
 	// concurrent Setenv/Unsetenv if locking is broken).
-	mockDecryptFn := func(path string, _ string) ([]byte, error) {
+	mockDecrypter := vsops.NewMemDecrypter(func(path string, _ string) ([]byte, error) {
 		_ = os.Getenv(authKey) // read that would race without lock
 
 		return os.ReadFile(path)
-	}
+	})
 
 	var (
 		wg      sync.WaitGroup
@@ -73,7 +74,7 @@ func TestSOPSDecryptConcurrencyWithRacing(t *testing.T) {
 			pctx.WorkingDir = filepath.Dir(filePath)
 			pctx.Venv.Env = map[string]string{authKey: fmt.Sprintf("token-%d", idx)}
 
-			result, err := sopsDecryptFileImpl(ctx, pctx, l, filePath, "json", mockDecryptFn)
+			result, err := sopsDecryptFileImpl(ctx, pctx, l, filePath, "json", mockDecrypter)
 			assert.NoError(t, err)
 			assert.Contains(t, result, `"value":"secret-from-unit-`)
 		}(i, f)

--- a/pkg/config/sops_test.go
+++ b/pkg/config/sops_test.go
@@ -12,13 +12,14 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
+	"github.com/gruntwork-io/terragrunt/internal/vsops"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // generateTestSecretFiles creates plain JSON files in a temp directory.
-// No SOPS encryption needed — the test injects a mock decryptFn to read raw files.
+// No SOPS encryption needed — the test injects a mock decrypter to read raw files.
 func generateTestSecretFiles(t *testing.T, count int) []string {
 	t.Helper()
 
@@ -62,15 +63,15 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 	secretFiles := generateTestSecretFiles(t, 1)
 	secretFile := secretFiles[0]
 
-	// Mock decryptFn that requires authKey to be set — simulates KMS auth.
-	authRequiringDecryptFn := func(path string, _ string) ([]byte, error) {
+	// Mock decrypter that requires authKey to be set — simulates KMS auth.
+	authRequiringDecrypter := vsops.NewMemDecrypter(func(path string, _ string) ([]byte, error) {
 		token := os.Getenv(authKey)
 		if token == "" {
 			return nil, errors.New("KMS auth failed: no credential set")
 		}
 
 		return os.ReadFile(path)
-	}
+	})
 
 	// Subtest 1: Existing process env vars are preserved (not overridden).
 	// Models: CI runner has real AWS_SESSION_TOKEN, auth-provider returns empty token.
@@ -93,7 +94,7 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 				l,
 				secretFile,
 				"json",
-				authRequiringDecryptFn,
+				authRequiringDecrypter,
 			)
 			require.NoError(t, err, "decrypt must succeed using existing process env credentials")
 			assert.Contains(t, result, `"value":"secret-from-unit-01"`)
@@ -123,7 +124,7 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 				l,
 				secretFile,
 				"json",
-				authRequiringDecryptFn,
+				authRequiringDecrypter,
 			)
 			require.NoError(t, err, "decrypt must succeed with fresh credentials from opts.Env")
 			assert.Contains(t, result, `"value":"secret-from-unit-01"`)
@@ -150,7 +151,7 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 			// Empty env — simulates auth-provider NOT having run (the original bug)
 			pctx.Venv.Env = map[string]string{}
 
-			_, err := sopsDecryptFileImpl(ctx, pctx, l, secretFile, "json", authRequiringDecryptFn)
+			_, err := sopsDecryptFileImpl(ctx, pctx, l, secretFile, "json", authRequiringDecrypter)
 			require.Error(t, err,
 				"decrypt must fail without auth credentials — reproduces original issue #5515")
 		},
@@ -186,20 +187,22 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 
 					expectedToken := fmt.Sprintf("token-%d", idx)
 
-					// Each goroutine's decryptFn verifies it sees ITS OWN token
-					tokenCheckFn := func(path string, _ string) ([]byte, error) {
-						actual := os.Getenv(authKey)
-						if actual != expectedToken {
-							return nil, fmt.Errorf(
-								"goroutine %d: expected %q, got %q",
-								idx,
-								expectedToken,
-								actual,
-							)
-						}
+					// Each goroutine's decrypter verifies it sees ITS OWN token
+					tokenCheckDecrypter := vsops.NewMemDecrypter(
+						func(path string, _ string) ([]byte, error) {
+							actual := os.Getenv(authKey)
+							if actual != expectedToken {
+								return nil, fmt.Errorf(
+									"goroutine %d: expected %q, got %q",
+									idx,
+									expectedToken,
+									actual,
+								)
+							}
 
-						return os.ReadFile(path)
-					}
+							return os.ReadFile(path)
+						},
+					)
 
 					l := logger.CreateLogger()
 					_, pctx := NewParsingContext(ctx, l, WithStrictControls(controls.New()))
@@ -212,7 +215,7 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 						l,
 						filePath,
 						"json",
-						tokenCheckFn,
+						tokenCheckDecrypter,
 					)
 					if decryptErr != nil {
 						t.Logf("goroutine %d failed: %v", idx, decryptErr)

--- a/test/helpers/venvtest/venvtest.go
+++ b/test/helpers/venvtest/venvtest.go
@@ -1,6 +1,6 @@
 // Package venvtest builds in-memory [venv.Venv] values for tests. New seeds
 // the mem defaults; callers refine individual handles with venv.Venv's fluent
-// With methods (WithHandler, WithExec, WithFS, WithEnv, WithGOOS,
+// With methods (WithHandler, WithExec, WithFS, WithSops, WithEnv, WithGOOS,
 // WithUserHomeDir). Production code builds venvs through [venv.OSVenv] instead.
 package venvtest
 
@@ -12,19 +12,22 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/vsops"
 	"github.com/gruntwork-io/terragrunt/internal/writer"
 )
 
 // New returns an in-memory venv: a no-op mem exec, an in-memory filesystem,
-// an empty (non-nil) environment, deterministic platform handles, and both
-// writers wired to [io.Discard]. Refine it with venv.Venv's fluent With methods.
+// a mem SOPS decrypter yielding empty cleartext, an empty (non-nil)
+// environment, deterministic platform handles, and both writers wired to
+// [io.Discard]. Refine it with venv.Venv's fluent With methods.
 func New() venv.Venv {
 	return venv.Venv{
 		Exec: vexec.NewMemExec(
 			func(context.Context, vexec.Invocation) vexec.Result { return vexec.Result{} },
 		),
-		FS:  vfs.NewMemMapFS(),
-		Env: map[string]string{},
+		FS:   vfs.NewMemMapFS(),
+		Sops: vsops.NewMemDecrypter(func(string, string) ([]byte, error) { return nil, nil }),
+		Env:  map[string]string{},
 		Platform: &venv.Platform{
 			UserHomeDir: func() (string, error) {
 				return "", nil


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds a `vsops` package to provide a virtual handler for SOPS usage.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for decrypting SOPS-encrypted files.
  * Added automatic file-format detection based on file extensions.
  * Improved decryption errors to provide more detailed failure information.

* **Bug Fixes**
  * Improved handling of decryption errors and missing SOPS metadata.

* **Tests**
  * Added coverage for file-format detection, decryption behavior, errors, and concurrent credential isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->