### PR TITLE
fix: Adding random URL segment to download URI

### DIFF
--- a/docs/src/data/changelog/v1.1.2/provider-cache-download-auth.mdx
+++ b/docs/src/data/changelog/v1.1.2/provider-cache-download-auth.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.2"
+category: "bug-fixes"
+---
+
+#### Provider cache downloads now require a secret URL
+
+The Provider Cache Server now hardens the download endpoint that fetches provider archives on the caller's behalf. That endpoint attaches whatever registry credentials are configured for the upstream host, and it was the only one on the server that did not require the token generated for the run, so any other process on the machine could use a running cache server to pull artifacts from a private registry with the credentials of whoever started the run.
+
+The download URLs handed to OpenTofu and Terraform now carry a secret path segment, generated fresh each time the cache server starts and redacted from the server's own logs. Requests that omit the segment get a 404.

--- a/internal/providercache/providercache_test.go
+++ b/internal/providercache/providercache_test.go
@@ -137,8 +137,8 @@ func TestProviderCache(t *testing.T) {
 			expectedBodyReg: regexp.MustCompile(
 				`\{.*` + regexp.QuoteMeta(
 					`"download_url":"http://127.0.0.1:`,
-				) + `\d+` + regexp.QuoteMeta(
-					`/downloads/releases.hashicorp.com/terraform-provider-aws/5.36.0/terraform-provider-aws_5.36.0_darwin_arm64.zip"`,
+				) + `\d+` + `/downloads/[A-Z2-7]{26}` + regexp.QuoteMeta(
+					`/releases.hashicorp.com/terraform-provider-aws/5.36.0/terraform-provider-aws_5.36.0_darwin_arm64.zip"`,
 				) + `.*\}`,
 			),
 		},

--- a/internal/tf/cache/controllers/downloader.go
+++ b/internal/tf/cache/controllers/downloader.go
@@ -1,8 +1,10 @@
 package controllers
 
 import (
+	"crypto/rand"
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/models"
@@ -20,11 +22,37 @@ type DownloaderController struct {
 
 	ProviderService      *services.ProviderService
 	ProxyProviderHandler *handlers.ProxyProviderHandler
+
+	segment string
+}
+
+// NewDownloaderController returns a controller whose download route is reachable
+// only through a secret path segment, generated fresh for every server.
+//
+// OpenTofu/Terraform fetch a provider archive from an ordinary URL rather than a
+// service endpoint, so they send no credentials with it and the path is the only
+// channel that can carry a secret. The segment is independent of the cache server
+// token so that a download URL surfacing in a log or a debug trace reveals nothing
+// about the token guarding the rest of the API.
+func NewDownloaderController(
+	providerService *services.ProviderService,
+	proxyProviderHandler *handlers.ProxyProviderHandler,
+) *DownloaderController {
+	return &DownloaderController{
+		ProviderService:      providerService,
+		ProxyProviderHandler: proxyProviderHandler,
+		segment:              rand.Text(),
+	}
+}
+
+// Segment returns the secret path segment that gates the download route.
+func (controller *DownloaderController) Segment() string {
+	return controller.segment
 }
 
 // Register implements router.Controller.Register
 func (controller *DownloaderController) Register(router *router.Router) {
-	controller.Router = router.Group(downloadPath)
+	controller.Router = router.Group(path.Join(downloadPath, controller.segment))
 
 	// Download provider
 	controller.GET("/:remote_host/:remote_path", controller.downloadProviderAction)

--- a/internal/tf/cache/download_auth_test.go
+++ b/internal/tf/cache/download_auth_test.go
@@ -1,0 +1,93 @@
+package cache_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestDownloadRouteRequiresSecretSegment verifies that the provider download
+// route is reachable only via the secret path segment the server generates for
+// itself. A caller that does not know the segment (another process on the same
+// host) cannot reach the credential-injecting reverse proxy, while
+// unauthenticated service discovery stays open for the tofu client.
+func TestDownloadRouteRequiresSecretSegment(t *testing.T) {
+	t.Parallel()
+
+	const token = "x-api-key:per-run-secret-token"
+
+	l := logger.CreateLogger()
+	tmp := t.TempDir()
+
+	server := cache.NewServer(
+		cache.WithHostname("127.0.0.1"),
+		cache.WithToken(token),
+		cache.WithLogger(l),
+		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l)),
+		cache.WithProxyProviderHandler(handlers.NewProxyProviderHandler(l, nil)),
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	ln, err := server.Listen(ctx)
+	require.NoError(t, err)
+
+	errGroup, ctx := errgroup.WithContext(ctx)
+	errGroup.Go(func() error { return server.Run(ctx, ln) })
+
+	// Requests that arrive before Serve accepts wait in the listener backlog, so
+	// no readiness poll is needed.
+	base := "http://" + ln.Addr().String()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	segment := server.DownloaderController.Segment()
+
+	const wrongSegment = "AAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+	// Service discovery is intentionally open: the tofu client fetches it
+	// without a token.
+	require.Equal(t, http.StatusOK,
+		getStatus(t, ctx, client, base+"/.well-known/terraform.json"),
+		"discovery must stay open")
+
+	// The pre-hardening URL shape (no secret segment) no longer routes.
+	require.Equal(t, http.StatusNotFound,
+		getStatus(t, ctx, client, base+"/downloads/registry.terraform.io/provider.zip"),
+		"download route must not be reachable without the secret segment")
+
+	require.Equal(t, http.StatusNotFound,
+		getStatus(t, ctx, client, base+"/downloads/"+wrongSegment+"/registry.terraform.io/provider.zip"),
+		"download route must reject an incorrect secret segment")
+
+	// The upstream host is unresolvable, so a routed request fails inside the
+	// proxy rather than 404ing. Any status but 404 proves the route matched,
+	// without depending on network access.
+	require.NotEqual(t, http.StatusNotFound,
+		getStatus(t, ctx, client, base+"/downloads/"+segment+"/example.invalid/provider.zip"),
+		"correct secret segment must resolve the download route")
+
+	cancel()
+	require.NoError(t, errGroup.Wait())
+}
+
+func getStatus(t *testing.T, ctx context.Context, client *http.Client, url string) int {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	return resp.StatusCode
+}

--- a/internal/tf/cache/middleware/logger.go
+++ b/internal/tf/cache/middleware/logger.go
@@ -1,21 +1,29 @@
 package middleware
 
 import (
+	"strings"
+
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )
 
-func Logger(logger log.Logger) echo.MiddlewareFunc {
+// Logger returns middleware that logs every request the cache server handles,
+// with the download route's secret segment scrubbed from the recorded URI.
+func Logger(logger log.Logger, downloadSegment string) echo.MiddlewareFunc {
 	return middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
 		LogStatus:   true,
 		LogURI:      true,
 		LogError:    true,
 		HandleError: true, // forwards error to the global error handler, so it can decide appropriate status code
 		LogValuesFunc: func(_ echo.Context, req middleware.RequestLoggerValues) error {
+			// Failed requests are logged at error level, and those logs end up in
+			// bug reports, where the segment would be a working download URL.
+			uri := strings.ReplaceAll(req.URI, downloadSegment, "REDACTED")
+
 			logger := logger.
-				WithField(placeholders.CacheServerURLKeyName, req.URI).
+				WithField(placeholders.CacheServerURLKeyName, uri).
 				WithField(placeholders.CacheServerStatusKeyName, req.Status)
 			if req.Error != nil {
 				logger.Errorf(

--- a/internal/tf/cache/server.go
+++ b/internal/tf/cache/server.go
@@ -21,9 +21,10 @@ import (
 type Server struct {
 	*router.Router
 	*Config
-	ProviderController *controllers.ProviderController
-	ModuleController   *controllers.ModuleController
-	services           []services.Service
+	ProviderController   *controllers.ProviderController
+	ModuleController     *controllers.ModuleController
+	DownloaderController *controllers.DownloaderController
+	services             []services.Service
 }
 
 // NewServer returns a new Server instance.
@@ -32,10 +33,10 @@ func NewServer(opts ...Option) *Server {
 
 	authMiddleware := middleware.KeyAuth(cfg.token)
 
-	downloaderController := &controllers.DownloaderController{
-		ProxyProviderHandler: cfg.proxyProviderHandler,
-		ProviderService:      cfg.providerService,
-	}
+	downloaderController := controllers.NewDownloaderController(
+		cfg.providerService,
+		cfg.proxyProviderHandler,
+	)
 
 	providerController := &controllers.ProviderController{
 		AuthMiddleware:              authMiddleware,
@@ -63,7 +64,7 @@ func NewServer(opts ...Option) *Server {
 	}
 
 	rootRouter := router.New()
-	rootRouter.Use(middleware.Logger(cfg.logger))
+	rootRouter.Use(middleware.Logger(cfg.logger, downloaderController.Segment()))
 	rootRouter.Use(middleware.Recover(cfg.logger))
 	rootRouter.Register(discoveryController, downloaderController)
 
@@ -75,11 +76,12 @@ func NewServer(opts ...Option) *Server {
 	}
 
 	return &Server{
-		Router:             rootRouter,
-		Config:             cfg,
-		services:           []services.Service{cfg.providerService},
-		ProviderController: providerController,
-		ModuleController:   moduleController,
+		Router:               rootRouter,
+		Config:               cfg,
+		services:             []services.Service{cfg.providerService},
+		ProviderController:   providerController,
+		ModuleController:     moduleController,
+		DownloaderController: downloaderController,
 	}
 }
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds a random segment to the download URL for the provider cache server to harden it against unauthenticated requests from other processes on the same host.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secured provider cache downloads with a unique secret URL segment generated for each server run.
  * Requests using missing or incorrect download credentials now return `404 Not Found`.
  * Download URLs are redacted in server logs to help prevent accidental exposure.

* **Documentation**
  * Added changelog documentation for the provider cache download security hardening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->