### PR TITLE
fix: support EKS Pod Identity for S3 source downloads

### DIFF
--- a/docs/src/data/changelog/v1.1.2/s3-eks-pod-identity.mdx
+++ b/docs/src/data/changelog/v1.1.2/s3-eks-pod-identity.mdx
@@ -5,4 +5,4 @@ category: "bug-fixes"
 
 #### Fixed S3 source downloads under EKS Pod Identity
 
-Downloading unit sources from private S3 buckets (`s3::https://...`) now works when EKS Pod Identity is the only credential source. Previously, the bundled `aws-sdk-go` v1 rejected the Pod Identity Agent endpoint (`169.254.170.23`) because it only allowed loopback hosts. Bumped to `aws-sdk-go` v1.55.6, which includes the EKS/ECS container endpoint allowlist.
+Downloading unit sources from private S3 buckets (`s3::https://...`) now works when EKS Pod Identity is the only credential source. Previously, the bundled `aws-sdk-go` v1 rejected the Pod Identity Agent endpoint (`169.254.170.23`) because it only allowed loopback hosts. Terragrunt now uses `aws-sdk-go` v1.55.6, which allows the EKS and ECS container credential endpoints.

--- a/docs/src/data/changelog/v1.1.2/s3-eks-pod-identity.mdx
+++ b/docs/src/data/changelog/v1.1.2/s3-eks-pod-identity.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.2"
+category: "bug-fixes"
+---
+
+#### Fixed S3 source downloads under EKS Pod Identity
+
+Downloading unit sources from private S3 buckets (`s3::https://...`) now works when EKS Pod Identity is the only credential source. Previously, the bundled `aws-sdk-go` v1 rejected the Pod Identity Agent endpoint (`169.254.170.23`) because it only allowed loopback hosts. Bumped to `aws-sdk-go` v1.55.6, which includes the EKS/ECS container endpoint allowlist.

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.5
+	github.com/aws/aws-sdk-go v1.55.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.30
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.29
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.60.1
@@ -146,7 +147,6 @@ require (
 	github.com/apparentlymart/go-versions v1.0.3 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
-	github.com/aws/aws-sdk-go v1.44.122 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.30 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.18 // indirect

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.31.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/aws-sdk-go v1.44.122 h1:p6mw01WBaNpbdP2xrisz5tIkcNwzj/HysobNoaAHjgo=
-github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
+github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=
 github.com/aws/aws-sdk-go-v2 v1.42.1/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 h1:3IZY0XAJquT3aHzbkHfPzy4ACPcEjVG0x87KOwtpqGY=
@@ -1165,7 +1165,6 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
 golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
@@ -1238,7 +1237,6 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/getter/s3_test.go
+++ b/internal/getter/s3_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -112,8 +111,8 @@ func TestDefaultClientCanonicalizesS3SourceURLs(t *testing.T) {
 // Verifies that the SDK allows EKS and ECS container credential endpoints
 // and rejects arbitrary hosts. Uses a recording RoundTripper so no real
 // network I/O occurs and results are deterministic on any runner.
-// This is a dependency-contract test: it exercises the same session constructor
-// go-getter/s3/v2 uses to verify the aws-sdk-go v1 version pin.
+// This is a dependency-contract test: it exercises the same default credential
+// provider that go-getter/s3/v2 uses to verify the aws-sdk-go v1 version pin.
 func TestS3SessionCredentialEndpointHosts(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -185,9 +184,9 @@ func TestS3SessionCredentialEndpointHosts(t *testing.T) {
 // the SDK reads the OS filesystem directly.
 func TestS3SessionEKSPodIdentityAuthTokenFile(t *testing.T) {
 	const (
-		fakeAccessKey = "AKIAIOSFODNN7EXAMPLE"
-		fakeSecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLE"
-		fakeToken     = "FwoGZXIvYXdzEBYaDHqa0AP"
+		fakeAccessKey = "test-access-key-id"
+		fakeSecretKey = "test-secret-access-key"
+		fakeToken     = "test-session-token"
 		authToken     = "k8s-pod-identity-token-xyz"
 	)
 
@@ -232,38 +231,6 @@ func TestS3SessionEKSPodIdentityAuthTokenFile(t *testing.T) {
 	assert.Equal(t, fakeSecretKey, creds.SecretAccessKey)
 	assert.Equal(t, fakeToken, creds.SessionToken)
 	assert.Equal(t, authToken, gotAuthHeader)
-}
-
-// Verifies the full credential flow via a local httptest server serving STS-shaped credentials.
-func TestS3SessionRetrievesCredsFromLocalEndpoint(t *testing.T) {
-	const (
-		fakeAccessKey = "AKIAIOSFODNN7EXAMPLE"
-		fakeSecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLE"
-		fakeToken     = "FwoGZXIvYXdzEBYaDHqa0AP"
-	)
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"AccessKeyId":     fakeAccessKey,
-			"SecretAccessKey": fakeSecretKey,
-			"Token":           fakeToken,
-			"Expiration":      time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
-		})
-	}))
-	t.Cleanup(srv.Close)
-
-	suppressAWSEnv(t)
-	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", srv.URL+"/v1/credentials")
-
-	sess, err := session.NewSession(&aws.Config{Region: aws.String("us-east-1")})
-	require.NoError(t, err)
-
-	creds, err := sess.Config.Credentials.Get()
-	require.NoError(t, err)
-	assert.Equal(t, fakeAccessKey, creds.AccessKeyID)
-	assert.Equal(t, fakeSecretKey, creds.SecretAccessKey)
-	assert.Equal(t, fakeToken, creds.SessionToken)
 }
 
 // suppressAWSEnv neutralizes all AWS credential env vars the SDK v1 chain inspects.

--- a/internal/getter/s3_test.go
+++ b/internal/getter/s3_test.go
@@ -2,14 +2,15 @@ package getter_test
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	gogetter "github.com/hashicorp/go-getter/v2"
@@ -17,17 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDefaultClientCanonicalizesS3SourceURLs pins that `s3::https://`
-// sources work in every AWS S3 endpoint form, including the
-// virtual-hosted style (`<bucket>.s3.<region>.amazonaws.com`) AWS
-// documents as canonical. The upstream go-getter/s3/v2 getter only
-// parses path-style hostnames (`s3.amazonaws.com`,
-// `s3-<region>.amazonaws.com`), so whichever getter claims the request
-// must canonicalize req.Src at Detect time: Client.Get re-parses
-// req.Src after detection into the URL the fetch uses.
-//
-// The test mirrors the outer client's getter-selection loop instead of
-// calling Client.Get so no network I/O happens.
+// TestDefaultClientCanonicalizesS3SourceURLs verifies S3 URL canonicalization across all AWS endpoint forms.
 func TestDefaultClientCanonicalizesS3SourceURLs(t *testing.T) {
 	t.Parallel()
 
@@ -93,86 +84,14 @@ func TestDefaultClientCanonicalizesS3SourceURLs(t *testing.T) {
 
 			u, err := url.Parse(req.Src)
 			require.NoError(t, err)
-			assert.Equal(
-				t,
-				tt.wantHost,
-				u.Host,
-				"Detect must canonicalize to a path-style host the bare go-getter/s3 v2 getter accepts",
-			)
+			assert.Equal(t, tt.wantHost, u.Host)
 			assert.Equal(t, tt.wantPath, u.Path)
 		})
 	}
 }
 
-// suppressAWSEnv clears all environment variables that the aws-sdk-go
-// v1 default credential chain inspects, ensuring the session falls
-// through to the container credential endpoint provider (set via
-// AWS_CONTAINER_CREDENTIALS_FULL_URI) or fails with no credentials.
-func suppressAWSEnv(t *testing.T) {
-	t.Helper()
-
-	for _, key := range []string{
-		"AWS_ACCESS_KEY_ID",
-		"AWS_SECRET_ACCESS_KEY",
-		"AWS_SESSION_TOKEN",
-		"AWS_SHARED_CREDENTIALS_FILE",
-		"AWS_CONFIG_FILE",
-		"AWS_METADATA_URL",
-		"AWS_PROFILE",
-		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
-		"AWS_EC2_METADATA_DISABLED",
-	} {
-		t.Setenv(key, "")
-	}
-
-	// Point shared config at /dev/null so no stale file is read.
-	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/dev/null")
-	t.Setenv("AWS_CONFIG_FILE", "/dev/null")
-	// Disable IMDS so the chain doesn't hang trying the EC2
-	// metadata service in a non-EC2 environment.
-	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
-}
-
-// newShortTimeoutSession creates an aws-sdk-go v1 session with a very
-// short HTTP timeout so tests that verify credential endpoint
-// acceptance don't hang waiting for unreachable endpoints
-// (169.254.170.x). CredentialsChainVerboseErrors is enabled so the
-// per-provider error messages (including endpoint host rejections)
-// surface in the final error string. The timeout only affects the HTTP
-// round-trip, not session construction or provider chain building.
-func newShortTimeoutSession(t *testing.T) *session.Session {
-	t.Helper()
-
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-east-1"),
-		HTTPClient: &http.Client{
-			Timeout: 200 * time.Millisecond,
-		},
-		CredentialsChainVerboseErrors: aws.Bool(true),
-	})
-	require.NoError(t, err)
-
-	return sess
-}
-
-// TestS3SessionCredentialEndpointHosts verifies that the aws-sdk-go v1
-// session — the same code path go-getter/s3/v2.Getter.newS3Client uses —
-// accepts EKS Pod Identity and ECS container credential endpoints while
-// rejecting arbitrary hosts.
-//
-// This is a regression test for github.com/gruntwork-io/terragrunt/issues/6450:
-// aws-sdk-go v1.44.122 rejected the EKS Pod Identity Agent endpoint
-// (169.254.170.23) because its isLoopbackHost check only allowed
-// 127.0.0.1. The fix bumps aws-sdk-go v1 to >= v1.47.11 which adds
-// the EKS/ECS container IPs to the allowlist.
-//
-// No AWS credentials or network connectivity are required. The test
-// verifies only the host validation in the credential provider chain,
-// not the actual credential retrieval.
-//
-// Cannot use t.Parallel because t.Setenv modifies process-global
-// environment variables. The subtests run sequentially for the same
-// reason.
+// Regression test for #6450: aws-sdk-go v1.44.122 rejected 169.254.170.23 (EKS Pod Identity).
+// Uses a recording RoundTripper — no real network I/O, deterministic on any runner.
 func TestS3SessionCredentialEndpointHosts(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -180,17 +99,17 @@ func TestS3SessionCredentialEndpointHosts(t *testing.T) {
 		wantReject bool
 	}{
 		{
-			name:       "EKS Pod Identity IPv4 endpoint accepted",
+			name:       "EKS Pod Identity IPv4 accepted",
 			endpoint:   "http://169.254.170.23/v1/credentials",
 			wantReject: false,
 		},
 		{
-			name:       "ECS container IPv4 endpoint accepted",
+			name:       "ECS container IPv4 accepted",
 			endpoint:   "http://169.254.170.2/v1/credentials",
 			wantReject: false,
 		},
 		{
-			name:       "loopback endpoint accepted",
+			name:       "loopback accepted",
 			endpoint:   "http://127.0.0.1/v1/credentials",
 			wantReject: false,
 		},
@@ -200,7 +119,7 @@ func TestS3SessionCredentialEndpointHosts(t *testing.T) {
 			wantReject: true,
 		},
 		{
-			name:       "arbitrary private IP 10.x rejected",
+			name:       "arbitrary 10.x IP rejected",
 			endpoint:   "http://10.0.0.1/v1/credentials",
 			wantReject: true,
 		},
@@ -211,38 +130,33 @@ func TestS3SessionCredentialEndpointHosts(t *testing.T) {
 			suppressAWSEnv(t)
 			t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", tt.endpoint)
 
-			sess := newShortTimeoutSession(t)
+			var called atomic.Bool
 
-			// Attempt to retrieve credentials. The session builds a
-			// credential chain; Get walks it. We care about whether
-			// the host was rejected statically (ErrorProvider), not
-			// whether the endpoint responded.
-			_, err := sess.Config.Credentials.Get()
-			require.Error(t, err, "credential retrieval should fail (no real endpoint)")
+			sess, err := session.NewSession(&aws.Config{
+				Region: aws.String("us-east-1"),
+				HTTPClient: &http.Client{
+					Transport: recordingTransport(&called),
+				},
+				CredentialsChainVerboseErrors: aws.Bool(true),
+				MaxRetries:                    aws.Int(0),
+			})
+			require.NoError(t, err)
 
-			// The rejection message in v1.44.122 is "only loopback hosts
-			// are allowed"; in v1.55.6 it's "only loopback/ecs/eks hosts
-			// are allowed". Both contain "only loopback".
-			const rejectMsg = "only loopback"
+			_, credErr := sess.Config.Credentials.Get()
+
 			if tt.wantReject {
-				assert.Contains(t, err.Error(), rejectMsg,
-					"arbitrary hosts must be rejected by the SDK credential chain")
-			} else {
-				assert.NotContains(t, err.Error(), rejectMsg,
-					"EKS/ECS/loopback hosts must NOT be rejected by the SDK credential chain")
+				assert.False(t, called.Load(), "transport must NOT be invoked for rejected hosts")
+				require.Error(t, credErr)
+
+				return
 			}
+
+			assert.True(t, called.Load(), "transport must be invoked for accepted hosts")
 		})
 	}
 }
 
-// TestS3SessionRetrievesCredsFromLocalEndpoint verifies the full
-// credential flow: an httptest server on loopback returns STS-shaped
-// credentials via AWS_CONTAINER_CREDENTIALS_FULL_URI, and a session
-// created the same way go-getter/s3/v2 does it picks them up. This
-// exercises the happy path without touching any real AWS endpoint.
-//
-// Cannot use t.Parallel because t.Setenv modifies process-global
-// environment variables.
+// Verifies the full credential flow via a local httptest server serving STS-shaped credentials.
 func TestS3SessionRetrievesCredsFromLocalEndpoint(t *testing.T) {
 	const (
 		fakeAccessKey = "AKIAIOSFODNN7EXAMPLE"
@@ -250,60 +164,12 @@ func TestS3SessionRetrievesCredsFromLocalEndpoint(t *testing.T) {
 		fakeToken     = "FwoGZXIvYXdzEBYaDHqa0AP"
 	)
 
-	// STS-shaped credential response the SDK expects from a container
-	// credential endpoint.
-	credsResponse := map[string]any{
-		"AccessKeyId":     fakeAccessKey,
-		"SecretAccessKey": fakeSecretKey,
-		"Token":           fakeToken,
-		"Expiration":      time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
-	}
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(credsResponse)
-	}))
-	t.Cleanup(srv.Close)
-
-	suppressAWSEnv(t)
-	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", srv.URL+"/v1/credentials")
-
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-east-1"),
-	})
-	require.NoError(t, err)
-
-	creds, err := sess.Config.Credentials.Get()
-	require.NoError(t, err)
-
-	assert.Equal(t, fakeAccessKey, creds.AccessKeyID)
-	assert.Equal(t, fakeSecretKey, creds.SecretAccessKey)
-	assert.Equal(t, fakeToken, creds.SessionToken)
-}
-
-// TestS3SessionEnvCredsPreemptEndpoint verifies the credential chain
-// precedence: when AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are set
-// (the workaround described in issue #6450), the environment provider
-// wins over the container endpoint provider. This confirms both the
-// workaround and the credential chain ordering.
-//
-// Cannot use t.Parallel because t.Setenv modifies process-global
-// environment variables.
-func TestS3SessionEnvCredsPreemptEndpoint(t *testing.T) {
-	const (
-		envAccessKey = "AKIAENVOVERRIDE"
-		envSecretKey = "envSecretOverride"
-	)
-
-	// The endpoint returns different credentials than the env vars.
-	// We never expect the endpoint to be called, but serve it just in
-	// case so we can distinguish which source won.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"AccessKeyId":     "AKIANOTTHISONE",
-			"SecretAccessKey": "notThisSecret",
-			"Token":           "notThisToken",
+			"AccessKeyId":     fakeAccessKey,
+			"SecretAccessKey": fakeSecretKey,
+			"Token":           fakeToken,
 			"Expiration":      time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
 		})
 	}))
@@ -311,40 +177,51 @@ func TestS3SessionEnvCredsPreemptEndpoint(t *testing.T) {
 
 	suppressAWSEnv(t)
 	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", srv.URL+"/v1/credentials")
-	t.Setenv("AWS_ACCESS_KEY_ID", envAccessKey)
-	t.Setenv("AWS_SECRET_ACCESS_KEY", envSecretKey)
 
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-east-1"),
-	})
+	sess, err := session.NewSession(&aws.Config{Region: aws.String("us-east-1")})
 	require.NoError(t, err)
 
 	creds, err := sess.Config.Credentials.Get()
 	require.NoError(t, err)
-
-	assert.Equal(t, envAccessKey, creds.AccessKeyID,
-		"env provider must win over container endpoint provider")
-	assert.Equal(t, envSecretKey, creds.SecretAccessKey)
+	assert.Equal(t, fakeAccessKey, creds.AccessKeyID)
+	assert.Equal(t, fakeSecretKey, creds.SecretAccessKey)
+	assert.Equal(t, fakeToken, creds.SessionToken)
 }
 
-// TestS3SessionNoCredsDoesNotPanic verifies that creating a session
-// with no credential source at all (no env vars, no shared config, no
-// IMDS) does not panic and returns a clear error on credential
-// retrieval. This covers the fallthrough in go-getter's credential
-// chain when running outside AWS entirely.
-//
-// Cannot use t.Parallel because t.Setenv modifies process-global
-// environment variables.
-func TestS3SessionNoCredsDoesNotPanic(t *testing.T) {
-	suppressAWSEnv(t)
-	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "")
+// suppressAWSEnv neutralizes all AWS credential env vars the SDK v1 chain inspects.
+func suppressAWSEnv(t *testing.T) {
+	t.Helper()
 
-	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String("us-east-1"),
-		Credentials: credentials.NewChainCredentials([]credentials.Provider{&credentials.EnvProvider{}}),
+	for _, key := range []string{
+		"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+		"AWS_ACCESS_KEY", "AWS_SECRET_KEY",
+		"AWS_PROFILE", "AWS_DEFAULT_PROFILE",
+		"AWS_SDK_LOAD_CONFIG",
+		"AWS_METADATA_URL",
+		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+		"AWS_CONTAINER_CREDENTIALS_FULL_URI",
+		"AWS_CONTAINER_AUTHORIZATION_TOKEN",
+		"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+		"AWS_WEB_IDENTITY_TOKEN_FILE",
+		"AWS_ROLE_ARN",
+		"AWS_ROLE_SESSION_NAME",
+	} {
+		t.Setenv(key, "")
+	}
+
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/dev/null")
+	t.Setenv("AWS_CONFIG_FILE", "/dev/null")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+}
+
+// recordingTransport returns a RoundTripper that records whether it was called and returns a sentinel error.
+func recordingTransport(called *atomic.Bool) http.RoundTripper {
+	return roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		called.Store(true)
+		return nil, errors.New("sentinel: transport invoked")
 	})
-	require.NoError(t, err)
-
-	_, err = sess.Config.Credentials.Get()
-	require.Error(t, err, "should fail with no credentials available")
 }
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }

--- a/internal/getter/s3_test.go
+++ b/internal/getter/s3_test.go
@@ -1,9 +1,16 @@
 package getter_test
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	gogetter "github.com/hashicorp/go-getter/v2"
 	"github.com/stretchr/testify/assert"
@@ -95,4 +102,249 @@ func TestDefaultClientCanonicalizesS3SourceURLs(t *testing.T) {
 			assert.Equal(t, tt.wantPath, u.Path)
 		})
 	}
+}
+
+// suppressAWSEnv clears all environment variables that the aws-sdk-go
+// v1 default credential chain inspects, ensuring the session falls
+// through to the container credential endpoint provider (set via
+// AWS_CONTAINER_CREDENTIALS_FULL_URI) or fails with no credentials.
+func suppressAWSEnv(t *testing.T) {
+	t.Helper()
+
+	for _, key := range []string{
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AWS_SHARED_CREDENTIALS_FILE",
+		"AWS_CONFIG_FILE",
+		"AWS_METADATA_URL",
+		"AWS_PROFILE",
+		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+		"AWS_EC2_METADATA_DISABLED",
+	} {
+		t.Setenv(key, "")
+	}
+
+	// Point shared config at /dev/null so no stale file is read.
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/dev/null")
+	t.Setenv("AWS_CONFIG_FILE", "/dev/null")
+	// Disable IMDS so the chain doesn't hang trying the EC2
+	// metadata service in a non-EC2 environment.
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+}
+
+// newShortTimeoutSession creates an aws-sdk-go v1 session with a very
+// short HTTP timeout so tests that verify credential endpoint
+// acceptance don't hang waiting for unreachable endpoints
+// (169.254.170.x). CredentialsChainVerboseErrors is enabled so the
+// per-provider error messages (including endpoint host rejections)
+// surface in the final error string. The timeout only affects the HTTP
+// round-trip, not session construction or provider chain building.
+func newShortTimeoutSession(t *testing.T) *session.Session {
+	t.Helper()
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-east-1"),
+		HTTPClient: &http.Client{
+			Timeout: 200 * time.Millisecond,
+		},
+		CredentialsChainVerboseErrors: aws.Bool(true),
+	})
+	require.NoError(t, err)
+
+	return sess
+}
+
+// TestS3SessionCredentialEndpointHosts verifies that the aws-sdk-go v1
+// session — the same code path go-getter/s3/v2.Getter.newS3Client uses —
+// accepts EKS Pod Identity and ECS container credential endpoints while
+// rejecting arbitrary hosts.
+//
+// This is a regression test for github.com/gruntwork-io/terragrunt/issues/6450:
+// aws-sdk-go v1.44.122 rejected the EKS Pod Identity Agent endpoint
+// (169.254.170.23) because its isLoopbackHost check only allowed
+// 127.0.0.1. The fix bumps aws-sdk-go v1 to >= v1.47.11 which adds
+// the EKS/ECS container IPs to the allowlist.
+//
+// No AWS credentials or network connectivity are required. The test
+// verifies only the host validation in the credential provider chain,
+// not the actual credential retrieval.
+//
+// Cannot use t.Parallel because t.Setenv modifies process-global
+// environment variables. The subtests run sequentially for the same
+// reason.
+func TestS3SessionCredentialEndpointHosts(t *testing.T) {
+	tests := []struct {
+		name       string
+		endpoint   string
+		wantReject bool
+	}{
+		{
+			name:       "EKS Pod Identity IPv4 endpoint accepted",
+			endpoint:   "http://169.254.170.23/v1/credentials",
+			wantReject: false,
+		},
+		{
+			name:       "ECS container IPv4 endpoint accepted",
+			endpoint:   "http://169.254.170.2/v1/credentials",
+			wantReject: false,
+		},
+		{
+			name:       "loopback endpoint accepted",
+			endpoint:   "http://127.0.0.1/v1/credentials",
+			wantReject: false,
+		},
+		{
+			name:       "arbitrary private IP rejected",
+			endpoint:   "http://192.168.1.1/v1/credentials",
+			wantReject: true,
+		},
+		{
+			name:       "arbitrary private IP 10.x rejected",
+			endpoint:   "http://10.0.0.1/v1/credentials",
+			wantReject: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suppressAWSEnv(t)
+			t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", tt.endpoint)
+
+			sess := newShortTimeoutSession(t)
+
+			// Attempt to retrieve credentials. The session builds a
+			// credential chain; Get walks it. We care about whether
+			// the host was rejected statically (ErrorProvider), not
+			// whether the endpoint responded.
+			_, err := sess.Config.Credentials.Get()
+			require.Error(t, err, "credential retrieval should fail (no real endpoint)")
+
+			// The rejection message in v1.44.122 is "only loopback hosts
+			// are allowed"; in v1.55.6 it's "only loopback/ecs/eks hosts
+			// are allowed". Both contain "only loopback".
+			const rejectMsg = "only loopback"
+			if tt.wantReject {
+				assert.Contains(t, err.Error(), rejectMsg,
+					"arbitrary hosts must be rejected by the SDK credential chain")
+			} else {
+				assert.NotContains(t, err.Error(), rejectMsg,
+					"EKS/ECS/loopback hosts must NOT be rejected by the SDK credential chain")
+			}
+		})
+	}
+}
+
+// TestS3SessionRetrievesCredsFromLocalEndpoint verifies the full
+// credential flow: an httptest server on loopback returns STS-shaped
+// credentials via AWS_CONTAINER_CREDENTIALS_FULL_URI, and a session
+// created the same way go-getter/s3/v2 does it picks them up. This
+// exercises the happy path without touching any real AWS endpoint.
+//
+// Cannot use t.Parallel because t.Setenv modifies process-global
+// environment variables.
+func TestS3SessionRetrievesCredsFromLocalEndpoint(t *testing.T) {
+	const (
+		fakeAccessKey = "AKIAIOSFODNN7EXAMPLE"
+		fakeSecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLE"
+		fakeToken     = "FwoGZXIvYXdzEBYaDHqa0AP"
+	)
+
+	// STS-shaped credential response the SDK expects from a container
+	// credential endpoint.
+	credsResponse := map[string]any{
+		"AccessKeyId":     fakeAccessKey,
+		"SecretAccessKey": fakeSecretKey,
+		"Token":           fakeToken,
+		"Expiration":      time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(credsResponse)
+	}))
+	t.Cleanup(srv.Close)
+
+	suppressAWSEnv(t)
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", srv.URL+"/v1/credentials")
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-east-1"),
+	})
+	require.NoError(t, err)
+
+	creds, err := sess.Config.Credentials.Get()
+	require.NoError(t, err)
+
+	assert.Equal(t, fakeAccessKey, creds.AccessKeyID)
+	assert.Equal(t, fakeSecretKey, creds.SecretAccessKey)
+	assert.Equal(t, fakeToken, creds.SessionToken)
+}
+
+// TestS3SessionEnvCredsPreemptEndpoint verifies the credential chain
+// precedence: when AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are set
+// (the workaround described in issue #6450), the environment provider
+// wins over the container endpoint provider. This confirms both the
+// workaround and the credential chain ordering.
+//
+// Cannot use t.Parallel because t.Setenv modifies process-global
+// environment variables.
+func TestS3SessionEnvCredsPreemptEndpoint(t *testing.T) {
+	const (
+		envAccessKey = "AKIAENVOVERRIDE"
+		envSecretKey = "envSecretOverride"
+	)
+
+	// The endpoint returns different credentials than the env vars.
+	// We never expect the endpoint to be called, but serve it just in
+	// case so we can distinguish which source won.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"AccessKeyId":     "AKIANOTTHISONE",
+			"SecretAccessKey": "notThisSecret",
+			"Token":           "notThisToken",
+			"Expiration":      time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	suppressAWSEnv(t)
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", srv.URL+"/v1/credentials")
+	t.Setenv("AWS_ACCESS_KEY_ID", envAccessKey)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", envSecretKey)
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-east-1"),
+	})
+	require.NoError(t, err)
+
+	creds, err := sess.Config.Credentials.Get()
+	require.NoError(t, err)
+
+	assert.Equal(t, envAccessKey, creds.AccessKeyID,
+		"env provider must win over container endpoint provider")
+	assert.Equal(t, envSecretKey, creds.SecretAccessKey)
+}
+
+// TestS3SessionNoCredsDoesNotPanic verifies that creating a session
+// with no credential source at all (no env vars, no shared config, no
+// IMDS) does not panic and returns a clear error on credential
+// retrieval. This covers the fallthrough in go-getter's credential
+// chain when running outside AWS entirely.
+//
+// Cannot use t.Parallel because t.Setenv modifies process-global
+// environment variables.
+func TestS3SessionNoCredsDoesNotPanic(t *testing.T) {
+	suppressAWSEnv(t)
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "")
+
+	sess, err := session.NewSession(&aws.Config{
+		Region:      aws.String("us-east-1"),
+		Credentials: credentials.NewChainCredentials([]credentials.Provider{&credentials.EnvProvider{}}),
+	})
+	require.NoError(t, err)
+
+	_, err = sess.Config.Credentials.Get()
+	require.Error(t, err, "should fail with no credentials available")
 }

--- a/internal/getter/s3_test.go
+++ b/internal/getter/s3_test.go
@@ -1,11 +1,15 @@
 package getter_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -18,7 +22,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDefaultClientCanonicalizesS3SourceURLs verifies S3 URL canonicalization across all AWS endpoint forms.
+// TestDefaultClientCanonicalizesS3SourceURLs pins that `s3::https://`
+// sources work in every AWS S3 endpoint form, including the
+// virtual-hosted style (`<bucket>.s3.<region>.amazonaws.com`) AWS
+// documents as canonical. The upstream go-getter/s3/v2 getter only
+// parses path-style hostnames (`s3.amazonaws.com`,
+// `s3-<region>.amazonaws.com`), so whichever getter claims the request
+// must canonicalize req.Src at Detect time: Client.Get re-parses
+// req.Src after detection into the URL the fetch uses.
+//
+// The test mirrors the outer client's getter-selection loop instead of
+// calling Client.Get so no network I/O happens.
 func TestDefaultClientCanonicalizesS3SourceURLs(t *testing.T) {
 	t.Parallel()
 
@@ -84,14 +98,22 @@ func TestDefaultClientCanonicalizesS3SourceURLs(t *testing.T) {
 
 			u, err := url.Parse(req.Src)
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantHost, u.Host)
+			assert.Equal(
+				t,
+				tt.wantHost,
+				u.Host,
+				"Detect must canonicalize to a path-style host the bare go-getter/s3 v2 getter accepts",
+			)
 			assert.Equal(t, tt.wantPath, u.Path)
 		})
 	}
 }
 
-// Regression test for #6450: aws-sdk-go v1.44.122 rejected 169.254.170.23 (EKS Pod Identity).
-// Uses a recording RoundTripper — no real network I/O, deterministic on any runner.
+// Verifies that the SDK allows EKS and ECS container credential endpoints
+// and rejects arbitrary hosts. Uses a recording RoundTripper so no real
+// network I/O occurs and results are deterministic on any runner.
+// This is a dependency-contract test: it exercises the same session constructor
+// go-getter/s3/v2 uses to verify the aws-sdk-go v1 version pin.
 func TestS3SessionCredentialEndpointHosts(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -156,6 +178,62 @@ func TestS3SessionCredentialEndpointHosts(t *testing.T) {
 	}
 }
 
+// Verifies the full EKS Pod Identity credential flow: endpoint acceptance,
+// authorization-token-file loading, header propagation, and response decoding.
+// Uses a recording RoundTripper against the EKS endpoint IP so no real
+// request reaches 169.254.170.23. The token file is a real temp file because
+// the SDK reads the OS filesystem directly.
+func TestS3SessionEKSPodIdentityAuthTokenFile(t *testing.T) {
+	const (
+		fakeAccessKey = "AKIAIOSFODNN7EXAMPLE"
+		fakeSecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLE"
+		fakeToken     = "FwoGZXIvYXdzEBYaDHqa0AP"
+		authToken     = "k8s-pod-identity-token-xyz"
+	)
+
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte(authToken), 0o600))
+
+	suppressAWSEnv(t)
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "http://169.254.170.23/v1/credentials")
+	t.Setenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", tokenFile)
+
+	credsJSON, err := json.Marshal(map[string]any{
+		"AccessKeyId":     fakeAccessKey,
+		"SecretAccessKey": fakeSecretKey,
+		"Token":           fakeToken,
+		"Expiration":      time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+	})
+	require.NoError(t, err)
+
+	var gotAuthHeader string
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-east-1"),
+		HTTPClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				gotAuthHeader = req.Header.Get("Authorization")
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": {"application/json"}},
+					Body:       io.NopCloser(bytes.NewReader(credsJSON)),
+				}, nil
+			}),
+		},
+		MaxRetries: aws.Int(0),
+	})
+	require.NoError(t, err)
+
+	creds, err := sess.Config.Credentials.Get()
+	require.NoError(t, err)
+
+	assert.Equal(t, fakeAccessKey, creds.AccessKeyID)
+	assert.Equal(t, fakeSecretKey, creds.SecretAccessKey)
+	assert.Equal(t, fakeToken, creds.SessionToken)
+	assert.Equal(t, authToken, gotAuthHeader)
+}
+
 // Verifies the full credential flow via a local httptest server serving STS-shaped credentials.
 func TestS3SessionRetrievesCredsFromLocalEndpoint(t *testing.T) {
 	const (
@@ -218,9 +296,12 @@ func suppressAWSEnv(t *testing.T) {
 func recordingTransport(called *atomic.Bool) http.RoundTripper {
 	return roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 		called.Store(true)
-		return nil, errors.New("sentinel: transport invoked")
+
+		return nil, errTransportSentinel
 	})
 }
+
+var errTransportSentinel = errors.New("sentinel: transport invoked")
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

- Pin github.com/aws/aws-sdk-go to v1.55.6 so the S3 getter accepts EKS Pod Identity and ECS container credential endpoints
- Add hermetic coverage for accepted EKS, ECS, and loopback credential hosts
- Verify that arbitrary private-network credential hosts remain rejected

Close: #6450

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed downloads from private S3 buckets when EKS Pod Identity is the only available credential source.
  * Added support for EKS Pod Identity credential endpoints and authorization token handling.

* **Documentation**
  * Added a v1.1.2 changelog entry describing the S3 download fix.

* **Tests**
  * Added coverage for valid credential endpoints and end-to-end EKS Pod Identity authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->