### PR TITLE
fix: Fixing issue where dependency mock outputs aren't used when bootstrapping hasn't run yet.

### DIFF
--- a/docs/src/data/changelog/v1.1.2/dependency-mock-outputs-missing-bucket.mdx
+++ b/docs/src/data/changelog/v1.1.2/dependency-mock-outputs-missing-bucket.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.2"
+category: "bug-fixes"
+---
+
+#### Dependency `mock_outputs` apply when the state bucket doesn't exist yet
+
+When reading a dependency's outputs directly from remote state (`--dependency-fetch-output-from-state`), Terragrunt fell back to `mock_outputs` only when the state object was missing, not when the S3 bucket itself didn't exist. A `dependency` on an environment that hadn't been bootstrapped yet would fail instead of using its mocks.
+
+A missing bucket is now treated the same as a missing state object, so commands like `plan` and `validate` can resolve mocks before the dependency's backend has been created.

--- a/docs/src/data/changelog/v1.1.3/dependency-mock-outputs-missing-bucket.mdx
+++ b/docs/src/data/changelog/v1.1.3/dependency-mock-outputs-missing-bucket.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.3"
+category: "bug-fixes"
+---
+
+#### Dependency `mock_outputs` apply when the state bucket doesn't exist yet
+
+When reading a dependency's outputs directly from remote state (`--dependency-fetch-output-from-state`), Terragrunt fell back to `mock_outputs` only when the state object was missing, not when the S3 bucket itself didn't exist. A `dependency` on an environment that hadn't been bootstrapped yet would fail instead of using its mocks.
+
+A missing bucket is now treated the same as a missing state object, so commands like `plan` and `validate` can resolve mocks before the dependency's backend has been created.

--- a/docs/src/data/changelog/v1.1.3/dependency-mock-outputs-missing-bucket.mdx
+++ b/docs/src/data/changelog/v1.1.3/dependency-mock-outputs-missing-bucket.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.1.2"
+version: "v1.1.3"
 category: "bug-fixes"
 ---
 

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
 	"github.com/gruntwork-io/terragrunt/internal/awshelper"
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
@@ -1077,20 +1079,30 @@ func resolveStackFilePath(rawConfigPath, targetConfigPath string) (string, bool)
 	}
 }
 
-func isAwsS3NoSuchKey(err error) bool {
-	if err != nil {
-		errStr := err.Error()
-		return strings.Contains(errStr, "NoSuchKey") || strings.Contains(errStr, "NotFound")
+// isAwsS3StateMissing reports whether err means the dependency's S3 state object or bucket doesn't
+// exist yet, the signal to fall back to mock outputs. It matches on the error code because GetObject
+// returns NoSuchBucket as a generic API error, not a *s3types.NoSuchBucket that errors.As could
+// match; AWS SDK v2 exposes no constants for the codes.
+func isAwsS3StateMissing(err error) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
 	}
 
-	return false
+	switch apiErr.ErrorCode() {
+	case "NoSuchKey", "NoSuchBucket", "NotFound":
+		return true
+	default:
+		return false
+	}
 }
 
 // shouldFallBackToMockOutputs reports whether a failed dependency output fetch should fall back to
-// mock outputs instead of being fatal: either the target's remote state doesn't exist yet (an S3
-// NoSuchKey), or the command is a render, which tolerates unresolved outputs.
+// mock outputs instead of being fatal: either the target's remote state doesn't exist yet (a
+// missing S3 state object or bucket), or the command is a render, which tolerates unresolved
+// outputs.
 func shouldFallBackToMockOutputs(pctx *ParsingContext, err error) bool {
-	return isAwsS3NoSuchKey(err) || isRenderJSONCommand(pctx) || isRenderCommand(pctx)
+	return isAwsS3StateMissing(err) || isRenderJSONCommand(pctx) || isRenderCommand(pctx)
 }
 
 // isRenderJSONCommand This function will true if terragrunt was invoked with render-json

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
 	"github.com/gruntwork-io/terragrunt/internal/awshelper"
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
@@ -1077,21 +1079,22 @@ func resolveStackFilePath(rawConfigPath, targetConfigPath string) (string, bool)
 	}
 }
 
-// isAwsS3StateMissing reports whether err means the dependency's S3 remote state isn't there yet:
-// the state object (NoSuchKey / NotFound) or the whole bucket (NoSuchBucket). Both are the "not
-// applied yet" signal that lets a dependency fall back to mock outputs, the latter covering a
-// dependency on an environment whose state bucket hasn't been bootstrapped. A permissions or
-// connectivity failure is not this, and stays fatal.
+// isAwsS3StateMissing reports whether err means the dependency's S3 state object or bucket doesn't
+// exist yet, the signal to fall back to mock outputs. It matches on the error code because GetObject
+// returns NoSuchBucket as a generic API error, not a *s3types.NoSuchBucket that errors.As could
+// match; AWS SDK v2 exposes no constants for the codes.
 func isAwsS3StateMissing(err error) bool {
-	if err == nil {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
 		return false
 	}
 
-	errStr := err.Error()
-
-	return strings.Contains(errStr, "NoSuchKey") ||
-		strings.Contains(errStr, "NoSuchBucket") ||
-		strings.Contains(errStr, "NotFound")
+	switch apiErr.ErrorCode() {
+	case "NoSuchKey", "NoSuchBucket", "NotFound":
+		return true
+	default:
+		return false
+	}
 }
 
 // shouldFallBackToMockOutputs reports whether a failed dependency output fetch should fall back to

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1077,20 +1077,29 @@ func resolveStackFilePath(rawConfigPath, targetConfigPath string) (string, bool)
 	}
 }
 
-func isAwsS3NoSuchKey(err error) bool {
-	if err != nil {
-		errStr := err.Error()
-		return strings.Contains(errStr, "NoSuchKey") || strings.Contains(errStr, "NotFound")
+// isAwsS3StateMissing reports whether err means the dependency's S3 remote state isn't there yet:
+// the state object (NoSuchKey / NotFound) or the whole bucket (NoSuchBucket). Both are the "not
+// applied yet" signal that lets a dependency fall back to mock outputs, the latter covering a
+// dependency on an environment whose state bucket hasn't been bootstrapped. A permissions or
+// connectivity failure is not this, and stays fatal.
+func isAwsS3StateMissing(err error) bool {
+	if err == nil {
+		return false
 	}
 
-	return false
+	errStr := err.Error()
+
+	return strings.Contains(errStr, "NoSuchKey") ||
+		strings.Contains(errStr, "NoSuchBucket") ||
+		strings.Contains(errStr, "NotFound")
 }
 
 // shouldFallBackToMockOutputs reports whether a failed dependency output fetch should fall back to
-// mock outputs instead of being fatal: either the target's remote state doesn't exist yet (an S3
-// NoSuchKey), or the command is a render, which tolerates unresolved outputs.
+// mock outputs instead of being fatal: either the target's remote state doesn't exist yet (a
+// missing S3 state object or bucket), or the command is a render, which tolerates unresolved
+// outputs.
 func shouldFallBackToMockOutputs(pctx *ParsingContext, err error) bool {
-	return isAwsS3NoSuchKey(err) || isRenderJSONCommand(pctx) || isRenderCommand(pctx)
+	return isAwsS3StateMissing(err) || isRenderJSONCommand(pctx) || isRenderCommand(pctx)
 }
 
 // isRenderJSONCommand This function will true if terragrunt was invoked with render-json

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -2742,6 +2742,52 @@ func TestAwsStackDependencyMockOutputsFromRemoteState(t *testing.T) {
 	assert.Contains(t, stdout, "mock-subnet-id", "the unapplied unit must still resolve to its mock output")
 }
 
+// TestAwsMockOutputsFromRemoteStateMissingBucket pins that a dependency read falls back to
+// mock_outputs when the state bucket itself doesn't exist yet (NoSuchBucket), not just when the
+// state object is missing (NoSuchKey). This lets a unit be planned before its dependency's
+// environment has been bootstrapped.
+func TestAwsMockOutputsFromRemoteStateMissingBucket(t *testing.T) { //nolint: paralleltest
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
+
+	// The bucket is intentionally never pre-created, so the dependency reads hit a missing bucket.
+	// The unit's own --backend-bootstrap creates it during init, so clean up regardless.
+	defer helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureOutputFromRemoteState)
+
+	rootTerragruntConfigPath := filepath.Join(
+		tmpEnvPath,
+		testFixtureOutputFromRemoteState,
+		"root.hcl",
+	)
+	helpers.CopyTerragruntConfigAndFillPlaceholders(
+		t,
+		rootTerragruntConfigPath,
+		rootTerragruntConfigPath,
+		s3BucketName,
+		"not-used",
+		"not-used",
+	)
+
+	environmentPath := filepath.Join(tmpEnvPath, testFixtureOutputFromRemoteState, "env1")
+
+	// Nothing is applied, so the state bucket has never been created. app2's dependencies (app1 and
+	// app3) must fall back to their mock_outputs rather than failing on the missing bucket.
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		fmt.Sprintf(
+			"terragrunt init --dependency-fetch-output-from-state --backend-bootstrap --non-interactive --working-dir %s/app2",
+			environmentPath,
+		),
+	)
+	require.NoError(
+		t,
+		err,
+		"a dependency whose state bucket doesn't exist yet must fall back to mock outputs; stderr=%s",
+		stderr,
+	)
+}
+
 func TestAwsParallelStateInit(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -2743,14 +2743,13 @@ func TestAwsStackDependencyMockOutputsFromRemoteState(t *testing.T) {
 }
 
 // TestAwsMockOutputsFromRemoteStateMissingBucket pins that a dependency read falls back to
-// mock_outputs when the state bucket itself doesn't exist yet (NoSuchBucket), not just when the
-// state object is missing (NoSuchKey). This lets a unit be planned before its dependency's
-// environment has been bootstrapped.
+// mock_outputs when the state bucket itself doesn't exist yet (NoSuchBucket), not only when the
+// state object is missing (NoSuchKey).
 func TestAwsMockOutputsFromRemoteStateMissingBucket(t *testing.T) { //nolint: paralleltest
 	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
 
-	// The bucket is intentionally never pre-created, so the dependency reads hit a missing bucket.
-	// The unit's own --backend-bootstrap creates it during init, so clean up regardless.
+	// Never pre-created, so the dependency reads hit a missing bucket; init bootstraps it, so clean
+	// up regardless.
 	defer helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureOutputFromRemoteState)
@@ -2771,8 +2770,6 @@ func TestAwsMockOutputsFromRemoteStateMissingBucket(t *testing.T) { //nolint: pa
 
 	environmentPath := filepath.Join(tmpEnvPath, testFixtureOutputFromRemoteState, "env1")
 
-	// Nothing is applied, so the state bucket has never been created. app2's dependencies (app1 and
-	// app3) must fall back to their mock_outputs rather than failing on the missing bucket.
 	_, stderr, err := helpers.RunTerragruntCommandWithOutput(
 		t,
 		fmt.Sprintf(

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -2742,6 +2742,49 @@ func TestAwsStackDependencyMockOutputsFromRemoteState(t *testing.T) {
 	assert.Contains(t, stdout, "mock-subnet-id", "the unapplied unit must still resolve to its mock output")
 }
 
+// TestAwsMockOutputsFromRemoteStateMissingBucket pins that a dependency read falls back to
+// mock_outputs when the state bucket itself doesn't exist yet (NoSuchBucket), not only when the
+// state object is missing (NoSuchKey).
+func TestAwsMockOutputsFromRemoteStateMissingBucket(t *testing.T) { //nolint: paralleltest
+	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
+
+	// Never pre-created, so the dependency reads hit a missing bucket; init bootstraps it, so clean
+	// up regardless.
+	defer helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureOutputFromRemoteState)
+
+	rootTerragruntConfigPath := filepath.Join(
+		tmpEnvPath,
+		testFixtureOutputFromRemoteState,
+		"root.hcl",
+	)
+	helpers.CopyTerragruntConfigAndFillPlaceholders(
+		t,
+		rootTerragruntConfigPath,
+		rootTerragruntConfigPath,
+		s3BucketName,
+		"not-used",
+		"not-used",
+	)
+
+	environmentPath := filepath.Join(tmpEnvPath, testFixtureOutputFromRemoteState, "env1")
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		fmt.Sprintf(
+			"terragrunt init --dependency-fetch-output-from-state --backend-bootstrap --non-interactive --working-dir %s/app2",
+			environmentPath,
+		),
+	)
+	require.NoError(
+		t,
+		err,
+		"a dependency whose state bucket doesn't exist yet must fall back to mock outputs; stderr=%s",
+		stderr,
+	)
+}
+
 func TestAwsParallelStateInit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6533.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mock outputs now work when a dependency’s remote-state bucket is missing.
  * Commands such as `plan` and `validate` can resolve dependency values before the backend is created.
  * Improved handling of missing remote-state resources for more reliable dependency resolution.

* **Documentation**
  * Added a changelog entry documenting the improved mock-output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->