### PR TITLE
fix: Correcting stale ComponentDiscovery call in tui model test

### DIFF
--- a/internal/cli/commands/catalog/tui/model_test.go
+++ b/internal/cli/commands/catalog/tui/model_test.go
@@ -360,7 +360,7 @@ func TestModelCtrlDOnPagerScaffoldsImmediatelyWithRacing(t *testing.T) {
 
 		repo := newFakeRepo(t, fsys, repoDir)
 
-		components, err := tui.NewComponentDiscovery().WithFS(fsys).Discover(repo)
+		components, err := tui.NewComponentDiscovery().Discover(fsys, repo)
 		require.NoError(t, err)
 		require.Len(t, components, 1)
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test setup for component discovery to use the current in-memory filesystem interface.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->