### PR TITLE
feat: Adding `--tf-update-source-out-of-cache` flag

### DIFF
--- a/docs/src/data/changelog/v1.1.2/tf-update-source-out-of-cache.mdx
+++ b/docs/src/data/changelog/v1.1.2/tf-update-source-out-of-cache.mdx
@@ -1,0 +1,16 @@
+---
+version: "v1.1.2"
+category: "experiments-added"
+---
+
+#### `patch-source-out-of-cache` — Repair relative paths for source-less units
+
+Units without a `terraform.source` have their OpenTofu/Terraform files copied several directory levels down into `.terragrunt-cache` before running. Any relative path that pointed outside the unit, such as a `module` block with `source = "../modules/foo"`, silently broke after the copy because it resolved against the cache directory instead of the unit.
+
+A new `patch-source-out-of-cache` experiment unlocks the `--tf-update-source-out-of-cache` flag (`TG_TF_UPDATE_SOURCE_OUT_OF_CACHE`), which detects relative paths in the copied `.tf` and `.tofu` files that escape the unit directory and rewrites them to escape `.terragrunt-cache` as well, so each reference resolves to its original target. Paths that stay inside the unit are left untouched.
+
+```bash
+terragrunt run --experiment patch-source-out-of-cache --tf-update-source-out-of-cache -- plan
+```
+
+To learn more, see the [experiment documentation](/reference/experiments/active#patch-source-out-of-cache).

--- a/docs/src/data/changelog/v1.1.3/tf-update-source-out-of-cache.mdx
+++ b/docs/src/data/changelog/v1.1.3/tf-update-source-out-of-cache.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.1.2"
+version: "v1.1.3"
 category: "experiments-added"
 ---
 

--- a/docs/src/data/commands/run.mdx
+++ b/docs/src/data/commands/run.mdx
@@ -77,6 +77,7 @@ flags:
   - summary-per-unit
   - tf-forward-stdout
   - tf-path
+  - tf-update-source-out-of-cache
   - units-that-include
   - use-partial-parse-config-cache
   - version-manager-file-name

--- a/docs/src/data/experiments/patch-source-out-of-cache.mdx
+++ b/docs/src/data/experiments/patch-source-out-of-cache.mdx
@@ -1,0 +1,21 @@
+---
+name: patch-source-out-of-cache
+---
+
+Rewrite relative paths that escape a source-less unit so they still resolve from the cache.
+
+### `patch-source-out-of-cache` - What it does
+When a unit has no `terraform.source`, Terragrunt copies its OpenTofu/Terraform files a few directory levels down into `.terragrunt-cache` before running them. Relative paths that pointed outside the unit, such as a `module` block with `source = "../modules/foo"`, break after the copy because they resolve against the cache directory instead of the unit.
+
+When enabled, this experiment unlocks the `--tf-update-source-out-of-cache` flag, which scans the copied `.tf` and `.tofu` files, finds relative paths that escape the unit directory, and prepends the path back out of `.terragrunt-cache` so each reference resolves to its original target.
+
+```bash
+terragrunt run --experiment patch-source-out-of-cache --tf-update-source-out-of-cache -- plan
+```
+
+### `patch-source-out-of-cache` - Criteria for stabilization
+To transition the `patch-source-out-of-cache` feature to a stable release, the following must be addressed:
+
+- [ ] Gather community feedback on units that mix in-unit and out-of-unit references.
+- [ ] Decide whether `.tf.json` and `.tofu.json` files should also be rewritten.
+- [ ] Confirm the rewrite handles relative paths in functions (`file`, `templatefile`) as users expect.

--- a/docs/src/data/flags/tf-update-source-out-of-cache.mdx
+++ b/docs/src/data/flags/tf-update-source-out-of-cache.mdx
@@ -1,0 +1,23 @@
+---
+name: tf-update-source-out-of-cache
+description: For units without a source, rewrite relative paths in the OpenTofu/Terraform files that point outside the unit so they still resolve after the files are copied into the .terragrunt-cache directory. Requires the patch-source-out-of-cache experiment.
+type: bool
+env:
+  - TG_TF_UPDATE_SOURCE_OUT_OF_CACHE
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Experimental">
+This flag is gated behind the [`patch-source-out-of-cache`](/reference/experiments/active#patch-source-out-of-cache) experiment. Enable it with `--experiment=patch-source-out-of-cache` or `TG_EXPERIMENT=patch-source-out-of-cache`; otherwise setting `--tf-update-source-out-of-cache` returns an error.
+</Aside>
+
+When a unit has no `terraform.source`, Terragrunt copies its OpenTofu/Terraform files a few directory levels down into `.terragrunt-cache` before running them. The copy preserves the unit's own directory structure, so references that stay inside the unit keep working, but a relative path that pointed outside the unit no longer resolves. A `module` block with `source = "../modules/foo"`, for example, now looks for `foo` relative to the cache directory rather than the unit.
+
+With this flag enabled, Terragrunt scans the copied `.tf` and `.tofu` files, finds relative paths that escape the unit directory, and prepends the path back out of `.terragrunt-cache` so each reference resolves to its original target. Only paths written with an explicit `./` or `../` prefix are considered, and paths that resolve back inside the unit are left alone. The `.tf.json` and `.tofu.json` variants are not rewritten.
+
+Example:
+
+```bash
+terragrunt run --experiment patch-source-out-of-cache --tf-update-source-out-of-cache -- plan
+```

--- a/internal/cli/commands/run/flags.go
+++ b/internal/cli/commands/run/flags.go
@@ -38,9 +38,10 @@ const (
 	NoDestroyDependenciesCheckFlagName = "no-destroy-dependencies-check"
 	DestroyDependenciesCheckFlagName   = "destroy-dependencies-check"
 
-	SourceFlagName       = "source"
-	SourceMapFlagName    = "source-map"
-	SourceUpdateFlagName = "source-update"
+	SourceFlagName                 = "source"
+	SourceMapFlagName              = "source-map"
+	SourceUpdateFlagName           = "source-update"
+	UpdateSourceOutOfCacheFlagName = "tf-update-source-out-of-cache"
 
 	NoStackGenerate = "no-stack-generate"
 
@@ -89,6 +90,40 @@ const (
 var ErrNoHooksRequiresExperiment = errors.New(
 	"--no-hooks requires the 'optional-hooks' experiment to be enabled (e.g., --experiment=optional-hooks)",
 )
+
+var ErrUpdateSourceOutOfCacheRequiresExperiment = errors.New(
+	"--tf-update-source-out-of-cache requires the 'patch-source-out-of-cache' experiment to be enabled (e.g., --experiment=patch-source-out-of-cache)",
+)
+
+// newUpdateSourceOutOfCacheFlag builds the --tf-update-source-out-of-cache flag.
+// The usage advertises the gating experiment only while it is still ongoing;
+// once the experiment stabilizes the flag no longer requires it, so the note is
+// dropped rather than lingering as stale help text.
+func newUpdateSourceOutOfCacheFlag(opts *options.TerragruntOptions, tgPrefix flags.Prefix) *flags.Flag {
+	usage := "For units without a source, rewrite relative paths in the OpenTofu/Terraform files that point outside the unit so they still resolve after the files are copied into the .terragrunt-cache directory."
+
+	if exp := opts.Experiments.Find(experiment.PatchSourceOutOfCache); exp != nil && exp.Status == experiment.StatusOngoing {
+		usage += " Requires the 'patch-source-out-of-cache' experiment."
+	}
+
+	return flags.NewFlag(&clihelper.BoolFlag{
+		Name:        UpdateSourceOutOfCacheFlagName,
+		EnvVars:     tgPrefix.EnvVars(UpdateSourceOutOfCacheFlagName),
+		Destination: &opts.UpdateSourceOutOfCache,
+		Usage:       usage,
+		Action: func(_ context.Context, _ *clihelper.Context, value bool) error {
+			if !value {
+				return nil
+			}
+
+			if opts.Experiments.Evaluate(experiment.PatchSourceOutOfCache) {
+				return nil
+			}
+
+			return ErrUpdateSourceOutOfCacheRequiresExperiment
+		},
+	})
+}
 
 // NewFlags creates and returns global flags.
 func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix) clihelper.Flags {
@@ -227,6 +262,8 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 				opts.StrictControls,
 			),
 		),
+
+		newUpdateSourceOutOfCacheFlag(opts, tgPrefix),
 
 		flags.NewFlag(
 			&clihelper.MapFlag[string, string]{

--- a/internal/cli/commands/run/flags_test.go
+++ b/internal/cli/commands/run/flags_test.go
@@ -38,3 +38,29 @@ func TestNoHooksFlagAllowedWithExperiment(t *testing.T) {
 	require.NoError(t, flags.RunActions(context.Background(), &clihelper.Context{}))
 	assert.True(t, opts.NoRunHooks)
 }
+
+func TestUpdateSourceOutOfCacheFlagRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	opts := options.NewTerragruntOptions()
+	flags := runcommand.NewFlags(logger.CreateLogger(), opts, nil)
+
+	require.NoError(t, flags.Parse(clihelper.Args{"--tf-update-source-out-of-cache"}))
+
+	err := flags.RunActions(t.Context(), &clihelper.Context{})
+
+	require.ErrorIs(t, err, runcommand.ErrUpdateSourceOutOfCacheRequiresExperiment)
+	assert.True(t, opts.UpdateSourceOutOfCache)
+}
+
+func TestUpdateSourceOutOfCacheFlagAllowedWithExperiment(t *testing.T) {
+	t.Parallel()
+
+	opts := options.NewTerragruntOptions()
+	require.NoError(t, opts.Experiments.EnableExperiment(experiment.PatchSourceOutOfCache))
+	flags := runcommand.NewFlags(logger.CreateLogger(), opts, nil)
+
+	require.NoError(t, flags.Parse(clihelper.Args{"--tf-update-source-out-of-cache"}))
+	require.NoError(t, flags.RunActions(t.Context(), &clihelper.Context{}))
+	assert.True(t, opts.UpdateSourceOutOfCache)
+}

--- a/internal/configbridge/bridge.go
+++ b/internal/configbridge/bridge.go
@@ -180,6 +180,7 @@ func NewRunOptions(opts *options.TerragruntOptions) *run.Options {
 	runOpts.FailIfBucketCreationRequired = opts.FailIfBucketCreationRequired
 	runOpts.DisableBucketUpdate = opts.DisableBucketUpdate
 	runOpts.SourceUpdate = opts.SourceUpdate
+	runOpts.UpdateSourceOutOfCache = opts.UpdateSourceOutOfCache
 	runOpts.CASCloneDepth = opts.CASCloneDepth
 	runOpts.NoCAS = opts.NoCAS
 	runOpts.NoHooks = opts.NoRunHooks

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -88,6 +88,11 @@ const (
 	// records through the configured logs exporter and correlating them with
 	// traces via the active span.
 	OtelLogs = "otel-logs"
+	// PatchSourceOutOfCache gates the --tf-update-source-out-of-cache flag, which
+	// rewrites relative paths in a source-less unit's OpenTofu/Terraform files so
+	// they still resolve after the files are copied into the .terragrunt-cache
+	// directory.
+	PatchSourceOutOfCache = "patch-source-out-of-cache"
 )
 
 const (
@@ -187,6 +192,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: OtelLogs,
+		},
+		{
+			Name: PatchSourceOutOfCache,
 		},
 	}
 }

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -139,6 +139,22 @@ func DownloadTerraformSource(
 		if err != nil {
 			return nil, err
 		}
+
+		// Only the copy-from-unit case (no terraform.source) reproduces the unit
+		// tree in the cache, so it is the only case where escaping relative paths
+		// map cleanly back to the unit dir. Rewriting the freshly copied files
+		// keeps the pass idempotent: every copy first restores their original
+		// contents.
+		if opts.UpdateSourceOutOfCache && sourceIsWorkingDir {
+			if err := RewriteRelativePathsOutOfCache(
+				l,
+				opts.FS,
+				opts.UnitDir,
+				terraformSource.WorkingDir,
+			); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	l, updatedOpts, err := opts.CloneWithConfigPath(l, opts.TerragruntConfigPath)

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -966,6 +966,129 @@ func TestDownloadWithNoSourceCreatesCache(t *testing.T) {
 	assert.Equal(t, mainTfContent, string(cachedContent), "File contents should match")
 }
 
+// TestDownloadWithNoSourceRewritesOutOfCachePaths verifies that with
+// --tf-update-source-out-of-cache enabled, a relative module source that
+// escapes the unit is rewritten to still resolve once the file is copied into
+// the cache, while an in-unit reference is left alone.
+func TestDownloadWithNoSourceRewritesOutOfCachePaths(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := helpers.TmpDirWOSymlinks(t)
+	defer os.RemoveAll(sourceDir)
+
+	mainTfContent := `module "escape" {
+  source = "../modules/escape"
+}
+
+module "local" {
+  source = "./modules/local"
+}
+`
+	require.NoError(
+		t,
+		os.WriteFile(filepath.Join(sourceDir, "main.tf"), []byte(mainTfContent), 0644),
+	)
+
+	downloadDir := helpers.TmpDirWOSymlinks(t)
+	defer os.RemoveAll(downloadDir)
+
+	opts, err := options.NewTerragruntOptionsForTest(filepath.Join(sourceDir, "terragrunt.hcl"))
+	require.NoError(t, err)
+
+	opts.WorkingDir = sourceDir
+	opts.DownloadDir = downloadDir
+	opts.Experiments = experiment.NewExperiments()
+	opts.UpdateSourceOutOfCache = true
+
+	cfg := &runcfg.RunConfig{
+		Terraform: runcfg.TerraformConfig{
+			ExtraArgs: []runcfg.TerraformExtraArguments{},
+		},
+	}
+
+	l := logger.CreateLogger()
+	l.SetOptions(log.WithOutput(io.Discard))
+
+	updatedOpts, err := run.DownloadTerraformSource(
+		t.Context(),
+		l,
+		venv.OSVenv(),
+		".",
+		configbridge.NewRunOptions(opts),
+		cfg,
+		report.NewReport(),
+	)
+	require.NoError(t, err)
+
+	prefix, err := filepath.Rel(updatedOpts.CacheDir, sourceDir)
+	require.NoError(t, err)
+
+	cachedContent, err := os.ReadFile(filepath.Join(updatedOpts.CacheDir, "main.tf"))
+	require.NoError(t, err)
+
+	expected := fmt.Sprintf(`module "escape" {
+  source = "%s/../modules/escape"
+}
+
+module "local" {
+  source = "./modules/local"
+}
+`, filepath.ToSlash(prefix))
+	assert.Equal(t, expected, string(cachedContent))
+}
+
+// TestDownloadWithNoSourceLeavesPathsWhenFlagDisabled verifies that without the
+// flag, the copied files are left exactly as authored.
+func TestDownloadWithNoSourceLeavesPathsWhenFlagDisabled(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := helpers.TmpDirWOSymlinks(t)
+	defer os.RemoveAll(sourceDir)
+
+	mainTfContent := `module "escape" {
+  source = "../modules/escape"
+}
+`
+	require.NoError(
+		t,
+		os.WriteFile(filepath.Join(sourceDir, "main.tf"), []byte(mainTfContent), 0644),
+	)
+
+	downloadDir := helpers.TmpDirWOSymlinks(t)
+	defer os.RemoveAll(downloadDir)
+
+	opts, err := options.NewTerragruntOptionsForTest(filepath.Join(sourceDir, "terragrunt.hcl"))
+	require.NoError(t, err)
+
+	opts.WorkingDir = sourceDir
+	opts.DownloadDir = downloadDir
+	opts.Experiments = experiment.NewExperiments()
+
+	cfg := &runcfg.RunConfig{
+		Terraform: runcfg.TerraformConfig{
+			ExtraArgs: []runcfg.TerraformExtraArguments{},
+		},
+	}
+
+	l := logger.CreateLogger()
+	l.SetOptions(log.WithOutput(io.Discard))
+
+	updatedOpts, err := run.DownloadTerraformSource(
+		t.Context(),
+		l,
+		venv.OSVenv(),
+		".",
+		configbridge.NewRunOptions(opts),
+		cfg,
+		report.NewReport(),
+	)
+	require.NoError(t, err)
+
+	cachedContent, err := os.ReadFile(filepath.Join(updatedOpts.CacheDir, "main.tf"))
+	require.NoError(t, err)
+	assert.Equal(t, mainTfContent, string(cachedContent))
+}
+
 // TestDownloadSourceWithCASExperimentDisabled tests that CAS is not used when the experiment is disabled
 func TestDownloadSourceWithCASExperimentDisabled(t *testing.T) {
 	t.Parallel()
@@ -1088,10 +1211,13 @@ func TestDownloadSourceOCIThroughCASExperimentGate(t *testing.T) {
 
 			registryAddr := registry.Listener.Addr().String()
 			src := &tf.Source{
-				CanonicalSourceURL: parseURL(t, "oci://"+registryAddr+"/terraform-modules/vpc?tag=1.0.0"),
-				DownloadDir:        tmpDir,
-				WorkingDir:         tmpDir,
-				VersionFile:        filepath.Join(tmpDir, "version-file.txt"),
+				CanonicalSourceURL: parseURL(
+					t,
+					"oci://"+registryAddr+"/terraform-modules/vpc?tag=1.0.0",
+				),
+				DownloadDir: tmpDir,
+				WorkingDir:  tmpDir,
+				VersionFile: filepath.Join(tmpDir, "version-file.txt"),
 			}
 
 			opts, err := options.NewTerragruntOptionsForTest("./should-not-be-used")

--- a/internal/runner/run/options.go
+++ b/internal/runner/run/options.go
@@ -87,6 +87,7 @@ type Options struct {
 	FailIfBucketCreationRequired bool
 	DisableBucketUpdate          bool
 	SourceUpdate                 bool
+	UpdateSourceOutOfCache       bool
 	ForwardTFStdout              bool
 	LogShowAbsPaths              bool
 	LogDisableErrorSummary       bool

--- a/internal/runner/run/update_source_out_of_cache.go
+++ b/internal/runner/run/update_source_out_of_cache.go
@@ -1,0 +1,214 @@
+package run
+
+import (
+	"io/fs"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+)
+
+// RewriteRelativePathsOutOfCache repairs relative filesystem references in the
+// OpenTofu/Terraform files that were copied from unitDir into workingDir.
+//
+// When a unit has no terraform.source, Terragrunt copies its .tf files several
+// directory levels down into .terragrunt-cache before running OpenTofu/Terraform.
+// The copy preserves the unit's own directory structure, so references that stay
+// inside the unit keep resolving, but any relative path that climbed out of the
+// unit (for example a module block whose source is "../modules/foo") now points
+// at the wrong place. Prefixing each such reference with the relative path from
+// workingDir back to unitDir restores the original target.
+//
+// Only native HCL files (.tf, .tofu) are rewritten; the .json variants are left
+// untouched because the native parser cannot read them.
+func RewriteRelativePathsOutOfCache(l log.Logger, fsys vfs.FS, unitDir, workingDir string) error {
+	// The copy reproduces the unit's directory tree under workingDir, so the
+	// hop from any copied file back to its original location is the same as the
+	// hop from workingDir to unitDir, regardless of how deep the file sits.
+	escapePrefix, err := filepath.Rel(workingDir, unitDir)
+	if err != nil {
+		return err
+	}
+
+	escapePrefix = filepath.ToSlash(escapePrefix)
+
+	files, err := tfFilesInCache(fsys, workingDir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		fileDir, err := filepath.Rel(workingDir, filepath.Dir(file))
+		if err != nil {
+			return err
+		}
+
+		if err := rewriteFileRelativePaths(
+			l,
+			fsys,
+			file,
+			filepath.ToSlash(fileDir),
+			escapePrefix,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// tfFilesInCache returns the native HCL files (.tf, .tofu) under root, skipping
+// the .json variants the parser cannot read.
+func tfFilesInCache(fsys vfs.FS, root string) ([]string, error) {
+	var files []string
+
+	err := vfs.WalkDir(fsys, root, func(filePath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() || !util.IsTFFile(filePath) || strings.HasSuffix(filePath, ".json") {
+			return nil
+		}
+
+		files = append(files, filePath)
+
+		return nil
+	})
+
+	return files, err
+}
+
+// rewriteFileRelativePaths rewrites the escaping relative paths in a single
+// file. fileDir is the file's directory relative to the copied unit root (in
+// slash form); escapePrefix is the relative path from the copied file back to
+// its original location. A file that fails to parse is left unchanged: the real
+// OpenTofu/Terraform run reports the syntax error with better context.
+func rewriteFileRelativePaths(l log.Logger, fsys vfs.FS, file, fileDir, escapePrefix string) error {
+	content, err := vfs.ReadFile(fsys, file)
+	if err != nil {
+		return err
+	}
+
+	parsed, diags := hclsyntax.ParseConfig(content, file, hcl.InitialPos)
+	if diags.HasErrors() {
+		l.Debugf("Skipping relative path rewrite for %s: %s", file, diags.Error())
+		return nil
+	}
+
+	body, ok := parsed.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil
+	}
+
+	var edits []pathEdit
+
+	// Walk only accumulates the diagnostics its Enter/Exit callbacks return, and
+	// walkFunc returns none from either, so a non-empty result would mean that
+	// invariant was broken rather than a real parse failure.
+	if diags := hclsyntax.Walk(body, walkFunc(func(node hclsyntax.Node) {
+		tmpl, ok := node.(*hclsyntax.TemplateExpr)
+		if !ok {
+			return
+		}
+
+		value, diags := tmpl.Value(nil)
+		if diags.HasErrors() || value.Type() != cty.String {
+			return
+		}
+
+		literal := value.AsString()
+		if !escapesUnitDir(fileDir, literal) {
+			return
+		}
+
+		rng := tmpl.Range()
+		edits = append(edits, pathEdit{
+			start: rng.Start.Byte,
+			end:   rng.End.Byte,
+			replacement: hclwrite.TokensForValue(cty.StringVal(escapePrefix + "/" + literal)).
+				Bytes(),
+		})
+	})); diags.HasErrors() {
+		panic("static HCL walk returned diagnostics: " + diags.Error())
+	}
+
+	if len(edits) == 0 {
+		return nil
+	}
+
+	info, err := fsys.Stat(file)
+	if err != nil {
+		return err
+	}
+
+	return vfs.WriteFile(fsys, file, applyPathEdits(content, edits), info.Mode().Perm())
+}
+
+// escapesUnitDir reports whether the relative path value, resolved against
+// fileDir within the copied unit tree, climbs above the unit root. Only paths
+// written with an explicit "./" or "../" prefix are considered: those are the
+// forms OpenTofu/Terraform accepts for local references, and requiring the
+// prefix keeps unrelated strings (remote sources, version constraints, arbitrary
+// text) from being mistaken for paths.
+func escapesUnitDir(fileDir, value string) bool {
+	if !strings.HasPrefix(value, "./") && !strings.HasPrefix(value, "../") {
+		return false
+	}
+
+	resolved := path.Join(fileDir, value)
+
+	return resolved == ".." || strings.HasPrefix(resolved, "../")
+}
+
+// pathEdit is a byte-range replacement within a file's contents.
+type pathEdit struct {
+	replacement []byte
+	start       int
+	end         int
+}
+
+// applyPathEdits returns a new buffer with every edit applied. Edits come from
+// distinct, non-overlapping string literals; sorting them by offset lets the
+// buffer be stitched front-to-back with the unedited spans between them. The
+// walk that produced them visits HCL attributes in map order, so the input is
+// not already sorted.
+func applyPathEdits(content []byte, edits []pathEdit) []byte {
+	slices.SortFunc(edits, func(a, b pathEdit) int {
+		return a.start - b.start
+	})
+
+	var out []byte
+
+	cursor := 0
+
+	for _, e := range edits {
+		out = append(out, content[cursor:e.start]...)
+		out = append(out, e.replacement...)
+		cursor = e.end
+	}
+
+	return append(out, content[cursor:]...)
+}
+
+// walkFunc adapts a plain visitor into an [hclsyntax.Walker]; only node entry
+// is of interest here.
+type walkFunc func(hclsyntax.Node)
+
+func (f walkFunc) Enter(node hclsyntax.Node) hcl.Diagnostics {
+	f(node)
+	return nil
+}
+
+func (f walkFunc) Exit(hclsyntax.Node) hcl.Diagnostics {
+	return nil
+}

--- a/internal/runner/run/update_source_out_of_cache_test.go
+++ b/internal/runner/run/update_source_out_of_cache_test.go
@@ -1,0 +1,198 @@
+package run_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/runner/run"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+func TestRewriteRelativePathsOutOfCache(t *testing.T) {
+	t.Parallel()
+
+	// The unit dir sits at /unit; workingDir mirrors the real cache layout,
+	// three directory levels (.terragrunt-cache/<hash>/<hash>) below it. An
+	// escaping path therefore gains a "../../../" prefix, so "../modules/foo"
+	// becomes "../../../../modules/foo".
+	const (
+		unitDir    = "/unit"
+		workingDir = "/unit/.terragrunt-cache/hash1/hash2"
+	)
+
+	testCases := []struct {
+		name     string
+		relPath  string
+		input    string
+		expected string
+	}{
+		{
+			name:    "module source escaping the unit is rewritten",
+			relPath: "main.tf",
+			input: `module "foo" {
+  source = "../modules/foo"
+}
+`,
+			expected: `module "foo" {
+  source = "../../../../modules/foo"
+}
+`,
+		},
+		{
+			name:    "in-unit reference is left untouched",
+			relPath: "main.tf",
+			input: `module "foo" {
+  source = "./modules/foo"
+}
+`,
+			expected: `module "foo" {
+  source = "./modules/foo"
+}
+`,
+		},
+		{
+			name:    "remote source is left untouched",
+			relPath: "main.tf",
+			input: `module "foo" {
+  source = "git::https://example.com/foo.git"
+}
+`,
+			expected: `module "foo" {
+  source = "git::https://example.com/foo.git"
+}
+`,
+		},
+		{
+			name:    "path passed to a function is rewritten",
+			relPath: "main.tf",
+			input: `locals {
+  x = file("../templates/x.tpl")
+}
+`,
+			expected: `locals {
+  x = file("../../../../templates/x.tpl")
+}
+`,
+		},
+		{
+			name:    "interpolated string is left untouched",
+			relPath: "main.tf",
+			input: `locals {
+  x = "${path.module}/../x"
+}
+`,
+			expected: `locals {
+  x = "${path.module}/../x"
+}
+`,
+		},
+		{
+			name:    "tofu extension is rewritten",
+			relPath: "main.tofu",
+			input: `module "foo" {
+  source = "../foo"
+}
+`,
+			expected: `module "foo" {
+  source = "../../../../foo"
+}
+`,
+		},
+		{
+			// A "../" from a subdir that resolves back inside the unit must not
+			// be rewritten; one that climbs above the unit root must be.
+			name:    "subdir reference is judged by where it resolves",
+			relPath: filepath.Join("sub", "main.tf"),
+			input: `module "a" {
+  source = "../sibling"
+}
+module "b" {
+  source = "../../escape"
+}
+`,
+			expected: `module "a" {
+  source = "../sibling"
+}
+module "b" {
+  source = "../../../../../escape"
+}
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fsys := vfs.NewMemMapFS()
+			file := filepath.Join(workingDir, tc.relPath)
+			require.NoError(t, vfs.WriteFile(fsys, file, []byte(tc.input), 0o644))
+
+			require.NoError(
+				t,
+				run.RewriteRelativePathsOutOfCache(
+					logger.CreateLogger(),
+					fsys,
+					unitDir,
+					workingDir,
+				),
+			)
+
+			got, err := vfs.ReadFile(fsys, file)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, string(got))
+		})
+	}
+}
+
+func TestRewriteRelativePathsOutOfCacheSkipsJSON(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	file := "/unit/.terragrunt-cache/hash1/hash2/main.tf.json"
+	content := `{"module":{"foo":{"source":"../modules/foo"}}}`
+	require.NoError(t, vfs.WriteFile(fsys, file, []byte(content), 0o644))
+
+	require.NoError(
+		t,
+		run.RewriteRelativePathsOutOfCache(
+			logger.CreateLogger(),
+			fsys,
+			"/unit",
+			"/unit/.terragrunt-cache/hash1/hash2",
+		),
+	)
+
+	got, err := vfs.ReadFile(fsys, file)
+	require.NoError(t, err)
+	require.Equal(t, content, string(got))
+}
+
+func TestRewriteRelativePathsOutOfCacheLeavesInvalidFileUnchanged(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	file := "/unit/.terragrunt-cache/hash1/hash2/main.tf"
+	content := `module "foo" {
+  source =
+}
+`
+	require.NoError(t, vfs.WriteFile(fsys, file, []byte(content), 0o644))
+
+	require.NoError(
+		t,
+		run.RewriteRelativePathsOutOfCache(
+			logger.CreateLogger(),
+			fsys,
+			"/unit",
+			"/unit/.terragrunt-cache/hash1/hash2",
+		),
+	)
+
+	got, err := vfs.ReadFile(fsys, file)
+	require.NoError(t, err)
+	require.Equal(t, content, string(got))
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -240,6 +240,9 @@ type TerragruntOptions struct {
 	RunAllAutoApprove bool
 	// If set to true, delete the contents of the temporary folder before downloading Terraform source code into it
 	SourceUpdate bool
+	// If set to true, rewrite relative paths in the copied OpenTofu/Terraform files that point out of the unit
+	// directory so they still resolve once the files are copied into the .terragrunt-cache directory.
+	UpdateSourceOutOfCache bool
 	// HCLValidateStrict is a strict mode for HCL validation files. When
 	// it's set to false the command will only return an error if required
 	// inputs are missing from all input sources (env vars, var files, etc).


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
