### PR TITLE
chore: Reducing race in vexec testing

### DIFF
--- a/internal/os/exec/cmd_unix_test.go
+++ b/internal/os/exec/cmd_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -22,6 +23,20 @@ import (
 var (
 	errExplicitError = errors.New("this is an explicit error")
 )
+
+// requireTrapReady blocks until the subprocess writes its marker file. Signalling on a
+// timer instead races the child's startup: a SIGINT that lands before the script reaches
+// its `trap` line kills it outright, so the handler never runs and the exit code is the
+// signal status rather than the value the test asserts on.
+func requireTrapReady(t *testing.T, readyPath string) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(readyPath)
+
+		return err == nil
+	}, 10*time.Second, 10*time.Millisecond, "child never wrote the trap-ready marker")
+}
 
 func TestExitCodeUnix(t *testing.T) {
 	t.Parallel()
@@ -62,11 +77,14 @@ func TestNewSignalsForwarderWaitUnix(t *testing.T) {
 
 	l := logger.CreateLogger()
 
+	readyPath := filepath.Join(t.TempDir(), "sigint-ready")
+
 	cmd := exec.Command(
 		t.Context(),
 		vexec.NewOSExec(),
 		"testdata/test_sigint_wait.sh",
 		strconv.Itoa(expectedWait),
+		readyPath,
 	)
 
 	runChannel := make(chan error)
@@ -75,7 +93,7 @@ func TestNewSignalsForwarderWaitUnix(t *testing.T) {
 		runChannel <- cmd.Run(l)
 	}()
 
-	time.Sleep(time.Second)
+	requireTrapReady(t, readyPath)
 
 	start := time.Now()
 
@@ -105,9 +123,11 @@ func TestNewSignalsForwarderMultipleUnix(t *testing.T) {
 
 	l := logger.CreateLogger()
 
+	readyPath := filepath.Join(t.TempDir(), "sigint-ready")
+
 	cmd := exec.Command(
 		t.Context(), vexec.NewOSExec(),
-		"testdata/test_sigint_multiple.sh", strconv.Itoa(expectedInterrupts),
+		"testdata/test_sigint_multiple.sh", strconv.Itoa(expectedInterrupts), readyPath,
 	)
 
 	runChannel := make(chan error)
@@ -116,7 +136,7 @@ func TestNewSignalsForwarderMultipleUnix(t *testing.T) {
 		runChannel <- cmd.Run(l)
 	}()
 
-	time.Sleep(time.Second)
+	requireTrapReady(t, readyPath)
 
 	interruptAndWaitForProcess := func() (int, error) {
 		var (
@@ -159,7 +179,9 @@ func TestGracefulShutdownOnContextCancelUnix(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	cmd := exec.Command(ctx, vexec.NewOSExec(), "testdata/test_graceful_shutdown.sh")
+	readyPath := filepath.Join(t.TempDir(), "sigint-ready")
+
+	cmd := exec.Command(ctx, vexec.NewOSExec(), "testdata/test_graceful_shutdown.sh", readyPath)
 
 	cmd.Configure(exec.WithGracefulShutdownDelay(5 * time.Second))
 
@@ -169,7 +191,7 @@ func TestGracefulShutdownOnContextCancelUnix(t *testing.T) {
 		runChannel <- cmd.Run(l)
 	}()
 
-	time.Sleep(500 * time.Millisecond)
+	requireTrapReady(t, readyPath)
 
 	cancel()
 

--- a/internal/os/exec/testdata/test_graceful_shutdown.sh
+++ b/internal/os/exec/testdata/test_graceful_shutdown.sh
@@ -6,6 +6,11 @@ set -e
 # It exits with code 1 if terminated by SIGKILL (or any other unexpected termination).
 # This is used to verify that the graceful shutdown sends SIGINT rather than SIGKILL.
 
+READY_FILE=$1
+
 trap 'exit 42' INT
+
+# The marker tells the test the INT trap is installed and a signal can be sent.
+: >"$READY_FILE"
 
 while true; do sleep 0.1; done

--- a/internal/os/exec/testdata/test_sigint_multiple.sh
+++ b/internal/os/exec/testdata/test_sigint_multiple.sh
@@ -3,6 +3,7 @@
 set -e
 
 INT_REQUIRED=$1
+READY_FILE=$2
 INT_COUNTER=0
 
 trap int_handler INT
@@ -11,6 +12,9 @@ trap int_handler INT
 function int_handler() {
 	INT_COUNTER=$((INT_COUNTER + 1))
 }
+
+# The marker tells the test the INT trap is installed and a signal can be sent.
+: >"$READY_FILE"
 
 while [[ $INT_COUNTER -lt $INT_REQUIRED ]]; do
 	sleep 0.1

--- a/internal/os/exec/testdata/test_sigint_wait.sh
+++ b/internal/os/exec/testdata/test_sigint_wait.sh
@@ -3,6 +3,7 @@
 set -e
 
 WAIT_TIME=$1
+READY_FILE=$2
 
 trap int_handler INT
 
@@ -10,5 +11,8 @@ function int_handler() {
 	sleep "$WAIT_TIME"
 	exit "$WAIT_TIME"
 }
+
+# The marker tells the test the INT trap is installed and a signal can be sent.
+: >"$READY_FILE"
 
 while true; do sleep 0.1; done

--- a/internal/vexec/vexec.go
+++ b/internal/vexec/vexec.go
@@ -145,7 +145,8 @@ func (osExec) LookPath(file string) (string, error) {
 }
 
 type osCmd struct {
-	cmd *exec.Cmd
+	cmd     *exec.Cmd
+	startMu sync.Mutex
 }
 
 func (c *osCmd) SetStdin(r io.Reader)  { c.cmd.Stdin = r }
@@ -158,16 +159,36 @@ func (c *osCmd) SetWaitDelay(d time.Duration) { c.cmd.WaitDelay = d }
 
 func (c *osCmd) SetCancel(fn func() error) { c.cmd.Cancel = fn }
 
+// Signal is documented to tolerate racing startup, so it may run on another
+// goroutine while Start is still populating the process handle. Reading that
+// handle under the same lock Start holds is what makes the race benign.
 func (c *osCmd) Signal(sig os.Signal) error {
-	if c.cmd.Process == nil {
+	c.startMu.Lock()
+	proc := c.cmd.Process
+	c.startMu.Unlock()
+
+	if proc == nil {
 		return ErrProcessNotStarted
 	}
 
-	return c.cmd.Process.Signal(sig)
+	return proc.Signal(sig)
 }
 
-func (c *osCmd) Run() error                      { return c.cmd.Run() }
-func (c *osCmd) Start() error                    { return c.cmd.Start() }
+func (c *osCmd) Run() error {
+	if err := c.Start(); err != nil {
+		return err
+	}
+
+	return c.cmd.Wait()
+}
+
+func (c *osCmd) Start() error {
+	c.startMu.Lock()
+	defer c.startMu.Unlock()
+
+	return c.cmd.Start()
+}
+
 func (c *osCmd) Wait() error                     { return c.cmd.Wait() }
 func (c *osCmd) Output() ([]byte, error)         { return c.cmd.Output() }
 func (c *osCmd) CombinedOutput() ([]byte, error) { return c.cmd.CombinedOutput() }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Reduces likelihood of races in the vexec tests.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command signal handling when a process is starting, preventing intermittent failures and ensuring safe concurrent operations.
  - Enhanced process execution flow so commands consistently wait for started processes to finish.

- **Tests**
  - Improved Unix signal-handling test reliability by waiting for subprocesses to be ready instead of relying on fixed delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->