### PR TITLE
fix: Fixing self-chained role assumption

### DIFF
--- a/docs/src/data/changelog/v1.1.2/iam-role-backend-self-assumption.mdx
+++ b/docs/src/data/changelog/v1.1.2/iam-role-backend-self-assumption.mdx
@@ -1,0 +1,14 @@
+---
+version: "v1.1.2"
+category: "bug-fixes"
+---
+
+#### Fixed roles assuming themselves for backend operations
+
+A regression in v1.1.1 broke setups that provide static AWS credentials and configure a role via the `iam_role` attribute, the `--iam-assume-role` flag, or `TG_IAM_ASSUME_ROLE`.
+
+In those setups, Terragrunt assumes the role once at the start of a run, and every later AWS call uses that role session. In v1.1.1, backend operations like bootstrapping the state bucket started performing an extra role assumption of their own. Since the run was already using the role session at that point, the role tried to assume itself, and AWS rejected the call with an `AccessDenied` error unless the role's trust policy happened to include the role itself.
+
+Backend operations now reuse the role session from the start of the run, as they did before v1.1.1.
+
+This does not affect the `assume_role` attribute of the `remote_state` block. Roles configured there are backend-specific and are still assumed on top of the supplied credentials, so the cross-account role assumption should continue to work as expected.

--- a/internal/awshelper/config.go
+++ b/internal/awshelper/config.go
@@ -101,7 +101,9 @@ func (b *AWSConfigBuilder) Build(ctx context.Context, l log.Logger) (aws.Config,
 
 	configOptions = append(configOptions, config.WithAppID("terragrunt/"+version.GetVersion()))
 
-	if envCreds := createCredentialsFromEnv(b.env); envCreds != nil {
+	envCreds := createCredentialsFromEnv(b.env)
+
+	if envCreds != nil {
 		l.Debugf("Using AWS credentials from auth provider command")
 
 		configOptions = append(configOptions, config.WithCredentialsProvider(envCreds))
@@ -139,11 +141,16 @@ func (b *AWSConfigBuilder) Build(ctx context.Context, l log.Logger) (aws.Config,
 		return aws.Config{}, fmt.Errorf("error loading AWS config: %w", err)
 	}
 
-	// Role assumption must not be skipped when env credentials are present: they serve as the
-	// source identity for the assumption. The role-assuming credential providers below capture
-	// cfg by value before cfg.Credentials is overwritten, so the STS calls they make are signed
-	// with the env credentials, chaining the two.
-	mergedIAMRoleOptions := getMergedIAMRoleOptions(b.sessionConfig, b.iamRoleOpts)
+	// Callers that set iamRoleOpts (iam_role / TG_IAM_ASSUME_ROLE) run the amazonsts credentials
+	// provider first, which writes the assumed role's session into the env. When env credentials
+	// are present, re-assuming that role here would make the role assume itself, so only the
+	// session config's role (assume_role in the remote_state block) is chained on top of them.
+	iamRoleOpts := b.iamRoleOpts
+	if envCreds != nil {
+		iamRoleOpts = iam.RoleOptions{}
+	}
+
+	mergedIAMRoleOptions := getMergedIAMRoleOptions(b.sessionConfig, iamRoleOpts)
 	if mergedIAMRoleOptions.RoleARN == "" {
 		return cfg, nil
 	}

--- a/internal/awshelper/config_test.go
+++ b/internal/awshelper/config_test.go
@@ -192,70 +192,142 @@ func TestAwsConfigWithAuthProviderEnvChainsAssumeRole(t *testing.T) {
 	assert.Contains(t, chainedARN, ":assumed-role/"+roleName+"/"+sessionName)
 }
 
-// TestAwsConfigEnvCredsIgnoreIAMRoleOptions verifies that env credentials are used verbatim even
-// when IAM role options (iam_role / TG_IAM_ASSUME_ROLE) are set: by the time a backend operation
-// builds its AWS config, those options were already applied by the amazonsts credentials provider
-// and the env credentials are the assumed role's session. Re-assuming would chain the role onto
-// itself and fail unless the role trusts itself.
-func TestAwsConfigEnvCredsIgnoreIAMRoleOptions(t *testing.T) {
+// credsExpectation names the credential resolution outcome a Build permutation must produce.
+type credsExpectation int
+
+const (
+	// wantEnvCredsVerbatim: resolution returns the env credentials as-is, with no role assumption.
+	wantEnvCredsVerbatim credsExpectation = iota
+	// wantAssumeAttempted: resolution performs an STS role assumption signed with the env credentials.
+	wantAssumeAttempted
+	// wantRoleProvider: a role-assuming provider is installed on top of the default credential chain.
+	wantRoleProvider
+	// wantDefaultChain: the default credential chain is left untouched.
+	wantDefaultChain
+)
+
+// TestAwsConfigRoleSourcePermutations covers every combination of ambient env credentials, merged
+// IAM role options (the iam_role attribute and the --iam-assume-role flag both arrive here), and
+// a backend role (the assume_role attribute of the remote_state block).
+//
+// When env credentials are present, IAM role options must be ignored: the amazonsts credentials
+// provider already applied them, so the env credentials are that role's session and re-assuming
+// would make the role assume itself. A backend role is never pre-applied, so it must always be
+// assumed, with present env credentials serving as the source identity for the exchange.
+func TestAwsConfigRoleSourcePermutations(t *testing.T) {
 	t.Parallel()
 
-	l := logger.CreateLogger()
-
-	env := map[string]string{
+	envCreds := map[string]string{
 		"AWS_ACCESS_KEY_ID":     "test-access-key",
 		"AWS_SECRET_ACCESS_KEY": "test-secret-key",
 		"AWS_SESSION_TOKEN":     "test-session-token",
 		"AWS_REGION":            "us-west-2",
 	}
-
-	cfg, err := awshelper.NewAWSConfigBuilder().
-		WithEnv(env).
-		WithIAMRoleOptions(iam.RoleOptions{
-			RoleARN: "arn:aws:iam::111111111111:role/deploy-role",
-		}).
-		Build(t.Context(), l)
-	require.NoError(t, err)
-	require.NotNil(t, cfg.Credentials)
-
-	creds, err := cfg.Credentials.Retrieve(t.Context())
-	require.NoError(t, err)
-	assert.Equal(t, "test-access-key", creds.AccessKeyID)
-	assert.Equal(t, "test-secret-key", creds.SecretAccessKey)
-	assert.Equal(t, "test-session-token", creds.SessionToken)
-}
-
-// TestAwsConfigEnvCredsStillChainSessionConfigRole verifies that a role from the session config
-// (the assume_role attribute of the remote_state block) is still assumed on top of env
-// credentials: unlike iam_role / TG_IAM_ASSUME_ROLE, it is never pre-applied into the env, so the
-// env credentials serve as the source identity for the STS exchange.
-func TestAwsConfigEnvCredsStillChainSessionConfigRole(t *testing.T) {
-	t.Parallel()
-
-	l := logger.CreateLogger()
-
-	env := map[string]string{
-		"AWS_ACCESS_KEY_ID":     "test-access-key",
-		"AWS_SECRET_ACCESS_KEY": "test-secret-key",
-		"AWS_REGION":            "us-west-2",
+	iamRoleOpts := iam.RoleOptions{
+		RoleARN: "arn:aws:iam::111111111111:role/deploy-role",
+	}
+	backendRole := &awshelper.AwsSessionConfig{
+		RoleArn: "arn:aws:iam::111111111111:role/backend-role",
 	}
 
-	cfg, err := awshelper.NewAWSConfigBuilder().
-		WithEnv(env).
-		WithSessionConfig(&awshelper.AwsSessionConfig{
-			RoleArn: "arn:aws:iam::111111111111:role/backend-role",
-		}).
-		Build(t.Context(), l)
-	require.NoError(t, err)
-	require.NotNil(t, cfg.Credentials)
+	testCases := []struct {
+		name          string
+		env           map[string]string
+		sessionConfig *awshelper.AwsSessionConfig
+		iamRoleOpts   iam.RoleOptions
+		want          credsExpectation
+	}{
+		{
+			name: "no-creds-no-roles",
+			env:  map[string]string{},
+			want: wantDefaultChain,
+		},
+		{
+			name:        "iam-role-only",
+			env:         map[string]string{},
+			iamRoleOpts: iamRoleOpts,
+			want:        wantRoleProvider,
+		},
+		{
+			name:          "backend-role-only",
+			env:           map[string]string{},
+			sessionConfig: backendRole,
+			want:          wantRoleProvider,
+		},
+		{
+			name:          "iam-role-and-backend-role",
+			env:           map[string]string{},
+			iamRoleOpts:   iamRoleOpts,
+			sessionConfig: backendRole,
+			want:          wantRoleProvider,
+		},
+		{
+			name: "env-creds-only",
+			env:  envCreds,
+			want: wantEnvCredsVerbatim,
+		},
+		{
+			name:        "env-creds-and-iam-role",
+			env:         envCreds,
+			iamRoleOpts: iamRoleOpts,
+			want:        wantEnvCredsVerbatim,
+		},
+		{
+			name:          "env-creds-and-backend-role",
+			env:           envCreds,
+			sessionConfig: backendRole,
+			want:          wantAssumeAttempted,
+		},
+		{
+			name:          "env-creds-iam-role-and-backend-role",
+			env:           envCreds,
+			iamRoleOpts:   iamRoleOpts,
+			sessionConfig: backendRole,
+			want:          wantAssumeAttempted,
+		},
+	}
 
-	// A canceled context makes the STS exchange fail before any network I/O: an error here proves
-	// credential resolution attempts the assumption instead of returning the env values verbatim.
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, err = cfg.Credentials.Retrieve(ctx)
-	require.Error(t, err)
+			l := logger.CreateLogger()
+
+			cfg, err := awshelper.NewAWSConfigBuilder().
+				WithEnv(tc.env).
+				WithSessionConfig(tc.sessionConfig).
+				WithIAMRoleOptions(tc.iamRoleOpts).
+				Build(t.Context(), l)
+			require.NoError(t, err)
+			require.NotNil(t, cfg.Credentials)
+
+			switch tc.want {
+			case wantEnvCredsVerbatim:
+				creds, err := cfg.Credentials.Retrieve(t.Context())
+				require.NoError(t, err)
+				assert.Equal(t, "test-access-key", creds.AccessKeyID)
+				assert.Equal(t, "test-secret-key", creds.SecretAccessKey)
+				assert.Equal(t, "test-session-token", creds.SessionToken)
+			case wantAssumeAttempted:
+				// A canceled context makes the STS exchange fail before any network I/O: an error
+				// here proves resolution attempts the assumption instead of returning the env
+				// values verbatim.
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+
+				_, err := cfg.Credentials.Retrieve(ctx)
+				require.Error(t, err)
+			case wantRoleProvider:
+				// Build installs role-assuming providers as aws.CredentialsProviderFunc; the
+				// default chain resolves to a different provider type. Retrieval is not probed
+				// here because without env credentials it would consult the host environment.
+				assert.IsType(t, aws.CredentialsProviderFunc(nil), cfg.Credentials)
+			case wantDefaultChain:
+				_, isRoleProvider := cfg.Credentials.(aws.CredentialsProviderFunc)
+				assert.False(t, isRoleProvider)
+			}
+		})
+	}
 }
 
 func TestAwsConfigRegionTakesPrecedenceOverEnvVars(t *testing.T) {

--- a/internal/awshelper/config_test.go
+++ b/internal/awshelper/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/gruntwork-io/terragrunt/internal/awshelper"
+	"github.com/gruntwork-io/terragrunt/internal/iam"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -189,6 +190,72 @@ func TestAwsConfigWithAuthProviderEnvChainsAssumeRole(t *testing.T) {
 
 	assert.NotEqual(t, baseARN, chainedARN)
 	assert.Contains(t, chainedARN, ":assumed-role/"+roleName+"/"+sessionName)
+}
+
+// TestAwsConfigEnvCredsIgnoreIAMRoleOptions verifies that env credentials are used verbatim even
+// when IAM role options (iam_role / TG_IAM_ASSUME_ROLE) are set: by the time a backend operation
+// builds its AWS config, those options were already applied by the amazonsts credentials provider
+// and the env credentials are the assumed role's session. Re-assuming would chain the role onto
+// itself and fail unless the role trusts itself.
+func TestAwsConfigEnvCredsIgnoreIAMRoleOptions(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+
+	env := map[string]string{
+		"AWS_ACCESS_KEY_ID":     "test-access-key",
+		"AWS_SECRET_ACCESS_KEY": "test-secret-key",
+		"AWS_SESSION_TOKEN":     "test-session-token",
+		"AWS_REGION":            "us-west-2",
+	}
+
+	cfg, err := awshelper.NewAWSConfigBuilder().
+		WithEnv(env).
+		WithIAMRoleOptions(iam.RoleOptions{
+			RoleARN: "arn:aws:iam::111111111111:role/deploy-role",
+		}).
+		Build(t.Context(), l)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Credentials)
+
+	creds, err := cfg.Credentials.Retrieve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "test-access-key", creds.AccessKeyID)
+	assert.Equal(t, "test-secret-key", creds.SecretAccessKey)
+	assert.Equal(t, "test-session-token", creds.SessionToken)
+}
+
+// TestAwsConfigEnvCredsStillChainSessionConfigRole verifies that a role from the session config
+// (the assume_role attribute of the remote_state block) is still assumed on top of env
+// credentials: unlike iam_role / TG_IAM_ASSUME_ROLE, it is never pre-applied into the env, so the
+// env credentials serve as the source identity for the STS exchange.
+func TestAwsConfigEnvCredsStillChainSessionConfigRole(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+
+	env := map[string]string{
+		"AWS_ACCESS_KEY_ID":     "test-access-key",
+		"AWS_SECRET_ACCESS_KEY": "test-secret-key",
+		"AWS_REGION":            "us-west-2",
+	}
+
+	cfg, err := awshelper.NewAWSConfigBuilder().
+		WithEnv(env).
+		WithSessionConfig(&awshelper.AwsSessionConfig{
+			RoleArn: "arn:aws:iam::111111111111:role/backend-role",
+		}).
+		Build(t.Context(), l)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Credentials)
+
+	// A canceled context makes the STS exchange fail before any network I/O: an error here proves
+	// credential resolution attempts the assumption instead of returning the env values verbatim.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err = cfg.Credentials.Retrieve(ctx)
+	require.Error(t, err)
 }
 
 func TestAwsConfigRegionTakesPrecedenceOverEnvVars(t *testing.T) {

--- a/internal/iam/iam_test.go
+++ b/internal/iam/iam_test.go
@@ -1,0 +1,80 @@
+package iam_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/iam"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMergeRoleOptions pins the precedence rule callers rely on when combining
+// the iam_role config attribute (target) with the --iam-assume-role CLI flag or
+// TG_IAM_ASSUME_ROLE env options (source): every non-zero source field wins,
+// and zero source fields keep the target's value.
+func TestMergeRoleOptions(t *testing.T) {
+	t.Parallel()
+
+	attr := iam.RoleOptions{
+		RoleARN:               "arn:aws:iam::111111111111:role/from-attribute",
+		AssumeRoleSessionName: "attribute-session",
+		AssumeRoleDuration:    1800,
+		WebIdentityToken:      "attribute-token",
+	}
+	flag := iam.RoleOptions{
+		RoleARN:               "arn:aws:iam::111111111111:role/from-flag",
+		AssumeRoleSessionName: "flag-session",
+		AssumeRoleDuration:    900,
+		WebIdentityToken:      "flag-token",
+	}
+
+	testCases := []struct {
+		name   string
+		target iam.RoleOptions
+		source iam.RoleOptions
+		want   iam.RoleOptions
+	}{
+		{
+			name:   "both-empty",
+			target: iam.RoleOptions{},
+			source: iam.RoleOptions{},
+			want:   iam.RoleOptions{},
+		},
+		{
+			name:   "attribute-only",
+			target: attr,
+			source: iam.RoleOptions{},
+			want:   attr,
+		},
+		{
+			name:   "flag-only",
+			target: iam.RoleOptions{},
+			source: flag,
+			want:   flag,
+		},
+		{
+			name:   "flag-overrides-attribute",
+			target: attr,
+			source: flag,
+			want:   flag,
+		},
+		{
+			name:   "partial-flag-keeps-remaining-attribute-fields",
+			target: attr,
+			source: iam.RoleOptions{AssumeRoleDuration: 900},
+			want: iam.RoleOptions{
+				RoleARN:               "arn:aws:iam::111111111111:role/from-attribute",
+				AssumeRoleSessionName: "attribute-session",
+				AssumeRoleDuration:    900,
+				WebIdentityToken:      "attribute-token",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, iam.MergeRoleOptions(tc.target, tc.source))
+		})
+	}
+}

--- a/internal/runner/run/creds/getter_test.go
+++ b/internal/runner/run/creds/getter_test.go
@@ -1,0 +1,102 @@
+package creds_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds"
+	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds/providers"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubProvider struct {
+	creds *providers.Credentials
+	name  string
+}
+
+func (p *stubProvider) Name() string { return p.name }
+
+func (p *stubProvider) GetCredentials(
+	_ context.Context,
+	_ log.Logger,
+	_ venv.Venv,
+) (*providers.Credentials, error) {
+	return p.creds, nil
+}
+
+// TestObtainAndUpdateEnvLaterProviderWins pins the ordering the S3 backend relies on: when an
+// auth-provider command supplies source credentials and the amazonsts provider then assumes a
+// role, the role session must be what ends up in v.Env. Backend operations read their
+// credentials from there and skip re-assuming the role, so the session has to win.
+func TestObtainAndUpdateEnvLaterProviderWins(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	v := venvtest.New()
+
+	authProvider := &stubProvider{
+		name: "external command",
+		creds: &providers.Credentials{
+			Name: providers.AWSCredentials,
+			Envs: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "source-access-key",
+				"AWS_SECRET_ACCESS_KEY": "source-secret-key",
+			},
+		},
+	}
+	stsProvider := &stubProvider{
+		name: "API calls to Amazon STS",
+		creds: &providers.Credentials{
+			Name: providers.AWSCredentials,
+			Envs: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "role-session-access-key",
+				"AWS_SECRET_ACCESS_KEY": "role-session-secret-key",
+				"AWS_SESSION_TOKEN":     "role-session-token",
+			},
+		},
+	}
+
+	err := creds.NewGetter().ObtainAndUpdateEnvIfNecessary(t.Context(), l, v, authProvider, stsProvider)
+	require.NoError(t, err)
+
+	assert.Equal(t, "role-session-access-key", v.Env["AWS_ACCESS_KEY_ID"])
+	assert.Equal(t, "role-session-secret-key", v.Env["AWS_SECRET_ACCESS_KEY"])
+	assert.Equal(t, "role-session-token", v.Env["AWS_SESSION_TOKEN"])
+}
+
+// TestObtainAndUpdateEnvNilCredsLeaveEnvUntouched pins that a provider with nothing to
+// contribute (e.g. amazonsts without a configured role) neither clobbers credentials written by
+// an earlier provider nor touches unrelated env entries.
+func TestObtainAndUpdateEnvNilCredsLeaveEnvUntouched(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	v := venvtest.New()
+	v.Env["UNRELATED"] = "kept"
+
+	authProvider := &stubProvider{
+		name: "external command",
+		creds: &providers.Credentials{
+			Name: providers.AWSCredentials,
+			Envs: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "source-access-key",
+				"AWS_SECRET_ACCESS_KEY": "source-secret-key",
+			},
+		},
+	}
+	noopProvider := &stubProvider{
+		name: "API calls to Amazon STS",
+	}
+
+	err := creds.NewGetter().ObtainAndUpdateEnvIfNecessary(t.Context(), l, v, authProvider, noopProvider)
+	require.NoError(t, err)
+
+	assert.Equal(t, "source-access-key", v.Env["AWS_ACCESS_KEY_ID"])
+	assert.Equal(t, "source-secret-key", v.Env["AWS_SECRET_ACCESS_KEY"])
+	assert.Equal(t, "kept", v.Env["UNRELATED"])
+}

--- a/test/fixtures/assume-role/flag-env-creds/main.tf
+++ b/test/fixtures/assume-role/flag-env-creds/main.tf
@@ -1,0 +1,4 @@
+resource "local_file" "test_file" {
+  content  = "test_file"
+  filename = "${path.module}/test_file.txt"
+}

--- a/test/fixtures/assume-role/flag-env-creds/terragrunt.hcl
+++ b/test/fixtures/assume-role/flag-env-creds/terragrunt.hcl
@@ -1,0 +1,13 @@
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket  = "__FILL_IN_BUCKET_NAME__"
+    key     = "${path_relative_to_include()}/terraform.tfstate"
+    region  = "__FILL_IN_REGION__"
+    encrypt = true
+  }
+}

--- a/test/fixtures/assume-role/iam-role-attr-env-creds/main.tf
+++ b/test/fixtures/assume-role/iam-role-attr-env-creds/main.tf
@@ -1,0 +1,4 @@
+resource "local_file" "test_file" {
+  content  = "test_file"
+  filename = "${path.module}/test_file.txt"
+}

--- a/test/fixtures/assume-role/iam-role-attr-env-creds/terragrunt.hcl
+++ b/test/fixtures/assume-role/iam-role-attr-env-creds/terragrunt.hcl
@@ -1,0 +1,15 @@
+iam_role = "__FILL_IN_ASSUME_ROLE__"
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket  = "__FILL_IN_BUCKET_NAME__"
+    key     = "${path_relative_to_include()}/terraform.tfstate"
+    region  = "__FILL_IN_REGION__"
+    encrypt = true
+  }
+}

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -58,6 +58,8 @@ const (
 	testFixtureS3BackendUseLockfile              = "fixtures/s3-backend/use-lockfile"
 	testFixtureS3BackendDisableInit              = "fixtures/s3-backend-disable-init"
 	testFixtureAssumeRoleWithExternalIDWithComma = "fixtures/assume-role/external-id-with-comma"
+	testFixtureIamRoleAttrEnvCreds               = "fixtures/assume-role/iam-role-attr-env-creds"
+	testFixtureIamRoleFlagEnvCreds               = "fixtures/assume-role/flag-env-creds"
 
 	// Fixtures referenced only by AWS-gated tests. They live here, rather than in
 	// their untagged sibling files, so the unused check does not flag them when
@@ -2264,6 +2266,104 @@ func TestAwsAssumeRoleDuration(t *testing.T) {
 	assert.NotContains(t, output, "Initializing the backend...")
 	assert.NotContains(t, output, "has been successfully initialized!")
 	assert.Contains(t, output, "no changes are needed.")
+}
+
+// TestAwsIamRoleAttrWithAmbientCredentials runs a unit whose role comes from the iam_role
+// attribute while the run's ambient AWS credentials can assume that role. Terragrunt assumes the
+// role once up front and must reuse that session for its own backend operations: a second
+// assumption would ask the role to assume itself, which STS rejects unless the role's trust
+// policy includes the role.
+func TestAwsIamRoleAttrWithAmbientCredentials(t *testing.T) {
+	t.Parallel()
+
+	assumeRole := os.Getenv("AWS_TEST_S3_ASSUME_ROLE")
+	if len(assumeRole) == 0 {
+		t.Error("AWS_TEST_S3_ASSUME_ROLE environment variable not set")
+		return
+	}
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureIamRoleAttrEnvCreds)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	testPath := filepath.Join(tmpEnvPath, testFixtureIamRoleAttrEnvCreds)
+
+	originalTerragruntConfigPath := filepath.Join(testFixtureIamRoleAttrEnvCreds, "terragrunt.hcl")
+	tmpTerragruntConfigFile := filepath.Join(testPath, "terragrunt.hcl")
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
+
+	defer helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
+
+	helpers.CopyAndFillMapPlaceholders(
+		t,
+		originalTerragruntConfigPath,
+		tmpTerragruntConfigFile,
+		map[string]string{
+			"__FILL_IN_BUCKET_NAME__": s3BucketName,
+			"__FILL_IN_REGION__":      helpers.TerraformRemoteStateS3Region,
+			"__FILL_IN_ASSUME_ROLE__": assumeRole,
+		},
+	)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := helpers.RunTerragruntCommand(
+		t,
+		"terragrunt apply -auto-approve --non-interactive --backend-bootstrap --working-dir "+testPath,
+		&stdout,
+		&stderr,
+	)
+	require.NoError(t, err)
+
+	output := fmt.Sprintf("%s %s", stderr.String(), stdout.String())
+	assert.Contains(t, output, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
+}
+
+// TestAwsIamRoleFlagWithAmbientCredentials is the --iam-assume-role flag variant of
+// [TestAwsIamRoleAttrWithAmbientCredentials]: same S3 backend without its own assume_role, with
+// the role supplied on the command line instead of the iam_role attribute.
+func TestAwsIamRoleFlagWithAmbientCredentials(t *testing.T) {
+	t.Parallel()
+
+	assumeRole := os.Getenv("AWS_TEST_S3_ASSUME_ROLE")
+	if len(assumeRole) == 0 {
+		t.Error("AWS_TEST_S3_ASSUME_ROLE environment variable not set")
+		return
+	}
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureIamRoleFlagEnvCreds)
+	helpers.CleanupTerraformFolder(t, tmpEnvPath)
+	testPath := filepath.Join(tmpEnvPath, testFixtureIamRoleFlagEnvCreds)
+
+	originalTerragruntConfigPath := filepath.Join(testFixtureIamRoleFlagEnvCreds, "terragrunt.hcl")
+	tmpTerragruntConfigFile := filepath.Join(testPath, "terragrunt.hcl")
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
+
+	defer helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
+
+	helpers.CopyAndFillMapPlaceholders(
+		t,
+		originalTerragruntConfigPath,
+		tmpTerragruntConfigFile,
+		map[string]string{
+			"__FILL_IN_BUCKET_NAME__": s3BucketName,
+			"__FILL_IN_REGION__":      helpers.TerraformRemoteStateS3Region,
+		},
+	)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := helpers.RunTerragruntCommand(
+		t,
+		"terragrunt apply -auto-approve --non-interactive --backend-bootstrap --iam-assume-role "+
+			assumeRole+" --working-dir "+testPath,
+		&stdout,
+		&stderr,
+	)
+	require.NoError(t, err)
+
+	output := fmt.Sprintf("%s %s", stderr.String(), stdout.String())
+	assert.Contains(t, output, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
 }
 
 // Regression testing for https://github.com/gruntwork-io/terragrunt/issues/906


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6514.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed backend role handling to reuse the existing role session instead of attempting to assume the same role again.
  - Prevented AWS `AccessDenied` errors during backend operations when using ambient credentials and IAM role configuration.
  - Improved credential selection when environment credentials, IAM role settings, and backend roles are combined.
  - Preserved existing `remote_state.assume_role` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->