### PR TITLE
perf: Memoize `find_in_parent_folders()`

### DIFF
--- a/docs/src/data/changelog/v1.1.2/find-in-parent-folders-lookups.mdx
+++ b/docs/src/data/changelog/v1.1.2/find-in-parent-folders-lookups.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.2"
+category: "performance-improvements"
+---
+
+#### Fewer filesystem checks when resolving `find_in_parent_folders()`
+
+`find_in_parent_folders()` walks up from a unit toward the filesystem root, checking each directory for the configuration file it was asked to find. Even when the call named a file, as in `find_in_parent_folders("root.hcl")`, each directory along the way was also checked for the default configuration filenames. Units sharing a parent chain then repeated every check their siblings had already made.
+
+Terragrunt now checks only the filename the call names, and reuses what it already learned about a directory for the rest of the command. Deeply nested estates benefit most, since every level between a unit and its root configuration used to be re-checked once per unit.
+
+In [micro-benchmarks](https://github.com/gruntwork-io/terragrunt/blob/main/pkg/config/find_in_parent_folders_bench_test.go), resolving the root configuration for 100 units nested eight directories deep went from 4.8ms to 0.49ms. Across the benchmarked shapes the lookups run between 7x and 10x faster, and the time saved grows with both the number of units and how deeply they sit below their root configuration.

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -775,6 +775,8 @@ func findInParentFoldersImpl(
 		fileToFindStr = fileToFindParam
 	}
 
+	probes := cache.ContextCache[bool](ctx, ParentFileProbeCacheContextKey)
+
 	// To avoid getting into an accidental infinite loop (e.g. do to cyclical symlinks), set a max on the number of
 	// parent folders we'll check
 	for range pctx.MaxFoldersToCheck {
@@ -791,12 +793,9 @@ func findInParentFoldersImpl(
 			}
 		}
 
-		fileToFind := GetDefaultConfigPath(currentDir)
-		if fileToFindParam != "" {
-			fileToFind = filepath.Join(currentDir, fileToFindParam)
-		}
+		fileToFind := parentFileCandidate(currentDir, fileToFindParam)
 
-		if util.FileExists(fileToFind) {
+		if parentFileExists(ctx, probes, fileToFind) {
 			return fileToFind, nil
 		}
 
@@ -808,6 +807,38 @@ func findInParentFoldersImpl(
 		File:  fileToFindStr,
 		Cause: fmt.Sprintf("Exceeded maximum folders to check (%d)", pctx.MaxFoldersToCheck),
 	}
+}
+
+// parentFileCandidate names the file to probe in dir. An empty fileName means
+// the caller passed no argument and wants whichever default config name is
+// present, which costs a probe per known name, so [GetDefaultConfigPath] is
+// only consulted in that case.
+func parentFileCandidate(dir, fileName string) string {
+	if fileName == "" {
+		return GetDefaultConfigPath(dir)
+	}
+
+	return filepath.Join(dir, fileName)
+}
+
+// parentFileExists reports whether path exists, memoizing the answer for the
+// run. Units in the same sub-tree walk the same ancestor chain, so without this
+// the run re-stats each shared ancestor once per unit.
+//
+// Negative answers are cached too, and that is where nearly all of the saving
+// is: every level below the one holding the file is a miss. A config file
+// created in an already-probed ancestor part-way through a run is therefore not
+// observed. Nothing Terragrunt generates lands in an ancestor it has already
+// walked past, and the cache lives only as long as one run.
+func parentFileExists(ctx context.Context, probes *cache.Cache[bool], path string) bool {
+	if exists, found := probes.Get(ctx, path); found {
+		return exists
+	}
+
+	exists := util.FileExists(path)
+	probes.Put(ctx, path, exists)
+
+	return exists
 }
 
 // PathRelativeToInclude returns the relative path between the included Terragrunt configuration file

--- a/pkg/config/config_helpers_test.go
+++ b/pkg/config/config_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestPathRelativeToInclude(t *testing.T) {
@@ -585,6 +587,96 @@ unit "test" {
 	region, exists := stackConfig.Locals["region"]
 	require.True(t, exists, "Expected 'region' local to be parsed")
 	require.Equal(t, "us-east-1", region)
+}
+
+func TestFindInParentFoldersSharedRunContext(t *testing.T) {
+	t.Parallel()
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	rootHclPath := filepath.Join(tempDir, "root.hcl")
+	require.NoError(t, os.WriteFile(rootHclPath, nil, 0644))
+
+	first := filepath.Join(tempDir, "region", "unit-a", config.DefaultTerragruntConfigPath)
+	second := filepath.Join(tempDir, "region", "unit-b", config.DefaultTerragruntConfigPath)
+
+	for _, configPath := range []string{first, second} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0755))
+	}
+
+	l := logger.CreateLogger()
+	baseCtx, pctx := newTestParsingContext(t, first)
+	ctx := config.WithConfigValues(baseCtx)
+
+	firstPath, err := config.FindInParentFolders(ctx, pctx, l, []string{"root.hcl"})
+	require.NoError(t, err)
+	assert.Equal(t, rootHclPath, firstPath)
+
+	// The sibling shares every ancestor with the first unit, so it reads the
+	// probes the first unit recorded rather than re-running them.
+	pctx.TerragruntConfigPath = second
+
+	secondPath, err := config.FindInParentFolders(ctx, pctx, l, []string{"root.hcl"})
+	require.NoError(t, err)
+	assert.Equal(t, rootHclPath, secondPath)
+
+	// A nearer root.hcl appearing after the ancestor was probed is picked up by
+	// the next run, since the probes live only as long as one run's context.
+	nearerPath := filepath.Join(tempDir, "region", "root.hcl")
+	require.NoError(t, os.WriteFile(nearerPath, nil, 0644))
+
+	nextRunPath, err := config.FindInParentFolders(
+		config.WithConfigValues(baseCtx),
+		pctx,
+		l,
+		[]string{"root.hcl"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, nearerPath, nextRunPath)
+}
+
+func TestFindInParentFoldersSharedRunContextWithRacing(t *testing.T) {
+	t.Parallel()
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	rootHclPath := filepath.Join(tempDir, "root.hcl")
+	require.NoError(t, os.WriteFile(rootHclPath, nil, 0644))
+
+	const units = 32
+
+	configPaths := make([]string, units)
+
+	for i := range units {
+		unitDir := filepath.Join(tempDir, "account", "region", "unit-"+strconv.Itoa(i))
+		require.NoError(t, os.MkdirAll(unitDir, 0755))
+
+		configPaths[i] = filepath.Join(unitDir, config.DefaultTerragruntConfigPath)
+	}
+
+	l := logger.CreateLogger()
+	baseCtx, basePctx := newTestParsingContext(t, configPaths[0])
+	ctx := config.WithConfigValues(baseCtx)
+
+	group, groupCtx := errgroup.WithContext(ctx)
+
+	for _, configPath := range configPaths {
+		group.Go(func() error {
+			pctx := basePctx.Clone()
+			pctx.TerragruntConfigPath = configPath
+
+			found, err := config.FindInParentFolders(groupCtx, pctx, l, []string{"root.hcl"})
+			if err != nil {
+				return err
+			}
+
+			if found != rootHclPath {
+				return fmt.Errorf("got %q, want %q", found, rootHclPath)
+			}
+
+			return nil
+		})
+	}
+
+	require.NoError(t, group.Wait())
 }
 
 func TestResolveTerragruntInterpolation(t *testing.T) {

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -19,6 +19,7 @@ const (
 	OutputLocksContextKey            configKey = iota
 	SopsCacheContextKey              configKey = iota
 	AutoIncludeSuffixCacheContextKey configKey = iota
+	ParentFileProbeCacheContextKey   configKey = iota
 
 	hclCacheName               = "hclCache"
 	configCacheName            = "configCache"
@@ -27,6 +28,7 @@ const (
 	jsonOutputCacheName        = "jsonOutputCache"
 	sopsCacheName              = "sopsCache"
 	autoIncludeSuffixCacheName = "autoIncludeSuffixCache"
+	parentFileProbeCacheName   = "parentFileProbeCache"
 )
 
 // WithConfigValues add to context default values for configuration.
@@ -58,6 +60,11 @@ func WithConfigValues(ctx context.Context) context.Context {
 		ctx,
 		AutoIncludeSuffixCacheContextKey,
 		cache.NewCache[string](autoIncludeSuffixCacheName),
+	)
+	ctx = context.WithValue(
+		ctx,
+		ParentFileProbeCacheContextKey,
+		cache.NewCache[bool](parentFileProbeCacheName),
 	)
 
 	return ctx

--- a/pkg/config/find_in_parent_folders_bench_test.go
+++ b/pkg/config/find_in_parent_folders_bench_test.go
@@ -1,0 +1,78 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkFindInParentFolders measures resolving the root config for every
+// unit in a run, the shape `run --all` produces. All units in a sub-tree share
+// an ancestor chain, so each one re-probes the directories its siblings already
+// probed. Depth is how many levels separate a unit from the root config.
+func BenchmarkFindInParentFolders(b *testing.B) {
+	for _, depth := range []int{1, 4, 8} {
+		for _, units := range []int{10, 100} {
+			configPaths := benchUnitTree(b, depth, units)
+
+			b.Run("depth="+strconv.Itoa(depth)+"/units="+strconv.Itoa(units), func(b *testing.B) {
+				l := logger.CreateLogger()
+				baseCtx, pctx := newTestParsingContext(b, configPaths[0])
+				params := []string{benchRootFileName}
+
+				for b.Loop() {
+					// A fresh cache per iteration: caches are per run, so a run
+					// never starts warm.
+					ctx := config.WithConfigValues(baseCtx)
+
+					for _, configPath := range configPaths {
+						pctx.TerragruntConfigPath = configPath
+
+						if _, err := config.FindInParentFolders(ctx, pctx, l, params); err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+const benchRootFileName = "root.hcl"
+
+// benchUnitTree lays out units nested depth levels below a root config and
+// returns their config paths. The intermediate directories are shared by every
+// unit, which is what makes the walks redundant.
+func benchUnitTree(b *testing.B, depth, units int) []string {
+	b.Helper()
+
+	const (
+		dirPerm  = 0755
+		filePerm = 0644
+	)
+
+	root := b.TempDir()
+	require.NoError(b, os.WriteFile(filepath.Join(root, benchRootFileName), nil, filePerm))
+
+	parent := root
+	for i := range depth - 1 {
+		parent = filepath.Join(parent, "level-"+strconv.Itoa(i))
+	}
+
+	configPaths := make([]string, units)
+
+	for i := range units {
+		unitDir := filepath.Join(parent, "unit-"+strconv.Itoa(i))
+		require.NoError(b, os.MkdirAll(unitDir, dirPerm))
+
+		configPaths[i] = filepath.Join(unitDir, config.DefaultTerragruntConfigPath)
+		require.NoError(b, os.WriteFile(configPaths[i], nil, filePerm))
+	}
+
+	return configPaths
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Improves `find_in_parent_folders()` performance by only checking the filenames that are necessary and memoizes results so that repeated calls to discover a file in a parent directory can short circuit.

<img width="2320" height="1780" alt="find-in-parent-folders-dark" src="https://github.com/user-attachments/assets/d04de8b8-cc1b-4426-ab1f-d1760601dd12" />

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved parent-folder configuration lookups by avoiding unnecessary filename checks.
  * Reused file-existence results during related lookups, improving performance for large or deeply nested configurations.
  * Preserved detection of newly available, nearer configuration files on subsequent runs.

* **Documentation**
  * Added release notes for version 1.1.2 describing the lookup optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->