### PR TITLE
docs: Adding search telemetry

### DIFF
--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -8,6 +8,7 @@ import HeadphonesIcon from '@assets/headset-icon.svg';
 import PipelineIcon from '@assets/pipelines.svg';
 import TerragruntLogo from '@assets/horizontal-logo-light.svg';
 import TerragruntIcon from '@assets/logo-dark-2.svg';
+import SearchTelemetry from '@components/SearchTelemetry.astro';
 import ThemeToggle from '@components/ThemeToggle.astro';
 import ButtonLink from '@components/ui/ButtonLink.astro';
 import { getGitHubRepo, formatStarCount } from '@lib/github';
@@ -212,6 +213,8 @@ if (!process.env.GITHUB_STARS) {
     </div>
   </div>
 </div>
+
+<SearchTelemetry />
 
 <!-- Google Tag Manager -->
 <script type="text/partytown">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/docs/src/components/SearchTelemetry.astro
+++ b/docs/src/components/SearchTelemetry.astro
@@ -1,0 +1,150 @@
+<script>
+  import { capture } from "@lib/analytics";
+  import {
+    KAPA_EVENT_NAMES,
+    createSearchTracker,
+    hasSettled,
+    kapaEventProperties,
+    normalizeQuery,
+    parseResultCount,
+    searchingPrefix,
+  } from "@lib/search-telemetry";
+
+  const TYPING_SETTLE_MS = 800;
+  const RESULTS_POLL_MS = 100;
+  const RESULTS_TIMEOUT_MS = 10_000;
+
+  type KapaFn = (
+    event: string,
+    handler: (payload: unknown) => void,
+    action: "add" | "remove",
+  ) => void;
+
+  /**
+   * Instruments Starlight's search modal from the outside. Starlight builds the modal and hands the
+   * inside of it to Pagefind, neither of which offers a hook we can pass a callback to, so the
+   * signals come from the markup both of them already style and depend on.
+   */
+  function instrumentSearch(siteSearch: Element) {
+    const dialog = siteSearch.querySelector("dialog");
+    if (!dialog) return;
+
+    const tracker = createSearchTracker(capture);
+    const results = () => siteSearch.querySelector("#starlight__search");
+    const message = () => results()?.querySelector(".pagefind-ui__message")?.textContent ?? null;
+    const loadingPrefix = searchingPrefix(siteSearch.getAttribute("data-translations"));
+
+    let trigger = "unknown";
+    let typingTimer = 0;
+    let resultsPoll = 0;
+    let pendingQuery = "";
+
+    const report = (query: string) => {
+      const rendered = results()?.querySelectorAll(".pagefind-ui__result").length ?? 0;
+      tracker.recordQuery(query, parseResultCount(message(), rendered));
+    };
+
+    const reportNow = () => {
+      window.clearTimeout(typingTimer);
+      window.clearInterval(resultsPoll);
+
+      const query = normalizeQuery(pendingQuery);
+      if (query) report(query);
+    };
+
+    const reportWhenResultsArrive = () => {
+      window.clearInterval(resultsPoll);
+
+      const query = normalizeQuery(pendingQuery);
+      if (!query) return;
+
+      const deadline = Date.now() + RESULTS_TIMEOUT_MS;
+
+      const attempt = () => {
+        if (!hasSettled(message(), query, loadingPrefix) && Date.now() < deadline) return false;
+
+        report(query);
+        return true;
+      };
+
+      if (attempt()) return;
+      resultsPoll = window.setInterval(() => {
+        if (attempt()) window.clearInterval(resultsPoll);
+      }, RESULTS_POLL_MS);
+    };
+
+    siteSearch.addEventListener("click", () => (trigger = "button"), true);
+    window.addEventListener(
+      "keydown",
+      (event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key === "k") trigger = "shortcut";
+      },
+      true,
+    );
+
+    new MutationObserver(() => {
+      if (dialog.open) {
+        tracker.open(trigger);
+        return;
+      }
+
+      reportNow();
+      tracker.close();
+      pendingQuery = "";
+    }).observe(dialog, { attributes: true, attributeFilter: ["open"] });
+
+    dialog.addEventListener("input", (event) => {
+      const input = event.target;
+      if (!(input instanceof HTMLInputElement)) return;
+      if (!input.classList.contains("pagefind-ui__search-input")) return;
+
+      pendingQuery = input.value;
+      window.clearTimeout(typingTimer);
+      window.clearInterval(resultsPoll);
+      typingTimer = window.setTimeout(reportWhenResultsArrive, TYPING_SETTLE_MS);
+    });
+
+    dialog.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const link = target.closest(".pagefind-ui__result-link");
+      if (!link) return;
+
+      reportNow();
+
+      const links = Array.from(results()?.querySelectorAll(".pagefind-ui__result-link") ?? []);
+      const href = new URL(link.getAttribute("href") ?? "", location.origin);
+
+      tracker.recordResultClick({
+        url: href.pathname + href.hash,
+        position: links.indexOf(link) + 1,
+        isSubResult: link.closest(".pagefind-ui__result-nested") !== null,
+      });
+    });
+  }
+
+  /**
+   * Forwards the kapa.ai widget's own events. The widget covers both asking the AI and a second
+   * search box, and shares a PostHog session with the modal above, so a reader who searches, finds
+   * nothing, and then asks the assistant stays a single session.
+   */
+  function instrumentKapa(): boolean {
+    const kapa = (window as unknown as { Kapa?: KapaFn }).Kapa;
+    if (typeof kapa !== "function") return false;
+
+    for (const [widgetEvent, name] of Object.entries(KAPA_EVENT_NAMES)) {
+      kapa(widgetEvent, (payload) => capture(name, kapaEventProperties(payload)), "add");
+    }
+
+    return true;
+  }
+
+  document.querySelectorAll("site-search").forEach(instrumentSearch);
+
+  if (!instrumentKapa()) {
+    document
+      .querySelector('script[src*="kapa-widget"]')
+      ?.addEventListener("load", () => instrumentKapa(), { once: true });
+  }
+</script>

--- a/docs/src/lib/analytics.ts
+++ b/docs/src/lib/analytics.ts
@@ -1,0 +1,70 @@
+interface PostHogClient {
+  capture(event: string, properties: Record<string, unknown>): void;
+}
+
+interface PendingEvent {
+  event: string;
+  properties: Record<string, unknown>;
+}
+
+const PRODUCTION_HOSTNAME = "docs.terragrunt.com";
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
+
+const PENDING_LIMIT = 20;
+const CLIENT_POLL_MS = 500;
+const CLIENT_TIMEOUT_MS = 30_000;
+
+const pending: PendingEvent[] = [];
+
+let pollingForClient = 0;
+
+/**
+ * Reports an event to PostHog.
+ */
+export function capture(event: string, properties: Record<string, unknown> = {}): void {
+  if (import.meta.env.DEV) {
+    console.debug(`[analytics] ${event}`, properties);
+    return;
+  }
+
+  const reported = { ...properties, docs_environment: environment() };
+
+  const posthog = client();
+  if (posthog) {
+    posthog.capture(event, reported);
+    return;
+  }
+
+  if (pending.length < PENDING_LIMIT) pending.push({ event, properties: reported });
+  waitForClient();
+}
+
+function client(): PostHogClient | undefined {
+  return (window as unknown as { posthog?: PostHogClient }).posthog;
+}
+
+function waitForClient(): void {
+  if (pollingForClient) return;
+
+  const deadline = Date.now() + CLIENT_TIMEOUT_MS;
+
+  pollingForClient = window.setInterval(() => {
+    const posthog = client();
+    if (!posthog && Date.now() < deadline) return;
+
+    window.clearInterval(pollingForClient);
+    pollingForClient = 0;
+
+    const held = pending.splice(0);
+    if (!posthog) return;
+
+    for (const { event, properties } of held) posthog.capture(event, properties);
+  }, CLIENT_POLL_MS);
+}
+
+function environment(): string {
+  if (location.hostname === PRODUCTION_HOSTNAME) return "production";
+  if (LOCAL_HOSTNAMES.has(location.hostname)) return "local";
+
+  return "preview";
+}

--- a/docs/src/lib/search-telemetry.test.ts
+++ b/docs/src/lib/search-telemetry.test.ts
@@ -1,0 +1,397 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SEARCH_EVENTS,
+  createSearchTracker,
+  hasSettled,
+  kapaEventProperties,
+  normalizeQuery,
+  parseResultCount,
+  redact,
+  searchingPrefix,
+} from "./search-telemetry";
+
+const TRANSLATIONS = JSON.stringify({
+  placeholder: "Search",
+  zero_results: "No results for [SEARCH_TERM]",
+  many_results: "[COUNT] results for [SEARCH_TERM]",
+  searching: "Searching for [SEARCH_TERM]...",
+});
+
+const LOADING_PREFIX = "Searching for ";
+
+interface CapturedEvent {
+  event: string;
+  properties: Record<string, unknown>;
+}
+
+function makeTracker() {
+  const captured: CapturedEvent[] = [];
+  const tracker = createSearchTracker((event, properties) => {
+    captured.push({ event, properties });
+  });
+  return { tracker, captured };
+}
+
+describe("normalizeQuery", () => {
+  test("trims surrounding whitespace", () => {
+    expect(normalizeQuery("  terragrunt run  ")).toBe("terragrunt run");
+  });
+
+  test("collapses runs of whitespace", () => {
+    expect(normalizeQuery("terragrunt\t\n  run")).toBe("terragrunt run");
+  });
+
+  test("returns an empty string for whitespace-only input", () => {
+    expect(normalizeQuery("   ")).toBe("");
+  });
+});
+
+describe("parseResultCount", () => {
+  test("reads the total from Pagefind's message", () => {
+    expect(parseResultCount("42 results for stacks", 5)).toBe(42);
+  });
+
+  test("ignores numbers inside the search term", () => {
+    expect(parseResultCount("No results for opentofu 1.5", 0)).toBe(0);
+  });
+
+  test("falls back to the rendered count when the message has no total", () => {
+    expect(parseResultCount("No results for stakcs. Showing results for stacks instead", 5)).toBe(5);
+  });
+
+  test("falls back to the rendered count when there is no message", () => {
+    expect(parseResultCount(null, 3)).toBe(3);
+  });
+});
+
+describe("redact", () => {
+  test("leaves ordinary searches alone", () => {
+    const searches = [
+      "terragrunt run --all apply",
+      "registry.opentofu.org/hashicorp/aws",
+      "arn:aws:iam::123456789012:role/terragrunt",
+      "S3_BUCKET_NAME",
+      "how do I configure a state backend?",
+      "terragrunt.stack.hcl",
+    ];
+
+    for (const search of searches) expect(redact(search)).toBe(search);
+  });
+
+  test("removes email addresses", () => {
+    expect(redact("invite example@acme.com to the org")).toBe("invite [email] to the org");
+  });
+
+  test("removes AWS access key ids", () => {
+    expect(redact("AKIAIOSFODNN7EXAMPLE denied")).toBe("[redacted] denied");
+  });
+
+  test("removes GitHub tokens", () => {
+    expect(redact("ghp_" + "a1b2c3d4e5".repeat(3) + " expired")).toBe("[redacted] expired");
+  });
+
+  test("removes Slack tokens", () => {
+    expect(redact("xoxb-1234567890-abcdefghij")).toBe("[redacted]");
+  });
+
+  test("removes JSON web tokens", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+    expect(redact(`auth failing with ${jwt}`)).toBe("auth failing with [redacted]");
+  });
+
+  test("removes private key blocks", () => {
+    expect(redact("-----BEGIN RSA PRIVATE KEY-----")).toBe("[redacted]");
+  });
+
+  test("removes the value assigned to a secret-ish name, keeping the name", () => {
+    expect(redact("password=hunter2")).toBe("password=[redacted]");
+    expect(redact("api_key: abc123")).toBe("api_key: [redacted]");
+    expect(redact("TOKEN = xyz")).toBe("TOKEN = [redacted]");
+  });
+
+  test("removes long generated-looking strings", () => {
+    expect(redact("wJalrXUtnFEMI1K7MDENG2bPxRfiCYEXAMPLEKEY")).toBe("[redacted]");
+  });
+
+  test("keeps long strings that are not mixed enough to be credentials", () => {
+    const slug = "terragrunt-stack-configuration-and-orchestration";
+    expect(redact(slug)).toBe(slug);
+  });
+});
+
+describe("searchingPrefix", () => {
+  test("takes the fixed part of Pagefind's searching message", () => {
+    expect(searchingPrefix(TRANSLATIONS)).toBe(LOADING_PREFIX);
+  });
+
+  test("works for a translation that leads with the search term", () => {
+    expect(searchingPrefix(JSON.stringify({ searching: "[SEARCH_TERM] wird gesucht..." }))).toBe("");
+  });
+
+  test("falls back to Pagefind's own wording when the site has not overridden it", () => {
+    expect(searchingPrefix(null)).toBe(LOADING_PREFIX);
+    expect(searchingPrefix("not json")).toBe(LOADING_PREFIX);
+    expect(searchingPrefix(JSON.stringify({ placeholder: "Search" }))).toBe(LOADING_PREFIX);
+  });
+});
+
+describe("hasSettled", () => {
+  test("treats a result count for the current query as settled", () => {
+    expect(hasSettled("28 results for lock file", "lock file", LOADING_PREFIX)).toBe(true);
+  });
+
+  test("treats no results for the current query as settled", () => {
+    expect(hasSettled("No results for lock file", "lock file", LOADING_PREFIX)).toBe(true);
+  });
+
+  test("does not treat Pagefind's searching message as settled", () => {
+    expect(hasSettled("Searching for lock file...", "lock file", LOADING_PREFIX)).toBe(false);
+  });
+
+  test("does not treat a missing message as settled", () => {
+    expect(hasSettled(null, "lock file", LOADING_PREFIX)).toBe(false);
+  });
+
+  test("does not treat the previous query's message as settled", () => {
+    expect(hasSettled("28 results for lock file", "provider cache", LOADING_PREFIX)).toBe(false);
+  });
+
+  test("ignores case when matching the query", () => {
+    expect(hasSettled("28 results for Lock File", "lock file", LOADING_PREFIX)).toBe(true);
+  });
+
+  test("keeps matching when no loading prefix could be derived", () => {
+    expect(hasSettled("28 results for lock file", "lock file", "")).toBe(true);
+  });
+
+  test("treats a leading total as final even when it starts with the loading prefix", () => {
+    expect(hasSettled("28 results for lock file", "lock file", "28 ")).toBe(true);
+  });
+});
+
+describe("createSearchTracker", () => {
+  test("reports the modal opening once per open", () => {
+    const { tracker, captured } = makeTracker();
+
+    tracker.open("shortcut");
+    tracker.open("shortcut");
+
+    expect(captured).toEqual([
+      { event: SEARCH_EVENTS.opened, properties: { trigger: "shortcut" } },
+    ]);
+  });
+
+  test("reports the modal opening again after it closes", () => {
+    const { tracker, captured } = makeTracker();
+
+    tracker.open("button");
+    tracker.close();
+    tracker.open("shortcut");
+
+    expect(captured.map((c) => c.properties.trigger)).toEqual(["button", "shortcut"]);
+  });
+
+  test("reports a query with its result count", () => {
+    const { tracker, captured } = makeTracker();
+
+    tracker.open("button");
+    tracker.recordQuery("  run   queue ", 7);
+
+    expect(captured[1]).toEqual({
+      event: SEARCH_EVENTS.query,
+      properties: { query: "run queue", query_length: 9, result_count: 7, has_results: true },
+    });
+  });
+
+  test("marks a query that found nothing", () => {
+    const { tracker, captured } = makeTracker();
+
+    tracker.open("button");
+    tracker.recordQuery("nonexistent", 0);
+
+    expect(captured[1]?.properties.has_results).toBe(false);
+  });
+
+  test("ignores an empty query", () => {
+    const { tracker, captured } = makeTracker();
+
+    tracker.open("button");
+    tracker.recordQuery("   ", 0);
+
+    expect(captured).toHaveLength(1);
+  });
+
+  test("reports a repeated query only once", () => {
+    const { tracker, captured } = makeTracker();
+
+    tracker.open("button");
+    tracker.recordQuery("stacks", 4);
+    tracker.recordQuery("stacks", 4);
+
+    expect(captured).toHaveLength(2);
+  });
+
+  test("reports a query the reader returns to after refining it", () => {
+    const { tracker, captured } = makeTracker();
+
+    tracker.open("button");
+    tracker.recordQuery("stack", 9);
+    tracker.recordQuery("stacks", 4);
+    tracker.recordQuery("stack", 9);
+
+    const queries = captured.filter((c) => c.event === SEARCH_EVENTS.query);
+    expect(queries.map((c) => c.properties.query)).toEqual(["stack", "stacks", "stack"]);
+  });
+
+  test("reports a redacted query, measured at the length the reader typed", () => {
+    const { tracker, captured } = makeTracker();
+    const typed = "reset password=hunter2";
+
+    tracker.open("button");
+    tracker.recordQuery(typed, 3);
+
+    expect(captured[1]?.properties).toEqual({
+      query: "reset password=[redacted]",
+      query_length: typed.length,
+      result_count: 3,
+      has_results: true,
+    });
+  });
+
+  test("keeps the query redacted on the events that follow it", () => {
+    const { tracker, captured } = makeTracker();
+
+    tracker.open("button");
+    tracker.recordQuery("mail example@acme.com", 2);
+    tracker.recordResultClick({ url: "/community/support/", position: 1, isSubResult: false });
+    tracker.close();
+    tracker.open("button");
+    tracker.recordQuery("mail example@acme.com", 2);
+    tracker.close();
+
+    const carrying = captured.filter((c) => "query" in c.properties);
+    expect(carrying.map((c) => c.event)).toEqual([
+      SEARCH_EVENTS.query,
+      SEARCH_EVENTS.resultClicked,
+      SEARCH_EVENTS.query,
+      SEARCH_EVENTS.abandoned,
+    ]);
+    expect(carrying.every((c) => c.properties.query === "mail [email]")).toBe(true);
+  });
+
+  test("attributes a result click to the query that produced it", () => {
+    const { tracker, captured } = makeTracker();
+
+    tracker.open("button");
+    tracker.recordQuery("stacks", 4);
+    tracker.recordResultClick({ url: "/features/stacks/", position: 2, isSubResult: true });
+
+    expect(captured[2]).toEqual({
+      event: SEARCH_EVENTS.resultClicked,
+      properties: {
+        query: "stacks",
+        result_count: 4,
+        url: "/features/stacks/",
+        position: 2,
+        is_sub_result: true,
+      },
+    });
+  });
+
+  test("reports an abandoned search when the modal closes without a click", () => {
+    const { tracker, captured } = makeTracker();
+
+    tracker.open("button");
+    tracker.recordQuery("stacks", 4);
+    tracker.close();
+
+    expect(captured[2]).toEqual({
+      event: SEARCH_EVENTS.abandoned,
+      properties: { query: "stacks", query_length: 6, result_count: 4 },
+    });
+  });
+
+  test("does not report an abandoned search after a result click", () => {
+    const { tracker, captured } = makeTracker();
+
+    tracker.open("button");
+    tracker.recordQuery("stacks", 4);
+    tracker.recordResultClick({ url: "/features/stacks/", position: 1, isSubResult: false });
+    tracker.close();
+
+    expect(captured.map((c) => c.event)).not.toContain(SEARCH_EVENTS.abandoned);
+  });
+
+  test("does not report an abandoned search when nothing was typed", () => {
+    const { tracker, captured } = makeTracker();
+
+    tracker.open("shortcut");
+    tracker.close();
+
+    expect(captured).toHaveLength(1);
+  });
+
+  test("does not carry a query across two openings of the modal", () => {
+    const { tracker, captured } = makeTracker();
+
+    tracker.open("button");
+    tracker.recordQuery("stacks", 4);
+    tracker.close();
+    tracker.open("button");
+    tracker.close();
+
+    expect(captured.filter((c) => c.event === SEARCH_EVENTS.abandoned)).toHaveLength(1);
+  });
+});
+
+describe("kapaEventProperties", () => {
+  test("converts payload keys to snake case", () => {
+    const properties = kapaEventProperties({ threadId: "t-1", questionAnswerId: "qa-1" });
+
+    expect(properties).toEqual({ thread_id: "t-1", question_answer_id: "qa-1" });
+  });
+
+  test("keeps numbers and booleans", () => {
+    expect(kapaEventProperties({ resultCount: 3, isFirst: false })).toEqual({
+      result_count: 3,
+      is_first: false,
+    });
+  });
+
+  test("replaces the answer with its length", () => {
+    expect(kapaEventProperties({ answer: "a".repeat(42) })).toEqual({ answer_length: 42 });
+  });
+
+  test("drops conversation history", () => {
+    const properties = kapaEventProperties({
+      question: "what is a stack?",
+      conversation: [{ role: "user", content: "what is a stack?" }],
+      sources: ["/features/stacks/"],
+    });
+
+    expect(properties).toEqual({ question: "what is a stack?" });
+  });
+
+  test("redacts credentials out of the question", () => {
+    expect(kapaEventProperties({ question: "why is AKIAIOSFODNN7EXAMPLE denied?" })).toEqual({
+      question: "why is [redacted] denied?",
+    });
+  });
+
+  test("truncates long strings", () => {
+    const properties = kapaEventProperties({ question: "a".repeat(1500) });
+
+    expect(properties.question).toHaveLength(1000);
+  });
+
+  test("drops values that are neither scalar nor a known bulky field", () => {
+    expect(kapaEventProperties({ threadId: "t-1", metadata: { tier: "free" } })).toEqual({
+      thread_id: "t-1",
+    });
+  });
+
+  test("returns no properties for a payload that is not an object", () => {
+    expect(kapaEventProperties(undefined)).toEqual({});
+    expect(kapaEventProperties("stacks")).toEqual({});
+  });
+});

--- a/docs/src/lib/search-telemetry.ts
+++ b/docs/src/lib/search-telemetry.ts
@@ -1,0 +1,240 @@
+export type CaptureFn = (event: string, properties: Record<string, unknown>) => void;
+
+export const SEARCH_EVENTS = {
+  opened: "docs_search_opened",
+  query: "docs_search_query",
+  resultClicked: "docs_search_result_clicked",
+  abandoned: "docs_search_abandoned",
+} as const;
+
+export const KAPA_EVENT_NAMES = {
+  onModalOpen: "kapa_modal_opened",
+  onModalClose: "kapa_modal_closed",
+  onModeSwitch: "kapa_mode_switched",
+  onAskAIQuerySubmit: "kapa_question_asked",
+  onAskAIExampleQuerySubmit: "kapa_example_question_asked",
+  onAskAIAnswerCompleted: "kapa_answer_completed",
+  onAskAIFeedbackSubmit: "kapa_answer_feedback_submitted",
+  onAskAIAnswerCopy: "kapa_answer_copied",
+  onAskAIGenerationStop: "kapa_generation_stopped",
+  onAskAIConversationReset: "kapa_conversation_reset",
+  onAskAILinkClick: "kapa_link_clicked",
+  onAskAISourceClick: "kapa_source_clicked",
+  onAskAIHandoffOpen: "kapa_handoff_opened",
+  onAskAIHandoffSubmit: "kapa_handoff_submitted",
+  onAskAIHandoffCancel: "kapa_handoff_cancelled",
+  onSearchResultsCompleted: "kapa_search_results_returned",
+  onSearchResultClick: "kapa_search_result_clicked",
+} as const;
+
+export interface SearchResultClick {
+  url: string;
+  position: number;
+  isSubResult: boolean;
+}
+
+export interface SearchTracker {
+  open(trigger: string): void;
+  recordQuery(rawQuery: string, resultCount: number): void;
+  recordResultClick(click: SearchResultClick): void;
+  close(): void;
+}
+
+/**
+ * Tracks one reader's journey through the search modal and reports it through `capture`.
+ *
+ * The caller drives it from DOM events; this holds the state needed to attribute a result click to
+ * the query that produced it, and to tell an abandoned search from a successful one.
+ */
+export function createSearchTracker(capture: CaptureFn): SearchTracker {
+  let isOpen = false;
+  let query = "";
+  let reportedQuery = "";
+  let resultCount = 0;
+  let clicked = false;
+
+  return {
+    open(trigger) {
+      if (isOpen) return;
+
+      isOpen = true;
+      query = "";
+      reportedQuery = "";
+      resultCount = 0;
+      clicked = false;
+
+      capture(SEARCH_EVENTS.opened, { trigger });
+    },
+
+    recordQuery(rawQuery, count) {
+      const normalized = normalizeQuery(rawQuery);
+      if (!normalized) return;
+
+      if (normalized === query) return;
+
+      query = normalized;
+      reportedQuery = redact(normalized);
+      resultCount = count;
+
+      capture(SEARCH_EVENTS.query, {
+        query: reportedQuery,
+        query_length: normalized.length,
+        result_count: count,
+        has_results: count > 0,
+      });
+    },
+
+    recordResultClick(click) {
+      clicked = true;
+
+      capture(SEARCH_EVENTS.resultClicked, {
+        query: reportedQuery,
+        result_count: resultCount,
+        url: click.url,
+        position: click.position,
+        is_sub_result: click.isSubResult,
+      });
+    },
+
+    close() {
+      isOpen = false;
+      if (!query || clicked) return;
+
+      capture(SEARCH_EVENTS.abandoned, {
+        query: reportedQuery,
+        query_length: query.length,
+        result_count: resultCount,
+      });
+    },
+  };
+}
+
+export function normalizeQuery(rawQuery: string): string {
+  return rawQuery.trim().replace(/\s+/g, " ");
+}
+
+const REDACTED = "[redacted]";
+
+/**
+ * Patterns are ordered from the most specific to the most general, so that a credential is described
+ * by the narrowest rule that recognizes it.
+ */
+const REDACTIONS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/[^\s@]+@[^\s@]+\.[^\s@]+/g, "[email]"],
+  [/-----BEGIN[^-]*PRIVATE KEY-----/gi, REDACTED],
+  [/\b(?:AKIA|ASIA|ABIA|ACCA|AGPA|AIDA|AIPA|ANPA|ANVA|AROA)[A-Z0-9]{16}\b/g, REDACTED],
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}/g, REDACTED],
+  [/\bxox[baprs]-[A-Za-z0-9-]{10,}/g, REDACTED],
+  [/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}[A-Za-z0-9._-]*/g, REDACTED],
+  [
+    /\b(password|passwd|secret|token|api[_-]?key|access[_-]?key|credentials?)(\s*[:=]\s*)\S+/gi,
+    `$1$2${REDACTED}`,
+  ],
+  [
+    /\b(?=[A-Za-z0-9+/=_-]*[a-z])(?=[A-Za-z0-9+/=_-]*[A-Z])(?=[A-Za-z0-9+/=_-]*\d)[A-Za-z0-9+/=_-]{32,}/g,
+    REDACTED,
+  ],
+];
+
+/**
+ * Removes credentials and addresses from text a reader typed. Search boxes attract pasted material,
+ * and a query is worth reporting for the words in it rather than for whatever came along with them.
+ */
+export function redact(text: string): string {
+  return REDACTIONS.reduce((redacted, [pattern, replacement]) => {
+    return redacted.replace(pattern, replacement);
+  }, text);
+}
+
+const SEARCH_TERM_PLACEHOLDER = "[SEARCH_TERM]";
+
+// Pagefind's own wording, which is what it renders unless the site overrides it. Starlight passes
+// through only the strings a site has customized, so this default is what readers here see.
+const DEFAULT_SEARCHING_MESSAGE = "Searching for [SEARCH_TERM]...";
+
+/**
+ * Pulls the fixed part of Pagefind's "still searching" message out of the translations Starlight
+ * serializes onto the search element, so that a translated site is read in its own language.
+ */
+export function searchingPrefix(translations: string | null): string {
+  const searching = parseTranslations(translations).searching;
+  const template = typeof searching === "string" ? searching : DEFAULT_SEARCHING_MESSAGE;
+
+  return template.split(SEARCH_TERM_PLACEHOLDER)[0] ?? "";
+}
+
+/**
+ * Decides whether the results on screen belong to `query` and are final. Pagefind names the search
+ * term both while it is loading its index and once it has answered, so recognizing the message it
+ * shows in the meantime is what keeps a search that has not happened yet from being reported as a
+ * search that found nothing.
+ */
+export function hasSettled(message: string | null, query: string, loadingPrefix: string): boolean {
+  if (!message) return false;
+  if (!message.toLowerCase().includes(query.toLowerCase())) return false;
+  if (/^\s*\d/.test(message)) return true;
+
+  return loadingPrefix.length === 0 || !message.startsWith(loadingPrefix);
+}
+
+function parseTranslations(translations: string | null): Record<string, unknown> {
+  if (!translations) return {};
+
+  try {
+    const parsed: unknown = JSON.parse(translations);
+    if (typeof parsed !== "object" || parsed === null) return {};
+
+    return parsed as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Reads the result count from Pagefind's status message, falling back to the number of results on
+ * screen. Pagefind paginates, so the rendered count undercounts whenever the message is missing or
+ * reports an alternative spelling instead of a total.
+ */
+export function parseResultCount(message: string | null, renderedCount: number): number {
+  const total = message?.match(/^\s*(\d+)/);
+  if (total) return Number(total[1]);
+
+  return renderedCount;
+}
+
+const KAPA_BULKY_FIELDS = new Set(["answer", "conversation", "history", "sources"]);
+
+const MAX_PROPERTY_LENGTH = 1000;
+
+/**
+ * Flattens a kapa.ai widget event payload into PostHog properties, keeping the scalars and dropping
+ * generated prose.
+ */
+export function kapaEventProperties(payload: unknown): Record<string, unknown> {
+  const properties: Record<string, unknown> = {};
+  if (typeof payload !== "object" || payload === null) return properties;
+
+  for (const [key, value] of Object.entries(payload)) {
+    if (key === "answer" && typeof value === "string") {
+      properties.answer_length = value.length;
+      continue;
+    }
+
+    if (KAPA_BULKY_FIELDS.has(key)) continue;
+
+    if (typeof value === "string") {
+      properties[snakeCase(key)] = redact(value).slice(0, MAX_PROPERTY_LENGTH);
+      continue;
+    }
+
+    if (typeof value === "number" || typeof value === "boolean") {
+      properties[snakeCase(key)] = value;
+    }
+  }
+
+  return properties;
+}
+
+function snakeCase(key: string): string {
+  return key.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds telemetry to search so that we can improve documentation.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added telemetry for documentation search activity, including searches opened, queries submitted, result clicks, and abandoned searches.
  - Added analytics tracking for Kapa AI widget interactions, such as questions, answers, feedback, and source clicks.
  - Sensitive information is automatically redacted from tracked search and AI interaction data.

- **Tests**
  - Added coverage for search tracking, result parsing, event properties, and sensitive-data redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->