### PR TITLE
chore: Register the `block-iteration` experiment

### DIFF
--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -97,6 +97,10 @@ const (
 	// directory instead of the git repository root: dependencies and dependents
 	// resolving outside it are not discovered.
 	BoundedDiscovery = "bounded-discovery"
+	// BlockIteration gates the expansion block, which iterates a dependency, unit,
+	// or stack block over a count or for_each, along with the enabled attribute on
+	// unit and stack blocks.
+	BlockIteration = "block-iteration"
 )
 
 const (
@@ -202,6 +206,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: BoundedDiscovery,
+		},
+		{
+			Name: BlockIteration,
 		},
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1490,6 +1490,10 @@ func ParseConfig(
 		return nil, err
 	}
 
+	if err := ValidateExpansionExperiment(pctx.Experiments, file); err != nil {
+		return nil, err
+	}
+
 	if terraformSourceReferencesDependency(file) {
 		return nil, TerraformSourceReferencesDependencyError{ConfigPath: file.ConfigPath}
 	}

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -591,6 +591,10 @@ func PartialParseConfig(
 		return nil, err
 	}
 
+	if err := ValidateExpansionExperiment(pctx.Experiments, file); err != nil {
+		return nil, err
+	}
+
 	if includeFromChild != nil && includeFromChild.Path != "" &&
 		!filepath.IsAbs(includeFromChild.Path) {
 		includeFromChild.Path = filepath.Clean(

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"strings"
+
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 )
 
 // Custom error types
@@ -462,5 +464,28 @@ func (err VersionAttributeSourceConstraintConflictError) Error() string {
 	return fmt.Sprintf(
 		"the terraform block in %s sets both the version attribute and an inline ?version= on its source; specify the version in only one place",
 		err.ConfigPath,
+	)
+}
+
+// ExpansionRequiresExperimentError is returned when a dependency, unit, or stack block
+// carries an expansion block without the block-iteration experiment enabled.
+type ExpansionRequiresExperimentError struct {
+	ConfigPath string
+	BlockType  string
+	BlockLabel string
+}
+
+func (err ExpansionRequiresExperimentError) Error() string {
+	block := err.BlockType
+	if err.BlockLabel != "" {
+		block = fmt.Sprintf("%s %q", err.BlockType, err.BlockLabel)
+	}
+
+	return fmt.Sprintf(
+		"the %s block in %s uses an expansion block, which requires the '%s' experiment; enable it with --experiment %s",
+		block,
+		err.ConfigPath,
+		experiment.BlockIteration,
+		experiment.BlockIteration,
 	)
 }

--- a/pkg/config/expansion.go
+++ b/pkg/config/expansion.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"slices"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
+)
+
+// ExpansionBlockName is the block that declares count/for_each iteration inside a
+// dependency, unit, or stack block.
+const ExpansionBlockName = "expansion"
+
+// expansionCapableBlocks are the block types an expansion block may appear in.
+var expansionCapableBlocks = []string{MetadataDependency, MetadataUnit, MetadataStack}
+
+// ValidateExpansionExperiment rejects expansion blocks while the block-iteration
+// experiment is disabled.
+//
+// This reads the raw body rather than the decoded config because unit and stack blocks
+// decode through an `hcl:",remain"` field, which absorbs an unrecognized expansion block
+// instead of rejecting it. Without this pass a user who writes expansion without the
+// experiment watches the block silently do nothing.
+//
+// JSON configs parse into a body this cannot walk, so they fall through to the decoder's
+// own unsupported-block error rather than the message naming the flag.
+func ValidateExpansionExperiment(experiments experiment.Experiments, file *hclparse.File) error {
+	if experiments.Evaluate(experiment.BlockIteration) {
+		return nil
+	}
+
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil
+	}
+
+	for _, block := range body.Blocks {
+		if !slices.Contains(expansionCapableBlocks, block.Type) {
+			continue
+		}
+
+		if !slices.ContainsFunc(block.Body.Blocks, func(inner *hclsyntax.Block) bool {
+			return inner.Type == ExpansionBlockName
+		}) {
+			continue
+		}
+
+		err := ExpansionRequiresExperimentError{
+			ConfigPath: file.ConfigPath,
+			BlockType:  block.Type,
+		}
+		if len(block.Labels) > 0 {
+			err.BlockLabel = block.Labels[0]
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -1,0 +1,336 @@
+package config_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const dependencyWithExpansionHCL = `
+dependency "aurora" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  config_path = "../aurora"
+}
+`
+
+const unitWithExpansionHCL = `
+unit "app" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  source = "./modules/app"
+  path   = "app"
+}
+`
+
+const stackWithExpansionHCL = `
+stack "team" {
+  expansion {
+    count = 2
+  }
+
+  source = "./stacks/team"
+  path   = "team"
+}
+`
+
+// TestValidateExpansionExperiment pins which blocks the gate rejects while the
+// block-iteration experiment is off, and that it names the offending block.
+func TestValidateExpansionExperiment(t *testing.T) {
+	t.Parallel()
+
+	skipInExperimentMode(t)
+
+	testCases := []struct {
+		name          string
+		configPath    string
+		cfg           string
+		wantBlockType string
+		wantLabel     string
+		wantErr       bool
+	}{
+		{
+			name:          "dependency with expansion",
+			configPath:    config.DefaultTerragruntConfigPath,
+			cfg:           dependencyWithExpansionHCL,
+			wantBlockType: "dependency",
+			wantLabel:     "aurora",
+			wantErr:       true,
+		},
+		{
+			name:          "unit with expansion",
+			configPath:    config.DefaultStackFile,
+			cfg:           unitWithExpansionHCL,
+			wantBlockType: "unit",
+			wantLabel:     "app",
+			wantErr:       true,
+		},
+		{
+			name:          "stack with expansion",
+			configPath:    config.DefaultStackFile,
+			cfg:           stackWithExpansionHCL,
+			wantBlockType: "stack",
+			wantLabel:     "team",
+			wantErr:       true,
+		},
+		{
+			name:       "dependency without expansion",
+			configPath: config.DefaultTerragruntConfigPath,
+			cfg: `
+dependency "vpc" {
+  config_path = "../vpc"
+}
+`,
+		},
+		{
+			name:       "unit without expansion",
+			configPath: config.DefaultStackFile,
+			cfg: `
+unit "app" {
+  source = "./modules/app"
+  path   = "app"
+}
+`,
+		},
+		{
+			name:       "expansion outside an expandable block",
+			configPath: config.DefaultTerragruntConfigPath,
+			cfg: `
+generate "backend" {
+  expansion {
+    count = 2
+  }
+
+  path      = "backend.tf"
+  if_exists = "overwrite"
+  contents  = ""
+}
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			file := parseHCLString(t, tc.cfg, tc.configPath)
+
+			err := config.ValidateExpansionExperiment(experiment.NewExperiments(), file)
+
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			var typed config.ExpansionRequiresExperimentError
+			require.ErrorAs(t, err, &typed)
+			assert.Equal(t, tc.wantBlockType, typed.BlockType)
+			assert.Equal(t, tc.wantLabel, typed.BlockLabel)
+			assert.Equal(t, tc.configPath, typed.ConfigPath)
+		})
+	}
+}
+
+// TestValidateExpansionExperimentEnabled pins that enabling the experiment clears the
+// gate for every block type it covers.
+func TestValidateExpansionExperimentEnabled(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		configPath string
+		cfg        string
+	}{
+		{
+			name:       "dependency",
+			configPath: config.DefaultTerragruntConfigPath,
+			cfg:        dependencyWithExpansionHCL,
+		},
+		{
+			name:       "unit",
+			configPath: config.DefaultStackFile,
+			cfg:        unitWithExpansionHCL,
+		},
+		{
+			name:       "stack",
+			configPath: config.DefaultStackFile,
+			cfg:        stackWithExpansionHCL,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			experiments := experiment.NewExperiments()
+			require.NoError(t, experiments.EnableExperiment(experiment.BlockIteration))
+
+			require.NoError(
+				t,
+				config.ValidateExpansionExperiment(experiments, parseHCLString(t, tc.cfg, tc.configPath)),
+			)
+		})
+	}
+}
+
+// TestParseConfigStringExpansionRequiresExperiment proves the gate is wired into the
+// unit config parse, not just callable on its own.
+func TestParseConfigStringExpansionRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	skipInExperimentMode(t)
+
+	l := logger.CreateLogger()
+	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+
+	_, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		l,
+		config.DefaultTerragruntConfigPath,
+		dependencyWithExpansionHCL,
+		nil,
+	)
+
+	var typed config.ExpansionRequiresExperimentError
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, "dependency", typed.BlockType)
+}
+
+// TestReadStackConfigStringExpansionRequiresExperiment proves the gate is wired into the
+// stack parse. A unit block decodes through an `hcl:",remain"` field that would otherwise
+// absorb the expansion block without complaint.
+func TestReadStackConfigStringExpansionRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	skipInExperimentMode(t)
+
+	testCases := []struct {
+		name          string
+		cfg           string
+		wantBlockType string
+	}{
+		{
+			name:          "unit",
+			cfg:           unitWithExpansionHCL,
+			wantBlockType: "unit",
+		},
+		{
+			name:          "stack",
+			cfg:           stackWithExpansionHCL,
+			wantBlockType: "stack",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := logger.CreateLogger()
+			ctx, pctx := newTestParsingContext(t, config.DefaultStackFile)
+
+			_, err := config.ReadStackConfigString(
+				ctx,
+				l,
+				pctx,
+				config.DefaultStackFile,
+				tc.cfg,
+				nil,
+			)
+
+			var typed config.ExpansionRequiresExperimentError
+			require.ErrorAs(t, err, &typed)
+			assert.Equal(t, tc.wantBlockType, typed.BlockType)
+		})
+	}
+}
+
+// TestReadStackConfigFileExpansionInIncludeRequiresExperiment pins that the gate follows
+// include blocks. Included stack files decode straight to StackConfigFile without going
+// back through ParseStackConfig, so they are gated separately.
+func TestReadStackConfigFileExpansionInIncludeRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	skipInExperimentMode(t)
+
+	const dir = "/stack"
+
+	fsys := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(
+		fsys,
+		filepath.Join(dir, "included.stack.hcl"),
+		[]byte(unitWithExpansionHCL),
+		0o644,
+	))
+
+	stackPath := filepath.Join(dir, config.DefaultStackFile)
+	require.NoError(t, vfs.WriteFile(fsys, stackPath, []byte(`
+include "extra" {
+  path = "included.stack.hcl"
+}
+`), 0o644))
+
+	l := logger.CreateLogger()
+	ctx, pctx := newTestParsingContext(t, stackPath)
+	pctx.Venv.FS = fsys
+
+	_, err := config.ReadStackConfigFile(ctx, l, pctx, stackPath, nil)
+
+	var typed config.ExpansionRequiresExperimentError
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, "unit", typed.BlockType)
+}
+
+// TestExpansionRequiresExperimentErrorNamesTheFlag pins that the error a user reads
+// names the experiment they need, with and without a block label.
+func TestExpansionRequiresExperimentErrorNamesTheFlag(t *testing.T) {
+	t.Parallel()
+
+	labeled := config.ExpansionRequiresExperimentError{
+		ConfigPath: config.DefaultTerragruntConfigPath,
+		BlockType:  "dependency",
+		BlockLabel: "aurora",
+	}
+	assert.Contains(t, labeled.Error(), experiment.BlockIteration)
+	assert.Contains(t, labeled.Error(), `dependency "aurora"`)
+
+	unlabeled := config.ExpansionRequiresExperimentError{
+		ConfigPath: config.DefaultStackFile,
+		BlockType:  "unit",
+	}
+	assert.Contains(t, unlabeled.Error(), experiment.BlockIteration)
+	assert.NotContains(t, unlabeled.Error(), `""`)
+}
+
+func parseHCLString(tb testing.TB, cfg, configPath string) *hclparse.File {
+	tb.Helper()
+
+	file, err := hclparse.NewParser().ParseFromString(cfg, configPath)
+	require.NoError(tb, err)
+
+	return file
+}
+
+// skipInExperimentMode skips a test that asserts disabled-experiment behavior, since
+// TG_EXPERIMENT_MODE forces every experiment on.
+func skipInExperimentMode(t *testing.T) {
+	t.Helper()
+
+	if helpers.IsExperimentMode(t) {
+		t.Skip(
+			"Skipping: TG_EXPERIMENT_MODE forces the block-iteration experiment on, so its disabled-state error can't be verified",
+		)
+	}
+}

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	inthclparse "github.com/gruntwork-io/terragrunt/internal/hclparse"
@@ -1058,6 +1059,10 @@ func ParseStackConfig(
 		parser = parser.WithValues(values)
 	}
 
+	if err := ValidateExpansionExperiment(parser.Experiments, file); err != nil {
+		return nil, err
+	}
+
 	if err := processLocals(ctx, l, parser, file); err != nil {
 		return nil, err
 	}
@@ -1094,6 +1099,7 @@ func ParseStackConfig(
 		stackDir,
 		evalParsingContext,
 		parser.ParserOptions,
+		parser.Experiments,
 	); err != nil {
 		return nil, err
 	}
@@ -1106,6 +1112,7 @@ func ParseStackConfig(
 		filepath.Base(file.ConfigPath),
 		evalParsingContext,
 		parser.ParserOptions,
+		parser.Experiments,
 	); err != nil {
 		return nil, err
 	}
@@ -1383,6 +1390,7 @@ func processStackConfigIncludes(
 	stackDir string,
 	evalCtx *hcl.EvalContext,
 	parserOpts []hclparse.Option,
+	experiments experiment.Experiments,
 ) error {
 	for _, inc := range config.Includes {
 		includePath := inc.Path
@@ -1393,6 +1401,10 @@ func processStackConfigIncludes(
 		incFile, err := hclparse.NewParser(parserOpts...).ParseFromFile(fsys, includePath)
 		if err != nil {
 			return fmt.Errorf("failed to read include %q: %w", inc.Name, err)
+		}
+
+		if err := ValidateExpansionExperiment(experiments, incFile); err != nil {
+			return err
 		}
 
 		included := &StackConfigFile{}
@@ -1448,6 +1460,7 @@ func mergeStackAutoIncludeFile(
 	stackDir, stackFileName string,
 	evalCtx *hcl.EvalContext,
 	parserOpts []hclparse.Option,
+	experiments experiment.Experiments,
 ) error {
 	// Never merge the autoinclude file into itself.
 	if stackFileName == inthclparse.AutoIncludeStackFile {
@@ -1482,6 +1495,10 @@ func mergeStackAutoIncludeFile(
 		filepath.Base(stackDir),
 	); typed != nil {
 		return *typed
+	}
+
+	if err := ValidateExpansionExperiment(experiments, incFile); err != nil {
+		return err
 	}
 
 	included := &StackConfigFile{}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Registers the `block-iteration` experiment to support `for_each`, `count`, and `enabled` down the line.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for expansion blocks controlled by the Block Iteration experiment.
  * Added validation across dependency, unit, stack, include, and autoinclude configurations.
  * Configuration errors now identify the affected block and required experiment.

* **Bug Fixes**
  * Invalid expansion configurations are rejected earlier during parsing.

* **Tests**
  * Added coverage for enabled and disabled experiment scenarios across configuration parsing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->