### PR TITLE
chore: Fixing panic in Windows test

### DIFF
--- a/internal/discovery/phase_relationship.go
+++ b/internal/discovery/phase_relationship.go
@@ -275,7 +275,7 @@ func (p *RelationshipPhase) dependencyToDiscover(
 
 	dep, created := interTransientComponents.EnsureComponent(newUnit)
 
-	if discovery.discoveryContext != nil {
+	if created && discovery.discoveryContext != nil {
 		discoveryCtx := discovery.discoveryContext.Copy()
 		discoveryCtx.SuggestOrigin(component.OriginRelationshipDiscovery)
 		dep.SetDiscoveryContext(discoveryCtx)

--- a/internal/discovery/phase_relationship_race_test.go
+++ b/internal/discovery/phase_relationship_race_test.go
@@ -1,0 +1,78 @@
+package discovery_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRelationshipPhase_ConcurrentSharedDependencyWithRacing pins that a
+// transient dependency's discovery context is written only by the goroutine that
+// creates it. When many components depend on one unit outside the discovered set,
+// several goroutines reach it at once; the context accessors are unlocked, so any
+// extra writer races. The shared unit lives under ext/ so it is created during
+// traversal rather than pre-discovered by the filesystem walk.
+func TestRelationshipPhase_ConcurrentSharedDependencyWithRacing(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	workingDir := filepath.Join(tmpDir, "root")
+	extDir := filepath.Join(tmpDir, "ext")
+
+	const fanOut = 8
+
+	writeUnit := func(baseDir, name string, deps ...string) {
+		dir := filepath.Join(baseDir, name)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+
+		var hcl strings.Builder
+
+		hcl.WriteString("# " + name + "\n")
+
+		for i, dep := range deps {
+			fmt.Fprintf(&hcl, "dependency \"d%d\" {\n  config_path = %q\n}\n", i, dep)
+		}
+
+		require.NoError(
+			t,
+			os.WriteFile(filepath.Join(dir, "terragrunt.hcl"), []byte(hcl.String()), 0644),
+		)
+	}
+
+	writeUnit(extDir, "shared")
+
+	for i := range fanOut {
+		writeUnit(workingDir, fmt.Sprintf("unit%02d", i), "../../ext/shared")
+	}
+
+	l := logger.CreateLogger()
+	opts := &options.TerragruntOptions{
+		WorkingDir:     workingDir,
+		RootWorkingDir: workingDir,
+	}
+
+	d := discovery.NewDiscovery(workingDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workingDir}).
+		WithRelationships()
+
+	components, err := d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	require.NoError(t, err)
+
+	sharedPath := filepath.Join(extDir, "shared")
+
+	for _, c := range components {
+		deps := c.Dependencies().Paths()
+		require.Containsf(t, deps, sharedPath, "unit %s missing shared dependency", c.Path())
+	}
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses a race condition in the relationship phase of discovery.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency discovery when multiple components reference the same shared dependency concurrently.
  * Prevented discovery metadata from being incorrectly applied to components that already exist.
  * Ensured relationship results consistently include shared dependencies during parallel discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->