### PR TITLE
fix: Fixing stack dependency mock outputs

### DIFF
--- a/docs/src/data/changelog/v1.1.2/stack-dependency-mock-outputs.mdx
+++ b/docs/src/data/changelog/v1.1.2/stack-dependency-mock-outputs.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.2"
+category: "bug-fixes"
+---
+
+#### Stack dependencies honor `mock_outputs` with `--dependency-fetch-output-from-state`
+
+A `dependency` block that reads outputs from a stack (its `config_path` points at a `terragrunt.stack.hcl` directory) used to fail when a unit in that stack had no state yet, even when the dependency declared `mock_outputs`. This blocked commands like `plan` and `validate` against a stack that hadn't been applied.
+
+Such a dependency now falls back to `mock_outputs` for the units that have no state yet. In a partially applied stack, applied units resolve to their real outputs while the rest use their mocks.

--- a/docs/src/data/changelog/v1.1.3/stack-dependency-mock-outputs.mdx
+++ b/docs/src/data/changelog/v1.1.3/stack-dependency-mock-outputs.mdx
@@ -8,3 +8,5 @@ category: "bug-fixes"
 A `dependency` block that reads outputs from a stack (its `config_path` points at a `terragrunt.stack.hcl` directory) used to fail when a unit in that stack had no state yet, even when the dependency declared `mock_outputs`. This blocked commands like `plan` and `validate` against a stack that hadn't been applied.
 
 Such a dependency now falls back to `mock_outputs` for the units that have no state yet. In a partially applied stack, applied units resolve to their real outputs while the rest use their mocks.
+
+Mocks for a stack dependency are keyed by unit name, so `mock_outputs` has to be a map or object. Declaring it as any other type now reports that directly, instead of leaving the units it can't cover out of the stack outputs.

--- a/docs/src/data/changelog/v1.1.3/stack-dependency-mock-outputs.mdx
+++ b/docs/src/data/changelog/v1.1.3/stack-dependency-mock-outputs.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.1.2"
+version: "v1.1.3"
 category: "bug-fixes"
 ---
 

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -912,11 +912,12 @@ func collectStackUnitOutputs(
 
 		jsonBytes, err := getOutputJSONWithCaching(ctx, pctx, l, unitConfigPath)
 		if err != nil {
-			if !shouldFallBackToMockOutputs(pctx, err) {
+			if !shouldFallBackToMockOutputs(pctx, err) ||
+				!dependencyConfig.shouldReturnMockOutputs(pctx) {
 				return nil, fmt.Errorf("stack unit %s output fetch failed: %w", unit.Name, err)
 			}
 
-			if mock, ok := unitMockOutput(dependencyConfig, unit.Name, pctx); ok {
+			if mock, ok := unitMockOutput(dependencyConfig, unit.Name); ok {
 				unitOutputs[unit.Name] = mock
 				continue
 			}
@@ -951,23 +952,29 @@ func collectStackUnitOutputs(
 	return unitOutputs, nil
 }
 
-// unitMockOutput returns the mock output for a named stack unit from the dependency's mock_outputs,
-// when mocks are allowed for the current command and the unit has a mock declared. It lets a
-// partially applied stack resolve: applied units contribute real outputs while unapplied ones fall
-// back to their mock.
+// unitMockOutput returns the mock declared for a named stack unit in the dependency's mock_outputs.
+// It lets a partially applied stack resolve: applied units contribute real outputs while unapplied
+// ones fall back to their mock.
 //
-// ok is false when mocks are disallowed, absent, or not keyed by unit name.
-func unitMockOutput(dep *Dependency, unitName string, pctx *ParsingContext) (cty.Value, bool) {
-	if dep.MockOutputs == nil || !dep.shouldReturnMockOutputs(pctx) {
+// Callers are responsible for checking that mocks are allowed for the current command. ok is false
+// when mock_outputs is absent, isn't keyed by unit name, or isn't a map or object.
+func unitMockOutput(dep *Dependency, unitName string) (cty.Value, bool) {
+	if dep.MockOutputs == nil {
 		return cty.NilVal, false
 	}
 
 	mock := *dep.MockOutputs
-	if mock.IsNull() || !mock.Type().IsObjectType() || !mock.Type().HasAttribute(unitName) {
+	if mock.IsNull() || !mock.IsKnown() {
 		return cty.NilVal, false
 	}
 
-	return mock.GetAttr(unitName), true
+	if mockType := mock.Type(); !mockType.IsObjectType() && !mockType.IsMapType() {
+		return cty.NilVal, false
+	}
+
+	unitMock, ok := mock.AsValueMap()[unitName]
+
+	return unitMock, ok
 }
 
 // tryGetStackOutput checks if targetConfigPath points to a stack directory

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -855,7 +855,7 @@ func getTerragruntOutput(
 
 	jsonBytes, err := getOutputJSONWithCaching(ctx, pctx, l, targetConfigPath)
 	if err != nil {
-		if !isRenderJSONCommand(pctx) && !isRenderCommand(pctx) && !isAwsS3NoSuchKey(err) {
+		if !shouldFallBackToMockOutputs(pctx, err) {
 			return nil, true, err
 		}
 
@@ -896,6 +896,7 @@ func collectStackUnitOutputs(
 	l log.Logger,
 	stackDir string,
 	units []*Unit,
+	dependencyConfig *Dependency,
 ) (map[string]cty.Value, error) {
 	unitOutputs := make(map[string]cty.Value)
 
@@ -911,7 +912,18 @@ func collectStackUnitOutputs(
 
 		jsonBytes, err := getOutputJSONWithCaching(ctx, pctx, l, unitConfigPath)
 		if err != nil {
-			return nil, fmt.Errorf("stack unit %s output fetch failed: %w", unit.Name, err)
+			if !shouldFallBackToMockOutputs(pctx, err) {
+				return nil, fmt.Errorf("stack unit %s output fetch failed: %w", unit.Name, err)
+			}
+
+			if mock, ok := unitMockOutput(dependencyConfig, unit.Name, pctx); ok {
+				unitOutputs[unit.Name] = mock
+				continue
+			}
+
+			l.Warnf("Stack unit %s has no remote state at %s yet, skipping", unit.Name, unitConfigPath)
+
+			continue
 		}
 
 		outputMap, err := TerraformOutputJSONToCtyValueMap(unitConfigPath, jsonBytes)
@@ -933,6 +945,25 @@ func collectStackUnitOutputs(
 	}
 
 	return unitOutputs, nil
+}
+
+// unitMockOutput returns the mock output for a named stack unit from the dependency's mock_outputs,
+// when mocks are allowed for the current command and the unit has a mock declared. It lets a
+// partially applied stack resolve: applied units contribute real outputs while unapplied ones fall
+// back to their mock.
+//
+// ok is false when mocks are disallowed, absent, or not keyed by unit name.
+func unitMockOutput(dep *Dependency, unitName string, pctx *ParsingContext) (cty.Value, bool) {
+	if dep.MockOutputs == nil || !dep.shouldReturnMockOutputs(pctx) {
+		return cty.NilVal, false
+	}
+
+	mock := *dep.MockOutputs
+	if mock.IsNull() || !mock.Type().IsObjectType() || !mock.Type().HasAttribute(unitName) {
+		return cty.NilVal, false
+	}
+
+	return mock.GetAttr(unitName), true
 }
 
 // tryGetStackOutput checks if targetConfigPath points to a stack directory
@@ -979,7 +1010,7 @@ func tryGetStackOutput(
 		return nil, true, fmt.Errorf("failed to parse stack config %s: %w", stackFilePath, err)
 	}
 
-	unitOutputs, err := collectStackUnitOutputs(ctx, pctx, l, stackDir, stackConfig.Units)
+	unitOutputs, err := collectStackUnitOutputs(ctx, pctx, l, stackDir, stackConfig.Units, dependencyConfig)
 	if err != nil {
 		return nil, true, fmt.Errorf(
 			"failed to collect stack unit outputs for %s: %w",
@@ -1024,6 +1055,13 @@ func isAwsS3NoSuchKey(err error) bool {
 	}
 
 	return false
+}
+
+// shouldFallBackToMockOutputs reports whether a failed dependency output fetch should fall back to
+// mock outputs instead of being fatal: either the target's remote state doesn't exist yet (an S3
+// NoSuchKey), or the command is a render, which tolerates unresolved outputs.
+func shouldFallBackToMockOutputs(pctx *ParsingContext, err error) bool {
+	return isAwsS3NoSuchKey(err) || isRenderJSONCommand(pctx) || isRenderCommand(pctx)
 }
 
 // isRenderJSONCommand This function will true if terragrunt was invoked with render-json

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -917,7 +917,12 @@ func collectStackUnitOutputs(
 				return nil, StackUnitOutputFetchError{UnitName: unit.Name, Err: err}
 			}
 
-			if mock, ok := unitMockOutput(dependencyConfig, unit.Name); ok {
+			mock, ok, mockErr := unitMockOutput(dependencyConfig, unit.Name)
+			if mockErr != nil {
+				return nil, mockErr
+			}
+
+			if ok {
 				unitOutputs[unit.Name] = mock
 				continue
 			}
@@ -957,24 +962,30 @@ func collectStackUnitOutputs(
 // ones fall back to their mock.
 //
 // Callers are responsible for checking that mocks are allowed for the current command. ok is false
-// when mock_outputs is absent, isn't keyed by unit name, or isn't a map or object.
-func unitMockOutput(dep *Dependency, unitName string) (cty.Value, bool) {
+// when mock_outputs is absent or declares no entry for the unit. A mock_outputs that can't be keyed
+// by unit name at all is a config error rather than a missing mock, so it returns an error instead
+// of leaving the caller to drop the unit and surface the mistake as an unresolved attribute later.
+func unitMockOutput(dep *Dependency, unitName string) (cty.Value, bool, error) {
 	if dep.MockOutputs == nil {
-		return cty.NilVal, false
+		return cty.NilVal, false, nil
 	}
 
 	mock := *dep.MockOutputs
 	if mock.IsNull() || !mock.IsKnown() {
-		return cty.NilVal, false
+		return cty.NilVal, false, nil
 	}
 
 	if mockType := mock.Type(); !mockType.IsObjectType() && !mockType.IsMapType() {
-		return cty.NilVal, false
+		return cty.NilVal, false, StackMockOutputsTypeError{
+			DependencyName: dep.Name,
+			UnitName:       unitName,
+			Actual:         mockType.FriendlyName(),
+		}
 	}
 
 	unitMock, ok := mock.AsValueMap()[unitName]
 
-	return unitMock, ok
+	return unitMock, ok, nil
 }
 
 // tryGetStackOutput checks if targetConfigPath points to a stack directory

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -914,7 +914,7 @@ func collectStackUnitOutputs(
 		if err != nil {
 			if !shouldFallBackToMockOutputs(pctx, err) ||
 				!dependencyConfig.shouldReturnMockOutputs(pctx) {
-				return nil, fmt.Errorf("stack unit %s output fetch failed: %w", unit.Name, err)
+				return nil, StackUnitOutputFetchError{UnitName: unit.Name, Err: err}
 			}
 
 			if mock, ok := unitMockOutput(dependencyConfig, unit.Name); ok {

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -921,7 +921,11 @@ func collectStackUnitOutputs(
 				continue
 			}
 
-			l.Warnf("Stack unit %s has no remote state at %s yet, skipping", unit.Name, unitConfigPath)
+			l.Warnf(
+				"Stack unit %s has no remote state at %s yet, skipping",
+				unit.Name,
+				unitConfigPath,
+			)
 
 			continue
 		}
@@ -1010,7 +1014,14 @@ func tryGetStackOutput(
 		return nil, true, fmt.Errorf("failed to parse stack config %s: %w", stackFilePath, err)
 	}
 
-	unitOutputs, err := collectStackUnitOutputs(ctx, pctx, l, stackDir, stackConfig.Units, dependencyConfig)
+	unitOutputs, err := collectStackUnitOutputs(
+		ctx,
+		pctx,
+		l,
+		stackDir,
+		stackConfig.Units,
+		dependencyConfig,
+	)
 	if err != nil {
 		return nil, true, fmt.Errorf(
 			"failed to collect stack unit outputs for %s: %w",

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -302,6 +302,21 @@ func (err TerragruntOutputEncodingError) Error() string {
 	)
 }
 
+// StackUnitOutputFetchError is returned when a dependency on a stack cannot read a unit's outputs
+// and has no mock to stand in for them.
+type StackUnitOutputFetchError struct {
+	Err      error
+	UnitName string
+}
+
+func (err StackUnitOutputFetchError) Error() string {
+	return fmt.Sprintf("stack unit %s output fetch failed: %s", err.UnitName, err.Err)
+}
+
+func (err StackUnitOutputFetchError) Unwrap() error {
+	return err.Err
+}
+
 type TerragruntOutputListEncodingError struct {
 	Err   error
 	Paths []string

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -317,6 +317,23 @@ func (err StackUnitOutputFetchError) Unwrap() error {
 	return err.Err
 }
 
+// StackMockOutputsTypeError is returned when a dependency on a stack declares mock_outputs that
+// isn't keyed by unit name, so no unit can be matched against it.
+type StackMockOutputsTypeError struct {
+	DependencyName string
+	UnitName       string
+	Actual         string
+}
+
+func (err StackMockOutputsTypeError) Error() string {
+	return fmt.Sprintf(
+		"mock_outputs for dependency %s must be a map or object keyed by stack unit name (e.g. { %s = { ... } }), but got %s",
+		err.DependencyName,
+		err.UnitName,
+		err.Actual,
+	)
+}
+
 type TerragruntOutputListEncodingError struct {
 	Err   error
 	Paths []string

--- a/test/fixtures/stacks/stack-deps-stack-mock-remote-state/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-remote-state/live/terragrunt.stack.hcl
@@ -1,0 +1,29 @@
+stack "networking" {
+  source = "../stacks/networking"
+  path   = "networking"
+}
+
+unit "app" {
+  source = "../units/app"
+  path   = "app"
+
+  autoinclude {
+    dependency "networking" {
+      config_path = stack.networking.path
+
+      mock_outputs = {
+        vpc = {
+          vpc_id = "mock-vpc-id"
+        }
+        subnets = {
+          subnet_id = "mock-subnet-id"
+        }
+      }
+    }
+
+    inputs = {
+      vpc_id    = dependency.networking.outputs.vpc.vpc_id
+      subnet_id = dependency.networking.outputs.subnets.subnet_id
+    }
+  }
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-remote-state/root.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-remote-state/root.hcl
@@ -1,0 +1,9 @@
+remote_state {
+  backend = "s3"
+  config = {
+    encrypt = true
+    bucket  = "__FILL_IN_BUCKET_NAME__"
+    key     = "${path_relative_to_include()}/terraform.tfstate"
+    region  = "us-west-2"
+  }
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-remote-state/stacks/networking/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-remote-state/stacks/networking/terragrunt.stack.hcl
@@ -1,0 +1,9 @@
+unit "vpc" {
+  source = "${get_repo_root()}/units/vpc"
+  path   = "vpc"
+}
+
+unit "subnets" {
+  source = "${get_repo_root()}/units/subnets"
+  path   = "subnets"
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/app/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/app/main.tf
@@ -1,0 +1,15 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnet_id" {
+  type = string
+}
+
+output "vpc_id" {
+  value = var.vpc_id
+}
+
+output "subnet_id" {
+  value = var.subnet_id
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/app/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/app/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
 variable "vpc_id" {
   type = string
 }

--- a/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/app/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/app/terragrunt.hcl
@@ -1,0 +1,7 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/subnets/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/subnets/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
 output "subnet_id" {
   value = "real-subnet-id"
 }

--- a/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/subnets/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/subnets/main.tf
@@ -1,0 +1,3 @@
+output "subnet_id" {
+  value = "real-subnet-id"
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/subnets/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/subnets/terragrunt.hcl
@@ -1,0 +1,7 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/vpc/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/vpc/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
 output "vpc_id" {
   value = "real-vpc-id"
 }

--- a/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/vpc/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/vpc/main.tf
@@ -1,0 +1,3 @@
+output "vpc_id" {
+  value = "real-vpc-id"
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/vpc/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-remote-state/units/vpc/terragrunt.hcl
@@ -1,0 +1,7 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/live/terragrunt.stack.hcl
@@ -12,3 +12,8 @@ unit "strict" {
   source = "../units/strict"
   path   = "strict"
 }
+
+unit "malformed" {
+  source = "../units/malformed"
+  path   = "malformed"
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/live/terragrunt.stack.hcl
@@ -1,0 +1,14 @@
+stack "networking" {
+  source = "../stacks/networking"
+  path   = "networking"
+}
+
+unit "app" {
+  source = "../units/app"
+  path   = "app"
+}
+
+unit "strict" {
+  source = "../units/strict"
+  path   = "strict"
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/root.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/root.hcl
@@ -1,0 +1,24 @@
+# Store state in an S3-compatible bucket (RustFS) so a unit that hasn't been applied yet fails with
+# a genuine NoSuchKey, which is the condition the stack dependency mock fallback keys on.
+remote_state {
+  backend = "s3"
+  config = {
+    bucket                      = "__FILL_IN_BUCKET_NAME__"
+    key                         = "${path_relative_to_include()}/terraform.tfstate"
+    region                      = "us-east-1"
+    endpoint                    = "__FILL_IN_S3_ENDPOINT__"
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    force_path_style            = true
+    encrypt                     = false
+
+    # Skip AWS-specific bucket operations not supported by S3-compatible stores
+    skip_bucket_versioning             = true
+    skip_bucket_ssencryption           = true
+    skip_bucket_accesslogging          = true
+    skip_bucket_root_access            = true
+    skip_bucket_enforced_tls           = true
+    skip_bucket_public_access_blocking = true
+  }
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/stacks/networking/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/stacks/networking/terragrunt.stack.hcl
@@ -1,0 +1,9 @@
+unit "vpc" {
+  source = "${get_repo_root()}/units/vpc"
+  path   = "vpc"
+}
+
+unit "subnets" {
+  source = "${get_repo_root()}/units/subnets"
+  path   = "subnets"
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/app/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/app/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {}
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnet_id" {
+  type = string
+}
+
+output "vpc_id" {
+  value = var.vpc_id
+}
+
+output "subnet_id" {
+  value = var.subnet_id
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/app/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/app/terragrunt.hcl
@@ -1,0 +1,27 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "."
+}
+
+# tomap() keeps the mocks a map rather than an object literal, which is the form a stack dependency
+# has to accept as well: subnets has no state, so its mock only resolves if maps are honored.
+dependency "networking" {
+  config_path = "../networking"
+
+  mock_outputs = tomap({
+    vpc = {
+      id = "mock-vpc-id"
+    }
+    subnets = {
+      id = "mock-subnet-id"
+    }
+  })
+}
+
+inputs = {
+  vpc_id    = dependency.networking.outputs.vpc.id
+  subnet_id = dependency.networking.outputs.subnets.id
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/malformed/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/malformed/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
+output "id" {
+  value = "real-malformed-id"
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/malformed/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/malformed/terragrunt.hcl
@@ -1,0 +1,16 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "."
+}
+
+# The outputs are deliberately unreferenced: mock_outputs that can't be keyed by unit name has to
+# fail while the stack outputs are collected, rather than passing here and only surfacing wherever
+# the outputs happen to be read.
+dependency "networking" {
+  config_path = "../networking"
+
+  mock_outputs = "not-keyed-by-unit-name"
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/strict/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/strict/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
+output "id" {
+  value = "real-strict-id"
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/strict/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/strict/terragrunt.hcl
@@ -1,0 +1,24 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "."
+}
+
+# The outputs are deliberately unreferenced: with mocks limited to validate, plan has to fail on the
+# stack unit that has no state, rather than on an input that can't be evaluated.
+dependency "networking" {
+  config_path = "../networking"
+
+  mock_outputs = {
+    vpc = {
+      id = "mock-vpc-id"
+    }
+    subnets = {
+      id = "mock-subnet-id"
+    }
+  }
+
+  mock_outputs_allowed_terraform_commands = ["validate"]
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/subnets/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/subnets/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
+output "id" {
+  value = "real-subnet-id"
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/subnets/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/subnets/terragrunt.hcl
@@ -1,0 +1,7 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "."
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/vpc/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/vpc/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
+output "id" {
+  value = "real-vpc-id"
+}

--- a/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/vpc/terragrunt.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-mock-rustfs/units/vpc/terragrunt.hcl
@@ -1,0 +1,7 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "."
+}

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -53,6 +53,7 @@ const (
 	testFixtureAssumeRoleDuration                = "fixtures/assume-role/duration"
 	testFixtureReadIamRole                       = "fixtures/read-config/iam_role_in_file"
 	testFixtureOutputFromRemoteState             = "fixtures/output-from-remote-state"
+	testFixtureStackDepsStackMockRemoteState     = "fixtures/stacks/stack-deps-stack-mock-remote-state"
 	testFixtureOutputFromDependency              = "fixtures/output-from-dependency"
 	testFixtureS3Backend                         = "fixtures/s3-backend"
 	testFixtureS3BackendDualLocking              = "fixtures/s3-backend/dual-locking"
@@ -2671,6 +2672,71 @@ func TestAwsMockOutputsFromRemoteState(t *testing.T) { //nolint: paralleltest
 
 	assert.Contains(t, stderr, "Failed to read outputs")
 	assert.Contains(t, stderr, "fallback to mock outputs")
+}
+
+// TestAwsStackDependencyMockOutputsFromRemoteState pins that a dependency on a stack directory
+// falls back to mock_outputs when a unit in that stack has no remote state yet, instead of
+// hard-failing on the S3 NoSuchKey. The single-unit dependency path already had this fallback.
+func TestAwsStackDependencyMockOutputsFromRemoteState(t *testing.T) {
+	t.Parallel()
+
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
+	defer helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackMockRemoteState)
+	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackMockRemoteState)
+
+	rootConfigPath := filepath.Join(gitPath, "root.hcl")
+	helpers.CopyTerragruntConfigAndFillPlaceholders(
+		t,
+		rootConfigPath,
+		rootConfigPath,
+		s3BucketName,
+		"not-used",
+		"not-used",
+	)
+
+	// The networking stack sources its units via get_repo_root(), so the fixture copy must be a git repo.
+	helpers.CreateGitRepo(t, gitPath)
+
+	rootPath := filepath.Join(gitPath, "live")
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --working-dir "+rootPath)
+
+	appPath := filepath.Join(rootPath, ".terragrunt-stack", "app")
+	vpcPath := filepath.Join(rootPath, ".terragrunt-stack", "networking", ".terragrunt-stack", "vpc")
+
+	planApp := func() (string, string) {
+		stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(
+			t,
+			"terragrunt plan --dependency-fetch-output-from-state --backend-bootstrap --non-interactive --working-dir "+appPath,
+		)
+		require.NoError(
+			t,
+			err,
+			"planning the app unit must not fail on a missing stack-unit state; stderr=%s",
+			stderr,
+		)
+
+		assert.NotContains(t, stderr, "output fetch failed")
+
+		return stdout, stderr
+	}
+
+	// Nothing is applied yet, so no unit has an S3 state key.
+	stdout, _ := planApp()
+	assert.Contains(t, stdout, "mock-vpc-id", "an unapplied unit must resolve to its mock output")
+	assert.Contains(t, stdout, "mock-subnet-id", "an unapplied unit must resolve to its mock output")
+
+	// Apply only the vpc unit so the stack is partially applied.
+	helpers.RunTerragrunt(
+		t,
+		"terragrunt apply --backend-bootstrap --auto-approve --non-interactive --working-dir "+vpcPath,
+	)
+
+	stdout, _ = planApp()
+	assert.Contains(t, stdout, "real-vpc-id", "an applied unit must resolve to its real output")
+	assert.Contains(t, stdout, "mock-subnet-id", "the unapplied unit must still resolve to its mock output")
 }
 
 func TestAwsParallelStateInit(t *testing.T) {

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -2681,6 +2681,9 @@ func TestAwsStackDependencyMockOutputsFromRemoteState(t *testing.T) {
 	t.Parallel()
 
 	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
+
+	// NOTE: This probably shouldn't be necessary. Needs investigation for clean-up.
+	createS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
 	defer helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackMockRemoteState)

--- a/test/integration_rustfs_test.go
+++ b/test/integration_rustfs_test.go
@@ -102,9 +102,9 @@ func TestRustFSOutputFromRemoteState(t *testing.T) { //nolint: paralleltest
 
 // TestRustFSStackDependencyMockOutputs covers stack dependency mock resolution against a live S3
 // API, where a unit that hasn't been applied yet fails with a real NoSuchKey. It pins that a
-// map-typed mock_outputs resolves for such a unit, and that a unit whose mocks
-// mock_outputs_allowed_terraform_commands rules out for the current command fails loudly instead of
-// being dropped from the aggregated stack outputs.
+// map-typed mock_outputs resolves for such a unit, and that a unit is never dropped silently from
+// the aggregated stack outputs: neither when mock_outputs_allowed_terraform_commands rules its mocks
+// out for the current command, nor when mock_outputs can't be keyed by unit name at all.
 func TestRustFSStackDependencyMockOutputs(t *testing.T) { //nolint: paralleltest
 	rustfsAddr := setupRustFS(t)
 
@@ -189,6 +189,24 @@ func TestRustFSStackDependencyMockOutputs(t *testing.T) { //nolint: paralleltest
 		"validate is in mock_outputs_allowed_terraform_commands, so the mock must stand in; stderr=%s",
 		stderr,
 	)
+
+	malformedPath := filepath.Join(stackPath, "malformed")
+
+	_, stderr, err = helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt plan --dependency-fetch-output-from-state --backend-bootstrap --non-interactive --working-dir "+malformedPath,
+	)
+
+	var mockTypeErr config.StackMockOutputsTypeError
+
+	require.ErrorAs(
+		t,
+		err,
+		&mockTypeErr,
+		"mock_outputs that can't be keyed by unit name must fail rather than drop the unit; stderr=%s",
+		stderr,
+	)
+	assert.Equal(t, "networking", mockTypeErr.DependencyName)
 }
 
 func setupRustFS(t *testing.T) string {

--- a/test/integration_rustfs_test.go
+++ b/test/integration_rustfs_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,6 +19,7 @@ import (
 
 const (
 	testFixtureOutputFromRemoteStateRustFS = "fixtures/output-from-remote-state-rustfs"
+	testFixtureStackDepsStackMockRustFS    = "fixtures/stacks/stack-deps-stack-mock-rustfs"
 )
 
 func TestRustFSOutputFromRemoteState(t *testing.T) { //nolint: paralleltest
@@ -96,6 +98,97 @@ func TestRustFSOutputFromRemoteState(t *testing.T) { //nolint: paralleltest
 	assert.Contains(t, stdout, "app3 output")
 	assert.NotContains(t, stderr, "terraform output -json")
 	assert.NotContains(t, stderr, "tofu output -json")
+}
+
+// TestRustFSStackDependencyMockOutputs covers stack dependency mock resolution against a live S3
+// API, where a unit that hasn't been applied yet fails with a real NoSuchKey. It pins that a
+// map-typed mock_outputs resolves for such a unit, and that a unit whose mocks
+// mock_outputs_allowed_terraform_commands rules out for the current command fails loudly instead of
+// being dropped from the aggregated stack outputs.
+func TestRustFSStackDependencyMockOutputs(t *testing.T) { //nolint: paralleltest
+	rustfsAddr := setupRustFS(t)
+
+	// RustFS default credentials
+	t.Setenv("AWS_ACCESS_KEY_ID", "rustfsadmin")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "rustfsadmin")
+	t.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackMockRustFS)
+	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackMockRustFS)
+
+	rootConfigPath := filepath.Join(gitPath, "root.hcl")
+	helpers.CopyAndFillMapPlaceholders(
+		t,
+		rootConfigPath,
+		rootConfigPath,
+		map[string]string{
+			"__FILL_IN_BUCKET_NAME__": s3BucketName,
+			"__FILL_IN_S3_ENDPOINT__": rustfsAddr,
+		},
+	)
+
+	// The networking stack sources its units via get_repo_root(), so the fixture copy must be a git repo.
+	helpers.CreateGitRepo(t, gitPath)
+
+	rootPath := filepath.Join(gitPath, "live")
+
+	helpers.RunTerragrunt(t, "terragrunt stack generate --working-dir "+rootPath)
+
+	stackPath := filepath.Join(rootPath, ".terragrunt-stack")
+	vpcPath := filepath.Join(stackPath, "networking", ".terragrunt-stack", "vpc")
+
+	// Applying vpc creates the bucket, so the subnets unit that follows is missing a key rather than
+	// a bucket. Only the former is treated as "not applied yet".
+	helpers.RunTerragrunt(
+		t,
+		"terragrunt apply --backend-bootstrap --auto-approve --non-interactive --working-dir "+vpcPath,
+	)
+
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt plan --dependency-fetch-output-from-state --backend-bootstrap --non-interactive --working-dir "+filepath.Join(
+			stackPath,
+			"app",
+		),
+	)
+	require.NoError(
+		t,
+		err,
+		"a map-typed mock_outputs must resolve for the stack unit with no state; stderr=%s",
+		stderr,
+	)
+	assert.Contains(t, stdout, "real-vpc-id", "the applied unit must resolve to its real output")
+	assert.Contains(t, stdout, "mock-subnet-id", "the unapplied unit must resolve to its mock")
+
+	strictPath := filepath.Join(stackPath, "strict")
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt plan --dependency-fetch-output-from-state --backend-bootstrap --non-interactive --working-dir "+strictPath,
+	)
+
+	var fetchErr config.StackUnitOutputFetchError
+
+	require.ErrorAs(
+		t,
+		err,
+		&fetchErr,
+		"plan is not in mock_outputs_allowed_terraform_commands, so the unit with no state must not be dropped silently",
+	)
+	assert.Equal(t, "subnets", fetchErr.UnitName)
+
+	_, stderr, err = helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt validate --dependency-fetch-output-from-state --backend-bootstrap --non-interactive --working-dir "+strictPath,
+	)
+	require.NoError(
+		t,
+		err,
+		"validate is in mock_outputs_allowed_terraform_commands, so the mock must stand in; stderr=%s",
+		stderr,
+	)
 }
 
 func setupRustFS(t *testing.T) string {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6529.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stack-based dependencies now honor configured mock outputs when fetching remote-state outputs.
  * Partially applied stacks can combine real outputs with mocks for units without state.
  * Commands provide clearer errors when mocks are unavailable, restricted, or incorrectly formatted.

* **Documentation**
  * Added changelog documentation describing improved stack dependency mock-output handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->