### PR TITLE
chore: Adding more tests for build metadata

### DIFF
--- a/internal/getter/tfr_test.go
+++ b/internal/getter/tfr_test.go
@@ -168,6 +168,36 @@ func TestRegistryGetterWithoutVersion(t *testing.T) {
 	assert.True(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
 }
 
+// TestRegistryGetterBuildMetadataVersion pins the download path for a version
+// carrying semver build metadata. The `+` reaches the getter percent-encoded,
+// which is what the constraint resolver writes, and the registry must be asked
+// for the version as published rather than for a `+`-decoded variant.
+func TestRegistryGetterBuildMetadataVersion(t *testing.T) {
+	t.Parallel()
+
+	var requestedVersion string
+
+	server := newBuildMetadataRegistryTestServer(t, &requestedVersion)
+
+	dstPath := helpers.TmpDirWOSymlinks(t)
+	moduleDestPath := filepath.Join(dstPath, "terraform-aws-vpc")
+	require.False(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+
+	src := "tfr://" + server.Listener.Addr().
+		String() +
+		"/cloudstoragesec/cloud-storage-security/aws?version=1.8.26%2Bcss9.10.001"
+	client := newRegistryTestClient(t, server.Client(), tfimpl.OpenTofu)
+
+	_, err := client.Get(t.Context(), &getter.Request{
+		Src:     src,
+		Dst:     moduleDestPath,
+		GetMode: getter.ModeDir,
+	})
+	require.NoError(t, err)
+	assert.True(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+	assert.Equal(t, "1.8.26+css9.10.001", requestedVersion)
+}
+
 // TestRegistryGetterEmptyVersion pins the typed error returned when
 // ?version= is present but empty.
 func TestRegistryGetterEmptyVersion(t *testing.T) {
@@ -207,6 +237,45 @@ func newRegistryTestClient(t *testing.T, httpClient *http.Client, impl tfimpl.Ty
 			&gogetter.HttpGetter{Client: httpClient, Netrc: true},
 		),
 	)
+}
+
+// newBuildMetadataRegistryTestServer stands up a mock registry for a module
+// published only under versions carrying build metadata, recording the version
+// segment of the download request in requestedVersion.
+func newBuildMetadataRegistryTestServer(t *testing.T, requestedVersion *string) *httptest.Server {
+	t.Helper()
+
+	zipBody := buildModuleZip(t)
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/.well-known/terraform.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"modules.v1":"/v1/modules/"}`))
+		assert.NoError(t, err)
+	})
+
+	mux.HandleFunc(
+		"/v1/modules/cloudstoragesec/cloud-storage-security/aws/{version}/download",
+		func(w http.ResponseWriter, r *http.Request) {
+			*requestedVersion = r.PathValue("version")
+
+			w.Header().Set("X-Terraform-Get", "https://"+r.Host+"/download/terraform-aws-vpc.zip")
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+
+	mux.HandleFunc("/download/terraform-aws-vpc.zip", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+
+		_, err := w.Write(zipBody)
+		assert.NoError(t, err)
+	})
+
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	return server
 }
 
 // buildModuleZip builds an in-memory zip archive that mirrors the shape of a

--- a/internal/getter/tfrhelpers_test.go
+++ b/internal/getter/tfrhelpers_test.go
@@ -100,6 +100,28 @@ func TestPinModuleVersion(t *testing.T) {
 	}
 }
 
+// TestPinModuleVersionBuildMetadata pins how a resolved version carrying
+// semver build metadata is written back into the source. The `+` is
+// percent-encoded so that re-parsing the pinned source yields the version the
+// registry published, rather than the `+`-as-space decoding a query string
+// would otherwise apply.
+func TestPinModuleVersionBuildMetadata(t *testing.T) {
+	t.Parallel()
+
+	server := newVersionsTestServer(t, buildMetadataVersionsBody)
+	source := "tfr://" + server.Listener.Addr().String() + "/foo/bar/baz"
+
+	pinned, err := getter.PinModuleVersion(
+		t.Context(), logger.CreateLogger(), server.Client(), tfimpl.OpenTofu, source, "~> 1.8.24",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, source+"?version=1.8.26%2Bcss9.10.001", pinned)
+
+	pinnedURL, err := url.Parse(pinned)
+	require.NoError(t, err)
+	assert.Equal(t, "1.8.26+css9.10.001", pinnedURL.Query().Get("version"))
+}
+
 func TestSourceHasVersionConstraint(t *testing.T) {
 	t.Parallel()
 
@@ -127,6 +149,21 @@ func TestSourceHasVersionConstraint(t *testing.T) {
 			name:   "non-tfr source",
 			source: "git::https://github.com/foo/bar.git?ref=v1.0.0",
 			want:   false,
+		},
+		{
+			name:   "exact pin with build metadata",
+			source: "tfr://registry.opentofu.org/cloudstoragesec/cloud-storage-security/aws?version=1.8.26%2Bcss9.10.001",
+			want:   false,
+		},
+		{
+			// A literal `+` in a query decodes to a space, so this hand-written
+			// pin reaches the parser as "1.8.26 css9.10.001" and fails to parse
+			// as a version. Terragrunt rejects the source rather than resolving
+			// the wrong module version. Encode the `+` as %2B, or express the
+			// version through the terraform block's version attribute.
+			name:   "unencoded build metadata pin",
+			source: "tfr://registry.opentofu.org/cloudstoragesec/cloud-storage-security/aws?version=1.8.26+css9.10.001",
+			want:   true,
 		},
 	}
 
@@ -271,6 +308,25 @@ func TestBuildRequestURLRelativePath(t *testing.T) {
 	)
 }
 
+// TestBuildRequestURLBuildMetadata pins that a version carrying build metadata
+// keeps its `+` in the download path. A `+` is a literal in a path segment, and
+// the OpenTofu registry serves the endpoint either way.
+func TestBuildRequestURLBuildMetadata(t *testing.T) {
+	t.Parallel()
+
+	requestURL, err := getter.BuildRequestURL(
+		"registry.opentofu.org",
+		"/v1/modules/",
+		"/cloudstoragesec/cloud-storage-security/aws",
+		"1.8.26+css9.10.001",
+	)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"https://registry.opentofu.org/v1/modules/cloudstoragesec/cloud-storage-security/aws/1.8.26+css9.10.001/download",
+		requestURL.String(),
+	)
+}
+
 func TestGetLatestModuleVersion(t *testing.T) {
 	t.Parallel()
 
@@ -340,6 +396,92 @@ func TestGetLatestModuleVersionSkipsUnparsable(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "1.0.0", latest)
+}
+
+// buildMetadataVersionsBody mirrors the list-versions response of
+// cloudstoragesec/cloud-storage-security/aws, a module whose every published
+// version carries semver build metadata. Requesting such a module without the
+// metadata is not an option: the registry serves 1.8.26+css9.10.001 and 404s
+// on 1.8.26.
+const buildMetadataVersionsBody = `{"modules":[{"versions":[` +
+	`{"version":"1.8.26+css9.10.001"},{"version":"1.8.25+css9.10.000"},` +
+	`{"version":"1.8.24+css9.09.002"}]}]}`
+
+// TestGetLatestModuleVersionBuildMetadata pins that the latest-version path
+// preserves build metadata, so a bare tfr:// source pointed at such a module
+// requests a version the registry actually publishes.
+func TestGetLatestModuleVersionBuildMetadata(t *testing.T) {
+	t.Parallel()
+
+	server := newVersionsTestServer(t, buildMetadataVersionsBody)
+
+	latest, err := getter.GetLatestModuleVersion(
+		t.Context(), logger.CreateLogger(), server.Client(),
+		server.Listener.Addr().String(), "/v1/modules/", "foo/bar/baz",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "1.8.26+css9.10.001", latest)
+}
+
+// TestGetMatchingModuleVersionBuildMetadata pins constraint resolution against
+// versions carrying build metadata. Metadata does not affect precedence, so a
+// constraint written without it still selects the published version, and the
+// metadata survives into the result.
+func TestGetMatchingModuleVersionBuildMetadata(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		constraint string
+		want       string
+	}{
+		{name: "exact without metadata", constraint: "1.8.25", want: "1.8.25+css9.10.000"},
+		{
+			name:       "exact with metadata",
+			constraint: "1.8.25+css9.10.000",
+			want:       "1.8.25+css9.10.000",
+		},
+		{name: "pessimistic patch", constraint: "~> 1.8.24", want: "1.8.26+css9.10.001"},
+		{name: "range", constraint: ">= 1.8.24, < 1.8.26", want: "1.8.25+css9.10.000"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newVersionsTestServer(t, buildMetadataVersionsBody)
+
+			got, err := getter.GetMatchingModuleVersion(
+				t.Context(), logger.CreateLogger(), server.Client(),
+				server.Listener.Addr().String(), "/v1/modules/", "foo/bar/baz", tc.constraint,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestGetMatchingModuleVersionPrereleaseBuildMetadata pins the combination of
+// both suffixes, modeled on waveaccounting/chatbot-slack-configuration/aws,
+// which publishes prereleases tagged with a commit SHA as build metadata. The
+// prerelease opt-in rule reads the constraint's prerelease and ignores its
+// metadata, so an alpha pinned without the SHA resolves to the published tag.
+func TestGetMatchingModuleVersionPrereleaseBuildMetadata(t *testing.T) {
+	t.Parallel()
+
+	server := newVersionsTestServer(
+		t,
+		`{"modules":[{"versions":[{"version":"1.1.0"},{"version":"1.1.0-alpha.3"},`+
+			`{"version":"1.1.0-alpha.2+a88b844"},{"version":"1.0.0"},`+
+			`{"version":"1.0.0-alpha.3+46e44c9"}]}]}`,
+	)
+
+	got, err := getter.GetMatchingModuleVersion(
+		t.Context(), logger.CreateLogger(), server.Client(),
+		server.Listener.Addr().String(), "/v1/modules/", "foo/bar/baz", "1.0.0-alpha.3",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0-alpha.3+46e44c9", got)
 }
 
 // matchVersionsBody is a list-versions response spanning several minor and
@@ -501,13 +643,19 @@ func newRegistryTestServer(t *testing.T) *httptest.Server {
 }
 
 // newVersionsTestServer stands up a TLS test server that responds to the
-// module list-versions endpoint with the supplied JSON body. Used by the
-// GetLatestModuleVersion tests that exercise prerelease filtering and the
-// unparsable-version skip path.
+// module list-versions endpoint with the supplied JSON body, plus the service
+// discovery endpoint so callers that resolve a source URL end to end can use it
+// too. Used by the GetLatestModuleVersion tests that exercise prerelease
+// filtering and the unparsable-version skip path.
 func newVersionsTestServer(t *testing.T, body string) *httptest.Server {
 	t.Helper()
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/terraform.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"modules.v1":"/v1/modules/"}`))
+		assert.NoError(t, err)
+	})
 	mux.HandleFunc(
 		"/v1/modules/foo/bar/baz/versions",
 		func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Comment [here](https://github.com/gruntwork-io/terragrunt/issues/6345#issuecomment-5063335232) pointed out that we don't have explicit tests for this.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Terraform module versions containing SemVer build metadata, such as `1.8.26+css9.10.001`.
  * Preserved build metadata when resolving versions, pinning module sources, and requesting downloads.
  * Improved support for matching latest, constrained, and prerelease versions with build metadata.

* **Tests**
  * Added coverage for encoded and unencoded build metadata across registry resolution and module downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->