### PR TITLE
chore: coverage report fixes

### DIFF
--- a/.github/scripts/coverage/coverage-report.sh
+++ b/.github/scripts/coverage/coverage-report.sh
@@ -219,7 +219,7 @@ print_bare_packages() {
 	fi
 
 	echo ""
-	echo "Packages that failed without a failing test (build error, panic, or timeout):"
+	echo "Packages that failed without a failing test (build failure, panic, or timeout):"
 
 	while IFS= read -r package; do
 		if [[ -z "$package" ]]; then
@@ -233,13 +233,13 @@ print_bare_packages() {
 # Emit one annotation naming the failures, so they are readable without opening the log
 print_failure_annotation() {
 	local failing_tests="$1" test_count="$2"
-	local package test names="" shown=0
+	local test names="" shown=0
 
 	if [[ -z "$failing_tests" ]]; then
 		return 0
 	fi
 
-	while IFS=$'\t' read -r package test; do
+	while IFS=$'\t' read -r _ test; do
 		if [[ -z "$test" ]]; then
 			continue
 		fi
@@ -260,7 +260,8 @@ print_failure_annotation() {
 		names+=", and $((test_count - shown)) more"
 	fi
 
-	echo "::error title=Failing tests ($test_count)::$names"
+	# On stderr, which the runner scans for workflow commands just as it does stdout.
+	echo "::error title=Failing tests ($test_count)::$names" >&2
 }
 
 # Print the "<package><TAB><test>" lines whose output gets replayed, capped at max_tests

--- a/.github/scripts/coverage/coverage-report.sh
+++ b/.github/scripts/coverage/coverage-report.sh
@@ -28,6 +28,8 @@ set -euo pipefail
 
 SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 COVERAGE_CHANGE_THRESHOLD="${COVERAGE_CHANGE_THRESHOLD:-3}"
+# How many test names one failure annotation lists before it says "and N more".
+ANNOTATION_NAME_LIMIT=10
 
 usage() {
 	sed -n '/^# Single entrypoint/,/^# baseline (current-only) report\.$/p' "$SELF"
@@ -83,89 +85,226 @@ cmd_failures() {
 		return 0
 	fi
 
-	# build-fail carries the package in ImportPath as "pkg [pkg.test]", and can be the only failure event.
-	local failed=""
-	failed=$(jq -r --raw-input '
-		select(length > 0)
-		| fromjson?
-		| select(.Action == "fail" or .Action == "build-fail")
-		| "\(.Package // ((.ImportPath // "") | split(" ")[0]))\t\(.Test // "")"
-	' "$events" 2>/dev/null | sort -u || true)
+	# Both lists are newline delimited; failing_tests holds "<package><TAB><test>" lines.
+	local failing_tests="" failing_packages=""
+	local package test
 
-	local failed_tests="" failed_pkgs=""
-	if [[ -n "$failed" ]]; then
-		failed_tests=$(awk -F'\t' '$2 != ""' <<<"$failed")
-		failed_pkgs=$(awk -F'\t' '$2 == "" {print $1}' <<<"$failed")
-	fi
+	while IFS=$'\t' read -r package test; do
+		if [[ -z "$package" ]]; then
+			continue
+		fi
 
-	# A package that failed with no failing test is a build error, a panic, or a timeout.
-	local bare_pkgs=""
-	if [[ -n "$failed_pkgs" ]]; then
-		bare_pkgs=$(comm -23 \
-			<(sort -u <<<"$failed_pkgs") \
-			<(awk -F'\t' '{print $1}' <<<"$failed_tests" | sort -u) || true)
-	fi
+		if [[ -z "$test" ]]; then
+			failing_packages+="$package"$'\n'
+			continue
+		fi
 
-	if [[ -z "$failed_tests" && -z "$bare_pkgs" ]]; then
+		failing_tests+="$package"$'\t'"$test"$'\n'
+	done < <(read_failure_keys "$events")
+
+	local bare_packages
+	bare_packages=$(packages_without_failing_tests "$failing_packages" "$failing_tests")
+
+	if [[ -z "$failing_tests" && -z "$bare_packages" ]]; then
 		echo "No failure events in $events; printing the tail of the stream instead."
 		print_event_tail "$events" "$max_lines"
 
 		return 0
 	fi
 
-	local test_count=0
-	if [[ -n "$failed_tests" ]]; then
-		test_count=$(awk 'END {print NR}' <<<"$failed_tests")
-	fi
+	local test_count
+	test_count=$(count_lines "$failing_tests")
 
 	echo ""
+	print_failing_tests "$failing_tests" "$test_count"
+	print_bare_packages "$bare_packages"
+	print_failure_annotation "$failing_tests" "$test_count"
 
-	if [[ -n "$failed_tests" ]]; then
-		echo "=== Failing tests: $test_count ==="
-		echo ""
-		awk -F'\t' '{printf "  %s\t%s\n", $2, $1}' <<<"$failed_tests" | column -t -s $'\t'
-	fi
-
-	if [[ -n "$bare_pkgs" ]]; then
-		echo ""
-		echo "Packages that failed without a failing test (build error, panic, or timeout):"
-		awk '{print "  " $0}' <<<"$bare_pkgs"
-	fi
-
-	# One annotation carrying the names, so the failure is readable without opening the log.
-	if [[ -n "$failed_tests" ]]; then
-		local names
-		names=$(awk -F'\t' 'NR > 1 {printf ", "} {printf "%s", $2}' <<<"$(head -n 10 <<<"$failed_tests")")
-		if [[ "$test_count" -gt 10 ]]; then
-			names="$names, and $((test_count - 10)) more"
-		fi
-		echo "::error title=Failing tests ($test_count)::$names"
-	fi
-
-	local selected="$failed_tests"
-	local omitted=0
-	if [[ "$test_count" -gt "$max_tests" ]]; then
-		selected=$(head -n "$max_tests" <<<"$failed_tests")
-		omitted=$((test_count - max_tests))
-	fi
-
-	# Package-level output is where a build error or panic explains itself.
-	if [[ -n "$bare_pkgs" ]]; then
-		selected=$(printf '%s\n' "$selected" "$(awk '{print $0 "\t"}' <<<"$bare_pkgs")" | grep -v '^$' || true)
-	fi
+	local selected
+	selected=$(select_for_replay "$failing_tests" "$bare_packages" "$max_tests")
 
 	echo ""
 	print_failure_output "$events" "$selected" "$max_lines"
 
-	if [[ "$omitted" -gt 0 ]]; then
+	if [[ "$test_count" -gt "$max_tests" ]]; then
 		echo ""
-		echo "Output shown for the first $max_tests failing tests; $omitted omitted." \
+		echo "Output shown for the first $max_tests failing tests; $((test_count - max_tests)) omitted." \
 			"Raise FAILURE_OUTPUT_TESTS, or read the full stream in the test-events.ndjson artifact."
 	fi
 
-	write_failure_step_summary "$failed_tests" "$bare_pkgs" "$test_count"
+	write_failure_step_summary "$failing_tests" "$bare_packages" "$test_count"
 
 	return 0
+}
+
+# Emit "<package><TAB><test>" per failure event, with an empty test for a package-level failure
+read_failure_keys() {
+	local events="$1"
+
+	# build-fail names the package in ImportPath as "pkg [pkg.test]", and can be its only failure event.
+	jq -r --raw-input '
+		select(length > 0)
+		| fromjson?
+		| select(.Action == "fail" or .Action == "build-fail")
+		| "\(.Package // ((.ImportPath // "") | split(" ")[0]))\t\(.Test // "")"
+	' "$events" 2>/dev/null | sort -u || true
+}
+
+# Print the packages that failed with no failing test of their own
+packages_without_failing_tests() {
+	local failing_packages="$1" failing_tests="$2"
+	local package
+
+	while IFS= read -r package; do
+		if [[ -z "$package" ]]; then
+			continue
+		fi
+
+		if owns_failing_test "$package" "$failing_tests"; then
+			continue
+		fi
+
+		echo "$package"
+	done <<<"$failing_packages"
+}
+
+# Report whether any of the failing tests belongs to the given package
+owns_failing_test() {
+	local package="$1" failing_tests="$2"
+	local candidate test
+
+	while IFS=$'\t' read -r candidate test; do
+		if [[ "$candidate" == "$package" && -n "$test" ]]; then
+			return 0
+		fi
+	done <<<"$failing_tests"
+
+	return 1
+}
+
+# Print the failing tests as an aligned "test  package" list
+print_failing_tests() {
+	local failing_tests="$1" test_count="$2"
+	local package test width=0
+
+	if [[ -z "$failing_tests" ]]; then
+		return 0
+	fi
+
+	while IFS=$'\t' read -r package test; do
+		if [[ "${#test}" -gt "$width" ]]; then
+			width="${#test}"
+		fi
+	done <<<"$failing_tests"
+
+	echo "=== Failing tests: $test_count ==="
+	echo ""
+
+	while IFS=$'\t' read -r package test; do
+		if [[ -z "$test" ]]; then
+			continue
+		fi
+
+		printf '  %-*s  %s\n' "$width" "$test" "$package"
+	done <<<"$failing_tests"
+}
+
+# Print the packages that failed without a failing test
+print_bare_packages() {
+	local bare_packages="$1"
+	local package
+
+	if [[ -z "$bare_packages" ]]; then
+		return 0
+	fi
+
+	echo ""
+	echo "Packages that failed without a failing test (build error, panic, or timeout):"
+
+	while IFS= read -r package; do
+		if [[ -z "$package" ]]; then
+			continue
+		fi
+
+		echo "  $package"
+	done <<<"$bare_packages"
+}
+
+# Emit one annotation naming the failures, so they are readable without opening the log
+print_failure_annotation() {
+	local failing_tests="$1" test_count="$2"
+	local package test names="" shown=0
+
+	if [[ -z "$failing_tests" ]]; then
+		return 0
+	fi
+
+	while IFS=$'\t' read -r package test; do
+		if [[ -z "$test" ]]; then
+			continue
+		fi
+
+		if [[ "$shown" -ge "$ANNOTATION_NAME_LIMIT" ]]; then
+			break
+		fi
+
+		if [[ -n "$names" ]]; then
+			names+=", "
+		fi
+
+		names+="$test"
+		shown=$((shown + 1))
+	done <<<"$failing_tests"
+
+	if [[ "$test_count" -gt "$shown" ]]; then
+		names+=", and $((test_count - shown)) more"
+	fi
+
+	echo "::error title=Failing tests ($test_count)::$names"
+}
+
+# Print the "<package><TAB><test>" lines whose output gets replayed, capped at max_tests
+select_for_replay() {
+	local failing_tests="$1" bare_packages="$2" max_tests="$3"
+	local package test shown=0
+
+	while IFS=$'\t' read -r package test; do
+		if [[ -z "$test" ]]; then
+			continue
+		fi
+
+		if [[ "$shown" -ge "$max_tests" ]]; then
+			break
+		fi
+
+		printf '%s\t%s\n' "$package" "$test"
+		shown=$((shown + 1))
+	done <<<"$failing_tests"
+
+	# A build error or a panic explains itself in the package-level output.
+	while IFS= read -r package; do
+		if [[ -z "$package" ]]; then
+			continue
+		fi
+
+		printf '%s\t\n' "$package"
+	done <<<"$bare_packages"
+}
+
+# Count the non-empty lines of a newline-delimited list
+count_lines() {
+	local list="$1"
+	local line count=0
+
+	while IFS= read -r line; do
+		if [[ -z "$line" ]]; then
+			continue
+		fi
+
+		count=$((count + 1))
+	done <<<"$list"
+
+	echo "$count"
 }
 
 # Replay the captured output of each selected "package<TAB>test" key
@@ -232,30 +371,64 @@ print_event_tail() {
 
 # Append the failing tests to the GitHub step summary when running in Actions
 write_failure_step_summary() {
-	local failed_tests="$1" bare_pkgs="$2" test_count="$3"
+	local failing_tests="$1" bare_packages="$2" test_count="$3"
 
 	if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
 		return 0
 	fi
 
 	{
-		if [[ -n "$failed_tests" ]]; then
-			echo "### Failing tests: $test_count"
-			echo ""
-			echo "| Test | Package |"
-			echo "|------|---------|"
-			awk -F'\t' '{printf "| `%s` | `%s` |\n", $2, $1}' <<<"$failed_tests"
-			echo ""
-		fi
-		if [[ -n "$bare_pkgs" ]]; then
-			echo "Packages that failed without a failing test:"
-			echo ""
-			while IFS= read -r pkg; do
-				echo "- \`$pkg\`"
-			done <<<"$bare_pkgs"
-			echo ""
-		fi
+		write_step_summary_table "$failing_tests" "$test_count"
+		write_step_summary_packages "$bare_packages"
 	} >>"$GITHUB_STEP_SUMMARY"
+}
+
+# Write the failing tests as a Markdown table
+write_step_summary_table() {
+	local failing_tests="$1" test_count="$2"
+	local package test
+
+	if [[ -z "$failing_tests" ]]; then
+		return 0
+	fi
+
+	echo "### Failing tests: $test_count"
+	echo ""
+	echo "| Test | Package |"
+	echo "|------|---------|"
+
+	while IFS=$'\t' read -r package test; do
+		if [[ -z "$test" ]]; then
+			continue
+		fi
+
+		echo "| \`$test\` | \`$package\` |"
+	done <<<"$failing_tests"
+
+	echo ""
+}
+
+# Write the packages that failed without a failing test as a Markdown list
+write_step_summary_packages() {
+	local bare_packages="$1"
+	local package
+
+	if [[ -z "$bare_packages" ]]; then
+		return 0
+	fi
+
+	echo "Packages that failed without a failing test:"
+	echo ""
+
+	while IFS= read -r package; do
+		if [[ -z "$package" ]]; then
+			continue
+		fi
+
+		echo "- \`$package\`"
+	done <<<"$bare_packages"
+
+	echo ""
 }
 
 # Roll a cover profile into per-package coverage JSON plus an HTML report

--- a/.github/scripts/coverage/coverage-report.sh
+++ b/.github/scripts/coverage/coverage-report.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 #                                    Packages default to ./... (the full suite).
 #   collect <out-dir> [packages...]  run + summary + timing in one call (tolerates
 #                                    test failures); produces both summaries.
+#   failures [events.ndjson]         Print failing tests + their output; runs automatically after a failing run.
 #   summary <cover.out> <out.json>   Roll a cover profile into per-package coverage
 #                                    JSON + an HTML report. Args default to
 #                                    coverage.out / coverage-summary.json.
@@ -57,7 +58,204 @@ cmd_run() {
 	echo "Events: $events ($(wc -l <"$events") lines)"
 	echo "Cover:  $cover"
 	echo "JUnit:  $junit"
+
+	# The -json stream lands in a file, so a failing run would otherwise print only the exit status.
+	if [[ "$status" -ne 0 ]]; then
+		cmd_failures "$events" || echo "Could not summarize failures from $events" >&2
+	fi
+
 	return "$status"
+}
+
+# Print the failing tests, and their captured output, from a go test -json stream
+cmd_failures() {
+	local events="${1:-test-events.ndjson}"
+	local max_tests="${FAILURE_OUTPUT_TESTS:-25}"
+	local max_lines="${FAILURE_OUTPUT_LINES:-200}"
+
+	if [[ ! -s "$events" ]]; then
+		echo "No test events at '$events'; cannot report failing tests." >&2
+		return 0
+	fi
+
+	if ! command -v jq >/dev/null 2>&1; then
+		echo "jq not found; cannot report failing tests from '$events'." >&2
+		return 0
+	fi
+
+	# build-fail carries the package in ImportPath as "pkg [pkg.test]", and can be the only failure event.
+	local failed=""
+	failed=$(jq -r --raw-input '
+		select(length > 0)
+		| fromjson?
+		| select(.Action == "fail" or .Action == "build-fail")
+		| "\(.Package // ((.ImportPath // "") | split(" ")[0]))\t\(.Test // "")"
+	' "$events" 2>/dev/null | sort -u || true)
+
+	local failed_tests="" failed_pkgs=""
+	if [[ -n "$failed" ]]; then
+		failed_tests=$(awk -F'\t' '$2 != ""' <<<"$failed")
+		failed_pkgs=$(awk -F'\t' '$2 == "" {print $1}' <<<"$failed")
+	fi
+
+	# A package that failed with no failing test is a build error, a panic, or a timeout.
+	local bare_pkgs=""
+	if [[ -n "$failed_pkgs" ]]; then
+		bare_pkgs=$(comm -23 \
+			<(sort -u <<<"$failed_pkgs") \
+			<(awk -F'\t' '{print $1}' <<<"$failed_tests" | sort -u) || true)
+	fi
+
+	if [[ -z "$failed_tests" && -z "$bare_pkgs" ]]; then
+		echo "No failure events in $events; printing the tail of the stream instead."
+		print_event_tail "$events" "$max_lines"
+
+		return 0
+	fi
+
+	local test_count=0
+	if [[ -n "$failed_tests" ]]; then
+		test_count=$(awk 'END {print NR}' <<<"$failed_tests")
+	fi
+
+	echo ""
+
+	if [[ -n "$failed_tests" ]]; then
+		echo "=== Failing tests: $test_count ==="
+		echo ""
+		awk -F'\t' '{printf "  %s\t%s\n", $2, $1}' <<<"$failed_tests" | column -t -s $'\t'
+	fi
+
+	if [[ -n "$bare_pkgs" ]]; then
+		echo ""
+		echo "Packages that failed without a failing test (build error, panic, or timeout):"
+		awk '{print "  " $0}' <<<"$bare_pkgs"
+	fi
+
+	# One annotation carrying the names, so the failure is readable without opening the log.
+	if [[ -n "$failed_tests" ]]; then
+		local names
+		names=$(awk -F'\t' 'NR > 1 {printf ", "} {printf "%s", $2}' <<<"$(head -n 10 <<<"$failed_tests")")
+		if [[ "$test_count" -gt 10 ]]; then
+			names="$names, and $((test_count - 10)) more"
+		fi
+		echo "::error title=Failing tests ($test_count)::$names"
+	fi
+
+	local selected="$failed_tests"
+	local omitted=0
+	if [[ "$test_count" -gt "$max_tests" ]]; then
+		selected=$(head -n "$max_tests" <<<"$failed_tests")
+		omitted=$((test_count - max_tests))
+	fi
+
+	# Package-level output is where a build error or panic explains itself.
+	if [[ -n "$bare_pkgs" ]]; then
+		selected=$(printf '%s\n' "$selected" "$(awk '{print $0 "\t"}' <<<"$bare_pkgs")" | grep -v '^$' || true)
+	fi
+
+	echo ""
+	print_failure_output "$events" "$selected" "$max_lines"
+
+	if [[ "$omitted" -gt 0 ]]; then
+		echo ""
+		echo "Output shown for the first $max_tests failing tests; $omitted omitted." \
+			"Raise FAILURE_OUTPUT_TESTS, or read the full stream in the test-events.ndjson artifact."
+	fi
+
+	write_failure_step_summary "$failed_tests" "$bare_pkgs" "$test_count"
+
+	return 0
+}
+
+# Replay the captured output of each selected "package<TAB>test" key
+print_failure_output() {
+	local events="$1" selected="$2" max_lines="$3"
+
+	local keys_json
+	keys_json=$(jq -R -s 'split("\n") | map(select(length > 0))' <<<"$selected" || true)
+	if [[ -z "$keys_json" ]]; then
+		return 0
+	fi
+
+	jq -rn --raw-input \
+		--argjson keys "$keys_json" \
+		--argjson maxlines "$max_lines" '
+		def heading($k): ($k | split("\t")) as $p
+			| if ($p[1] // "") == "" then "\($p[0]) (package)" else "\($p[1])  \($p[0])" end;
+
+		# Build output is keyed by ImportPath ("pkg [pkg.test]"), not Package.
+		def owner: .Package // ((.ImportPath // "") | split(" ")[0]);
+
+		($keys | map({key: ., value: true}) | from_entries) as $want
+		| reduce (
+			inputs
+			| select(length > 0)
+			| fromjson?
+			| select(.Action == "output" or .Action == "build-output")
+		) as $e (
+			{};
+			"\($e | owner)\t\($e.Test // "")" as $k
+			| if $want[$k] then .[$k] = ((.[$k] // []) + [$e.Output]) else . end
+		)
+		| . as $collected
+		| $keys[]
+		| . as $k
+		| ($collected[$k] // []) as $lines
+		| "::group::\(heading($k))",
+		  (
+			if ($lines | length) > $maxlines then
+				"... \(($lines | length) - $maxlines) earlier lines omitted; see the test-events.ndjson artifact\n"
+				+ ($lines[-$maxlines:] | join(""))
+			else
+				($lines | join(""))
+			end
+		  ),
+		  "::endgroup::"
+	' "$events" || true
+}
+
+# Fall back to the tail of the stream when no failure event was recorded
+print_event_tail() {
+	local events="$1" max_lines="$2"
+
+	echo "::group::Last $max_lines output lines"
+	# -j, not -r: Output already carries its own trailing newline.
+	jq -j --raw-input '
+		select(length > 0)
+		| fromjson?
+		| select(.Action == "output" or .Action == "build-output")
+		| .Output
+	' "$events" 2>/dev/null | tail -n "$max_lines" || true
+	echo "::endgroup::"
+}
+
+# Append the failing tests to the GitHub step summary when running in Actions
+write_failure_step_summary() {
+	local failed_tests="$1" bare_pkgs="$2" test_count="$3"
+
+	if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+		return 0
+	fi
+
+	{
+		if [[ -n "$failed_tests" ]]; then
+			echo "### Failing tests: $test_count"
+			echo ""
+			echo "| Test | Package |"
+			echo "|------|---------|"
+			awk -F'\t' '{printf "| `%s` | `%s` |\n", $2, $1}' <<<"$failed_tests"
+			echo ""
+		fi
+		if [[ -n "$bare_pkgs" ]]; then
+			echo "Packages that failed without a failing test:"
+			echo ""
+			while IFS= read -r pkg; do
+				echo "- \`$pkg\`"
+			done <<<"$bare_pkgs"
+			echo ""
+		fi
+	} >>"$GITHUB_STEP_SUMMARY"
 }
 
 # Roll a cover profile into per-package coverage JSON plus an HTML report
@@ -747,6 +945,7 @@ main() {
 	case "$cmd" in
 	run) cmd_run "$@" ;;
 	collect) cmd_collect "$@" ;;
+	failures) cmd_failures "$@" ;;
 	summary) cmd_summary "$@" ;;
 	timing) cmd_timing "$@" ;;
 	compare-coverage) cmd_compare_coverage "$@" ;;

--- a/.github/scripts/coverage/tests/failures.bats
+++ b/.github/scripts/coverage/tests/failures.bats
@@ -1,5 +1,8 @@
 #!/usr/bin/env bats
 
+# Required for `run --separate-stderr`, which pins where the annotation is written.
+bats_require_minimum_version 1.5.0
+
 setup() {
   SCRIPT="${BATS_TEST_DIRNAME}/../coverage-report.sh"
   EVENTS="${BATS_TEST_TMPDIR}/events.ndjson"
@@ -39,9 +42,10 @@ EOF
   [[ "$output" == *"example.com/b"* ]]
 }
 
-@test "emits an error annotation naming the failures" {
-  run "$SCRIPT" failures "$EVENTS"
-  [[ "$output" == *"::error title=Failing tests (1)::TestFails"* ]]
+@test "emits an error annotation naming the failures, on stderr" {
+  run --separate-stderr "$SCRIPT" failures "$EVENTS"
+  [[ "$stderr" == *"::error title=Failing tests (1)::TestFails"* ]]
+  [[ "$output" != *"::error"* ]]
 }
 
 @test "writes the failing tests to the step summary" {

--- a/.github/scripts/coverage/tests/failures.bats
+++ b/.github/scripts/coverage/tests/failures.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../coverage-report.sh"
+  EVENTS="${BATS_TEST_TMPDIR}/events.ndjson"
+
+  cat >"$EVENTS" <<'EOF'
+{"Action":"run","Package":"example.com/a","Test":"TestFails"}
+{"Action":"output","Package":"example.com/a","Test":"TestFails","Output":"    a_test.go:9: boom: expected 1 got 2\n"}
+{"Action":"fail","Package":"example.com/a","Test":"TestFails","Elapsed":0.01}
+{"Action":"output","Package":"example.com/a","Test":"TestPasses","Output":"--- PASS: TestPasses\n"}
+{"Action":"pass","Package":"example.com/a","Test":"TestPasses","Elapsed":0.01}
+{"Action":"fail","Package":"example.com/a","Elapsed":0.02}
+{"ImportPath":"example.com/b [example.com/b.test]","Action":"build-output","Output":"b/b_test.go:6:2: undefined: undefinedSymbol\n"}
+{"ImportPath":"example.com/b [example.com/b.test]","Action":"build-fail"}
+EOF
+}
+
+@test "names the failing test" {
+  run "$SCRIPT" failures "$EVENTS"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TestFails"* ]]
+  [[ "$output" == *"example.com/a"* ]]
+}
+
+@test "replays the failing test output" {
+  run "$SCRIPT" failures "$EVENTS"
+  [[ "$output" == *"boom: expected 1 got 2"* ]]
+}
+
+@test "does not report passing tests" {
+  run "$SCRIPT" failures "$EVENTS"
+  [[ "$output" != *"TestPasses"* ]]
+}
+
+@test "surfaces a build error, keyed by ImportPath rather than Package" {
+  run "$SCRIPT" failures "$EVENTS"
+  [[ "$output" == *"undefined: undefinedSymbol"* ]]
+  [[ "$output" == *"example.com/b"* ]]
+}
+
+@test "emits an error annotation naming the failures" {
+  run "$SCRIPT" failures "$EVENTS"
+  [[ "$output" == *"::error title=Failing tests (1)::TestFails"* ]]
+}
+
+@test "writes the failing tests to the step summary" {
+  GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/summary.md" run "$SCRIPT" failures "$EVENTS"
+  run cat "${BATS_TEST_TMPDIR}/summary.md"
+  [[ "$output" == *"TestFails"* ]]
+}
+
+@test "reports what a cap dropped" {
+  FAILURE_OUTPUT_LINES=0 run "$SCRIPT" failures "$EVENTS"
+  [[ "$output" == *"omitted"* ]]
+}
+
+@test "falls back to the stream tail when no failure event was recorded" {
+  local partial="${BATS_TEST_TMPDIR}/partial.ndjson"
+  head -n 2 "$EVENTS" >"$partial"
+
+  run "$SCRIPT" failures "$partial"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"printing the tail of the stream"* ]]
+  [[ "$output" == *"boom: expected 1 got 2"* ]]
+}
+
+@test "tolerates a missing event stream" {
+  run "$SCRIPT" failures "${BATS_TEST_TMPDIR}/nonexistent.ndjson"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"cannot report failing tests"* ]]
+}

--- a/.github/workflows/base-test.yml
+++ b/.github/workflows/base-test.yml
@@ -118,6 +118,7 @@ jobs:
           retention-days: 30
 
       - name: Upload Report (${{ matrix.os }})
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-report-${{ matrix.os }}

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -60,6 +60,7 @@ jobs:
           TIMEOUT: ${{ matrix.flake.timeout }}
 
       - name: Upload Report (${{ matrix.flake.name }})
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-report-${{ matrix.flake.name }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -273,6 +273,7 @@ jobs:
           HAS_DOCKER: ${{ runner.os == 'Linux' }}
 
       - name: Upload Test Results (${{ matrix.integration.name }})
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results-${{ matrix.integration.name }}
@@ -290,6 +291,7 @@ jobs:
           group_suite: "true"
 
       - name: Print Failed Tests (${{ matrix.integration.name }})
+        if: always()
         run: |
           echo "Failed Tests in ${{ matrix.integration.name }}"
           if [[ -f test_output.log ]]; then

--- a/.github/workflows/oidc-integration-test.yml
+++ b/.github/workflows/oidc-integration-test.yml
@@ -129,6 +129,7 @@ jobs:
           TEST_ARGS: ${{ matrix.integration.test_args }}
 
       - name: Upload Report (${{ matrix.integration.name }})
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-report-${{ matrix.integration.name }}

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -57,7 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: bats
-        run: mise x bats -- bats --print-output-on-failure .github/scripts/release/tests/
+        run: mise x bats -- bats --print-output-on-failure .github/scripts/release/tests/ .github/scripts/coverage/tests/
 
   test-js:
     name: Test JS scripts


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* Fix test failures being unreportable

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added failure-only test reporting, including failing test names, package-level errors, and replayed output.
  * Added optional GitHub Actions step summaries and configurable limits for failure annotations.
* **Bug Fixes**
  * Test reports, logs, and artifacts are now uploaded even when preceding test steps fail.
  * Improved handling and reporting when failure event files are missing or incomplete.
* **Tests**
  * Added automated coverage for failure reporting, annotations, summaries, output limits, and build errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->