### PR TITLE
fix: handling deleted dependencies in filter

### DIFF
--- a/docs/src/content/docs/03-features/08-filter/06-git.mdx
+++ b/docs/src/content/docs/03-features/08-filter/06-git.mdx
@@ -126,6 +126,12 @@ This is a safeguard to prevent unintended destruction of infrastructure.
 
 </Aside>
 
+<Aside type="note" title="Dependencies deleted in the diff">
+
+When the diff deletes a unit's directory while a live unit still references it via a `dependency` block, the dangling reference does not fail the run. The live unit runs normally, falling back to `mock_outputs` where configured, and the deleted unit still receives its destroy plan from the `from` side of the diff when `--filter-allow-destroy` is set.
+
+</Aside>
+
 ## The `--filter-affected` flag
 
 For the common use case of comparing the default branch (typically `main`) with `HEAD`, you can use the `--filter-affected` flag as a convenient shorthand:

--- a/docs/src/data/changelog/v1.1.2/run-all-git-filter-deleted-dependency-crash.mdx
+++ b/docs/src/data/changelog/v1.1.2/run-all-git-filter-deleted-dependency-crash.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.2"
+category: "bug-fixes"
+---
+
+#### `run --all` no longer crashes when a Git filter's diff deletes a unit another unit depends on
+
+Running `run --all` with a Git-range filter (for example `...[main...HEAD]...`) crashed the entire invocation when the diff deleted a unit's directory while another live unit still had a `dependency` block pointing at it. The error reported the deleted dependency's path ("does not contain a terragrunt.hcl file") rather than the unit referencing it, and `find`/`list` reported the same filter as healthy right before the crash, making the failure hard to diagnose in CI.
+
+Dependency discovery in a Git filter context now treats a dependency whose config was deleted in the diff the same way `find` and `list` already did: the reference is skipped instead of failing the run. The live unit runs normally (falling back to `mock_outputs` where configured), and the deleted unit still receives its destroy plan from the `from` side of the diff when `--filter-allow-destroy` is set. Outside of Git filters, a dangling `config_path` keeps failing the run as before.

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -127,6 +127,33 @@ func isExternal(workingDir string, componentPath string) bool {
 	return relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator))
 }
 
+// inGitFilterContext reports whether this discovery evaluates Git filter expressions,
+// either directly or as a worktree sub-discovery (identified by a Git ref on its
+// discovery context).
+func (d *Discovery) inGitFilterContext() bool {
+	if len(d.gitExpressions) > 0 {
+		return true
+	}
+
+	return d.discoveryContext != nil && d.discoveryContext.Ref != ""
+}
+
+// skipMissingDependencyConfig reports whether a parse failure for a dependency reached
+// during relationship or graph traversal should be skipped instead of failing discovery.
+// Only missing-config errors qualify, and only in a Git filter context: a diff
+// legitimately deletes unit directories that live units still reference, and find/list
+// already tolerate those. Without Git filters a dangling config_path keeps failing the
+// run, as it always has.
+func (d *Discovery) skipMissingDependencyConfig(err error) bool {
+	if !d.inGitFilterContext() {
+		return false
+	}
+
+	var notFoundErr config.TerragruntConfigNotFoundError
+
+	return errors.As(err, &notFoundErr)
+}
+
 // componentFromDependencyPath returns a component for a dependency path. If the path already
 // exists in the thread-safe components, it returns that. If the path contains a stack file,
 // it creates a stack. Otherwise, it creates a unit.

--- a/internal/discovery/missing_dependency_config_test.go
+++ b/internal/discovery/missing_dependency_config_test.go
@@ -1,0 +1,172 @@
+package discovery_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/worktrees"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupDeletedDependencyRepo commits a consumer unit depending on dep, then deletes
+// dep in a second commit so HEAD~1...HEAD carries a dangling dependency reference.
+func setupDeletedDependencyRepo(t *testing.T) string {
+	t.Helper()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	createUnit(t, tmpDir, "dep", `# dep`)
+	createUnit(t, tmpDir, "consumer", `dependency "dep" {
+  config_path = "../dep"
+  mock_outputs = { name = "mock" }
+  mock_outputs_allowed_terraform_commands = ["plan", "destroy"]
+}`)
+
+	commitChanges(t, runner, "Initial commit")
+
+	require.NoError(t, os.RemoveAll(filepath.Join(tmpDir, "dep")))
+	commitChanges(t, runner, "Delete dep")
+
+	return tmpDir
+}
+
+// runAllStyleDiscovery mirrors run --all discovery: worktrees for git filters,
+// relationship discovery enabled, and parse errors NOT suppressed.
+func runAllStyleDiscovery(
+	t *testing.T,
+	tmpDir string,
+	queries []string,
+) (component.Components, error) {
+	t.Helper()
+
+	l := logger.CreateLogger()
+
+	filters, err := filter.ParseFilterQueries(l, queries)
+	require.NoError(t, err)
+
+	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+		WorkingDir:     tmpDir,
+		GitExpressions: filters.UniqueGitFilters(),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		require.NoError(t, cleanupErr)
+	})
+
+	opts := options.NewTerragruntOptions()
+	opts.WorkingDir = tmpDir
+	opts.RootWorkingDir = tmpDir
+
+	d := discovery.NewDiscovery(tmpDir).
+		WithDiscoveryContext(&component.DiscoveryContext{
+			WorkingDir: tmpDir,
+			Cmd:        "plan",
+		}).
+		WithRelationships().
+		WithWorktrees(w).
+		WithFilters(filters)
+
+	return d.Discover(t.Context(), l, venv.OSVenv(), opts)
+}
+
+// TestRelationshipPhase_GitFilterDeletedDependency pins that run --all-style discovery
+// does not fail when a git-range filter's diff deletes a unit that a live unit still
+// references via a dependency block. Regression test for
+// https://github.com/gruntwork-io/terragrunt/issues/6540.
+func TestRelationshipPhase_GitFilterDeletedDependency(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := setupDeletedDependencyRepo(t)
+
+	// The union with the path filter pulls the live consumer in from the working
+	// directory, whose dangling dependency the relationship phase then parses.
+	components, err := runAllStyleDiscovery(t, tmpDir, []string{
+		"...[HEAD~1...HEAD]... | ./**",
+	})
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(components))
+	for _, c := range components {
+		names = append(names, filepath.Base(c.Path()))
+	}
+
+	assert.Contains(t, names, "consumer")
+}
+
+// TestGraphPhase_GitFilterDeletedDependency pins the same crash for the graph phase,
+// reached when the git-range filter expands through the dependency graph and the
+// changed unit's dependency was deleted in the same diff.
+func TestGraphPhase_GitFilterDeletedDependency(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	createUnit(t, tmpDir, "dep", `# dep`)
+	createUnit(t, tmpDir, "consumer", `dependency "dep" {
+  config_path = "../dep"
+  mock_outputs = { name = "mock" }
+  mock_outputs_allowed_terraform_commands = ["plan", "destroy"]
+}`)
+
+	commitChanges(t, runner, "Initial commit")
+
+	// Modify consumer AND delete dep in the same diff so the graph expansion
+	// traverses consumer's dangling dependency in the current worktree.
+	createUnit(t, tmpDir, "consumer", `dependency "dep" {
+  config_path = "../dep"
+  mock_outputs = { name = "mock" }
+  mock_outputs_allowed_terraform_commands = ["plan", "destroy"]
+}
+# modified`)
+	require.NoError(t, os.RemoveAll(filepath.Join(tmpDir, "dep")))
+	commitChanges(t, runner, "Modify consumer, delete dep")
+
+	components, err := runAllStyleDiscovery(t, tmpDir, []string{"[HEAD~1...HEAD]..."})
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, components.Paths())
+}
+
+// TestRelationshipPhase_MissingDependencyConfigWithoutGitFilter pins that without
+// git filter expressions a dangling dependency reference still fails discovery,
+// preserving the long-standing run --all behavior for typo'd config_path values.
+func TestRelationshipPhase_MissingDependencyConfigWithoutGitFilter(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	createUnit(t, tmpDir, "consumer", `dependency "dep" {
+  config_path = "../dep"
+}`)
+	// A second unit keeps the relationship phase's terminal tracker non-empty so
+	// traversal actually descends into consumer's dangling dependency.
+	createUnit(t, tmpDir, "other", `# other`)
+	commitChanges(t, runner, "Initial commit")
+
+	l := logger.CreateLogger()
+	opts := options.NewTerragruntOptions()
+	opts.WorkingDir = tmpDir
+	opts.RootWorkingDir = tmpDir
+
+	d := discovery.NewDiscovery(tmpDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
+		WithRelationships()
+
+	_, err := d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	require.Error(t, err)
+
+	var notFoundErr config.TerragruntConfigNotFoundError
+	require.ErrorAs(t, err, &notFoundErr)
+}

--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -286,6 +286,14 @@ func (p *GraphPhase) discoverDependencies(
 	ctx = contextWithParsePhase(ctx, parsePhaseTagGraphDependencies)
 
 	if err := ensureParsed(ctx, l, v, c, state.opts, state.discovery); err != nil {
+		// Defensive: resolveDependency already filters missing configs before
+		// publishing, so this only fires for a traversal root deleted in the diff.
+		if state.discovery.skipMissingDependencyConfig(err) {
+			l.Debugf("Skipping dependency traversal for %s: config not found", c.Path())
+
+			return nil
+		}
+
 		return err
 	}
 
@@ -316,7 +324,7 @@ func (p *GraphPhase) discoverDependencies(
 	for _, depPath := range depPaths {
 		g.Go(func() error {
 			depComponent, err := p.resolveDependency(
-				c, depPath, state.threadSafeComponents,
+				ctx, l, v, state, c, depPath,
 			)
 			if err != nil {
 				errMu.Lock()
@@ -793,11 +801,17 @@ func (p *GraphPhase) processUpstreamCandidate(
 	return nil
 }
 
-// resolveDependency resolves a dependency path to a component.
+// resolveDependency resolves a dependency path to a component and links it to the
+// parent. It returns nil (no error) for a dependency deleted in the diff: even a
+// bare edge would resurrect it through graph-expression evaluation, so it is
+// skipped entirely.
 func (p *GraphPhase) resolveDependency(
+	ctx context.Context,
+	l log.Logger,
+	v venv.Venv,
+	state *graphTraversalState,
 	parent component.Component,
 	depPath string,
-	threadSafeComponents *component.ThreadSafeComponents,
 ) (component.Component, error) {
 	parentCtx := parent.DiscoveryContext()
 	if parentCtx == nil {
@@ -808,11 +822,23 @@ func (p *GraphPhase) resolveDependency(
 		return nil, NewMissingWorkingDirectoryError(parent.Path())
 	}
 
-	depComponent := componentFromDependencyPath(depPath, threadSafeComponents)
+	depComponent := componentFromDependencyPath(depPath, state.threadSafeComponents)
+
+	// Other parse errors are deliberately not returned here; recursion into the
+	// dependency surfaces them, as before.
+	if err := ensureParsed(ctx, l, v, depComponent, state.opts, state.discovery); err != nil {
+		if state.discovery.skipMissingDependencyConfig(err) {
+			l.Debugf("Skipping dependency %s of %s: config not found", depPath, parent.Path())
+
+			return nil, nil
+		}
+
+		l.Debugf("Deferring parse error for %s to recursion: %v", depPath, err)
+	}
 
 	assignGraphDiscoveryContext(depComponent, parentCtx, depPath)
 
-	addedComponent, _ := threadSafeComponents.EnsureComponent(depComponent)
+	addedComponent, _ := state.threadSafeComponents.EnsureComponent(depComponent)
 
 	parent.AddDependency(addedComponent)
 

--- a/internal/discovery/phase_relationship.go
+++ b/internal/discovery/phase_relationship.go
@@ -166,6 +166,14 @@ func (p *RelationshipPhase) discoverRelationships(
 	ctx = contextWithParsePhase(ctx, parsePhaseTagRelationship)
 
 	if err := ensureParsed(ctx, l, v, c, state.opts, state.discovery); err != nil {
+		// Defensive: dependencyToDiscover already filters missing configs before
+		// publishing, so this only fires for a traversal root deleted in the diff.
+		if state.discovery.skipMissingDependencyConfig(err) {
+			l.Debugf("Skipping relationship discovery for %s: config not found", c.Path())
+
+			return nil
+		}
+
 		return err
 	}
 
@@ -189,12 +197,17 @@ func (p *RelationshipPhase) discoverRelationships(
 
 	for _, path := range paths {
 		dep, created := p.dependencyToDiscover(
+			ctx,
+			l,
+			v,
 			c,
 			path,
-			state.allComponents,
-			state.interTransientComponents,
-			state.discovery,
+			state,
 		)
+
+		if dep == nil {
+			continue
+		}
 
 		tracker.remove(dep.Path())
 
@@ -254,14 +267,17 @@ func (p *RelationshipPhase) discoverRelationships(
 }
 
 // dependencyToDiscover resolves a dependency path and links it to the component.
+// It returns nil for a dependency deleted in the diff: even a bare edge would
+// resurrect the config-less component through graph-expression evaluation.
 func (p *RelationshipPhase) dependencyToDiscover(
+	ctx context.Context,
+	l log.Logger,
+	v venv.Venv,
 	c component.Component,
 	path string,
-	allComponents *component.Components,
-	interTransientComponents *component.ThreadSafeComponents,
-	discovery *Discovery,
+	state *relationshipTraversalState,
 ) (component.Component, bool) {
-	for _, dep := range *allComponents {
+	for _, dep := range *state.allComponents {
 		if dep.Path() == path {
 			if !slices.Contains(c.Dependencies(), dep) {
 				c.AddDependency(dep)
@@ -271,12 +287,32 @@ func (p *RelationshipPhase) dependencyToDiscover(
 		}
 	}
 
+	// A component already in the transient set passed the missing-config check when
+	// it was created, so link it without re-parsing.
+	if existing := state.interTransientComponents.FindByPath(path); existing != nil {
+		c.AddDependency(existing)
+
+		return existing, false
+	}
+
 	newUnit := component.NewUnit(path)
 
-	dep, created := interTransientComponents.EnsureComponent(newUnit)
+	// Parse before linking so a missing config is caught while the dependency is
+	// still unpublished. Other parse errors surface during recursion, as before.
+	if err := ensureParsed(ctx, l, v, newUnit, state.opts, state.discovery); err != nil {
+		if state.discovery.skipMissingDependencyConfig(err) {
+			l.Debugf("Skipping dependency %s of %s: config not found", path, c.Path())
 
-	if created && discovery.discoveryContext != nil {
-		discoveryCtx := discovery.discoveryContext.Copy()
+			return nil, false
+		}
+
+		l.Debugf("Deferring parse error for %s to recursion: %v", path, err)
+	}
+
+	dep, created := state.interTransientComponents.EnsureComponent(newUnit)
+
+	if created && state.discovery.discoveryContext != nil {
+		discoveryCtx := state.discovery.discoveryContext.Copy()
 		discoveryCtx.SuggestOrigin(component.OriginRelationshipDiscovery)
 		dep.SetDiscoveryContext(discoveryCtx)
 

--- a/test/integration_filter_test.go
+++ b/test/integration_filter_test.go
@@ -2841,3 +2841,71 @@ func TestRunAllGitFilterMarkGlobAsReadDeleted(t *testing.T) {
 		})
 	}
 }
+
+// TestRunAllGitFilterDeletedDependencyUnit verifies that `run --all -- plan` with a
+// git-range filter does not crash when the diff deletes a unit that a live, unmodified
+// unit still references via a dependency block. The consumer keeps planning with mocks
+// on the HEAD side and the deleted unit gets its destroy plan on the from side.
+// Regression test for https://github.com/gruntwork-io/terragrunt/issues/6540.
+func TestRunAllGitFilterDeletedDependencyUnit(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+	runner := helpers.InitTestGitRunner(t, tmpDir)
+
+	depDir := filepath.Join(tmpDir, "dep")
+	require.NoError(t, os.MkdirAll(depDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(depDir, "terragrunt.hcl"), []byte(`# dep`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(depDir, "main.tf"), []byte("# minimal"), 0644))
+
+	consumerDir := filepath.Join(tmpDir, "consumer")
+	require.NoError(t, os.MkdirAll(consumerDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(consumerDir, "terragrunt.hcl"), []byte(`dependency "dep" {
+  config_path = "../dep"
+  mock_outputs = { name = "mock" }
+  mock_outputs_allowed_terraform_commands = ["plan", "destroy"]
+}`), 0644))
+	require.NoError(
+		t,
+		os.WriteFile(filepath.Join(consumerDir, "main.tf"), []byte("# minimal"), 0644),
+	)
+
+	require.NoError(t, runner.Add(t.Context(), "."))
+	require.NoError(t, runner.Commit(t.Context(), "Baseline units"))
+
+	// Delete only dep; consumer is untouched but still references it.
+	require.NoError(t, os.RemoveAll(depDir))
+	require.NoError(t, runner.Add(t.Context(), "."))
+	require.NoError(t, runner.Commit(t.Context(), "Delete dep"))
+
+	helpers.CleanupTerraformFolder(t, tmpDir)
+
+	reportFilePath := filepath.Join(tmpDir, helpers.ReportFile)
+
+	cmd := "terragrunt run --all --non-interactive --no-color --working-dir " + tmpDir +
+		" --filter '...[HEAD~1...HEAD]... | ./**' --filter-allow-destroy --report-file " +
+		reportFilePath + " -- plan"
+
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	// A missing IaC binary may fail the plan itself, but discovery must not fail
+	// with the missing-config crash this test pins.
+	if err != nil && !strings.Contains(stderr, "executable file not found") {
+		require.NoError(t, err, "Unexpected error\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+
+	assert.NotContains(t, stderr, "does not contain a terragrunt.hcl",
+		"run --all must not crash on the consumer's dangling dependency reference")
+
+	require.FileExists(t, reportFilePath, "Report file should exist at %s", reportFilePath)
+
+	runs, parseErr := report.ParseJSONRunsFromFile(reportFilePath)
+	require.NoError(t, parseErr, "Should be able to parse report JSON")
+
+	runNames := make([]string, 0, len(runs))
+	for i := range runs {
+		runNames = append(runNames, filepath.Base(runs[i].Name))
+	}
+
+	assert.Contains(t, runNames, "consumer", "live consumer must be part of the run")
+	assert.Contains(t, runNames, "dep", "deleted dep must get its destroy plan")
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

`run --all` with a git-range filter crashed with "does not contain a terragrunt.hcl file" when the diff deleted a unit's directory while a live unit still referenced it via a `dependency` block — while `find`/`list` reported the same filter as healthy

Fixes #6540

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `run --all` with Git-range filters crashing when a deleted unit is still referenced by another unit.
  * Live units now continue processing, optionally using configured mock outputs.
  * Deleted units still receive destroy plans when destroy filtering is enabled.
  * Outside Git filters, missing dependency configurations continue to report errors as expected.

* **Documentation**
  * Added guidance explaining behavior for deleted units with remaining dependency references.
  * Added a v1.1.2 changelog entry for the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->