### PR TITLE
docs: Adding changelog entry for #5995

### DIFF
--- a/docs/src/data/changelog/v1.1.2/run-all-feature-defaults-isolation.mdx
+++ b/docs/src/data/changelog/v1.1.2/run-all-feature-defaults-isolation.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.2"
+category: "bug-fixes"
+---
+
+#### Feature flag defaults no longer leak between units in `run --all`
+
+A [`feature`](/reference/hcl/blocks#feature) block's `default` was recorded once per run and shared by every unit. During `run --all`, the first unit to be parsed set the value for a flag name, so a unit defining `default = false` could evaluate `feature.toggle.value` as `true` because a sibling unit was parsed first. Which unit won depended on parsing order, making the result vary between runs.
+
+Defaults are now resolved per unit, including defaults inherited through `include`. Overrides passed with `--feature` or `TG_FEATURE` continue to apply to every unit in the run.
+
+Thanks to [@dhotcolorado](https://github.com/dhotcolorado) for reporting and fixing this!


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adding changelog entry for #5995.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `run --all` so `feature` block `default` isolation is handled consistently, removing order-dependent results caused by how units are parsed.
  * Ensured defaults inherited via includes are resolved per unit, while `--feature` / `TG_FEATURE` overrides still apply across all units.
* **Documentation**
  * Updated the v1.1.2 changelog entry to clarify the new default-resolution behavior and precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->