### PR TITLE
chore: Fixing pprof venv access

### DIFF
--- a/internal/cli/commands/profiling.go
+++ b/internal/cli/commands/profiling.go
@@ -35,7 +35,7 @@ var ErrProfilingRequiresExperiment = errors.New(
 func WrapWithProfiling(
 	l log.Logger,
 	opts *options.TerragruntOptions,
-	v venv.Venv,
+	v *venv.Venv,
 ) func(ctx context.Context, cliCtx *clihelper.Context, action clihelper.ActionFunc) error {
 	var profilingInProgress bool
 

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -920,7 +920,7 @@ func setTerragruntNullValuesRunCfg(opts *Options, cfg *runcfg.RunConfig) (string
 }
 
 // SetTofuCPUProfileEnv points downstream OpenTofu at a unit-specific CPU profile path when directory collection is enabled.
-func SetTofuCPUProfileEnv(l log.Logger, v venv.Venv, opts *Options) error {
+func SetTofuCPUProfileEnv(l log.Logger, v *venv.Venv, opts *Options) error {
 	if opts.ProfileDir == "" {
 		return nil
 	}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes bug caused by merging pprof branch when it was behind main.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profiling and CPU profile environment setup to reliably apply virtual environment configuration.
  * Ensured environment updates are preserved consistently during command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->