### PR TITLE
chore: Using vfs handle for `ParseFromFile`

### DIFF
--- a/internal/cli/commands/hcl/validate/validate.go
+++ b/internal/cli/commands/hcl/validate/validate.go
@@ -173,7 +173,8 @@ func RunValidate(
 				parser = parser.WithValues(values)
 			}
 
-			file, err := hclparse.NewParser(parser.ParserOptions...).ParseFromFile(stackFilePath)
+			file, err := hclparse.NewParser(parser.ParserOptions...).
+				ParseFromFile(parser.Venv.FS, stackFilePath)
 			if err != nil {
 				parseErrs = append(parseErrs, err)
 				continue

--- a/internal/discovery/graph_target_test.go
+++ b/internal/discovery/graph_target_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -232,7 +233,7 @@ func memGitTopLevelVenv(t *testing.T, repoRoot string) *venv.Venv {
 		return vexec.Result{ExitCode: 1}
 	})
 
-	return venvtest.New().WithExec(exec)
+	return venvtest.New().WithExec(exec).WithFS(vfs.NewOSFS())
 }
 
 // mockGraphTargetOption implements the GraphTarget() interface for testing.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1401,7 +1401,8 @@ func ParseConfigFile(
 				// Parse the HCL file into an AST body that can be decoded multiple times later without having to re-parse
 				var parseErr error
 
-				file, parseErr = hclparse.NewParser(pctx.ParserOptions...).ParseFromFile(configPath)
+				file, parseErr = hclparse.NewParser(pctx.ParserOptions...).
+					ParseFromFile(pctx.Venv.FS, configPath)
 				if parseErr != nil {
 					return parseErr
 				}

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -461,7 +461,8 @@ func PartialParseConfigFile(
 			} else {
 				var parseErr error
 
-				file, parseErr = hclparse.NewParser(pctx.ParserOptions...).ParseFromFile(configPath)
+				file, parseErr = hclparse.NewParser(pctx.ParserOptions...).
+					ParseFromFile(pctx.Venv.FS, configPath)
 				if parseErr != nil {
 					return parseErr
 				}

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -2035,7 +2035,8 @@ func parseAutoIncludeFileCached(
 		return cached.Rebind(hclparse.NewParser(pctx.ParserOptions...)), nil
 	}
 
-	file, err := hclparse.NewParser(pctx.ParserOptions...).ParseFromFile(autoIncludePath)
+	file, err := hclparse.NewParser(pctx.ParserOptions...).
+		ParseFromFile(pctx.Venv.FS, autoIncludePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/hclparse/parser.go
+++ b/pkg/config/hclparse/parser.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
@@ -38,8 +39,9 @@ func (parser *Parser) withOptions(opts ...Option) *Parser {
 	return parser
 }
 
-func (parser *Parser) ParseFromFile(configPath string) (*File, error) {
-	content, err := os.ReadFile(configPath)
+// ParseFromFile reads configPath from fsys and parses it into an HCL file body.
+func (parser *Parser) ParseFromFile(fsys vfs.FS, configPath string) (*File, error) {
+	content, err := vfs.ReadFile(fsys, configPath)
 	if err != nil {
 		parser.logger.Warnf("Error reading file %s: %v", configPath, err)
 

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -294,6 +294,7 @@ func resolveStackAutoIncludes(
 	// terragrunt.autoinclude.stack.hcl overrides same-name components wholesale, so an overridden
 	// component must not inherit the base block's resolved unit-level autoinclude.
 	if pruneErr := pruneOverriddenStackAutoIncludes(
+		scopedPctx.Venv.FS,
 		autoIncludes,
 		stackSourceDir,
 		prodEvalCtx,
@@ -1014,7 +1015,8 @@ func ReadStackConfigFile(
 	stackPctx.TerragruntConfigPath = filePath
 	stackPctx.OriginalTerragruntConfigPath = filePath
 
-	file, err := hclparse.NewParser(stackPctx.ParserOptions...).ParseFromFile(filePath)
+	file, err := hclparse.NewParser(stackPctx.ParserOptions...).
+		ParseFromFile(stackPctx.Venv.FS, filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -1069,6 +1071,7 @@ func ParseStackConfig(
 	// can reference where sibling components generate to (e.g. to pass a unit path
 	// down to a child stack).
 	if err := injectStackComponentRefs(
+		parser.Venv.FS,
 		file,
 		evalParsingContext,
 		filepath.Dir(file.ConfigPath),
@@ -1086,6 +1089,7 @@ func ParseStackConfig(
 	stackDir := filepath.Dir(file.ConfigPath)
 
 	if err := processStackConfigIncludes(
+		parser.Venv.FS,
 		config,
 		stackDir,
 		evalParsingContext,
@@ -1095,6 +1099,7 @@ func ParseStackConfig(
 	}
 
 	if err := mergeStackAutoIncludeFile(
+		parser.Venv.FS,
 		l,
 		config,
 		stackDir,
@@ -1159,6 +1164,7 @@ func (h *stackComponentHeader) GeneratedPath(stackDir string) string {
 // overridden component's path reflects the override, not the stale base path.
 // stackDir is the directory containing the stack file.
 func injectStackComponentRefs(
+	fsys vfs.FS,
 	file *hclparse.File,
 	evalCtx *hcl.EvalContext,
 	stackDir string,
@@ -1173,7 +1179,7 @@ func injectStackComponentRefs(
 	// stack.<name>.path can resolve against the base components, matching how the full decode resolves them.
 	setStackComponentRefVars(evalCtx, stackDir, headers.Units, headers.Stacks)
 
-	autoUnits, autoStacks, err := stackAutoIncludeComponentHeaders(stackDir, evalCtx, parserOpts)
+	autoUnits, autoStacks, err := stackAutoIncludeComponentHeaders(fsys, stackDir, evalCtx, parserOpts)
 	if err != nil {
 		return err
 	}
@@ -1225,16 +1231,23 @@ func setStackComponentRefVars(
 // stackAutoIncludeComponentHeaders decodes the unit and stack block headers (name and path only) declared
 // by a sibling terragrunt.autoinclude.stack.hcl. It returns nil slices when no autoinclude file exists.
 func stackAutoIncludeComponentHeaders(
+	fsys vfs.FS,
 	stackDir string,
 	evalCtx *hcl.EvalContext,
 	parserOpts []hclparse.Option,
 ) ([]*stackComponentHeader, []*stackComponentHeader, error) {
 	autoIncludePath := filepath.Join(stackDir, inthclparse.AutoIncludeStackFile)
-	if !util.FileExists(autoIncludePath) {
+
+	exists, err := vfs.FileExists(fsys, autoIncludePath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !exists {
 		return nil, nil, nil
 	}
 
-	incFile, err := hclparse.NewParser(parserOpts...).ParseFromFile(autoIncludePath)
+	incFile, err := hclparse.NewParser(parserOpts...).ParseFromFile(fsys, autoIncludePath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read stack autoinclude %q: %w", autoIncludePath, err)
 	}
@@ -1279,16 +1292,23 @@ type stackComponentLabels struct {
 // names do not depend on local.*/unit.*/stack.* being populated in the eval context. It returns nil slices
 // when no autoinclude file exists.
 func stackAutoIncludeComponentNames(
+	fsys vfs.FS,
 	stackDir string,
 	evalCtx *hcl.EvalContext,
 	parserOpts []hclparse.Option,
 ) (unitNames, stackNames []string, err error) {
 	autoIncludePath := filepath.Join(stackDir, inthclparse.AutoIncludeStackFile)
-	if !util.FileExists(autoIncludePath) {
+
+	exists, err := vfs.FileExists(fsys, autoIncludePath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !exists {
 		return nil, nil, nil
 	}
 
-	incFile, err := hclparse.NewParser(parserOpts...).ParseFromFile(autoIncludePath)
+	incFile, err := hclparse.NewParser(parserOpts...).ParseFromFile(fsys, autoIncludePath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read stack autoinclude %q: %w", autoIncludePath, err)
 	}
@@ -1327,6 +1347,7 @@ func stackAutoIncludeComponentNames(
 // pruning it is a no-op. It reads only block names so it never evaluates an injected path expression that
 // the generate-path eval context cannot resolve.
 func pruneOverriddenStackAutoIncludes(
+	fsys vfs.FS,
 	autoIncludes map[string]*inthclparse.AutoIncludeResolved,
 	stackDir string,
 	evalCtx *hcl.EvalContext,
@@ -1336,7 +1357,7 @@ func pruneOverriddenStackAutoIncludes(
 		return nil
 	}
 
-	unitNames, stackNames, err := stackAutoIncludeComponentNames(stackDir, evalCtx, parserOpts)
+	unitNames, stackNames, err := stackAutoIncludeComponentNames(fsys, stackDir, evalCtx, parserOpts)
 	if err != nil {
 		return err
 	}
@@ -1357,6 +1378,7 @@ func pruneOverriddenStackAutoIncludes(
 // its units and stacks into the main config so generation sees all components,
 // not just those in the root file.
 func processStackConfigIncludes(
+	fsys vfs.FS,
 	config *StackConfigFile,
 	stackDir string,
 	evalCtx *hcl.EvalContext,
@@ -1368,7 +1390,7 @@ func processStackConfigIncludes(
 			includePath = filepath.Join(stackDir, includePath)
 		}
 
-		incFile, err := hclparse.NewParser(parserOpts...).ParseFromFile(includePath)
+		incFile, err := hclparse.NewParser(parserOpts...).ParseFromFile(fsys, includePath)
 		if err != nil {
 			return fmt.Errorf("failed to read include %q: %w", inc.Name, err)
 		}
@@ -1420,6 +1442,7 @@ func processStackConfigIncludes(
 // autoinclude block materialize in the nested stack the same way a unit's
 // terragrunt.autoinclude.hcl merges into its terragrunt.hcl via [mergeAutoIncludeIfPresent].
 func mergeStackAutoIncludeFile(
+	fsys vfs.FS,
 	l log.Logger,
 	config *StackConfigFile,
 	stackDir, stackFileName string,
@@ -1432,11 +1455,17 @@ func mergeStackAutoIncludeFile(
 	}
 
 	autoIncludePath := filepath.Join(stackDir, inthclparse.AutoIncludeStackFile)
-	if !util.FileExists(autoIncludePath) {
+
+	exists, err := vfs.FileExists(fsys, autoIncludePath)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
 		return nil
 	}
 
-	incFile, err := hclparse.NewParser(parserOpts...).ParseFromFile(autoIncludePath)
+	incFile, err := hclparse.NewParser(parserOpts...).ParseFromFile(fsys, autoIncludePath)
 	if err != nil {
 		return fmt.Errorf("failed to read stack autoinclude %q: %w", autoIncludePath, err)
 	}
@@ -1622,13 +1651,18 @@ func ReadValues(
 
 	filePath := filepath.Join(directory, valuesFile)
 
-	if util.FileNotExists(filePath) {
+	exists, err := vfs.FileExists(pctx.Venv.FS, filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if !exists {
 		return nil, nil
 	}
 
 	l.Debugf("Reading Terragrunt stack values file at %s", filePath)
 
-	file, err := hclparse.NewParser(pctx.ParserOptions...).ParseFromFile(filePath)
+	file, err := hclparse.NewParser(pctx.ParserOptions...).ParseFromFile(pctx.Venv.FS, filePath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds `vfs` handle for `ParseFromFile` in `hclparse.Parser`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration and stack validation when files are accessed through configured virtual filesystems.
  * Ensured included, autoincluded, and values configuration files are consistently discovered and parsed.
  * Improved support for validation and parsing in virtualized or in-memory environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->