### PR TITLE
chore: Refactor for network isolation in tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -142,12 +142,19 @@ jobs:
             run: "^TestTofu"
           - name: Exec
             os: ubuntu
-            target: ./internal/vexec/...
+            target: ./...
             tags: exec
+            run: "^TestExec"
           - name: Exec Windows
             os: windows
-            target: ./internal/vexec/...
+            target: ./...
             tags: exec
+            run: "^TestExec"
+          - name: HTTP
+            os: ubuntu
+            target: ./...
+            tags: http
+            run: "^TestHTTP"
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6

--- a/internal/git/git_exec_test.go
+++ b/internal/git/git_exec_test.go
@@ -1,0 +1,416 @@
+//go:build exec && !windows
+
+// Real-git parity tests for GitRunner. Everything in this file spawns the
+// actual git binary, so it is gated behind the exec tag alongside the vexec
+// OS-backend parity tests; the default build pins the same contracts through
+// the in-memory exec in git_test.go. All remotes are local ([git.Server] or
+// file:// paths), so even these tests stay off the network. Constrained to
+// !windows because the unit matrix has only ever run them on ubuntu/macos.
+
+package git_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecGitRunner_LsRemote(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	url := startCommittedServer(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	t.Run("valid repository", func(t *testing.T) {
+		t.Parallel()
+
+		results, err := runner.LsRemote(ctx, url, "HEAD")
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+		assert.Regexp(t, "^[0-9a-f]{40}$", results[0].Hash)
+		assert.Equal(t, "HEAD", results[0].Ref)
+	})
+
+	t.Run("invalid repository", func(t *testing.T) {
+		t.Parallel()
+
+		missing := "file://" + filepath.ToSlash(filepath.Join(t.TempDir(), "missing.git"))
+
+		_, err := runner.LsRemote(ctx, missing, "HEAD")
+		require.Error(t, err)
+
+		var wrappedErr *git.WrappedError
+		require.ErrorAs(t, err, &wrappedErr)
+		assert.ErrorIs(t, wrappedErr.Err, git.ErrCommandSpawn)
+	})
+
+	t.Run("nonexistent reference", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := runner.LsRemote(ctx, url, "nonexistent-branch")
+		require.Error(t, err)
+
+		var wrappedErr *git.WrappedError
+		require.ErrorAs(t, err, &wrappedErr)
+		assert.ErrorIs(t, wrappedErr.Err, git.ErrNoMatchingReference)
+	})
+}
+
+func TestExecGitRunner_Clone(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	url := startCommittedServer(t)
+
+	t.Run("shallow clone", func(t *testing.T) {
+		t.Parallel()
+
+		cloneDir := helpers.TmpDirWOSymlinks(t)
+		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		require.NoError(t, err)
+
+		runner = runner.WithWorkDir(cloneDir)
+		err = runner.Clone(ctx, url, true, 1, "main")
+		require.NoError(t, err)
+
+		// Verify it's a git repository
+		_, err = os.Stat(filepath.Join(cloneDir, "HEAD"))
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid repository", func(t *testing.T) {
+		t.Parallel()
+
+		cloneDir := helpers.TmpDirWOSymlinks(t)
+		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		require.NoError(t, err)
+
+		missing := "file://" + filepath.ToSlash(filepath.Join(t.TempDir(), "missing.git"))
+
+		runner = runner.WithWorkDir(cloneDir)
+		err = runner.Clone(ctx, missing, false, 1, "")
+		require.Error(t, err)
+
+		var wrappedErr *git.WrappedError
+		require.ErrorAs(t, err, &wrappedErr)
+		assert.ErrorIs(t, wrappedErr.Err, git.ErrGitClone)
+	})
+}
+
+func TestExecGitRunner_LsTree(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// LsTreeRecursive only reads, so both subtests can share one clone.
+	cloneDir := cloneCommittedServer(t)
+
+	t.Run("valid repository", func(t *testing.T) {
+		t.Parallel()
+
+		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		require.NoError(t, err)
+
+		tree, err := runner.WithWorkDir(cloneDir).LsTreeRecursive(ctx, "HEAD")
+		require.NoError(t, err)
+		require.NotEmpty(t, tree.Entries())
+	})
+
+	t.Run("invalid reference", func(t *testing.T) {
+		t.Parallel()
+
+		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		require.NoError(t, err)
+
+		_, err = runner.WithWorkDir(cloneDir).LsTreeRecursive(ctx, "nonexistent")
+		require.Error(t, err)
+
+		var wrappedErr *git.WrappedError
+		require.ErrorAs(t, err, &wrappedErr)
+		assert.ErrorIs(t, wrappedErr.Err, git.ErrReadTree)
+	})
+
+	t.Run("invalid repository", func(t *testing.T) {
+		t.Parallel()
+
+		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		require.NoError(t, err)
+
+		// Try to ls-tree in an empty directory
+		_, err = runner.WithWorkDir(helpers.TmpDirWOSymlinks(t)).LsTreeRecursive(ctx, "HEAD")
+		require.Error(t, err)
+
+		var wrappedErr *git.WrappedError
+		require.ErrorAs(t, err, &wrappedErr)
+		assert.ErrorIs(t, wrappedErr.Err, git.ErrReadTree)
+	})
+}
+
+func TestExecGitRunner_InitBare(t *testing.T) {
+	t.Parallel()
+
+	dir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(dir)
+
+	require.NoError(t, runner.InitBare(t.Context()))
+
+	_, err = os.Stat(filepath.Join(dir, "HEAD"))
+	require.NoError(t, err)
+
+	// Idempotent: second call must not error.
+	require.NoError(t, runner.InitBare(t.Context()))
+}
+
+func TestExecGitRunner_FetchAndHasObject(t *testing.T) {
+	t.Parallel()
+
+	url := startCommittedServer(t)
+
+	dir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(dir)
+	require.NoError(t, runner.InitBare(t.Context()))
+
+	// HasObject returns false (without error) for a missing object.
+	missing := "0000000000000000000000000000000000000000"
+	has, err := runner.HasObject(t.Context(), missing)
+	require.NoError(t, err)
+	assert.False(t, has)
+
+	// Fetch HEAD into the bare repo.
+	require.NoError(t, runner.Fetch(t.Context(), url, "HEAD", 0))
+
+	// Resolve the HEAD hash through ls-remote and confirm HasObject is now true.
+	results, err := runner.LsRemote(t.Context(), url, "HEAD")
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+
+	has, err = runner.HasObject(t.Context(), results[0].Hash)
+	require.NoError(t, err)
+	assert.True(t, has)
+}
+
+func TestExecGitRunner_FetchRejectsOptionInjectionRef(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	src := newCommittedRepo(t)
+
+	bareDir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(bareDir)
+	require.NoError(t, runner.InitBare(ctx))
+
+	marker := filepath.Join(helpers.TmpDirWOSymlinks(t), "injected")
+
+	// A literal space is fine here since the ref is passed straight to git, not created as a branch name.
+	injectedRef := "--upload-pack=touch " + marker
+
+	err = runner.Fetch(ctx, "file://"+src, injectedRef, 1)
+	require.Error(t, err)
+
+	var wrappedErr *git.WrappedError
+	require.ErrorAs(t, err, &wrappedErr)
+	require.ErrorIs(t, wrappedErr.Err, git.ErrGitFetch)
+
+	assert.NoFileExists(t, marker)
+}
+
+func TestExecGitRunner_LsRemoteRejectsOptionInjectionRepo(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	marker := filepath.Join(helpers.TmpDirWOSymlinks(t), "injected")
+
+	// A repo beginning with a git option must be treated as a positional.
+	injectedRepo := "--upload-pack=touch " + marker
+
+	_, err = runner.LsRemote(ctx, injectedRepo, "HEAD")
+	require.Error(t, err)
+
+	assert.NoFileExists(t, marker)
+}
+
+func TestExecGitRunner_HasObjectSurfacesNonMissingFailures(t *testing.T) {
+	t.Parallel()
+
+	dir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(dir)
+	require.NoError(t, runner.InitBare(t.Context()))
+
+	// A malformed object name returns exit 128 (fatal). HasObject must
+	// return an error rather than report missing, so a corrupted store
+	// does not trigger a refetch loop.
+	_, err = runner.HasObject(t.Context(), "not-a-hash")
+	require.Error(t, err)
+}
+
+// TestGitRunner_AddCommitCheckoutConfig drives the local-mutation wrappers
+// (ConfigSet, Add, Commit, Checkout) through a stage -> commit -> branch flow
+// against a fresh repository, and checks the state via the read helpers
+// (HasUncommittedChanges, GetCurrentBranch, Config) at each step.
+func TestExecGitRunner_AddCommitCheckoutConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	dir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(dir)
+	require.NoError(t, runner.Init(ctx))
+
+	require.NoError(t, runner.ConfigSet(ctx, "user.email", "test@example.com"))
+	require.NoError(t, runner.ConfigSet(ctx, "user.name", "Terragrunt Test"))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello"), 0o600))
+
+	require.NoError(t, runner.Add(ctx, "hello.txt"))
+	assert.True(t, runner.HasUncommittedChanges(ctx))
+
+	require.NoError(t, runner.Commit(ctx, "initial commit"))
+	assert.False(t, runner.HasUncommittedChanges(ctx))
+
+	require.NoError(t, runner.Checkout(ctx, "feature", true))
+	assert.Equal(t, "feature", runner.GetCurrentBranch(ctx))
+
+	email, err := runner.Config(ctx, "user.email")
+	require.NoError(t, err)
+	assert.Equal(t, "test@example.com", email)
+}
+
+// TestGitRunner_SubmoduleURLs exercises the `git config --blob` path
+// against a real repository: the .gitmodules blob committed by the test
+// server is located through ls-tree and parsed by git itself.
+func TestExecGitRunner_SubmoduleURLs(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	srv, err := git.NewServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	require.NoError(t, srv.CommitFile(t.Context(), "README.md", []byte("# repo"), "add readme"))
+
+	const pinnedHash = "0123456789abcdef0123456789abcdef01234567"
+
+	require.NoError(t, srv.CommitSubmodule(
+		t.Context(), "modules/child", "https://example.com/child.git", pinnedHash, "add submodule",
+	))
+
+	url, err := srv.Start(ctx)
+	require.NoError(t, err)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(helpers.TmpDirWOSymlinks(t))
+	require.NoError(t, runner.Clone(ctx, url, true, 0, ""))
+
+	tree, err := runner.LsTreeRecursive(ctx, "HEAD")
+	require.NoError(t, err)
+
+	var gitmodulesHash string
+
+	for _, entry := range tree.Entries() {
+		if entry.Path == git.GitmodulesPath {
+			gitmodulesHash = entry.Hash
+		}
+	}
+
+	require.NotEmpty(t, gitmodulesHash, ".gitmodules entry not found in tree")
+
+	urls, err := runner.SubmoduleURLs(ctx, gitmodulesHash)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"modules/child": "https://example.com/child.git"}, urls)
+}
+
+// startCommittedServer starts a local git HTTP server seeded with a single
+// commit and returns its clone URL.
+func startCommittedServer(t *testing.T) string {
+	t.Helper()
+
+	srv, err := git.NewServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	require.NoError(t, srv.CommitFile(t.Context(), "README.md", []byte("# test"), "initial"))
+
+	url, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	return url
+}
+
+// cloneCommittedServer clones a freshly seeded local server into a bare repo
+// and returns the clone directory.
+func cloneCommittedServer(t *testing.T) string {
+	t.Helper()
+
+	url := startCommittedServer(t)
+
+	cloneDir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	require.NoError(t, runner.WithWorkDir(cloneDir).Clone(t.Context(), url, true, 1, "main"))
+
+	return cloneDir
+}
+
+// newCommittedRepo creates a local repo with one commit for use as a file:// remote.
+func newCommittedRepo(t *testing.T) string {
+	t.Helper()
+
+	ctx := t.Context()
+
+	dir := helpers.TmpDirWOSymlinks(t)
+
+	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(dir)
+
+	require.NoError(t, runner.Init(ctx))
+	require.NoError(t, runner.ConfigSet(ctx, "user.email", "test@example.com"))
+	require.NoError(t, runner.ConfigSet(ctx, "user.name", "Terragrunt Test"))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(""), 0o600))
+	require.NoError(t, runner.Add(ctx, "main.tf"))
+	require.NoError(t, runner.Commit(ctx, "initial commit"))
+
+	return dir
+}

--- a/internal/git/git_exec_test.go
+++ b/internal/git/git_exec_test.go
@@ -275,7 +275,7 @@ func TestExecGitRunner_HasObjectSurfacesNonMissingFailures(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestGitRunner_AddCommitCheckoutConfig drives the local-mutation wrappers
+// TestExecGitRunner_AddCommitCheckoutConfig drives the local-mutation wrappers
 // (ConfigSet, Add, Commit, Checkout) through a stage -> commit -> branch flow
 // against a fresh repository, and checks the state via the read helpers
 // (HasUncommittedChanges, GetCurrentBranch, Config) at each step.
@@ -311,7 +311,7 @@ func TestExecGitRunner_AddCommitCheckoutConfig(t *testing.T) {
 	assert.Equal(t, "test@example.com", email)
 }
 
-// TestGitRunner_SubmoduleURLs exercises the `git config --blob` path
+// TestExecGitRunner_SubmoduleURLs exercises the `git config --blob` path
 // against a real repository: the .gitmodules blob committed by the test
 // server is located through ls-tree and parsed by git itself.
 func TestExecGitRunner_SubmoduleURLs(t *testing.T) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3,43 +3,45 @@ package git_test
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
-	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
+const headHash = "deadbeefcafefacedeadbeefcafefacedeadbeef"
+
 func TestGitRunner_LsRemote(t *testing.T) {
 	t.Parallel()
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
-	require.NoError(t, err)
-
 	ctx := t.Context()
 
-	t.Run("valid repository", func(t *testing.T) {
+	t.Run("parses hash and ref", func(t *testing.T) {
 		t.Parallel()
 
-		results, err := runner.LsRemote(
-			ctx,
-			"https://github.com/gruntwork-io/terragrunt.git",
-			"HEAD",
-		)
+		runner := newMemRunner(t, staticResult(vexec.Result{
+			Stdout: []byte(headHash + "\tHEAD\n"),
+		}))
+
+		results, err := runner.LsRemote(ctx, "https://example.com/repo.git", "HEAD")
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
-		assert.Regexp(t, "^[0-9a-f]{40}$", results[0].Hash)
+		assert.Equal(t, headHash, results[0].Hash)
 		assert.Equal(t, "HEAD", results[0].Ref)
 	})
 
-	t.Run("invalid repository", func(t *testing.T) {
+	t.Run("command failure", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := runner.LsRemote(ctx, "https://github.com/nonexistent/repo.git", "HEAD")
+		runner := newMemRunner(t, staticResult(vexec.Result{
+			ExitCode: 128,
+			Stderr:   []byte("fatal: repository not found"),
+		}))
+
+		_, err := runner.LsRemote(ctx, "https://example.com/nonexistent.git", "HEAD")
 		require.Error(t, err)
 
 		var wrappedErr *git.WrappedError
@@ -50,11 +52,10 @@ func TestGitRunner_LsRemote(t *testing.T) {
 	t.Run("nonexistent reference", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := runner.LsRemote(
-			ctx,
-			"https://github.com/gruntwork-io/terragrunt.git",
-			"nonexistent-branch",
-		)
+		// ls-remote exits zero with empty output when the ref does not exist.
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+
+		_, err := runner.LsRemote(ctx, "https://example.com/repo.git", "nonexistent-branch")
 		require.Error(t, err)
 
 		var wrappedErr *git.WrappedError
@@ -68,27 +69,16 @@ func TestGitRunner_Clone(t *testing.T) {
 
 	ctx := t.Context()
 
-	t.Run("shallow clone", func(t *testing.T) {
-		t.Parallel()
-		cloneDir := helpers.TmpDirWOSymlinks(t)
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
-		require.NoError(t, err)
-
-		runner = runner.WithWorkDir(cloneDir)
-		err = runner.Clone(ctx, "https://github.com/gruntwork-io/terragrunt.git", true, 1, "main")
-		require.NoError(t, err)
-
-		// Verify it's a git repository
-		_, err = os.Stat(filepath.Join(cloneDir, "HEAD"))
-		require.NoError(t, err)
-	})
-
 	t.Run("clone without workdir fails", func(t *testing.T) {
 		t.Parallel()
 
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
-		require.NoError(t, err)
-		err = runner.Clone(ctx, "https://github.com/gruntwork-io/terragrunt.git", true, 1, "main")
+		runner := newMemRunner(t, func(context.Context, vexec.Invocation) vexec.Result {
+			t.Error("git must not be spawned when no working directory is set")
+
+			return vexec.Result{}
+		})
+
+		err := runner.Clone(ctx, "https://example.com/repo.git", true, 1, "main")
 		require.Error(t, err)
 
 		var wrappedErr *git.WrappedError
@@ -96,14 +86,15 @@ func TestGitRunner_Clone(t *testing.T) {
 		assert.ErrorIs(t, wrappedErr.Err, git.ErrNoWorkDir)
 	})
 
-	t.Run("invalid repository", func(t *testing.T) {
+	t.Run("command failure", func(t *testing.T) {
 		t.Parallel()
-		cloneDir := helpers.TmpDirWOSymlinks(t)
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
-		require.NoError(t, err)
 
-		runner = runner.WithWorkDir(cloneDir)
-		err = runner.Clone(ctx, "https://github.com/gruntwork-io/terragrunt-fake.git", false, 1, "")
+		runner := newMemRunner(t, staticResult(vexec.Result{
+			ExitCode: 128,
+			Stderr:   []byte("fatal: repository not found"),
+		}))
+
+		err := runner.WithWorkDir(t.TempDir()).Clone(ctx, "https://example.com/nonexistent.git", false, 1, "")
 		require.Error(t, err)
 
 		var wrappedErr *git.WrappedError
@@ -112,11 +103,104 @@ func TestGitRunner_Clone(t *testing.T) {
 	})
 }
 
+func TestGitRunner_LsTree(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("parses recursive tree", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{
+			Stdout: []byte("100644 blob aaaabeefcafefacedeadbeefcafefacedeadbeef\tREADME.md\n" +
+				"100644 blob bbbbbeefcafefacedeadbeefcafefacedeadbeef\tdir/file.txt\n"),
+		}))
+
+		tree, err := runner.WithWorkDir(t.TempDir()).LsTreeRecursive(ctx, "HEAD")
+		require.NoError(t, err)
+
+		entries := tree.Entries()
+		require.Len(t, entries, 2)
+		assert.Equal(t, "README.md", entries[0].Path)
+		assert.Equal(t, "dir/file.txt", entries[1].Path)
+	})
+
+	t.Run("ls-tree without workdir fails", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+
+		_, err := runner.LsTreeRecursive(ctx, "HEAD")
+		require.Error(t, err)
+
+		var wrappedErr *git.WrappedError
+		require.ErrorAs(t, err, &wrappedErr)
+		assert.ErrorIs(t, wrappedErr.Err, git.ErrNoWorkDir)
+	})
+
+	t.Run("command failure", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{
+			ExitCode: 128,
+			Stderr:   []byte("fatal: not a tree object"),
+		}))
+
+		_, err := runner.WithWorkDir(t.TempDir()).LsTreeRecursive(ctx, "nonexistent")
+		require.Error(t, err)
+
+		var wrappedErr *git.WrappedError
+		require.ErrorAs(t, err, &wrappedErr)
+		assert.ErrorIs(t, wrappedErr.Err, git.ErrReadTree)
+	})
+}
+
+func TestGitRunner_HasObject(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("present object", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+
+		has, err := runner.WithWorkDir(t.TempDir()).HasObject(ctx, headHash)
+		require.NoError(t, err)
+		assert.True(t, has)
+	})
+
+	t.Run("missing object", func(t *testing.T) {
+		t.Parallel()
+
+		// `git cat-file -e` exits 1 for an absent object.
+		runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 1}))
+
+		has, err := runner.WithWorkDir(t.TempDir()).HasObject(ctx, headHash)
+		require.NoError(t, err)
+		assert.False(t, has)
+	})
+
+	t.Run("fatal failure surfaces as error", func(t *testing.T) {
+		t.Parallel()
+
+		// Exit 128 (e.g. corrupted store) must be an error rather than a
+		// missing-object report, so callers do not loop into a refetch.
+		runner := newMemRunner(t, staticResult(vexec.Result{
+			ExitCode: 128,
+			Stderr:   []byte("fatal: not a valid object name"),
+		}))
+
+		_, err := runner.WithWorkDir(t.TempDir()).HasObject(ctx, "not-a-hash")
+		require.Error(t, err)
+	})
+}
+
 func TestCreateTempDir(t *testing.T) {
 	t.Parallel()
 
-	gitRunner, err := git.NewGitRunner(vexec.NewOSExec())
-	require.NoError(t, err)
+	gitRunner := newMemRunner(t, staticResult(vexec.Result{}))
+
 	dir, cleanup, err := gitRunner.CreateTempDir()
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -166,213 +250,28 @@ func TestExtractRepoName(t *testing.T) {
 	}
 }
 
-func TestGitRunner_LsTree(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	t.Run("valid repository", func(t *testing.T) {
-		t.Parallel()
-		cloneDir := helpers.TmpDirWOSymlinks(t)
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
-		require.NoError(t, err)
-
-		runner = runner.WithWorkDir(cloneDir)
-
-		// First clone a repository
-		err = runner.Clone(ctx, "https://github.com/gruntwork-io/terragrunt.git", true, 1, "main")
-		require.NoError(t, err)
-
-		// Then try to ls-tree HEAD
-		tree, err := runner.LsTreeRecursive(ctx, "HEAD")
-		require.NoError(t, err)
-		require.NotEmpty(t, tree)
-	})
-
-	t.Run("ls-tree without workdir fails", func(t *testing.T) {
-		t.Parallel()
-
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
-		require.NoError(t, err)
-
-		_, err = runner.LsTreeRecursive(ctx, "HEAD")
-		require.Error(t, err)
-
-		var wrappedErr *git.WrappedError
-		require.ErrorAs(t, err, &wrappedErr)
-		assert.ErrorIs(t, wrappedErr.Err, git.ErrNoWorkDir)
-	})
-
-	t.Run("invalid reference", func(t *testing.T) {
-		t.Parallel()
-		cloneDir := helpers.TmpDirWOSymlinks(t)
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
-		require.NoError(t, err)
-
-		runner = runner.WithWorkDir(cloneDir)
-
-		// First clone a repository
-		err = runner.Clone(ctx, "https://github.com/gruntwork-io/terragrunt.git", true, 1, "main")
-		require.NoError(t, err)
-
-		// Try to ls-tree an invalid reference
-		_, err = runner.LsTreeRecursive(ctx, "nonexistent")
-		require.Error(t, err)
-
-		var wrappedErr *git.WrappedError
-		require.ErrorAs(t, err, &wrappedErr)
-		assert.ErrorIs(t, wrappedErr.Err, git.ErrReadTree)
-	})
-
-	t.Run("invalid repository", func(t *testing.T) {
-		t.Parallel()
-
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
-		require.NoError(t, err)
-		runner = runner.WithWorkDir(helpers.TmpDirWOSymlinks(t))
-
-		// Try to ls-tree in an empty directory
-		_, err = runner.LsTreeRecursive(ctx, "HEAD")
-		require.Error(t, err)
-
-		var wrappedErr *git.WrappedError
-		require.ErrorAs(t, err, &wrappedErr)
-		assert.ErrorIs(t, wrappedErr.Err, git.ErrReadTree)
-	})
-}
-
 func TestGitRunner_RequiresWorkDir(t *testing.T) {
 	t.Parallel()
 
 	t.Run("with workdir", func(t *testing.T) {
 		t.Parallel()
 
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
-		require.NoError(t, err)
-		runner = runner.WithWorkDir(helpers.TmpDirWOSymlinks(t))
-		err = runner.RequiresWorkDir()
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+		err := runner.WithWorkDir(t.TempDir()).RequiresWorkDir()
 		assert.NoError(t, err)
 	})
 
 	t.Run("without workdir", func(t *testing.T) {
 		t.Parallel()
 
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
-		require.NoError(t, err)
-		err = runner.RequiresWorkDir()
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+		err := runner.RequiresWorkDir()
 		require.Error(t, err)
 
 		var wrappedErr *git.WrappedError
 		require.ErrorAs(t, err, &wrappedErr)
 		assert.ErrorIs(t, wrappedErr.Err, git.ErrNoWorkDir)
 	})
-}
-
-func TestGitRunner_InitBare(t *testing.T) {
-	t.Parallel()
-
-	dir := helpers.TmpDirWOSymlinks(t)
-
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
-	require.NoError(t, err)
-
-	runner = runner.WithWorkDir(dir)
-
-	require.NoError(t, runner.InitBare(t.Context()))
-
-	_, err = os.Stat(filepath.Join(dir, "HEAD"))
-	require.NoError(t, err)
-
-	// Idempotent: second call must not error.
-	require.NoError(t, runner.InitBare(t.Context()))
-}
-
-func TestGitRunner_FetchAndHasObject(t *testing.T) {
-	t.Parallel()
-
-	srv, err := git.NewServer()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = srv.Close() })
-
-	require.NoError(t, srv.CommitFile(t.Context(), "README.md", []byte("# test"), "initial"))
-
-	url, err := srv.Start(t.Context())
-	require.NoError(t, err)
-
-	dir := helpers.TmpDirWOSymlinks(t)
-
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
-	require.NoError(t, err)
-
-	runner = runner.WithWorkDir(dir)
-	require.NoError(t, runner.InitBare(t.Context()))
-
-	// HasObject returns false (without error) for a missing object.
-	missing := "0000000000000000000000000000000000000000"
-	has, err := runner.HasObject(t.Context(), missing)
-	require.NoError(t, err)
-	assert.False(t, has)
-
-	// Fetch HEAD into the bare repo.
-	require.NoError(t, runner.Fetch(t.Context(), url, "HEAD", 0))
-
-	// Resolve the HEAD hash through ls-remote and confirm HasObject is now true.
-	results, err := runner.LsRemote(t.Context(), url, "HEAD")
-	require.NoError(t, err)
-	require.NotEmpty(t, results)
-
-	has, err = runner.HasObject(t.Context(), results[0].Hash)
-	require.NoError(t, err)
-	assert.True(t, has)
-}
-
-func TestGitRunner_FetchRejectsOptionInjectionRef(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	src := newCommittedRepo(t)
-
-	bareDir := helpers.TmpDirWOSymlinks(t)
-
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
-	require.NoError(t, err)
-
-	runner = runner.WithWorkDir(bareDir)
-	require.NoError(t, runner.InitBare(ctx))
-
-	marker := filepath.Join(helpers.TmpDirWOSymlinks(t), "injected")
-
-	// A literal space is fine here since the ref is passed straight to git, not created as a branch name.
-	injectedRef := "--upload-pack=touch " + marker
-
-	err = runner.Fetch(ctx, "file://"+src, injectedRef, 1)
-	require.Error(t, err)
-
-	var wrappedErr *git.WrappedError
-	require.ErrorAs(t, err, &wrappedErr)
-	require.ErrorIs(t, wrappedErr.Err, git.ErrGitFetch)
-
-	assert.NoFileExists(t, marker)
-}
-
-func TestGitRunner_LsRemoteRejectsOptionInjectionRepo(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
-	require.NoError(t, err)
-
-	marker := filepath.Join(helpers.TmpDirWOSymlinks(t), "injected")
-
-	// A repo beginning with a git option must be treated as a positional.
-	injectedRepo := "--upload-pack=touch " + marker
-
-	_, err = runner.LsRemote(ctx, injectedRepo, "HEAD")
-	require.Error(t, err)
-
-	assert.NoFileExists(t, marker)
 }
 
 func TestGitRunner_FetchInsertsOptionTerminator(t *testing.T) {
@@ -380,7 +279,7 @@ func TestGitRunner_FetchInsertsOptionTerminator(t *testing.T) {
 
 	var got []string
 
-	runner := newArgvCapturingRunner(t, &got, nil).WithWorkDir(helpers.TmpDirWOSymlinks(t))
+	runner := newArgvCapturingRunner(t, &got, nil).WithWorkDir(t.TempDir())
 
 	require.NoError(t, runner.Fetch(t.Context(), "file:///repo", "somebranch", 1))
 	assert.Equal(t,
@@ -394,7 +293,7 @@ func TestGitRunner_CloneInsertsOptionTerminator(t *testing.T) {
 
 	var got []string
 
-	workDir := helpers.TmpDirWOSymlinks(t)
+	workDir := t.TempDir()
 	runner := newArgvCapturingRunner(t, &got, nil).WithWorkDir(workDir)
 
 	require.NoError(t, runner.Clone(t.Context(), "file:///repo", true, 1, "main"))
@@ -421,45 +320,108 @@ func TestGitRunner_LsRemoteInsertsOptionTerminator(t *testing.T) {
 
 	var got []string
 
-	runner := newArgvCapturingRunner(
-		t,
-		&got,
-		[]byte("deadbeefcafefacedeadbeefcafefacedeadbeef\trefs/heads/main\n"),
-	)
+	runner := newArgvCapturingRunner(t, &got, []byte(headHash+"\trefs/heads/main\n"))
 
 	_, err := runner.LsRemote(t.Context(), "file:///repo", "main")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ls-remote", "--", "file:///repo", "main"}, got)
 }
 
-func TestGitRunner_HasObjectSurfacesNonMissingFailures(t *testing.T) {
+// TestGitRunner_ArgvConstruction pins the argv each wrapper hands to git.
+// Commands taking remote URLs are pinned separately by the
+// *InsertsOptionTerminator tests; behavior tests above stay argv-agnostic.
+func TestGitRunner_ArgvConstruction(t *testing.T) {
 	t.Parallel()
 
-	dir := helpers.TmpDirWOSymlinks(t)
+	workDir := t.TempDir()
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
-	require.NoError(t, err)
+	tests := []struct {
+		invoke func(ctx context.Context, r *git.GitRunner) error
+		name   string
+		want   []string
+	}{
+		{
+			name: "ls-tree recursive",
+			invoke: func(ctx context.Context, r *git.GitRunner) error {
+				_, err := r.LsTreeRecursive(ctx, "HEAD")
+				return err
+			},
+			want: []string{"ls-tree", "-r", "HEAD"},
+		},
+		{
+			name: "cat-file existence check",
+			invoke: func(ctx context.Context, r *git.GitRunner) error {
+				_, err := r.HasObject(ctx, headHash)
+				return err
+			},
+			want: []string{"cat-file", "-e", headHash},
+		},
+		{
+			name: "repo root",
+			invoke: func(ctx context.Context, r *git.GitRunner) error {
+				_, err := r.GetRepoRoot(ctx)
+				return err
+			},
+			want: []string{"rev-parse", "--show-toplevel"},
+		},
+		{
+			name: "add",
+			invoke: func(ctx context.Context, r *git.GitRunner) error {
+				return r.Add(ctx, "a.txt", "b.txt")
+			},
+			want: []string{"add", "a.txt", "b.txt"},
+		},
+		{
+			name: "commit splices flags before message",
+			invoke: func(ctx context.Context, r *git.GitRunner) error {
+				return r.Commit(ctx, "initial commit", "--amend")
+			},
+			want: []string{"commit", "--amend", "-m", "initial commit"},
+		},
+		{
+			name: "checkout new branch",
+			invoke: func(ctx context.Context, r *git.GitRunner) error {
+				return r.Checkout(ctx, "feature", true)
+			},
+			want: []string{"checkout", "-b", "feature"},
+		},
+		{
+			name: "checkout existing branch",
+			invoke: func(ctx context.Context, r *git.GitRunner) error {
+				return r.Checkout(ctx, "main", false)
+			},
+			want: []string{"checkout", "main"},
+		},
+		{
+			name: "config set",
+			invoke: func(ctx context.Context, r *git.GitRunner) error {
+				return r.ConfigSet(ctx, "user.email", "test@example.com")
+			},
+			want: []string{"config", "user.email", "test@example.com"},
+		},
+	}
 
-	runner = runner.WithWorkDir(dir)
-	require.NoError(t, runner.InitBare(t.Context()))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// A malformed object name returns exit 128 (fatal). HasObject must
-	// return an error rather than report missing, so a corrupted store
-	// does not trigger a refetch loop.
-	_, err = runner.HasObject(t.Context(), "not-a-hash")
-	require.Error(t, err)
+			var got []string
+
+			runner := newArgvCapturingRunner(t, &got, nil).WithWorkDir(workDir)
+
+			require.NoError(t, tt.invoke(t.Context(), runner))
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestGitRunner_WithWorkDirGetRepoRootWithRacing(t *testing.T) {
 	t.Parallel()
 
-	dir := helpers.TmpDirWOSymlinks(t)
+	dir := t.TempDir()
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
-	require.NoError(t, err)
-
+	runner := newMemRunner(t, staticResult(vexec.Result{Stdout: []byte(dir + "\n")}))
 	runner = runner.WithWorkDir(dir)
-	require.NoError(t, runner.Init(t.Context()))
 
 	// GetRepoRoot memoizes on first success, so only that first call writes.
 	// Derive a fresh runner per round and race the memoizing call against a
@@ -485,40 +447,23 @@ func TestGitRunner_WithWorkDirGetRepoRootWithRacing(t *testing.T) {
 	require.NoError(t, g.Wait())
 }
 
-// TestGitRunner_AddCommitCheckoutConfig drives the local-mutation wrappers
-// (ConfigSet, Add, Commit, Checkout) through a stage -> commit -> branch flow
-// against a fresh repository, and checks the state via the read helpers
-// (HasUncommittedChanges, GetCurrentBranch, Config) at each step.
-func TestGitRunner_AddCommitCheckoutConfig(t *testing.T) {
-	t.Parallel()
+// newMemRunner returns a runner backed by an in-memory exec dispatching every
+// git invocation to h.
+func newMemRunner(t *testing.T, h vexec.Handler) *git.GitRunner {
+	t.Helper()
 
-	ctx := t.Context()
-
-	dir := helpers.TmpDirWOSymlinks(t)
-
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	r, err := git.NewGitRunner(vexec.NewMemExec(h))
 	require.NoError(t, err)
 
-	runner = runner.WithWorkDir(dir)
-	require.NoError(t, runner.Init(ctx))
+	return r
+}
 
-	require.NoError(t, runner.ConfigSet(ctx, "user.email", "test@example.com"))
-	require.NoError(t, runner.ConfigSet(ctx, "user.name", "Terragrunt Test"))
-
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello"), 0o600))
-
-	require.NoError(t, runner.Add(ctx, "hello.txt"))
-	assert.True(t, runner.HasUncommittedChanges(ctx))
-
-	require.NoError(t, runner.Commit(ctx, "initial commit"))
-	assert.False(t, runner.HasUncommittedChanges(ctx))
-
-	require.NoError(t, runner.Checkout(ctx, "feature", true))
-	assert.Equal(t, "feature", runner.GetCurrentBranch(ctx))
-
-	email, err := runner.Config(ctx, "user.email")
-	require.NoError(t, err)
-	assert.Equal(t, "test@example.com", email)
+// staticResult returns a handler replying with the same result to every
+// invocation.
+func staticResult(res vexec.Result) vexec.Handler {
+	return func(context.Context, vexec.Invocation) vexec.Result {
+		return res
+	}
 }
 
 // newArgvCapturingRunner returns a runner backed by an in-memory exec that
@@ -526,39 +471,13 @@ func TestGitRunner_AddCommitCheckoutConfig(t *testing.T) {
 func newArgvCapturingRunner(t *testing.T, captured *[]string, stdout []byte) *git.GitRunner {
 	t.Helper()
 
-	e := vexec.NewMemExec(
-		func(_ context.Context, inv vexec.Invocation) vexec.Result {
-			*captured = inv.Args
-			return vexec.Result{Stdout: stdout}
-		},
-		vexec.WithLookPath(func(string) (string, error) { return "git", nil }),
-	)
+	e := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		*captured = inv.Args
+		return vexec.Result{Stdout: stdout}
+	})
 
 	r, err := git.NewGitRunner(e)
 	require.NoError(t, err)
 
 	return r
-}
-
-// newCommittedRepo creates a local repo with one commit for use as a file:// remote.
-func newCommittedRepo(t *testing.T) string {
-	t.Helper()
-
-	ctx := t.Context()
-
-	dir := helpers.TmpDirWOSymlinks(t)
-
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
-	require.NoError(t, err)
-
-	runner = runner.WithWorkDir(dir)
-
-	require.NoError(t, runner.Init(ctx))
-	require.NoError(t, runner.ConfigSet(ctx, "user.email", "test@example.com"))
-	require.NoError(t, runner.ConfigSet(ctx, "user.name", "Terragrunt Test"))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(""), 0o600))
-	require.NoError(t, runner.Add(ctx, "main.tf"))
-	require.NoError(t, runner.Commit(ctx, "initial commit"))
-
-	return dir
 }

--- a/internal/git/server_test.go
+++ b/internal/git/server_test.go
@@ -1,3 +1,9 @@
+//go:build exec && !windows
+
+// Server drives the real git binary (init, commit, push, http-backend), so
+// its tests are exec-gated like the rest of the real-git tests in
+// git_exec_test.go, and !windows-constrained for the same reason.
+
 package git_test
 
 import (
@@ -12,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestServer(t *testing.T) {
+func TestExecServer(t *testing.T) {
 	t.Parallel()
 
 	t.Run("start and clone", func(t *testing.T) {

--- a/internal/git/submodule_test.go
+++ b/internal/git/submodule_test.go
@@ -4,10 +4,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
-	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestResolveSubmoduleURL(t *testing.T) {
@@ -145,51 +142,4 @@ func TestParseSubmoduleConfig(t *testing.T) {
 			assert.Equal(t, tt.want, git.ParseSubmoduleConfig(tt.output))
 		})
 	}
-}
-
-// TestGitRunner_SubmoduleURLs exercises the `git config --blob` path
-// against a real repository: the .gitmodules blob committed by the test
-// server is located through ls-tree and parsed by git itself.
-func TestGitRunner_SubmoduleURLs(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	srv, err := git.NewServer()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = srv.Close() })
-
-	require.NoError(t, srv.CommitFile(t.Context(), "README.md", []byte("# repo"), "add readme"))
-
-	const pinnedHash = "0123456789abcdef0123456789abcdef01234567"
-
-	require.NoError(t, srv.CommitSubmodule(
-		t.Context(), "modules/child", "https://example.com/child.git", pinnedHash, "add submodule",
-	))
-
-	url, err := srv.Start(ctx)
-	require.NoError(t, err)
-
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
-	require.NoError(t, err)
-
-	runner = runner.WithWorkDir(helpers.TmpDirWOSymlinks(t))
-	require.NoError(t, runner.Clone(ctx, url, true, 0, ""))
-
-	tree, err := runner.LsTreeRecursive(ctx, "HEAD")
-	require.NoError(t, err)
-
-	var gitmodulesHash string
-
-	for _, entry := range tree.Entries() {
-		if entry.Path == git.GitmodulesPath {
-			gitmodulesHash = entry.Hash
-		}
-	}
-
-	require.NotEmpty(t, gitmodulesHash, ".gitmodules entry not found in tree")
-
-	urls, err := runner.SubmoduleURLs(ctx, gitmodulesHash)
-	require.NoError(t, err)
-	assert.Equal(t, map[string]string{"modules/child": "https://example.com/child.git"}, urls)
 }

--- a/internal/providercache/providercache_http_test.go
+++ b/internal/providercache/providercache_http_test.go
@@ -1,0 +1,20 @@
+//go:build http
+
+// Opt-in variant of TestProviderCache that talks to the real
+// registry.terraform.io and releases.hashicorp.com instead of the in-memory
+// registry. Run with `go test -tags http` when real-network coverage is
+// wanted; the default build stays fully offline.
+
+package providercache_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+)
+
+func TestHTTPProviderCache(t *testing.T) {
+	t.Parallel()
+
+	testProviderCache(t, vhttp.NewOSClient())
+}

--- a/internal/providercache/providercache_test.go
+++ b/internal/providercache/providercache_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -55,16 +54,21 @@ func createFakeProvider(t *testing.T, cacheDir, relativePath string) string {
 func TestProviderCache(t *testing.T) {
 	t.Parallel()
 
+	testProviderCache(t, vhttp.NewMemClient(registryHandler(t)))
+}
+
+// testProviderCache drives the provider cache server through discovery,
+// version listing, and provider download over c. The default build passes an
+// in-memory client synthesizing registry.terraform.io; the http-tagged
+// variant passes an OS client so the same scenarios run against the real
+// registry.
+func testProviderCache(t *testing.T, c vhttp.Client) {
+	t.Helper()
+
 	token := fmt.Sprintf("%s:%s", providercache.APIKeyAuth, uuid.New().String())
 
 	providerCacheDir := helpers.TmpDirWOSymlinks(t)
 	pluginCacheDir := helpers.TmpDirWOSymlinks(t)
-
-	fakeRegistry := newFakeRegistryServer(t)
-	fakeRegistryURLs := &handlers.RegistryURLs{
-		ModulesV1:   fakeRegistry.URL + "/v1/modules",
-		ProvidersV1: fakeRegistry.URL + "/v1/providers",
-	}
 
 	opts := make([]cache.Option, 0, 3)
 	opts = append(
@@ -148,19 +152,20 @@ func TestProviderCache(t *testing.T) {
 			errGroup, ctx := errgroup.WithContext(ctx)
 			l := logger.CreateLogger()
 
-			providerService := services.NewProviderService(providerCacheDir, pluginCacheDir, nil, l)
+			providerService := services.NewProviderService(
+				providerCacheDir,
+				pluginCacheDir,
+				nil,
+				l,
+				services.WithHTTPClient(c),
+			)
 			providerHandler := handlers.NewDirectProviderHandler(
 				l,
-				vhttp.NewOSClient(),
+				c,
 				new(cliconfig.ProviderInstallationDirect),
 				nil,
 			)
-			// Seed discovery so the direct handler resolves registry.terraform.io
-			// against the in-process fake registry instead of doing live discovery.
-			// The proxy handler below keeps its own discovery cache untouched.
-			providerHandler.SetDiscoveryURLCache("registry.terraform.io", fakeRegistryURLs)
-
-			proxyProviderHandler := handlers.NewProxyProviderHandler(l, vhttp.NewOSClient(), nil)
+			proxyProviderHandler := handlers.NewProxyProviderHandler(l, c, nil)
 
 			tc.opts = append(tc.opts,
 				cache.WithProviderService(providerService),
@@ -233,6 +238,140 @@ func TestProviderCache(t *testing.T) {
 	}
 }
 
+// fakeRelease is a canned response served from releases.hashicorp.com.
+type fakeRelease struct {
+	contentType string
+	body        []byte
+}
+
+// registryHandler synthesizes the slice of the provider registry protocol the
+// cache server exercises: service discovery, version listings, platform
+// download documents, and the release archives, checksums and signatures
+// themselves. Anything else gets a 404, which is also what the real registry
+// returns for the fabricated 1234.5678.9 version — the cache must then fall
+// back to the user plugin dir.
+func registryHandler(t *testing.T) vhttp.Handler {
+	t.Helper()
+
+	registry := map[string][]byte{
+		"/.well-known/terraform.json": []byte(`{"providers.v1":"/v1/providers"}`),
+	}
+	releases := make(map[string]fakeRelease)
+
+	addFakeProvider(t, registry, releases, "aws", "5.36.0", "x5", "darwin", "arm64")
+	addFakeProvider(t, registry, releases, "template", "2.2.0", "x4", "linux", "amd64")
+
+	return func(_ context.Context, req *http.Request) (*http.Response, error) {
+		switch req.URL.Host {
+		case "registry.terraform.io":
+			if body, ok := registry[req.URL.Path]; ok {
+				return vhttp.Respond(http.StatusOK, body,
+					http.Header{"Content-Type": []string{"application/json"}}), nil
+			}
+		case "releases.hashicorp.com":
+			if release, ok := releases[req.URL.Path]; ok {
+				return vhttp.Respond(http.StatusOK, release.body,
+					http.Header{"Content-Type": []string{release.contentType}}), nil
+			}
+		}
+
+		return vhttp.Respond(http.StatusNotFound, nil, nil), nil
+	}
+}
+
+// addFakeProvider registers the responses needed to fully cache one hashicorp
+// provider platform: the versions list and download document on the registry,
+// plus the archive, its SHA256SUMS document and a dummy signature on the
+// release host. The download document carries no GPG keys, so package
+// authentication runs both checksum checks and skips the signature check.
+func addFakeProvider(
+	t *testing.T,
+	registry map[string][]byte,
+	releases map[string]fakeRelease,
+	name, version, protocolSuffix, osName, arch string,
+) {
+	t.Helper()
+
+	const releasesURL = "https://releases.hashicorp.com"
+
+	archive := zipWithFile(
+		t,
+		fmt.Sprintf("terraform-provider-%s_v%s_%s", name, version, protocolSuffix),
+	)
+	filename := fmt.Sprintf("terraform-provider-%s_%s_%s_%s.zip", name, version, osName, arch)
+	checksum := sha256.Sum256(archive)
+
+	releaseDir := fmt.Sprintf("/terraform-provider-%s/%s/", name, version)
+	archivePath := releaseDir + filename
+	shasumsPath := fmt.Sprintf("%sterraform-provider-%s_%s_SHA256SUMS", releaseDir, name, version)
+	signaturePath := shasumsPath + ".sig"
+
+	versionsBody, err := json.Marshal(struct {
+		Versions models.Versions `json:"versions"`
+	}{
+		Versions: models.Versions{
+			{
+				Version:   version,
+				Protocols: []string{"5.0"},
+				Platforms: models.Platforms{
+					{OS: "darwin", Arch: "arm64"},
+					{OS: "linux", Arch: "amd64"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	downloadBody, err := json.Marshal(&models.ResponseBody{
+		Platform:               models.Platform{OS: osName, Arch: arch},
+		Filename:               filename,
+		DownloadURL:            releasesURL + archivePath,
+		SHA256SumsURL:          releasesURL + shasumsPath,
+		SHA256SumsSignatureURL: releasesURL + signaturePath,
+		SHA256Sum:              hex.EncodeToString(checksum[:]),
+		Protocols:              []string{"5.0"},
+	})
+	require.NoError(t, err)
+
+	registry["/v1/providers/hashicorp/"+name+"/versions"] = versionsBody
+	registry[fmt.Sprintf(
+		"/v1/providers/hashicorp/%s/%s/download/%s/%s",
+		name,
+		version,
+		osName,
+		arch,
+	)] = downloadBody
+
+	releases[archivePath] = fakeRelease{contentType: "application/zip", body: archive}
+	releases[shasumsPath] = fakeRelease{
+		contentType: "text/plain",
+		body:        fmt.Appendf(nil, "%x  %s\n", checksum, filename),
+	}
+	releases[signaturePath] = fakeRelease{
+		contentType: "application/octet-stream",
+		body:        []byte("fake-signature"),
+	}
+}
+
+// zipWithFile builds an in-memory zip archive holding a single file, standing
+// in for a provider release archive.
+func zipWithFile(t *testing.T, name string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	zw := zip.NewWriter(&buf)
+
+	w, err := zw.Create(name)
+	require.NoError(t, err)
+
+	_, err = w.Write([]byte("fake provider binary"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	return buf.Bytes()
+}
+
 func TestProviderCacheHomeless(t *testing.T) {
 	cacheDir := helpers.TmpDirWOSymlinks(t)
 
@@ -300,140 +439,4 @@ func TestProviderCacheWithProviderCacheDir(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, server, "Init should return a valid server when using VFS")
 	})
-}
-
-// fakeRegistryRoute is a canned response served by newFakeRegistryServer.
-type fakeRegistryRoute struct {
-	contentType string
-	body        []byte
-}
-
-// newFakeRegistryServer starts an in-process provider registry that serves
-// versions metadata, download metadata, archives and checksums for the
-// providers requested by TestProviderCache, so the direct-handler test cases
-// never make requests outside localhost. The proxy test case keeps its own
-// discovery cache and still performs live discovery against
-// registry.terraform.io. Unknown paths, such as versions that do not exist
-// upstream, get 404 responses.
-func newFakeRegistryServer(t *testing.T) *httptest.Server {
-	t.Helper()
-
-	routes := make(map[string]fakeRegistryRoute)
-	addFakeRegistryProvider(t, routes, "aws", "5.36.0", "x5", "darwin", "arm64")
-	addFakeRegistryProvider(t, routes, "template", "2.2.0", "x4", "linux", "amd64")
-
-	server := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			route, ok := routes[r.URL.Path]
-			if !ok {
-				w.WriteHeader(http.StatusNotFound)
-
-				return
-			}
-
-			w.Header().Set("Content-Type", route.contentType)
-
-			if _, err := w.Write(route.body); err != nil {
-				t.Errorf("fake registry write failed: %v", err)
-			}
-		}),
-	)
-	t.Cleanup(server.Close)
-
-	return server
-}
-
-// addFakeRegistryProvider registers the registry responses needed to fully
-// cache one hashicorp provider platform: the versions list, the download
-// metadata, the archive, its SHA256SUMS document and a dummy signature.
-// The download metadata uses root-relative URLs that the direct handler
-// resolves against the fake registry, and carries no GPG keys so package
-// authentication runs both checksum checks and skips the signature check.
-func addFakeRegistryProvider(
-	t *testing.T,
-	routes map[string]fakeRegistryRoute,
-	name, version, protocolSuffix, osName, arch string,
-) {
-	t.Helper()
-
-	archive := buildFakeProviderZip(
-		t,
-		fmt.Sprintf("terraform-provider-%s_v%s_%s", name, version, protocolSuffix),
-	)
-	filename := fmt.Sprintf("terraform-provider-%s_%s_%s_%s.zip", name, version, osName, arch)
-	checksum := sha256.Sum256(archive)
-
-	archivePath := "/archives/" + filename
-	shasumsPath := fmt.Sprintf("/shasums/terraform-provider-%s_%s_SHA256SUMS", name, version)
-	shasumsSignaturePath := shasumsPath + ".sig"
-	downloadPath := fmt.Sprintf(
-		"/v1/providers/hashicorp/%s/%s/download/%s/%s",
-		name,
-		version,
-		osName,
-		arch,
-	)
-
-	versionsBody, err := json.Marshal(struct {
-		Versions models.Versions `json:"versions"`
-	}{
-		Versions: models.Versions{
-			{
-				Version:   version,
-				Protocols: []string{"5.0"},
-				Platforms: models.Platforms{
-					{OS: "darwin", Arch: "arm64"},
-					{OS: "linux", Arch: "amd64"},
-				},
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	downloadBody, err := json.Marshal(&models.ResponseBody{
-		Platform:               models.Platform{OS: osName, Arch: arch},
-		Filename:               filename,
-		DownloadURL:            archivePath,
-		SHA256SumsURL:          shasumsPath,
-		SHA256SumsSignatureURL: shasumsSignaturePath,
-		SHA256Sum:              hex.EncodeToString(checksum[:]),
-		Protocols:              []string{"5.0"},
-	})
-	require.NoError(t, err)
-
-	routes["/v1/providers/hashicorp/"+name+"/versions"] = fakeRegistryRoute{
-		contentType: "application/json",
-		body:        versionsBody,
-	}
-	routes[downloadPath] = fakeRegistryRoute{
-		contentType: "application/json",
-		body:        downloadBody,
-	}
-	routes[archivePath] = fakeRegistryRoute{
-		contentType: "application/zip",
-		body:        archive,
-	}
-	routes[shasumsPath] = fakeRegistryRoute{
-		contentType: "text/plain",
-		body:        fmt.Appendf(nil, "%x  %s\n", checksum, filename),
-	}
-	routes[shasumsSignaturePath] = fakeRegistryRoute{
-		contentType: "application/octet-stream",
-		body:        []byte("fake-signature"),
-	}
-}
-
-// buildFakeProviderZip returns an in-memory provider archive containing a
-// single empty file entry named after the provider binary.
-func buildFakeProviderZip(t *testing.T, binaryName string) []byte {
-	t.Helper()
-
-	buffer := new(bytes.Buffer)
-	zipWriter := zip.NewWriter(buffer)
-
-	_, err := zipWriter.Create(binaryName)
-	require.NoError(t, err)
-	require.NoError(t, zipWriter.Close())
-
-	return buffer.Bytes()
 }

--- a/internal/runner/run/creds/getter_test.go
+++ b/internal/runner/run/creds/getter_test.go
@@ -24,7 +24,7 @@ func (p *stubProvider) Name() string { return p.name }
 func (p *stubProvider) GetCredentials(
 	_ context.Context,
 	_ log.Logger,
-	_ venv.Venv,
+	_ *venv.Venv,
 ) (*providers.Credentials, error) {
 	return p.creds, nil
 }

--- a/internal/tf/cache/download_auth_test.go
+++ b/internal/tf/cache/download_auth_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -38,7 +39,9 @@ func TestDownloadRouteRequiresSecretSegment(t *testing.T) {
 		cache.WithToken(token),
 		cache.WithLogger(l),
 		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l)),
-		cache.WithProxyProviderHandler(handlers.NewProxyProviderHandler(l, nil)),
+		cache.WithProxyProviderHandler(
+			handlers.NewProxyProviderHandler(l, vhttp.NewNoNetworkClient(), nil),
+		),
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -74,9 +77,8 @@ func TestDownloadRouteRequiresSecretSegment(t *testing.T) {
 		getStatus(t, ctx, client, base+"/downloads/"+wrongSegment+"/registry.terraform.io/provider.zip"),
 		"download route must reject an incorrect secret segment")
 
-	// The upstream host is unresolvable, so a routed request fails inside the
-	// proxy rather than 404ing. Any status but 404 proves the route matched,
-	// without depending on network access.
+	// The proxy's client refuses every request, so a routed request fails inside
+	// the proxy rather than 404ing. Any status but 404 proves the route matched.
 	require.NotEqual(t, http.StatusNotFound,
 		getStatus(t, ctx, client, base+"/downloads/"+segment+"/example.invalid/provider.zip"),
 		"correct secret segment must resolve the download route")
@@ -107,7 +109,9 @@ func TestDownloadSegmentIsRedactedFromLogs(t *testing.T) {
 		cache.WithHostname("127.0.0.1"),
 		cache.WithLogger(l),
 		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l)),
-		cache.WithProxyProviderHandler(handlers.NewProxyProviderHandler(l, nil)),
+		cache.WithProxyProviderHandler(
+			handlers.NewProxyProviderHandler(l, vhttp.NewNoNetworkClient(), nil),
+		),
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())

--- a/internal/vexec/osexec_posix_test.go
+++ b/internal/vexec/osexec_posix_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOSExec_Output(t *testing.T) {
+func TestExecOS_Output(t *testing.T) {
 	t.Parallel()
 
 	out, err := vexec.Output(vexec.NewOSExec(), t.Context(), "echo", "hello")
@@ -28,7 +28,7 @@ func TestOSExec_Output(t *testing.T) {
 	assert.Equal(t, "hello\n", string(out))
 }
 
-func TestOSExec_LookPath(t *testing.T) {
+func TestExecOS_LookPath(t *testing.T) {
 	t.Parallel()
 
 	e := vexec.NewOSExec()
@@ -42,7 +42,7 @@ func TestOSExec_LookPath(t *testing.T) {
 	assert.ErrorIs(t, err, exec.ErrNotFound)
 }
 
-func TestOSExec_ExitCode(t *testing.T) {
+func TestExecOS_ExitCode(t *testing.T) {
 	t.Parallel()
 
 	err := vexec.Run(vexec.NewOSExec(), t.Context(), "bash", "-c", "exit 3")
@@ -51,7 +51,7 @@ func TestOSExec_ExitCode(t *testing.T) {
 	assert.Equal(t, 3, vexec.ExitCode(err))
 }
 
-func TestOSExec_StartWait(t *testing.T) {
+func TestExecOS_StartWait(t *testing.T) {
 	t.Parallel()
 
 	var stdout, stderr bytes.Buffer
@@ -69,7 +69,7 @@ func TestOSExec_StartWait(t *testing.T) {
 	assert.True(t, cmd.ProcessState().Success())
 }
 
-func TestOSExec_CombinedOutput(t *testing.T) {
+func TestExecOS_CombinedOutput(t *testing.T) {
 	t.Parallel()
 
 	out, err := vexec.NewOSExec().
@@ -82,7 +82,7 @@ func TestOSExec_CombinedOutput(t *testing.T) {
 	assert.Contains(t, string(out), "err")
 }
 
-func TestOSExec_SetDir(t *testing.T) {
+func TestExecOS_SetDir(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
@@ -102,7 +102,7 @@ func TestOSExec_SetDir(t *testing.T) {
 	)
 }
 
-func TestOSExec_SetEnv(t *testing.T) {
+func TestExecOS_SetEnv(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
@@ -115,7 +115,7 @@ func TestOSExec_SetEnv(t *testing.T) {
 	assert.Equal(t, "bar", buf.String())
 }
 
-func TestOSExec_SetStdin(t *testing.T) {
+func TestExecOS_SetStdin(t *testing.T) {
 	t.Parallel()
 
 	var stdout bytes.Buffer
@@ -130,7 +130,7 @@ func TestOSExec_SetStdin(t *testing.T) {
 
 // ProcessState parity is deliberately not asserted: osCmd populates it after
 // Wait, memCmd always returns nil. Callers that need it should not migrate.
-func TestParity_OSVsMem(t *testing.T) {
+func TestExecParity_OSVsMem(t *testing.T) {
 	t.Parallel()
 
 	runParityCases(t, []parityCase{
@@ -155,7 +155,7 @@ func TestParity_OSVsMem(t *testing.T) {
 	})
 }
 
-func TestOSExec_SetCancelFiresOnContextCancel(t *testing.T) {
+func TestExecOS_SetCancelFiresOnContextCancel(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -178,7 +178,7 @@ func TestOSExec_SetCancelFiresOnContextCancel(t *testing.T) {
 	assert.True(t, called.Load(), "cancel fn must have been invoked")
 }
 
-func TestOSExec_SignalBeforeStartReturnsErrProcessNotStarted(t *testing.T) {
+func TestExecOS_SignalBeforeStartReturnsErrProcessNotStarted(t *testing.T) {
 	t.Parallel()
 
 	cmd := vexec.NewOSExec().Command(t.Context(), "echo", "hi")

--- a/internal/vexec/osexec_windows_test.go
+++ b/internal/vexec/osexec_windows_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOSExec_Output_Windows(t *testing.T) {
+func TestExecOS_Output_Windows(t *testing.T) {
 	t.Parallel()
 
 	out, err := vexec.Output(vexec.NewOSExec(), t.Context(), "cmd", "/C", "echo hello")
@@ -26,7 +26,7 @@ func TestOSExec_Output_Windows(t *testing.T) {
 	assert.Equal(t, "hello", strings.TrimSpace(string(out)))
 }
 
-func TestOSExec_LookPath_Windows(t *testing.T) {
+func TestExecOS_LookPath_Windows(t *testing.T) {
 	t.Parallel()
 
 	e := vexec.NewOSExec()
@@ -40,7 +40,7 @@ func TestOSExec_LookPath_Windows(t *testing.T) {
 	assert.ErrorIs(t, err, exec.ErrNotFound)
 }
 
-func TestOSExec_ExitCode_Windows(t *testing.T) {
+func TestExecOS_ExitCode_Windows(t *testing.T) {
 	t.Parallel()
 
 	err := vexec.Run(vexec.NewOSExec(), t.Context(), "cmd", "/C", "exit 3")
@@ -49,7 +49,7 @@ func TestOSExec_ExitCode_Windows(t *testing.T) {
 	assert.Equal(t, 3, vexec.ExitCode(err))
 }
 
-func TestOSExec_StartWait_Windows(t *testing.T) {
+func TestExecOS_StartWait_Windows(t *testing.T) {
 	t.Parallel()
 
 	var stdout, stderr bytes.Buffer
@@ -67,7 +67,7 @@ func TestOSExec_StartWait_Windows(t *testing.T) {
 	assert.True(t, cmd.ProcessState().Success())
 }
 
-func TestOSExec_CombinedOutput_Windows(t *testing.T) {
+func TestExecOS_CombinedOutput_Windows(t *testing.T) {
 	t.Parallel()
 
 	out, err := vexec.NewOSExec().
@@ -80,7 +80,7 @@ func TestOSExec_CombinedOutput_Windows(t *testing.T) {
 	assert.Contains(t, string(out), "err")
 }
 
-func TestOSExec_SetDir_Windows(t *testing.T) {
+func TestExecOS_SetDir_Windows(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
@@ -98,7 +98,7 @@ func TestOSExec_SetDir_Windows(t *testing.T) {
 	)
 }
 
-func TestOSExec_SetEnv_Windows(t *testing.T) {
+func TestExecOS_SetEnv_Windows(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
@@ -112,7 +112,7 @@ func TestOSExec_SetEnv_Windows(t *testing.T) {
 	assert.Equal(t, "bar", strings.TrimSpace(buf.String()))
 }
 
-func TestOSExec_SetStdin_Windows(t *testing.T) {
+func TestExecOS_SetStdin_Windows(t *testing.T) {
 	t.Parallel()
 
 	var stdout bytes.Buffer
@@ -126,7 +126,7 @@ func TestOSExec_SetStdin_Windows(t *testing.T) {
 	assert.Equal(t, "hello from stdin", strings.TrimSpace(stdout.String()))
 }
 
-func TestParity_OSVsMem_Windows(t *testing.T) {
+func TestExecParity_OSVsMem_Windows(t *testing.T) {
 	t.Parallel()
 
 	runParityCases(t, []parityCase{

--- a/test/integration_exec_test.go
+++ b/test/integration_exec_test.go
@@ -16,6 +16,10 @@ import (
 func TestExecCommand(t *testing.T) {
 	t.Parallel()
 
+	if helpers.IsWindows() {
+		t.Skip("Skipping test on Windows since bash script execution is not supported")
+	}
+
 	testCases := []struct {
 		scriptPath string
 		runInDir   string
@@ -71,6 +75,10 @@ func TestExecCommand(t *testing.T) {
 
 func TestExecCommandTfPath(t *testing.T) {
 	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("Skipping test on Windows since bash script execution is not supported")
+	}
 
 	testCases := []struct {
 		expected string


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Refactors tests that call out to external services to use vhttp and vexec instead to make the unit tests in this project more hermetic.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened Git command handling to reject unsafe option injection and surface meaningful errors.
  * Improved reliability of Git operations, including reference lookup, object checks, cloning, fetching, and submodule processing.
  * Clarified integration-test behavior on Windows by skipping unsupported shell-based scenarios.

* **Tests**
  * Expanded end-to-end Git coverage, including shallow clones, bare repositories, and HTTP interactions.
  * Added optional HTTP integration coverage for provider caching.
  * Improved test isolation and consistency through in-memory test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->