### PR TITLE
fix: Fixing report path prefix trim

### DIFF
--- a/docs/src/data/changelog/v1.1.2/report-sibling-path-names.mdx
+++ b/docs/src/data/changelog/v1.1.2/report-sibling-path-names.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.2"
+category: "bug-fixes"
+---
+
+#### Run report no longer mangles the names of paths that share a prefix with the working directory
+
+When a run's path shared a string prefix with the working directory without being nested under it, the run report shortened its name by shearing off the prefix mid-segment. A working directory of `/repo/project` alongside a run at `/repo/project-staging/unit` produced the name `-staging/unit`.
+
+The report now shortens a path only when it is genuinely nested under the working directory. Sibling paths keep their full name.

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1518,8 +1518,8 @@ func TestWriteJSONWithDiscoveryWorkingDir(t *testing.T) {
 	// - Worktree path: /tmp/terragrunt-worktree-xxx/original/repo
 	// - Unit path in worktree: /tmp/terragrunt-worktree-xxx/original/repo/module/unit
 
-	originalRepoDir := "/original-repo"
-	worktreeDir := "/worktree"
+	originalRepoDir := filepath.FromSlash("/original-repo")
+	worktreeDir := filepath.FromSlash("/worktree")
 	unitPath := filepath.Join(worktreeDir, "module", "unit")
 
 	// Create a report with the original repo as working dir (simulating non-worktree scenario)
@@ -1552,7 +1552,7 @@ func TestWriteJSONWithDiscoveryWorkingDir(t *testing.T) {
 
 	// The name should be relative to the worktree dir, not the original repo dir
 	// Without the fix, this would be the full absolute path since unitPath doesn't start with originalRepoDir
-	assert.Equal(t, "module/unit", runs[0].Name,
+	assert.Equal(t, filepath.FromSlash("module/unit"), runs[0].Name,
 		"Run name should be relative to DiscoveryWorkingDir, not report.workingDir")
 }
 
@@ -1562,8 +1562,8 @@ func TestWriteCSVWithDiscoveryWorkingDir(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	originalRepoDir := "/original-repo"
-	worktreeDir := "/worktree"
+	originalRepoDir := filepath.FromSlash("/original-repo")
+	worktreeDir := filepath.FromSlash("/worktree")
 	unitPath := filepath.Join(worktreeDir, "module", "unit")
 
 	// Create a report with the original repo as working dir
@@ -1589,8 +1589,41 @@ func TestWriteCSVWithDiscoveryWorkingDir(t *testing.T) {
 	require.Len(t, records, 2) // header + 1 data row
 
 	// The name (first column) should be relative to worktree dir
-	assert.Equal(t, "module/unit", records[1][0],
+	assert.Equal(t, filepath.FromSlash("module/unit"), records[1][0],
 		"Run name should be relative to DiscoveryWorkingDir, not report.workingDir")
+}
+
+// TestWriteJSONWithRootWorkingDir verifies that a root working directory, which already
+// ends in a separator, still trims to a relative name rather than falling back to the
+// absolute path.
+func TestWriteJSONWithRootWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+
+	rootDir := string(os.PathSeparator)
+	unitPath := filepath.Join(rootDir, "module", "unit")
+
+	r := report.NewReport().WithWorkingDir(rootDir)
+
+	run := newRun(t, unitPath)
+	r.AddRun(l, run)
+	r.EndRun(l, unitPath, report.WithResult(report.ResultSucceeded))
+
+	var buf bytes.Buffer
+
+	err := r.WriteJSON(&buf)
+	require.NoError(t, err)
+
+	var runs []report.JSONRun
+
+	err = json.Unmarshal(buf.Bytes(), &runs)
+	require.NoError(t, err)
+
+	require.Len(t, runs, 1)
+
+	assert.Equal(t, filepath.FromSlash("module/unit"), runs[0].Name,
+		"Run name should be relative to the root working dir, not the absolute path")
 }
 
 // TestParseJSONRuns verifies that JSON report data can be parsed from bytes.

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
+const testWorkingDir = "/repo"
+
 func TestNewReport(t *testing.T) {
 	t.Parallel()
 
@@ -34,7 +36,7 @@ func TestNewReport(t *testing.T) {
 func TestNewRun(t *testing.T) {
 	t.Parallel()
 
-	tmp := helpers.TmpDirWOSymlinks(t)
+	tmp := testWorkingDir
 
 	path := filepath.Join(tmp, "test-run")
 	run := newRun(t, path)
@@ -50,7 +52,7 @@ func TestNewRun(t *testing.T) {
 func TestAddRun(t *testing.T) {
 	t.Parallel()
 
-	tmp := helpers.TmpDirWOSymlinks(t)
+	tmp := testWorkingDir
 
 	l := logger.CreateLogger()
 
@@ -70,7 +72,7 @@ func TestAddRun(t *testing.T) {
 func TestGetRun(t *testing.T) {
 	t.Parallel()
 
-	tmp := helpers.TmpDirWOSymlinks(t)
+	tmp := testWorkingDir
 
 	l := logger.CreateLogger()
 
@@ -112,7 +114,7 @@ func TestGetRun(t *testing.T) {
 func TestEnsureRun(t *testing.T) {
 	t.Parallel()
 
-	tmp := helpers.TmpDirWOSymlinks(t)
+	tmp := testWorkingDir
 
 	l := logger.CreateLogger()
 
@@ -201,7 +203,7 @@ func TestEnsureRun(t *testing.T) {
 func TestEndRun(t *testing.T) {
 	t.Parallel()
 
-	tmp := helpers.TmpDirWOSymlinks(t)
+	tmp := testWorkingDir
 
 	l := logger.CreateLogger()
 
@@ -293,7 +295,7 @@ func TestEndRun(t *testing.T) {
 func TestEndRunAlreadyEnded(t *testing.T) {
 	t.Parallel()
 
-	tmp := helpers.TmpDirWOSymlinks(t)
+	tmp := testWorkingDir
 
 	l := logger.CreateLogger()
 
@@ -381,7 +383,7 @@ func TestEndRunAlreadyEnded(t *testing.T) {
 func TestSummarize(t *testing.T) {
 	t.Parallel()
 
-	tmp := helpers.TmpDirWOSymlinks(t)
+	tmp := testWorkingDir
 
 	l := logger.CreateLogger()
 
@@ -528,35 +530,18 @@ func TestWriteCSV(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			tmp := helpers.TmpDirWOSymlinks(t)
+			tmp := testWorkingDir
 
 			l := logger.CreateLogger()
-
-			// Create a temporary file for the CSV
-			csvFile := filepath.Join(tmp, "report.csv")
-			file, err := os.Create(csvFile)
-			require.NoError(t, err)
-
-			defer file.Close()
 
 			// Setup and write the report
 			r := report.NewReport().WithWorkingDir(tmp)
 			tt.setup(l, tmp, r)
 
-			err = r.WriteCSV(file)
-			require.NoError(t, err)
+			var buf bytes.Buffer
+			require.NoError(t, r.WriteCSV(&buf))
 
-			// Close the file before reading
-			file.Close()
-
-			// Read the CSV file
-			file, err = os.Open(csvFile)
-			require.NoError(t, err)
-
-			defer file.Close()
-
-			reader := csv.NewReader(file)
-			records, err := reader.ReadAll()
+			records, err := csv.NewReader(&buf).ReadAll()
 			require.NoError(t, err)
 
 			// Verify the number of records
@@ -710,41 +695,21 @@ func TestWriteJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			tmp := helpers.TmpDirWOSymlinks(t)
-
-			// Create a temporary file for the JSON
-			jsonFile := filepath.Join(tmp, "report.json")
-			file, err := os.Create(jsonFile)
-			require.NoError(t, err)
-
-			defer file.Close()
+			tmp := testWorkingDir
 
 			// Setup and write the report
 			r := report.NewReport().WithWorkingDir(tmp)
 			tt.setup(l, tmp, r)
 
-			err = r.WriteJSON(file)
-			require.NoError(t, err)
-
-			// Close the file before reading
-			file.Close()
-
-			// Read the JSON file
-			file, err = os.Open(jsonFile)
-			require.NoError(t, err)
-
-			defer file.Close()
-
-			// Read the actual output
-			actualBytes, err := os.ReadFile(jsonFile)
-			require.NoError(t, err)
+			var buf bytes.Buffer
+			require.NoError(t, r.WriteJSON(&buf))
 
 			// Parse both expected and actual JSON to compare them
 			var expectedJSON, actualJSON []map[string]any
 
-			err = json.Unmarshal([]byte(tt.expected), &expectedJSON)
+			err := json.Unmarshal([]byte(tt.expected), &expectedJSON)
 			require.NoError(t, err)
-			err = json.Unmarshal(actualBytes, &actualJSON)
+			err = json.Unmarshal(buf.Bytes(), &actualJSON)
 			require.NoError(t, err)
 
 			// Verify the number of records
@@ -827,6 +792,40 @@ func TestWriteJSON(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWriteJSONSiblingPrefixPath verifies that a run whose path merely shares a
+// string prefix with the working directory (a sibling like `<workingDir>-other`)
+// keeps its full path as its name, rather than having the working directory
+// sheared off mid-segment.
+func TestWriteJSONSiblingPrefixPath(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+
+	workingDir := filepath.Join(testWorkingDir, "project")
+	siblingPath := filepath.Join(testWorkingDir, "project-staging", "unit")
+	subDirPath := filepath.Join(workingDir, "unit")
+
+	r := report.NewReport().WithWorkingDir(workingDir)
+
+	siblingRun := newRun(t, siblingPath)
+	require.NoError(t, r.AddRun(l, siblingRun))
+	require.NoError(t, r.EndRun(l, siblingRun.Path))
+
+	subRun := newRun(t, subDirPath)
+	require.NoError(t, r.AddRun(l, subRun))
+	require.NoError(t, r.EndRun(l, subRun.Path))
+
+	var buf bytes.Buffer
+	require.NoError(t, r.WriteJSON(&buf))
+
+	runs, err := report.ParseJSONRuns(buf.Bytes())
+	require.NoError(t, err)
+
+	names := runs.Names()
+	assert.Contains(t, names, siblingPath)
+	assert.Contains(t, names, "unit")
 }
 
 const ExpectedSchema = `{
@@ -991,7 +990,7 @@ func TestExpectedSchemaIsInDocs(t *testing.T) {
 func TestWriteSummary(t *testing.T) {
 	t.Parallel()
 
-	tmp := helpers.TmpDirWOSymlinks(t)
+	tmp := testWorkingDir
 
 	l := logger.CreateLogger()
 
@@ -1091,7 +1090,7 @@ func TestWriteSummary(t *testing.T) {
 func TestSchemaIsValid(t *testing.T) {
 	t.Parallel()
 
-	tmp := helpers.TmpDirWOSymlinks(t)
+	tmp := testWorkingDir
 
 	l := logger.CreateLogger()
 
@@ -1150,37 +1149,16 @@ func TestSchemaIsValid(t *testing.T) {
 		report.WithCauseIgnoreBlock("ignore-block"),
 	)
 
-	// Write the report to a JSON file
-	reportFile := filepath.Join(tmp, "report.json")
-	file, err := os.Create(reportFile)
-	require.NoError(t, err)
+	var reportBuf bytes.Buffer
+	require.NoError(t, r.WriteJSON(&reportBuf))
 
-	defer file.Close()
+	var schemaBuf bytes.Buffer
+	require.NoError(t, report.WriteSchema(&schemaBuf))
 
-	err = r.WriteJSON(file)
-	require.NoError(t, err)
-	file.Close()
-
-	// Write the schema to a file
-	schemaFile := filepath.Join(tmp, "schema.json")
-	file, err = os.Create(schemaFile)
-	require.NoError(t, err)
-
-	defer file.Close()
-
-	err = report.WriteSchema(file)
-	require.NoError(t, err)
-	file.Close()
-
-	// Read the schema and report files
-	schemaBytes, err := os.ReadFile(schemaFile)
-	require.NoError(t, err)
-
-	reportBytes, err := os.ReadFile(reportFile)
-	require.NoError(t, err)
+	reportBytes := reportBuf.Bytes()
 
 	// Create a new schema loader
-	schemaLoader := gojsonschema.NewBytesLoader(schemaBytes)
+	schemaLoader := gojsonschema.NewBytesLoader(schemaBuf.Bytes())
 	documentLoader := gojsonschema.NewBytesLoader(reportBytes)
 
 	// Validate the report against the schema
@@ -1260,7 +1238,7 @@ func TestSchemaIsValid(t *testing.T) {
 func TestWriteUnitLevelSummary(t *testing.T) {
 	t.Parallel()
 
-	tmp := helpers.TmpDirWOSymlinks(t)
+	tmp := testWorkingDir
 
 	l := logger.CreateLogger()
 
@@ -1540,14 +1518,9 @@ func TestWriteJSONWithDiscoveryWorkingDir(t *testing.T) {
 	// - Worktree path: /tmp/terragrunt-worktree-xxx/original/repo
 	// - Unit path in worktree: /tmp/terragrunt-worktree-xxx/original/repo/module/unit
 
-	// Create temp directories
-	originalRepoDir := helpers.TmpDirWOSymlinks(t)
-	worktreeDir := helpers.TmpDirWOSymlinks(t)
-
-	// Create the "unit" path in the worktree
+	originalRepoDir := "/original-repo"
+	worktreeDir := "/worktree"
 	unitPath := filepath.Join(worktreeDir, "module", "unit")
-	err := os.MkdirAll(unitPath, 0755)
-	require.NoError(t, err)
 
 	// Create a report with the original repo as working dir (simulating non-worktree scenario)
 	r := report.NewReport().WithWorkingDir(originalRepoDir)
@@ -1566,7 +1539,7 @@ func TestWriteJSONWithDiscoveryWorkingDir(t *testing.T) {
 	// Write JSON and verify the name is relative to DiscoveryWorkingDir, not report.workingDir
 	var buf bytes.Buffer
 
-	err = r.WriteJSON(&buf)
+	err := r.WriteJSON(&buf)
 	require.NoError(t, err)
 
 	// Parse the JSON
@@ -1589,14 +1562,9 @@ func TestWriteCSVWithDiscoveryWorkingDir(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	// Create temp directories (simulating worktree scenario)
-	originalRepoDir := helpers.TmpDirWOSymlinks(t)
-	worktreeDir := helpers.TmpDirWOSymlinks(t)
-
-	// Create the "unit" path in the worktree
+	originalRepoDir := "/original-repo"
+	worktreeDir := "/worktree"
 	unitPath := filepath.Join(worktreeDir, "module", "unit")
-	err := os.MkdirAll(unitPath, 0755)
-	require.NoError(t, err)
 
 	// Create a report with the original repo as working dir
 	r := report.NewReport().WithWorkingDir(originalRepoDir)
@@ -1610,7 +1578,7 @@ func TestWriteCSVWithDiscoveryWorkingDir(t *testing.T) {
 	// Write CSV
 	var buf bytes.Buffer
 
-	err = r.WriteCSV(&buf)
+	err := r.WriteCSV(&buf)
 	require.NoError(t, err)
 
 	// Parse the CSV

--- a/internal/report/writer.go
+++ b/internal/report/writer.go
@@ -452,7 +452,10 @@ func nameOfPath(path string, workingDir string) string {
 		return filepath.Base(path)
 	}
 
-	prefix := workingDir + string(os.PathSeparator)
+	prefix := workingDir
+	if !strings.HasSuffix(prefix, string(os.PathSeparator)) {
+		prefix += string(os.PathSeparator)
+	}
 
 	if !strings.HasPrefix(path, prefix) {
 		return path

--- a/internal/report/writer.go
+++ b/internal/report/writer.go
@@ -448,22 +448,17 @@ func WriteSchema(w io.Writer) error {
 //
 //   - Otherwise, return the path relative to the working directory, with any leading slashes removed.
 func nameOfPath(path string, workingDir string) string {
-	// If the path is the same as the working directory,
-	// return the base name of the path.
 	if path == workingDir {
 		return filepath.Base(path)
 	}
 
-	// If the path is not a subdirectory of the working directory,
-	// return the path as is.
-	if !strings.HasPrefix(path, workingDir) {
+	prefix := workingDir + string(os.PathSeparator)
+
+	if !strings.HasPrefix(path, prefix) {
 		return path
 	}
 
-	path = strings.TrimPrefix(path, workingDir)
-	path = strings.TrimPrefix(path, string(os.PathSeparator))
-
-	return path
+	return strings.TrimPrefix(path, prefix)
 }
 
 // effectiveWorkingDir returns the working directory to use for path computation.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes the path prefix trim done for the report file.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed report name generation for paths that share a prefix with the working directory but are not truly nested.
  * Report paths are now shortened only when they are genuinely located under the working directory; sibling (non-nested) paths keep their full names.

* **Documentation**
  * Added a changelog entry describing the corrected path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->