### PR TITLE
chore: Updating testing for provider cache server url segment

### DIFF
--- a/internal/providercache/providercache_test.go
+++ b/internal/providercache/providercache_test.go
@@ -13,7 +13,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"testing"
 
@@ -72,20 +71,19 @@ func TestProviderCache(t *testing.T) {
 	)
 
 	testCases := []struct {
-		expectedBodyReg    *regexp.Regexp
-		fullURLPath        string
-		relURLPath         string
-		expectedCachePath  string
-		opts               []cache.Option
-		expectedStatusCode int
+		fullURLPath          string
+		relURLPath           string
+		expectedBody         string
+		expectedDownloadPath string
+		expectedCachePath    string
+		opts                 []cache.Option
+		expectedStatusCode   int
 	}{
 		{
 			opts:               opts,
 			fullURLPath:        "/.well-known/terraform.json",
 			expectedStatusCode: http.StatusOK,
-			expectedBodyReg: regexp.MustCompile(
-				regexp.QuoteMeta(`{"providers.v1":"/v1/providers"}`),
-			),
+			expectedBody:       `{"providers.v1":"/v1/providers"}`,
 		},
 		{
 			opts:               append(opts, cache.WithToken("")),
@@ -96,9 +94,7 @@ func TestProviderCache(t *testing.T) {
 			opts:               opts,
 			relURLPath:         "/cache/registry.terraform.io/hashicorp/aws/versions",
 			expectedStatusCode: http.StatusOK,
-			expectedBodyReg: regexp.MustCompile(
-				regexp.QuoteMeta(`"version":"5.36.0","protocols":["5.0"],"platforms"`),
-			),
+			expectedBody:       `"version":"5.36.0","protocols":["5.0"],"platforms"`,
 		},
 		{
 			opts:               opts,
@@ -134,13 +130,8 @@ func TestProviderCache(t *testing.T) {
 			opts:               opts,
 			relURLPath:         "//registry.terraform.io/hashicorp/aws/5.36.0/download/darwin/arm64",
 			expectedStatusCode: http.StatusOK,
-			expectedBodyReg: regexp.MustCompile(
-				`\{.*` + regexp.QuoteMeta(
-					`"download_url":"http://127.0.0.1:`,
-				) + `\d+` + `/downloads/[A-Z2-7]{26}` + regexp.QuoteMeta(
-					`/releases.hashicorp.com/terraform-provider-aws/5.36.0/terraform-provider-aws_5.36.0_darwin_arm64.zip"`,
-				) + `.*\}`,
-			),
+			expectedDownloadPath: "/releases.hashicorp.com/terraform-provider-aws/5.36.0/" +
+				"terraform-provider-aws_5.36.0_darwin_arm64.zip",
 		},
 	}
 
@@ -203,10 +194,21 @@ func TestProviderCache(t *testing.T) {
 
 			assert.Equal(t, tc.expectedStatusCode, resp.StatusCode)
 
-			if tc.expectedBodyReg != nil {
+			if tc.expectedBody != "" || tc.expectedDownloadPath != "" {
 				body, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
-				assert.Regexp(t, tc.expectedBodyReg, string(body))
+
+				if tc.expectedBody != "" {
+					assert.Contains(t, string(body), tc.expectedBody)
+				}
+
+				if tc.expectedDownloadPath != "" {
+					downloadURL := "http://" + ln.Addr().String() +
+						"/downloads/" + server.DownloaderController.Segment() +
+						tc.expectedDownloadPath
+
+					assert.Contains(t, string(body), `"download_url":"`+downloadURL+`"`)
+				}
 			}
 
 			// Skip WaitForCacheReady for unauthorized test cases since they don't trigger background operations,

--- a/internal/tf/cache/download_auth_test.go
+++ b/internal/tf/cache/download_auth_test.go
@@ -2,14 +2,20 @@ package cache_test
 
 import (
 	"context"
+	"io"
 	"net/http"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
@@ -77,6 +83,86 @@ func TestDownloadRouteRequiresSecretSegment(t *testing.T) {
 
 	cancel()
 	require.NoError(t, errGroup.Wait())
+}
+
+// TestDownloadSegmentIsRedactedFromLogs verifies that the secret segment never
+// reaches a log entry, where it would otherwise travel into a bug report as a
+// working download URL.
+func TestDownloadSegmentIsRedactedFromLogs(t *testing.T) {
+	t.Parallel()
+
+	hook := new(urlFieldHook)
+
+	// Successful requests are logged at trace level, failed ones at error level;
+	// trace captures the URI either way, so the assertion below does not depend
+	// on how far into the proxy the request gets.
+	l := logger.CreateLogger().WithOptions(
+		log.WithLevel(log.TraceLevel),
+		log.WithOutput(io.Discard),
+		log.WithHooks(hook),
+	)
+	tmp := t.TempDir()
+
+	server := cache.NewServer(
+		cache.WithHostname("127.0.0.1"),
+		cache.WithLogger(l),
+		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l)),
+		cache.WithProxyProviderHandler(handlers.NewProxyProviderHandler(l, nil)),
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	ln, err := server.Listen(ctx)
+	require.NoError(t, err)
+
+	errGroup, ctx := errgroup.WithContext(ctx)
+	errGroup.Go(func() error { return server.Run(ctx, ln) })
+
+	segment := server.DownloaderController.Segment()
+
+	getStatus(t, ctx, &http.Client{Timeout: 5 * time.Second},
+		"http://"+ln.Addr().String()+"/downloads/"+segment+"/example.invalid/provider.zip")
+
+	// Shutting the server down first joins the request goroutine that logs.
+	cancel()
+	require.NoError(t, errGroup.Wait())
+
+	uris := hook.URIs()
+	require.Len(t, uris, 1)
+	require.NotContains(t, uris[0], segment, "the secret segment must not reach the logs")
+	require.Contains(t, uris[0], "example.invalid", "the rest of the URI must still be logged")
+}
+
+// urlFieldHook collects the URI of every request the cache server logs.
+type urlFieldHook struct {
+	uris []string
+	mu   sync.Mutex
+}
+
+func (hook *urlFieldHook) Levels() []logrus.Level {
+	return log.AllLevels.ToLogrusLevels()
+}
+
+func (hook *urlFieldHook) Fire(entry *logrus.Entry) error {
+	uri, ok := entry.Data[placeholders.CacheServerURLKeyName].(string)
+	if !ok {
+		return nil
+	}
+
+	hook.mu.Lock()
+	defer hook.mu.Unlock()
+
+	hook.uris = append(hook.uris, uri)
+
+	return nil
+}
+
+func (hook *urlFieldHook) URIs() []string {
+	hook.mu.Lock()
+	defer hook.mu.Unlock()
+
+	return slices.Clone(hook.uris)
 }
 
 func getStatus(t *testing.T, ctx context.Context, client *http.Client, url string) int {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Cleans up the tests added in #6549.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved provider cache response validation for more reliable download URL checks.
  * Added coverage to ensure secret download URL segments are excluded from cache server logs while preserving upstream host details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->