### PR TITLE
chore: fixed lint issues after merge multiple branches

### DIFF
--- a/internal/getter/casgetter_oci_test.go
+++ b/internal/getter/casgetter_oci_test.go
@@ -11,6 +11,7 @@ import (
 
 	tgcas "github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	gogetter "github.com/hashicorp/go-getter/v2"
@@ -147,8 +148,7 @@ func TestCASGetterDoesNotClaimOCIWithoutFetcher(t *testing.T) {
 	c, err := tgcas.New(tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v, err := tgcas.OSVenv()
-	require.NoError(t, err)
+	v := venv.OSVenv()
 
 	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{})
 
@@ -268,8 +268,7 @@ func newOCICASHarness(
 	c, err := tgcas.New(tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v, err := tgcas.OSVenv()
-	require.NoError(t, err)
+	v := venv.OSVenv()
 
 	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},
 		getter.WithGenericFetchers(map[string]gogetter.Getter{

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -598,7 +598,7 @@ func tryCASDownload(
 	}
 
 	if ociEnabled {
-		dispatchOpts = append(dispatchOpts, getter.WithOCIConfig(l, v, casVenv.FS))
+		dispatchOpts = append(dispatchOpts, getter.WithOCIConfig(l, v, v.FS))
 	}
 
 	// CAS-only client: CASProtocolGetter handles cas::sha1:<hash> sources


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* fixed lint issues after merge multiple branches


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OCI-backed content downloads when using the CAS-only download path.
  - Ensured OCI fetch attempts use the correct filesystem context, improving download reliability.
  - Updated internal test setup to better validate OCI behavior when no fetcher is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->