### PR TITLE
docs: Adding CLI flag precedence rule

### DIFF
--- a/docs/src/content/docs/07-process/02-cli-rules.mdx
+++ b/docs/src/content/docs/07-process/02-cli-rules.mdx
@@ -128,3 +128,15 @@ In addition, if you find that a certain pattern that's reliably followed in the 
         `iam-assume-role-duration` —> `TG_IAM_ASSUME_ROLE_DURATION`
    </details>
 
+10. When a setting can be provided by both a flag and configuration, resolution follows a fixed order of precedence, most specific first:
+
+    **CLI argument → environment variable → configuration → built-in default.**
+
+    An explicitly set flag always wins over a configuration value. Configuration overrides only Terragrunt's built-in default for that setting, never a value the user set explicitly on the flag (or its environment variable).
+
+    <details>
+        <summary><Badge text="Example" variant="note" /></summary>
+
+        An explicit `--download-dir` takes precedence over `download_dir` in the configuration. The `download_dir` attribute applies only when `--download-dir` is left at its default, filling in that default rather than overriding the flag.
+    </details>
+


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds a flag precedence rule so that we're consistent about this design in the CLI.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CLI configuration precedence guidance.
  * Clarified the order: CLI flags, environment variables, configuration values, then built-in defaults.
  * Included an example showing how `--download-dir` interacts with configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->