### PR TITLE
Fixed: scaffold not detecting URL correctly when referring to tfr

### DIFF
--- a/docs/src/data/changelog/v1.1.2/scaffold-tfr-source.mdx
+++ b/docs/src/data/changelog/v1.1.2/scaffold-tfr-source.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.2"
+category: "enhancement"
+---
+
+#### `scaffold` now supports `tfr://` registry sources
+
+`terragrunt scaffold` failed on `tfr://` registry source URLs with `Failed to parse url`, `git: 'remote-tfr' is not a git command`, and a download error, even though the same URL worked fine in a `source` attribute of a terraform block. Scaffold built its module/template downloader without the registry getter the normal run path uses, and its URL-rewrite helpers assumed every source was git-shaped.
+
+`scaffold` now registers the registry getter for both module and template downloads, and skips git-only steps (tag lookup, git-ssh URL rewriting) for non-git schemes like `tfr`, `s3`, `gcs`, and `oci`.

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -32,7 +32,9 @@ import (
 	"github.com/gruntwork-io/boilerplate/templates"
 	"github.com/gruntwork-io/boilerplate/variables"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/hashicorp/go-cleanhttp"
 )
 
 const (
@@ -45,6 +47,8 @@ const (
 	refVar              = "Ref"
 	// refParam - ?ref param from url
 	refParam = "ref"
+	// versionParam - ?version param from url, used for tfr:// registry sources
+	versionParam = "version"
 
 	moduleURLPattern = `(?:git|hg|s3|gcs)::([^:]+)://([^/]+)(/.*)`
 	moduleURLParts   = 4
@@ -254,7 +258,10 @@ func Prepare(
 		Collect(ctx, l, "scaffold_get_module", map[string]any{
 			"module_url": resolvedURL,
 		}, func(ctx context.Context, l log.Logger) error {
-			if _, getErr := getter.GetAny(ctx, tempDir, resolvedURL); getErr != nil {
+			getterOpts := getter.WithTFRegistry(getter.NewRegistryGetter(l, v.FS).
+				WithTofuImplementation(opts.TofuImplementation))
+
+			if _, getErr := getter.GetAny(ctx, tempDir, resolvedURL, getterOpts); getErr != nil {
 				return fmt.Errorf("downloading scaffold module from %s: %w", resolvedURL, getErr)
 			}
 
@@ -420,9 +427,10 @@ func Run(
 	return plan.Generate(ctx, l, v, opts, nil)
 }
 
-// BuildSourceURL returns the original module URL with the ref query param
-// from the resolved URL appended, so the scaffolded source preserves the
-// user's original URL format while including the resolved version tag.
+// BuildSourceURL returns the original module URL with the pin query param
+// (ref for git sources, version for tfr registry sources) from the resolved
+// URL appended, so the scaffolded source preserves the user's original URL
+// format while including the resolved pin.
 //
 // When vars sets SourceUrlType to git-ssh, the resolved URL is returned
 // instead so that the scaffolded source carries the Git/SSH rewrite that
@@ -433,21 +441,37 @@ func BuildSourceURL(originalURL, resolvedURL string, vars map[string]any) string
 		return resolvedURL
 	}
 
-	refVal := ExtractQueryParam(resolvedURL, refParam)
-	if refVal == "" {
+	pinParam, pinVal := extractPinParam(resolvedURL)
+	if pinVal == "" {
 		return originalURL
 	}
 
 	base, rawQuery := splitURLQuery(originalURL)
 
 	params, err := url.ParseQuery(rawQuery)
-	if err != nil || params.Has(refParam) {
+	if err != nil || params.Has(pinParam) {
 		return originalURL
 	}
 
-	params.Set(refParam, refVal)
+	params.Set(pinParam, pinVal)
 
 	return base + "?" + params.Encode()
+}
+
+// extractPinParam returns whichever version-pinning query param is present
+// on resolvedURL: ref for git sources, or version for tfr registry sources.
+// The two are mutually exclusive, since a source is resolved through either
+// the git-tag lookup or the registry-version lookup, never both.
+func extractPinParam(resolvedURL string) (string, string) {
+	if ref := ExtractQueryParam(resolvedURL, refParam); ref != "" {
+		return refParam, ref
+	}
+
+	if version := ExtractQueryParam(resolvedURL, versionParam); version != "" {
+		return versionParam, version
+	}
+
+	return "", ""
 }
 
 // ExtractQueryParam extracts a query parameter value from a URL string.
@@ -583,7 +607,10 @@ func downloadTemplate(
 		Collect(ctx, l, "scaffold_get_template", map[string]any{
 			"template_url": baseURL.String(),
 		}, func(ctx context.Context, l log.Logger) error {
-			if _, getErr := getter.GetAny(ctx, templateDir, baseURL.String()); getErr != nil {
+			getterOpts := getter.WithTFRegistry(getter.NewRegistryGetter(l, v.FS).
+				WithTofuImplementation(opts.TofuImplementation))
+
+			if _, getErr := getter.GetAny(ctx, templateDir, baseURL.String(), getterOpts); getErr != nil {
 				return fmt.Errorf(
 					"downloading scaffold template from %s: %w",
 					baseURL.String(),
@@ -756,29 +783,27 @@ func rewriteModuleURL(
 		sourceURLType = fmt.Sprintf("%s", value)
 	}
 
-	// expand module url
-	parsedValue, err := parseURL(l, moduleURL)
-	if err != nil {
-		l.Warnf("Failed to parse module url %s", moduleURL)
-
-		parsedModuleURL, err := tf.ToSourceURL(updatedModuleURL, opts.WorkingDir)
+	// The scheme/host/path regex below only matters for the git-ssh rewrite.
+	// For every other source URL type, moduleURL is already a successfully
+	// parsed URL (from tf.ToSourceURL upstream), so skip the regex parse
+	// entirely rather than logging a misleading "Failed to parse url" for
+	// schemes it was never meant to handle (tfr://, s3://, plain https://, ...).
+	if sourceURLType == sourceURLTypeGit {
+		parsedValue, err := parseURL(l, moduleURL)
 		if err != nil {
-			return nil, err
-		}
+			l.Warnf("Failed to parse module url %s", moduleURL)
+		} else if parsedValue.scheme == "https" {
+			// try to rewrite module url if is https and is requested to be git
+			// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
+			// git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs
+			gitUser := sourceGitSSHUser
+			if value, found := vars[sourceGitSSHUserVar]; found {
+				gitUser = fmt.Sprintf("%s", value)
+			}
 
-		return parsedModuleURL, nil
-	}
-	// try to rewrite module url if is https and is requested to be git
-	// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
-	// git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs
-	if parsedValue.scheme == "https" && sourceURLType == sourceURLTypeGit {
-		gitUser := sourceGitSSHUser
-		if value, found := vars[sourceGitSSHUserVar]; found {
-			gitUser = fmt.Sprintf("%s", value)
+			path := strings.TrimPrefix(parsedValue.path, "/")
+			updatedModuleURL = fmt.Sprintf("%s@%s:%s", gitUser, parsedValue.host, path)
 		}
-
-		path := strings.TrimPrefix(parsedValue.path, "/")
-		updatedModuleURL = fmt.Sprintf("%s@%s:%s", gitUser, parsedValue.host, path)
 	}
 
 	// persist changes in url.URL
@@ -812,9 +837,9 @@ func rewriteTemplateURL(
 			return nil, err
 		}
 
-		if rootSourceURL.Scheme == "" || rootSourceURL.Scheme == "file" {
-			l.Debugf("Skipping git tag lookup for local template path: %s", rootSourceURL)
-			return updatedTemplateURL, nil
+		if !isGitShapedScheme(rootSourceURL.Scheme) {
+			l.Debugf("Skipping git tag lookup for non-git template URL: %s", rootSourceURL)
+			return pinLatestRegistryVersion(ctx, l, opts, updatedTemplateURL, rootSourceURL), nil
 		}
 
 		tag, err := shell.GitLastReleaseTag(ctx, l, v, opts.WorkingDir, rootSourceURL)
@@ -861,6 +886,14 @@ func addRefToModuleURL(
 			return nil, err
 		}
 
+		// Non-git schemes (registry, cloud storage, HTTP, OCI, local paths) have no
+		// git tags to look up, and shelling out to `git ls-remote` against them
+		// fails with a confusing "not a git command" error.
+		if !isGitShapedScheme(rootSourceURL.Scheme) {
+			l.Debugf("Skipping git tag lookup for non-git source URL: %s", rootSourceURL)
+			return pinLatestRegistryVersion(ctx, l, opts, moduleURL, rootSourceURL), nil
+		}
+
 		tag, err := shell.GitLastReleaseTag(ctx, l, v, opts.WorkingDir, rootSourceURL)
 		if err != nil || tag == "" {
 			l.Warnf("Failed to find last release tag for %s", rootSourceURL)
@@ -871,6 +904,74 @@ func addRefToModuleURL(
 	}
 
 	return moduleURL, nil
+}
+
+// isGitShapedScheme reports whether scheme belongs to a source that git
+// understands, so a `git ls-remote` tag lookup makes sense. Forced-getter
+// URLs (git::..., s3::..., gcs::...) carry the getter name as a "::"
+// separated scheme segment; a bare scheme (tfr, oci, http, https, ...) with
+// no "git"/"ssh" segment means the URL was never detected as a git remote,
+// and shelling out to git for it just fails with a confusing error.
+func isGitShapedScheme(scheme string) bool {
+	if scheme == "" || scheme == "file" {
+		return true
+	}
+
+	for _, part := range strings.Split(scheme, "::") {
+		if part == "git" || part == "ssh" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// pinLatestRegistryVersion pins a tfr:// registry source with no ?version=
+// query param to the latest stable version published on the registry,
+// mirroring the git-ref pinning shell.GitLastReleaseTag does for git
+// sources. Any other scheme, or a source that already has a version
+// pinned, is returned unchanged. Resolution failures are non-fatal,
+// matching the "leave ref unset on failure" behavior for git: warn and
+// return the source unpinned rather than failing the whole scaffold.
+func pinLatestRegistryVersion(
+	ctx context.Context,
+	l log.Logger,
+	opts *options.TerragruntOptions,
+	sourceURL, rootSourceURL *url.URL,
+) *url.URL {
+	if rootSourceURL.Scheme != "tfr" {
+		return sourceURL
+	}
+
+	params := sourceURL.Query()
+	if params.Get(versionParam) != "" {
+		return sourceURL
+	}
+
+	registryDomain := rootSourceURL.Host
+	if registryDomain == "" {
+		registryDomain = tfimpl.DefaultRegistryDomain(opts.TofuImplementation)
+	}
+
+	modulePath, _ := getter.SourceDirSubdir(rootSourceURL.Path)
+	httpClient := cleanhttp.DefaultClient()
+
+	basePath, err := getter.GetModuleRegistryURLBasePath(ctx, l, httpClient, registryDomain)
+	if err != nil {
+		l.Warnf("Failed to resolve latest version for registry module %s: %v", rootSourceURL, err)
+		return sourceURL
+	}
+
+	latest, err := getter.GetLatestModuleVersion(ctx, l, httpClient, registryDomain, basePath, modulePath)
+	if err != nil {
+		l.Warnf("Failed to resolve latest version for registry module %s: %v", rootSourceURL, err)
+		return sourceURL
+	}
+
+	params.Set(versionParam, latest)
+	sourceURL.RawQuery = params.Encode()
+
+	return sourceURL
 }
 
 // parseURL parses module url to scheme, host and path

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gruntwork-io/boilerplate/templates"
 	"github.com/gruntwork-io/boilerplate/variables"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
@@ -46,6 +47,8 @@ const (
 	refVar              = "Ref"
 	// refParam - ?ref param from url
 	refParam = "ref"
+	// versionParam - ?version param from url, used for tfr:// registry sources
+	versionParam = "version"
 
 	moduleURLPattern = `(?:git|hg|s3|gcs)::([^:]+)://([^/]+)(/.*)`
 	moduleURLParts   = 4
@@ -266,7 +269,10 @@ func Prepare(
 		Collect(ctx, l, "scaffold_get_module", map[string]any{
 			"module_url": resolvedURL,
 		}, func(ctx context.Context, l log.Logger) error {
-			if _, getErr := getter.GetAny(ctx, v, tempDir, resolvedURL); getErr != nil {
+			getterOpts := getter.WithTFRegistry(getter.NewRegistryGetter(l, v).
+				WithTofuImplementation(opts.TofuImplementation))
+
+			if _, getErr := getter.GetAny(ctx, v, tempDir, resolvedURL, getterOpts); getErr != nil {
 				return fmt.Errorf("downloading scaffold module from %s: %w", resolvedURL, getErr)
 			}
 
@@ -521,9 +527,10 @@ func Run(
 	return plan.Generate(ctx, l, v, opts, nil)
 }
 
-// BuildSourceURL returns the original module URL with the ref query param
-// from the resolved URL appended, so the scaffolded source preserves the
-// user's original URL format while including the resolved version tag.
+// BuildSourceURL returns the original module URL with the pin query param
+// (ref for git sources, version for tfr registry sources) from the resolved
+// URL appended, so the scaffolded source preserves the user's original URL
+// format while including the resolved pin.
 //
 // When vars sets SourceUrlType to git-ssh, the resolved URL is returned
 // instead so that the scaffolded source carries the Git/SSH rewrite that
@@ -534,21 +541,37 @@ func BuildSourceURL(originalURL, resolvedURL string, vars map[string]any) string
 		return resolvedURL
 	}
 
-	refVal := ExtractQueryParam(resolvedURL, refParam)
-	if refVal == "" {
+	pinParam, pinVal := extractPinParam(resolvedURL)
+	if pinVal == "" {
 		return originalURL
 	}
 
 	base, rawQuery := splitURLQuery(originalURL)
 
 	params, err := url.ParseQuery(rawQuery)
-	if err != nil || params.Has(refParam) {
+	if err != nil || params.Has(pinParam) {
 		return originalURL
 	}
 
-	params.Set(refParam, refVal)
+	params.Set(pinParam, pinVal)
 
 	return base + "?" + params.Encode()
+}
+
+// extractPinParam returns whichever version-pinning query param is present
+// on resolvedURL: ref for git sources, or version for tfr registry sources.
+// The two are mutually exclusive, since a source is resolved through either
+// the git-tag lookup or the registry-version lookup, never both.
+func extractPinParam(resolvedURL string) (string, string) {
+	if ref := ExtractQueryParam(resolvedURL, refParam); ref != "" {
+		return refParam, ref
+	}
+
+	if version := ExtractQueryParam(resolvedURL, versionParam); version != "" {
+		return versionParam, version
+	}
+
+	return "", ""
 }
 
 // ExtractQueryParam extracts a query parameter value from a URL string.
@@ -683,7 +706,10 @@ func downloadTemplate(
 		Collect(ctx, l, "scaffold_get_template", map[string]any{
 			"template_url": baseURL.String(),
 		}, func(ctx context.Context, l log.Logger) error {
-			if _, getErr := getter.GetAny(ctx, v, templateDir, baseURL.String()); getErr != nil {
+			getterOpts := getter.WithTFRegistry(getter.NewRegistryGetter(l, v).
+				WithTofuImplementation(opts.TofuImplementation))
+
+			if _, getErr := getter.GetAny(ctx, v, templateDir, baseURL.String(), getterOpts); getErr != nil {
 				return fmt.Errorf(
 					"downloading scaffold template from %s: %w",
 					baseURL.String(),
@@ -855,29 +881,27 @@ func rewriteModuleURL(
 		sourceURLType = fmt.Sprintf("%s", value)
 	}
 
-	// expand module url
-	parsedValue, err := parseURL(l, moduleURL)
-	if err != nil {
-		l.Warnf("Failed to parse module url %s", moduleURL)
-
-		parsedModuleURL, err := tf.ToSourceURL(updatedModuleURL, opts.WorkingDir)
+	// The scheme/host/path regex below only matters for the git-ssh rewrite.
+	// For every other source URL type, moduleURL is already a successfully
+	// parsed URL (from tf.ToSourceURL upstream), so skip the regex parse
+	// entirely rather than logging a misleading "Failed to parse url" for
+	// schemes it was never meant to handle (tfr://, s3://, plain https://, ...).
+	if sourceURLType == sourceURLTypeGit {
+		parsedValue, err := parseURL(l, moduleURL)
 		if err != nil {
-			return nil, err
-		}
+			l.Warnf("Failed to parse module url %s", moduleURL)
+		} else if parsedValue.scheme == "https" {
+			// try to rewrite module url if is https and is requested to be git
+			// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
+			// git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs
+			gitUser := sourceGitSSHUser
+			if value, found := vars[sourceGitSSHUserVar]; found {
+				gitUser = fmt.Sprintf("%s", value)
+			}
 
-		return parsedModuleURL, nil
-	}
-	// try to rewrite module url if is https and is requested to be git
-	// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
-	// git::ssh://git@github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs
-	if parsedValue.scheme == "https" && sourceURLType == sourceURLTypeGit {
-		gitUser := sourceGitSSHUser
-		if value, found := vars[sourceGitSSHUserVar]; found {
-			gitUser = fmt.Sprintf("%s", value)
+			path := strings.TrimPrefix(parsedValue.path, "/")
+			updatedModuleURL = fmt.Sprintf("%s@%s:%s", gitUser, parsedValue.host, path)
 		}
-
-		path := strings.TrimPrefix(parsedValue.path, "/")
-		updatedModuleURL = fmt.Sprintf("%s@%s:%s", gitUser, parsedValue.host, path)
 	}
 
 	// persist changes in url.URL
@@ -911,9 +935,9 @@ func rewriteTemplateURL(
 			return nil, err
 		}
 
-		if rootSourceURL.Scheme == "" || rootSourceURL.Scheme == "file" {
-			l.Debugf("Skipping git tag lookup for local template path: %s", rootSourceURL)
-			return updatedTemplateURL, nil
+		if !isGitShapedScheme(rootSourceURL.Scheme) {
+			l.Debugf("Skipping git tag lookup for non-git template URL: %s", rootSourceURL)
+			return pinLatestRegistryVersion(ctx, l, v, opts, updatedTemplateURL, rootSourceURL), nil
 		}
 
 		tag, err := shell.GitLastReleaseTag(ctx, l, v, opts.WorkingDir, rootSourceURL)
@@ -960,6 +984,14 @@ func addRefToModuleURL(
 			return nil, err
 		}
 
+		// Non-git schemes (registry, cloud storage, HTTP, OCI, local paths) have no
+		// git tags to look up, and shelling out to `git ls-remote` against them
+		// fails with a confusing "not a git command" error.
+		if !isGitShapedScheme(rootSourceURL.Scheme) {
+			l.Debugf("Skipping git tag lookup for non-git source URL: %s", rootSourceURL)
+			return pinLatestRegistryVersion(ctx, l, v, opts, moduleURL, rootSourceURL), nil
+		}
+
 		tag, err := shell.GitLastReleaseTag(ctx, l, v, opts.WorkingDir, rootSourceURL)
 		if err != nil || tag == "" {
 			l.Warnf("Failed to find last release tag for %s", rootSourceURL)
@@ -970,6 +1002,78 @@ func addRefToModuleURL(
 	}
 
 	return moduleURL, nil
+}
+
+// isGitShapedScheme reports whether scheme belongs to a source that git
+// understands, so a `git ls-remote` tag lookup makes sense. Forced-getter
+// URLs (git::..., s3::..., gcs::...) carry the getter name as a "::"
+// separated scheme segment; a bare scheme (tfr, oci, http, https, ...) with
+// no "git"/"ssh" segment means the URL was never detected as a git remote,
+// and shelling out to git for it just fails with a confusing error.
+func isGitShapedScheme(scheme string) bool {
+	if scheme == "" || scheme == "file" {
+		return true
+	}
+
+	for _, part := range strings.Split(scheme, "::") {
+		if part == "git" || part == "ssh" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// pinLatestRegistryVersion pins a tfr:// registry source with no ?version=
+// query param to the latest stable version published on the registry,
+// mirroring the git-ref pinning shell.GitLastReleaseTag does for git
+// sources. Any other scheme, or a source that already has a version
+// pinned, is returned unchanged. Resolution failures are non-fatal,
+// matching the "leave ref unset on failure" behavior for git: warn and
+// return the source unpinned rather than failing the whole scaffold.
+func pinLatestRegistryVersion(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+	opts *options.TerragruntOptions,
+	sourceURL, rootSourceURL *url.URL,
+) *url.URL {
+	if rootSourceURL.Scheme != getter.SchemeTFR {
+		return sourceURL
+	}
+
+	params := sourceURL.Query()
+	if params.Get(versionParam) != "" {
+		return sourceURL
+	}
+
+	v.RequireHTTP()
+	v.RequireEnv()
+
+	registryDomain := rootSourceURL.Host
+	if registryDomain == "" {
+		registryDomain = tfimpl.DefaultRegistryDomain(v.Env, opts.TofuImplementation)
+	}
+
+	modulePath, _ := getter.SourceDirSubdir(rootSourceURL.Path)
+	auth := getter.NewRegistryAuth(v)
+
+	basePath, err := getter.GetModuleRegistryURLBasePath(ctx, l, v.HTTP, auth, registryDomain)
+	if err != nil {
+		l.Warnf("Failed to resolve latest version for registry module %s: %v", rootSourceURL, err)
+		return sourceURL
+	}
+
+	latest, err := getter.GetLatestModuleVersion(ctx, l, v.HTTP, auth, registryDomain, basePath, modulePath)
+	if err != nil {
+		l.Warnf("Failed to resolve latest version for registry module %s: %v", rootSourceURL, err)
+		return sourceURL
+	}
+
+	params.Set(versionParam, latest)
+	sourceURL.RawQuery = params.Encode()
+
+	return sourceURL
 }
 
 // parseURL parses module url to scheme, host and path

--- a/internal/cli/commands/scaffold/scaffold_internal_test.go
+++ b/internal/cli/commands/scaffold/scaffold_internal_test.go
@@ -1,0 +1,131 @@
+package scaffold
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseModuleURLTFRRoundTrip verifies that a tfr:// registry source
+// survives parseModuleURL without a "Failed to parse url" warning path and
+// without shelling out to git for a tag, keeping the ?version= query param
+// intact end to end. See https://github.com/gruntwork-io/terragrunt/issues/3677.
+func TestParseModuleURLTFRRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	opts := options.NewTerragruntOptions()
+
+	moduleURL := "tfr:///terraform-aws-modules/eks/aws?version=20.31.4"
+
+	resolved, err := parseModuleURL(t.Context(), l, &venv.Venv{}, opts, map[string]any{}, moduleURL)
+	require.NoError(t, err)
+	assert.Equal(t, "20.31.4", ExtractQueryParam(resolved, "version"))
+}
+
+func TestRewriteModuleURLSkipsRegexForNonGitSSHRewrite(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	opts := options.NewTerragruntOptions()
+
+	testCases := []struct {
+		vars      map[string]any
+		name      string
+		moduleURL string
+	}{
+		{
+			name:      "tfr scheme, default SourceUrlType",
+			moduleURL: "tfr://registry.opentofu.org/terraform-aws-modules/eks/aws",
+			vars:      map[string]any{},
+		},
+		{
+			name:      "tfr scheme, explicit git-https",
+			moduleURL: "tfr://registry.opentofu.org/terraform-aws-modules/eks/aws",
+			vars:      map[string]any{sourceURLTypeVar: sourceURLTypeHTTPS},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := rewriteModuleURL(l, opts, tc.vars, tc.moduleURL)
+			require.NoError(t, err)
+			assert.Equal(t, "tfr", result.Scheme)
+		})
+	}
+}
+
+func TestAddRefToModuleURLSkipsGitLookupForNonGitSchemes(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	opts := options.NewTerragruntOptions()
+
+	testCases := []struct {
+		name   string
+		rawURL string
+	}{
+		{name: "tfr", rawURL: "tfr://registry.opentofu.org/terraform-aws-modules/eks/aws?version=20.31.4"},
+		{name: "https, no forced getter", rawURL: "https://example.com/module.zip"},
+		{name: "oci", rawURL: "oci://example.com/module:1.0.0"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := url.Parse(tc.rawURL)
+			require.NoError(t, err)
+
+			before := parsed.String()
+
+			// A zero-value venv.Venv is safe here: addRefToModuleURL must
+			// return before it ever touches v by shelling out to git for
+			// these schemes. If it didn't skip, RunCommandWithOutput would
+			// panic or fail on the zero-value venv/writers well before any
+			// git error message, which is a stronger signal than trying to
+			// assert on log output.
+			result, err := addRefToModuleURL(t.Context(), l, &venv.Venv{}, opts, parsed, map[string]any{})
+			require.NoError(t, err)
+			assert.Equal(t, before, result.String())
+		})
+	}
+}
+
+func TestIsGitShapedScheme(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		scheme   string
+		expected bool
+	}{
+		{"", true},
+		{"file", true},
+		{"git", true},
+		{"ssh", true},
+		{"git::https", true},
+		{"git::ssh", true},
+		{"tfr", false},
+		{"s3", false},
+		{"s3::https", false},
+		{"gcs::https", false},
+		{"http", false},
+		{"https", false},
+		{"oci", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.scheme, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, isGitShapedScheme(tc.scheme))
+		})
+	}
+}

--- a/internal/cli/commands/scaffold/scaffold_internal_test.go
+++ b/internal/cli/commands/scaffold/scaffold_internal_test.go
@@ -1,0 +1,132 @@
+package scaffold
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseModuleURLTFRRoundTrip verifies that a tfr:// registry source
+// survives parseModuleURL without a "Failed to parse url" warning path and
+// without shelling out to git for a tag, keeping the ?version= query param
+// intact end to end. See https://github.com/gruntwork-io/terragrunt/issues/3677.
+func TestParseModuleURLTFRRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
+
+	moduleURL := "tfr:///terraform-aws-modules/eks/aws?version=20.31.4"
+
+	resolved, err := parseModuleURL(t.Context(), l, &venv.Venv{}, opts, map[string]any{}, moduleURL)
+	require.NoError(t, err)
+	assert.Equal(t, "20.31.4", ExtractQueryParam(resolved, "version"))
+}
+
+func TestRewriteModuleURLSkipsRegexForNonGitSSHRewrite(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
+
+	testCases := []struct {
+		vars      map[string]any
+		name      string
+		moduleURL string
+	}{
+		{
+			name:      "tfr scheme, default SourceUrlType",
+			moduleURL: "tfr://registry.opentofu.org/terraform-aws-modules/eks/aws",
+			vars:      map[string]any{},
+		},
+		{
+			name:      "tfr scheme, explicit git-https",
+			moduleURL: "tfr://registry.opentofu.org/terraform-aws-modules/eks/aws",
+			vars:      map[string]any{sourceURLTypeVar: sourceURLTypeHTTPS},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := rewriteModuleURL(l, opts, tc.vars, tc.moduleURL)
+			require.NoError(t, err)
+			assert.Equal(t, "tfr", result.Scheme)
+		})
+	}
+}
+
+func TestAddRefToModuleURLSkipsGitLookupForNonGitSchemes(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
+
+	testCases := []struct {
+		name   string
+		rawURL string
+	}{
+		{name: "tfr", rawURL: "tfr://registry.opentofu.org/terraform-aws-modules/eks/aws?version=20.31.4"},
+		{name: "https, no forced getter", rawURL: "https://example.com/module.zip"},
+		{name: "oci", rawURL: "oci://example.com/module:1.0.0"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := url.Parse(tc.rawURL)
+			require.NoError(t, err)
+
+			before := parsed.String()
+
+			// A zero-value venv.Venv is safe here: addRefToModuleURL must
+			// return before it ever touches v by shelling out to git for
+			// these schemes. If it didn't skip, RunCommandWithOutput would
+			// panic or fail on the zero-value venv/writers well before any
+			// git error message, which is a stronger signal than trying to
+			// assert on log output.
+			result, err := addRefToModuleURL(t.Context(), l, &venv.Venv{}, opts, parsed, map[string]any{})
+			require.NoError(t, err)
+			assert.Equal(t, before, result.String())
+		})
+	}
+}
+
+func TestIsGitShapedScheme(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		scheme   string
+		expected bool
+	}{
+		{"", true},
+		{"file", true},
+		{"git", true},
+		{"ssh", true},
+		{"git::https", true},
+		{"git::ssh", true},
+		{"tfr", false},
+		{"s3", false},
+		{"s3::https", false},
+		{"gcs::https", false},
+		{"http", false},
+		{"https", false},
+		{"oci", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.scheme, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, isGitShapedScheme(tc.scheme))
+		})
+	}
+}

--- a/test/integration_scaffold_test.go
+++ b/test/integration_scaffold_test.go
@@ -55,6 +55,58 @@ func TestScaffoldModule(t *testing.T) {
 	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
 }
 
+// TestScaffoldModuleTFRSource verifies that `terragrunt scaffold` works
+// against a tfr:// registry source, not just git-shaped sources.
+// See https://github.com/gruntwork-io/terragrunt/issues/3677.
+func TestScaffoldModuleTFRSource(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
+
+	moduleURL := registryTestModuleSource + "?version=0.0.2"
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		fmt.Sprintf(
+			"terragrunt scaffold --non-interactive --working-dir %s %s",
+			tmpEnvPath,
+			moduleURL,
+		),
+	)
+	require.NoError(t, err)
+	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
+
+	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
+	require.NoError(t, err)
+	assert.Contains(t, content, `source = "`+moduleURL+`"`)
+}
+
+// TestScaffoldModuleTFRSourceUnpinned verifies that a tfr:// source with no
+// ?version= query param gets pinned to the latest stable registry version in
+// the generated source, mirroring the ?ref= pinning git sources get from
+// their latest release tag. registryTestModuleSource has exactly two
+// published versions, 0.0.1 and 0.0.2, so the expected pin is deterministic.
+func TestScaffoldModuleTFRSourceUnpinned(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		fmt.Sprintf(
+			"terragrunt scaffold --non-interactive --working-dir %s %s",
+			tmpEnvPath,
+			registryTestModuleSource,
+		),
+	)
+	require.NoError(t, err)
+	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
+
+	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
+	require.NoError(t, err)
+	assert.Contains(t, content, `source = "`+registryTestModuleSource+`?version=0.0.2"`)
+}
+
 func TestScaffoldModuleShortUrl(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration_scaffold_test.go
+++ b/test/integration_scaffold_test.go
@@ -20,6 +20,13 @@ const (
 	testScaffoldLocalTofuModulePath = "fixtures/scaffold/scaffold-module-tofu"
 	testScaffoldCopyableUnitPath    = "fixtures/scaffold/copyable/units/app"
 	testScaffoldCopyableStackPath   = "fixtures/scaffold/copyable/stacks/prod"
+
+	// testScaffoldRegistryModuleSource is the tfr:// module the registry
+	// scaffold tests resolve against. It has exactly two published versions,
+	// 0.0.1 and 0.0.2, so the latest-version pin is deterministic. It mirrors
+	// registryTestModuleSource in integration_registry_test.go, which is
+	// behind the `tf` build tag and so is not visible here.
+	testScaffoldRegistryModuleSource = "tfr://registry.opentofu.org/yorinasub17/terragrunt-registry-test/null"
 )
 
 // scaffoldModuleURL returns the canonical scaffold-module source on the
@@ -63,6 +70,58 @@ func TestScaffoldModule(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
+}
+
+// TestScaffoldModuleTFRSource verifies that `terragrunt scaffold` works
+// against a tfr:// registry source, not just git-shaped sources.
+// See https://github.com/gruntwork-io/terragrunt/issues/3677.
+func TestScaffoldModuleTFRSource(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
+
+	moduleURL := testScaffoldRegistryModuleSource + "?version=0.0.2"
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		fmt.Sprintf(
+			"terragrunt scaffold --non-interactive --working-dir %s %s",
+			tmpEnvPath,
+			moduleURL,
+		),
+	)
+	require.NoError(t, err)
+	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
+
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), tmpEnvPath+"/terragrunt.hcl")
+	require.NoError(t, err)
+	assert.Contains(t, content, `source = "`+moduleURL+`"`)
+}
+
+// TestScaffoldModuleTFRSourceUnpinned verifies that a tfr:// source with no
+// ?version= query param gets pinned to the latest stable registry version in
+// the generated source, mirroring the ?ref= pinning git sources get from
+// their latest release tag. testScaffoldRegistryModuleSource has exactly two
+// published versions, 0.0.1 and 0.0.2, so the expected pin is deterministic.
+func TestScaffoldModuleTFRSourceUnpinned(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		fmt.Sprintf(
+			"terragrunt scaffold --non-interactive --working-dir %s %s",
+			tmpEnvPath,
+			testScaffoldRegistryModuleSource,
+		),
+	)
+	require.NoError(t, err)
+	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
+
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), tmpEnvPath+"/terragrunt.hcl")
+	require.NoError(t, err)
+	assert.Contains(t, content, `source = "`+testScaffoldRegistryModuleSource+`?version=0.0.2"`)
 }
 
 func TestScaffoldModuleShortUrl(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes terragrunt scaffold failing on tfr:// registry source URLs.
Closes #3677 .

`terragrunt scaffold tfr:///terraform-aws-modules/eks/aws?version=20.31.4` previously failed with three errors: `Failed to parse url tfr://...`, `git: 'remote-tfr' is not a git command`, and `error downloading 'tfr://...'`. A plain terraform { source = "tfr://..." } block already worked through the normal run path. Only scaffold was broken, because it built its go-getter client without the WithTFRegistry option the run path uses, and its URL-rewrite helpers assumed every source was git-shaped.

This PR fixes the above mentioned problems.

## TODOs

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs. (was not needed as the original doc says terragrunt already supports this)
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `scaffold` now supports OpenTofu and Terraform registry module sources, including `tfr://`.
  * Preserves existing Git `ref` and registry `version` pins.
  * Automatically pins unversioned registry sources to the latest stable published version.
  * Avoids unnecessary Git lookups for non-Git sources.
  * Gracefully leaves sources unchanged when registry resolution is unavailable.

* **Documentation**
  * Added changelog documentation for registry source support and version pinning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->