### PR TITLE
feat: Adding `mutable` attribute to the `generate` block

### DIFF
--- a/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -1423,6 +1423,26 @@ The `generate` block supports the following arguments:
 - `contents` (attribute): The contents of the generated file.
 - `disable` (attribute): Disables this generate block.
 
+<Since version="1.1.2">
+
+- `mutable` (attribute): When `true`, the generated file is an ordinary writable file. Defaults to `false`. Optional.
+
+  <Aside type="tip" title="Experimental">
+    The `mutable` attribute is gated behind the `mutable-generate` experiment. Enable it with `--experiment mutable-generate` (or `TG_EXPERIMENT=mutable-generate`) until it graduates to general availability. See the [experiment documentation](/reference/experiments/active#mutable-generate).
+  </Aside>
+
+  At the default of `false`, the generated contents are stored in the
+  [content-addressable storage (CAS)](/features/caching/cas) store, and the file written at `path` is a read-only link
+  to that stored copy. Set `mutable` to `true` when something edits the generated file in place, such as a hook that
+  patches it before `tofu`/`terraform` runs. Terragrunt regenerates the file rather than editing it, and
+  `tofu`/`terraform` only read it, so most `generate` blocks do not need it.
+
+  Because the stored copy is addressed by the hash of its contents, anything else generating identical contents links
+  to the same copy instead of writing its own. The CAS is required for this, so `--no-cas` writes generated files
+  directly and `mutable` has no effect.
+
+</Since>
+
 Example:
 
 ```hcl

--- a/docs/src/data/changelog/v1.1.2/mutable-generate.mdx
+++ b/docs/src/data/changelog/v1.1.2/mutable-generate.mdx
@@ -1,0 +1,25 @@
+---
+version: "v1.1.2"
+category: "experiments-added"
+---
+
+#### `mutable-generate` - Deduplicated `generate` block output
+
+The `mutable-generate` experiment has been added. With it enabled, the contents a `generate` block produces are stored in Content Addressable Storage, and the file written at `path` is a read-only link to that stored copy rather than a file of its own.
+
+Since the stored copy is addressed by the hash of its contents, anything generating identical contents links to the same copy. A `generate` block inherited by several hundred units therefore costs one copy in `.terragrunt-cache` rather than several hundred.
+
+The link is read-only because that copy is shared. Where a generated file does need to be edited in place, a new `mutable` attribute on the `generate` block gives it a writable file of its own:
+
+```hcl
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite"
+  mutable   = true
+  contents  = "..."
+}
+```
+
+Setting `mutable` without the experiment enabled is an error, since earlier Terragrunt versions reject the attribute. The CAS is required, so `--no-cas` writes generated files directly and `mutable` has no effect.
+
+For details, see the [experiment documentation](/reference/experiments/active#mutable-generate).

--- a/docs/src/data/changelog/v1.1.3/mutable-generate.mdx
+++ b/docs/src/data/changelog/v1.1.3/mutable-generate.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.1.2"
+version: "v1.1.3"
 category: "experiments-added"
 ---
 

--- a/docs/src/data/experiments/mutable-generate.mdx
+++ b/docs/src/data/experiments/mutable-generate.mdx
@@ -1,0 +1,77 @@
+---
+name: mutable-generate
+since: "1.1.2"
+---
+
+Deduplicate the files produced by `generate` blocks through content-addressable storage, with a `mutable` attribute to opt out.
+
+### `mutable-generate` - What it does
+
+With the experiment enabled, the contents a `generate` block produces are stored
+in the [CAS](/features/caching/cas), and the file written at `path` is a
+read-only link to that stored copy rather than a file of its own. The link is
+read-only because the stored copy is shared: an edit through one path would
+otherwise change what every later reader of that content sees.
+
+Because the stored copy is addressed by the hash of its contents, anything
+generating identical contents links to the same copy instead of writing its own.
+That matters most for a `generate` block declared in a parent configuration,
+which writes the same content into every unit that includes it. A provider or
+backend block shared across a few hundred units used to mean a few hundred copies
+in `.terragrunt-cache`, and now means one.
+
+The experiment also adds a `mutable` attribute to the `generate` block, for cases
+where a shared read-only file does not work:
+
+```hcl
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite"
+  mutable   = true
+  contents  = <<EOF
+provider "aws" {
+  region = "us-east-1"
+}
+EOF
+}
+```
+
+`mutable = true` gives the block a writable file of its own. Use it when
+something rewrites the generated file in place, such as a hook that patches it
+before `tofu`/`terraform` runs. Terragrunt regenerates the file rather than
+editing it, and `tofu`/`terraform` only read it, so most `generate` blocks do
+not need it.
+
+Setting `mutable` without the experiment enabled is an error, because older
+Terragrunt versions reject the attribute outright. The CAS is required, so
+`--no-cas` writes generated files directly and `mutable` has no effect.
+
+### `mutable-generate` - How to enable it
+
+```bash
+# Via CLI flag
+terragrunt --experiment mutable-generate run --all -- apply
+
+# Via environment variable
+export TG_EXPERIMENT=mutable-generate
+terragrunt run --all -- apply
+```
+
+### `mutable-generate` - How to provide feedback
+
+Track and discuss this experiment in [gruntwork-io/terragrunt#6559](https://github.com/gruntwork-io/terragrunt/issues/6559).
+When reporting issues or providing feedback, please include:
+
+- Whether anything in your pipeline writes to a generated file after Terragrunt creates it.
+- The `generate` blocks involved, and how many units share them.
+- The disk usage of `.terragrunt-cache` before and after enabling the experiment.
+
+### `mutable-generate` - Criteria for stabilization
+
+To transition the `mutable-generate` feature to a stable release, the following must be addressed, at a minimum:
+
+- [x] A `mutable` attribute on the `generate` block, parsed from both the block and attribute forms.
+- [x] Deduplication of non-mutable generated files through the CAS store, materialized as read-only hard links.
+- [ ] Confirmation that read-only generated files break no established workflow, including hooks and IaC engines.
+- [ ] A decision on whether `remote_state.generate` should participate, given its per-unit backend keys rarely repeat.
+- [ ] Community feedback on the disk savings actually observed at scale.

--- a/internal/cli/commands/aws-provider-patch/aws-provider-patch.go
+++ b/internal/cli/commands/aws-provider-patch/aws-provider-patch.go
@@ -55,7 +55,7 @@ func runSingle(
 
 	runCfg := prepared.Cfg.ToRunConfig(l)
 
-	if err := prepare.PrepareGenerate(l, v, updatedOpts, runCfg); err != nil {
+	if err := prepare.PrepareGenerate(ctx, l, v, updatedOpts, runCfg); err != nil {
 		return err
 	}
 

--- a/internal/cli/commands/exec/exec.go
+++ b/internal/cli/commands/exec/exec.go
@@ -40,7 +40,7 @@ func Run(
 	runCfg := prepared.Cfg.ToRunConfig(l)
 
 	// Generate config
-	if err := prepare.PrepareGenerate(l, v, updatedOpts, runCfg); err != nil {
+	if err := prepare.PrepareGenerate(ctx, l, v, updatedOpts, runCfg); err != nil {
 		return err
 	}
 

--- a/internal/cli/commands/hcl/validate/validate.go
+++ b/internal/cli/commands/hcl/validate/validate.go
@@ -382,6 +382,7 @@ func RunValidateInputs(
 
 		// Generate config
 		if err := prepare.PrepareGenerate(
+			ctx,
 			l,
 			unitV,
 			updatedOpts,

--- a/internal/codegen/generate.go
+++ b/internal/codegen/generate.go
@@ -139,7 +139,7 @@ func WriteToFile(
 		targetPath = filepath.Join(basePath, config.Path)
 	}
 
-	targetInfo, statErr := v.FS.Stat(targetPath)
+	targetInfo, statErr := vfs.Lstat(v.FS, targetPath)
 	if statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
 		return statErr
 	}
@@ -205,6 +205,7 @@ func WriteToFile(
 
 	// A surviving target may be a read-only hard link into the store, and even a
 	// writable one would block a fresh link and silently degrade it into a copy.
+	// A symlink must go too, or the write follows it to its destination.
 	if targetFileExists && !targetInfo.IsDir() {
 		if err := v.FS.Remove(targetPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return err
@@ -354,6 +355,18 @@ func shouldRemoveWithFileExists(
 // generated string will be prefixed with the configured comment prefix, the check needs to see if the first line ends
 // with the signature string.
 func fileWasGeneratedByTerragrunt(v *venv.Venv, path string) (generated bool, err error) {
+	info, err := vfs.Lstat(v.FS, path)
+	if err != nil {
+		return false, err
+	}
+
+	// Generation only ever writes a regular file or links one into place, so a
+	// symlink came from elsewhere. Reading through it would check a signature
+	// belonging to the destination, while the caller replaces the link itself.
+	if info.Mode()&fs.ModeSymlink != 0 {
+		return false, nil
+	}
+
 	file, err := v.FS.Open(path)
 	if err != nil {
 		return false, err

--- a/internal/codegen/generate.go
+++ b/internal/codegen/generate.go
@@ -2,11 +2,11 @@ package codegen
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -18,7 +18,9 @@ import (
 
 	"errors"
 
-	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
@@ -29,6 +31,8 @@ const (
 
 	// The default prefix to use for comments in the generated file
 	DefaultCommentPrefix = "# "
+
+	generatedFilePerms = 0644
 )
 
 // GenerateConfigExists is an enum to represent valid values for if_exists.
@@ -82,6 +86,7 @@ const (
 // GenerateConfig is configuration for generating code
 type GenerateConfig struct {
 	HclFmt           *bool  `cty:"hcl_fmt"`
+	Mutable          *bool  `cty:"mutable"`
 	Path             string `cty:"path"`
 	IfExistsStr      string `cty:"if_exists"`
 	IfDisabledStr    string `cty:"if_disabled"`
@@ -93,12 +98,39 @@ type GenerateConfig struct {
 	Disable          bool `cty:"disable"`
 }
 
+// WriteOption configures a single [WriteToFile] call.
+type WriteOption func(*writeOpts)
+
+type writeOpts struct {
+	store *cas.Content
+}
+
+// WithContentStore deduplicates generated files that do not opt into
+// mutability: identical contents are written once into store and hard-linked
+// read-only into each working directory. Without it every generated file is
+// written directly and stays writable, and [GenerateConfig.Mutable] has no effect.
+func WithContentStore(store *cas.Content) WriteOption {
+	return func(o *writeOpts) { o.store = store }
+}
+
 // WriteToFile will generate a new file at the given target path with the given contents. If a file already exists at
 // the target path, the behavior depends on the value of IfExists:
 // - if ExistsError, return an error.
 // - if ExistsSkip, do nothing and return
 // - if ExistsOverwrite, overwrite the existing file
-func WriteToFile(l log.Logger, basePath string, config *GenerateConfig) error {
+func WriteToFile(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+	basePath string,
+	config *GenerateConfig,
+	opts ...WriteOption,
+) error {
+	var o writeOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	// Figure out the target path to generate the code in. If relative, merge with basePath.
 	var targetPath string
 	if filepath.IsAbs(config.Path) {
@@ -107,7 +139,12 @@ func WriteToFile(l log.Logger, basePath string, config *GenerateConfig) error {
 		targetPath = filepath.Join(basePath, config.Path)
 	}
 
-	targetFileExists := util.FileExists(targetPath)
+	targetInfo, statErr := v.FS.Stat(targetPath)
+	if statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
+		return statErr
+	}
+
+	targetFileExists := statErr == nil
 
 	// If this GenerateConfig is disabled then skip further processing.
 	if config.Disable {
@@ -116,12 +153,13 @@ func WriteToFile(l log.Logger, basePath string, config *GenerateConfig) error {
 		if targetFileExists {
 			if shouldRemove, err := shouldRemoveWithFileExists(
 				l,
+				v,
 				targetPath,
 				config.IfDisabled,
 			); err != nil {
 				return err
 			} else if shouldRemove {
-				if err := os.Remove(targetPath); err != nil {
+				if err := v.FS.Remove(targetPath); err != nil {
 					return err
 				}
 			}
@@ -131,7 +169,7 @@ func WriteToFile(l log.Logger, basePath string, config *GenerateConfig) error {
 	}
 
 	if targetFileExists {
-		shouldContinue, err := shouldContinueWithFileExists(l, targetPath, config.IfExists)
+		shouldContinue, err := shouldContinueWithFileExists(l, v, targetPath, config.IfExists)
 		if err != nil || !shouldContinue {
 			return err
 		}
@@ -165,15 +203,15 @@ func WriteToFile(l log.Logger, basePath string, config *GenerateConfig) error {
 		contentsToWrite = hclwrite.Format(contentsToWrite)
 	}
 
-	// CAS may materialize the target as a read-only hard link, so remove it before writing
-	if targetFileExists && util.IsFile(targetPath) {
-		if err := os.Remove(targetPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+	// A surviving target may be a read-only hard link into the store, and even a
+	// writable one would block a fresh link and silently degrade it into a copy.
+	if targetFileExists && !targetInfo.IsDir() {
+		if err := v.FS.Remove(targetPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}
 	}
 
-	const ownerWriteGlobalReadPerms = 0644
-	if err := os.WriteFile(targetPath, contentsToWrite, ownerWriteGlobalReadPerms); err != nil {
+	if err := materialize(ctx, l, v, targetPath, contentsToWrite, config.Mutable, o.store); err != nil {
 		return err
 	}
 
@@ -182,10 +220,36 @@ func WriteToFile(l log.Logger, basePath string, config *GenerateConfig) error {
 	return nil
 }
 
+// materialize puts contents at targetPath, sharing one stored copy across
+// working directories unless the block opts into mutability.
+func materialize(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+	targetPath string,
+	contents []byte,
+	mutable *bool,
+	store *cas.Content,
+) error {
+	if store == nil || (mutable != nil && *mutable) {
+		return vfs.WriteFile(v.FS, targetPath, contents, generatedFilePerms)
+	}
+
+	// Matches how the blob store keys files ingested from local sources, so a
+	// generated file also dedupes against an identical file from a module.
+	hash := cas.HashSHA256.Sum(contents)
+	if err := store.Ensure(l, v, hash, contents); err != nil {
+		return err
+	}
+
+	return store.Link(ctx, v, hash, targetPath, generatedFilePerms)
+}
+
 // Whether or not file generation should continue if the file path already exists. The answer depends on the
 // ifExists configuration.
 func shouldContinueWithFileExists(
 	l log.Logger,
+	v *venv.Venv,
 	path string,
 	ifExists GenerateConfigExists,
 ) (bool, error) {
@@ -209,7 +273,7 @@ func shouldContinueWithFileExists(
 	case ExistsOverwriteTerragrunt:
 		// If file was not generated, error out because overwrite_terragrunt if_exists setting only handles if the
 		// existing file was generated by terragrunt.
-		wasGenerated, err := fileWasGeneratedByTerragrunt(path)
+		wasGenerated, err := fileWasGeneratedByTerragrunt(v, path)
 		if err != nil {
 			return false, err
 		}
@@ -238,6 +302,7 @@ func shouldContinueWithFileExists(
 // shouldRemoveWithFileExists returns true if the already existing file should be removed.
 func shouldRemoveWithFileExists(
 	l log.Logger,
+	v *venv.Venv,
 	path string,
 	ifDisable GenerateConfigDisabled,
 ) (bool, error) {
@@ -259,7 +324,7 @@ func shouldRemoveWithFileExists(
 		// If file was not generated, error out because remove_terragrunt
 		// if_disabled setting only handles if the existing file was
 		// generated by terragrunt.
-		wasGenerated, err := fileWasGeneratedByTerragrunt(path)
+		wasGenerated, err := fileWasGeneratedByTerragrunt(v, path)
 		if err != nil {
 			return false, err
 		}
@@ -288,16 +353,17 @@ func shouldRemoveWithFileExists(
 // Check if the file was generated by terragrunt by checking if the first line of the file has the signature. Since the
 // generated string will be prefixed with the configured comment prefix, the check needs to see if the first line ends
 // with the signature string.
-func fileWasGeneratedByTerragrunt(path string) (bool, error) {
-	file, err := os.Open(path)
+func fileWasGeneratedByTerragrunt(v *venv.Venv, path string) (generated bool, err error) {
+	file, err := v.FS.Open(path)
 	if err != nil {
 		return false, err
 	}
-	defer file.Close()
 
-	reader := bufio.NewReader(file)
+	defer func() {
+		err = errors.Join(err, file.Close())
+	}()
 
-	firstLine, err := reader.ReadString('\n')
+	firstLine, err := bufio.NewReader(file).ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
 		return false, err
 	}

--- a/internal/codegen/generate_test.go
+++ b/internal/codegen/generate_test.go
@@ -8,8 +8,10 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/codegen"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
@@ -334,7 +336,7 @@ func TestFmtGeneratedFile(t *testing.T) {
 			}
 
 			l := logger.CreateLogger()
-			err := codegen.WriteToFile(l, "", &config)
+			err := codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config)
 			require.NoError(t, err)
 
 			assert.True(t, util.FileExists(tc.path))
@@ -389,7 +391,7 @@ func TestGenerateDisabling(t *testing.T) {
 			}
 
 			l := logger.CreateLogger()
-			err := codegen.WriteToFile(l, "", &config)
+			err := codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config)
 			require.NoError(t, err)
 
 			if tc.disabled {
@@ -553,7 +555,7 @@ func TestWriteToFileOverwritesReadOnlyTarget(t *testing.T) {
 			}
 
 			l := logger.CreateLogger()
-			require.NoError(t, codegen.WriteToFile(l, "", &config))
+			require.NoError(t, codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config))
 
 			fileContent, err := os.ReadFile(path)
 			require.NoError(t, err)
@@ -607,7 +609,7 @@ func TestWriteToFileSkipAndErrorLeaveExistingFileIntact(t *testing.T) {
 			}
 
 			l := logger.CreateLogger()
-			writeErr := codegen.WriteToFile(l, "", &config)
+			writeErr := codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config)
 
 			if tc.wantErr {
 				var existsErr codegen.GenerateFileExistsError
@@ -656,7 +658,7 @@ func TestWriteToFileOverwriteDoesNotMutateHardlinkedStore(t *testing.T) {
 	}
 
 	l := logger.CreateLogger()
-	require.NoError(t, codegen.WriteToFile(l, "", &config))
+	require.NoError(t, codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config))
 
 	storeContentAfter, err := os.ReadFile(storePath)
 	require.NoError(t, err)
@@ -699,7 +701,7 @@ func TestWriteToFileTargetIsDirectory(t *testing.T) {
 	}
 
 	l := logger.CreateLogger()
-	require.Error(t, codegen.WriteToFile(l, "", &config))
+	require.Error(t, codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config))
 	assert.DirExists(t, targetPath)
 }
 
@@ -722,7 +724,7 @@ func TestWriteToFileDisabledRemovesReadOnlyFile(t *testing.T) {
 	}
 
 	l := logger.CreateLogger()
-	require.NoError(t, codegen.WriteToFile(l, "", &config))
+	require.NoError(t, codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config))
 	assert.True(t, util.FileNotExists(targetPath))
 }
 
@@ -767,7 +769,7 @@ func TestWriteToFileSignatureWithoutTrailingNewline(t *testing.T) {
 			}
 
 			l := logger.CreateLogger()
-			require.NoError(t, codegen.WriteToFile(l, "", &config))
+			require.NoError(t, codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config))
 
 			if tc.disable {
 				assert.True(t, util.FileNotExists(path))
@@ -834,7 +836,7 @@ func TestWriteToFileUnsignedFileWithoutTrailingNewline(t *testing.T) {
 			}
 
 			l := logger.CreateLogger()
-			writeErr := codegen.WriteToFile(l, "", &config)
+			writeErr := codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config)
 
 			if tc.disable {
 				var removeErr codegen.GenerateFileRemoveError
@@ -853,6 +855,159 @@ func TestWriteToFileUnsignedFileWithoutTrailingNewline(t *testing.T) {
 			assert.Equal(t, tc.contents, string(fileContent), "existing file must stay intact")
 		})
 	}
+}
+
+// TestWriteToFileWithContentStoreDeduplicates verifies that two targets
+// generated from the same contents end up sharing one read-only inode.
+func TestWriteToFileWithContentStoreDeduplicates(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only permission bits are not meaningfully observable on Windows")
+	}
+
+	testDir := helpers.TmpDirWOSymlinks(t)
+	store := newTestContentStore(t, testDir)
+	contents := "terraform {\n  required_version = \">= 1.3.0\"\n}\n"
+
+	first := filepath.Join(testDir, "unit-a", "versions.tf")
+	second := filepath.Join(testDir, "unit-b", "versions.tf")
+
+	for _, path := range []string{first, second} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+
+		config := codegen.GenerateConfig{
+			Path:             path,
+			IfExists:         codegen.ExistsOverwrite,
+			DisableSignature: true,
+			Contents:         contents,
+		}
+
+		l := logger.CreateLogger()
+		require.NoError(t, codegen.WriteToFile(
+			t.Context(), l, venv.OSVenv(), "", &config, codegen.WithContentStore(store),
+		))
+	}
+
+	firstInfo, err := os.Stat(first)
+	require.NoError(t, err)
+
+	secondInfo, err := os.Stat(second)
+	require.NoError(t, err)
+
+	assert.True(t, os.SameFile(firstInfo, secondInfo),
+		"identical generated contents must share one inode")
+	assert.Equal(t, os.FileMode(0444), firstInfo.Mode().Perm(),
+		"deduplicated files must be read-only so an edit cannot reach the store")
+
+	firstContents, err := os.ReadFile(first)
+	require.NoError(t, err)
+	assert.Equal(t, contents, string(firstContents))
+}
+
+// TestWriteToFileWithContentStoreMutableOptsOut verifies that a generate block
+// asking for mutability gets a private, writable file even when a store is
+// available.
+func TestWriteToFileWithContentStoreMutableOptsOut(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only permission bits are not meaningfully observable on Windows")
+	}
+
+	testDir := helpers.TmpDirWOSymlinks(t)
+	store := newTestContentStore(t, testDir)
+	contents := "terraform {\n  required_version = \">= 1.3.0\"\n}\n"
+
+	shared := filepath.Join(testDir, "unit-a", "versions.tf")
+	private := filepath.Join(testDir, "unit-b", "versions.tf")
+
+	for _, tc := range []struct {
+		mutable *bool
+		path    string
+	}{
+		{path: shared},
+		{path: private, mutable: new(true)},
+	} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(tc.path), 0755))
+
+		config := codegen.GenerateConfig{
+			Path:             tc.path,
+			IfExists:         codegen.ExistsOverwrite,
+			DisableSignature: true,
+			Contents:         contents,
+			Mutable:          tc.mutable,
+		}
+
+		l := logger.CreateLogger()
+		require.NoError(t, codegen.WriteToFile(
+			t.Context(), l, venv.OSVenv(), "", &config, codegen.WithContentStore(store),
+		))
+	}
+
+	sharedInfo, err := os.Stat(shared)
+	require.NoError(t, err)
+
+	privateInfo, err := os.Stat(private)
+	require.NoError(t, err)
+
+	assert.False(t, os.SameFile(sharedInfo, privateInfo),
+		"a mutable generate block must not share an inode with the store")
+	assert.NotZero(t, privateInfo.Mode().Perm()&0200, "a mutable generate block must stay writable")
+}
+
+// TestWriteToFileWithContentStoreRegeneratesChangedContents verifies that
+// changing the contents replaces the link rather than writing through it into
+// the shared store, which every other unit on the old blob still reads.
+func TestWriteToFileWithContentStoreRegeneratesChangedContents(t *testing.T) {
+	t.Parallel()
+
+	v := venv.OSVenv()
+	testDir := helpers.TmpDirWOSymlinks(t)
+	store := newTestContentStore(t, testDir)
+	targetPath := filepath.Join(testDir, "versions.tf")
+
+	var firstGenerated []byte
+
+	for _, version := range []string{">= 1.0.0", ">= 1.3.0"} {
+		config := codegen.GenerateConfig{
+			Path:             targetPath,
+			IfExists:         codegen.ExistsOverwrite,
+			DisableSignature: true,
+			Contents:         fmt.Sprintf("terraform {\n  required_version = %q\n}\n", version),
+		}
+
+		l := logger.CreateLogger()
+		require.NoError(t, codegen.WriteToFile(
+			t.Context(), l, v, "", &config, codegen.WithContentStore(store),
+		))
+
+		if firstGenerated == nil {
+			generated, err := os.ReadFile(targetPath)
+			require.NoError(t, err)
+
+			firstGenerated = generated
+		}
+	}
+
+	targetContents, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(targetContents), ">= 1.3.0")
+
+	storedFirst, err := store.Read(v, cas.HashSHA256.Sum(firstGenerated))
+	require.NoError(t, err)
+	assert.Equal(t, firstGenerated, storedFirst, "the superseded blob must survive intact")
+}
+
+// newTestContentStore returns a store rooted under dir so tests never touch the
+// user's real CAS.
+func newTestContentStore(t *testing.T, dir string) *cas.Content {
+	t.Helper()
+
+	c, err := cas.New(cas.WithStorePath(filepath.Join(dir, "cas")))
+	require.NoError(t, err)
+
+	return cas.NewContent(c.BlobStore())
 }
 
 // writeFileWithPerms writes contents first and tightens permissions afterwards

--- a/internal/codegen/generate_test.go
+++ b/internal/codegen/generate_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
@@ -495,7 +494,7 @@ enabled=true`,
 func TestWriteToFileOverwritesReadOnlyTarget(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if helpers.IsWindows() {
 		t.Skip("read-only permission bits are not meaningfully observable on Windows")
 	}
 
@@ -634,7 +633,7 @@ func TestWriteToFileSkipAndErrorLeaveExistingFileIntact(t *testing.T) {
 func TestWriteToFileOverwriteDoesNotMutateHardlinkedStore(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if helpers.IsWindows() {
 		t.Skip("read-only permission bits are not meaningfully observable on Windows")
 	}
 
@@ -862,7 +861,7 @@ func TestWriteToFileUnsignedFileWithoutTrailingNewline(t *testing.T) {
 func TestWriteToFileWithContentStoreDeduplicates(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if helpers.IsWindows() {
 		t.Skip("read-only permission bits are not meaningfully observable on Windows")
 	}
 
@@ -911,7 +910,7 @@ func TestWriteToFileWithContentStoreDeduplicates(t *testing.T) {
 func TestWriteToFileWithContentStoreMutableOptsOut(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == "windows" {
+	if helpers.IsWindows() {
 		t.Skip("read-only permission bits are not meaningfully observable on Windows")
 	}
 
@@ -997,6 +996,141 @@ func TestWriteToFileWithContentStoreRegeneratesChangedContents(t *testing.T) {
 	storedFirst, err := store.Read(v, cas.HashSHA256.Sum(firstGenerated))
 	require.NoError(t, err)
 	assert.Equal(t, firstGenerated, storedFirst, "the superseded blob must survive intact")
+}
+
+// TestWriteToFileOverwritesDanglingSymlink verifies that a target occupied by a
+// symlink pointing nowhere is replaced rather than followed, which would try to
+// create the symlink's missing destination instead of the generated file.
+func TestWriteToFileOverwritesDanglingSymlink(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("creating symlinks requires elevated privileges on Windows")
+	}
+
+	testDir := helpers.TmpDirWOSymlinks(t)
+	contents := "provider \"null\" {\n}\n"
+
+	for _, tc := range []struct {
+		mutable  *bool
+		name     string
+		useStore bool
+	}{
+		{name: "mutable", mutable: new(true), useStore: true},
+		{name: "immutable", useStore: true},
+		{name: "no-store"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			targetDir := filepath.Join(testDir, tc.name)
+			require.NoError(t, os.MkdirAll(targetDir, 0755))
+
+			targetPath := filepath.Join(targetDir, "provider.tf")
+			require.NoError(t, os.Symlink(filepath.Join(targetDir, "nonexistent.tf"), targetPath))
+
+			config := codegen.GenerateConfig{
+				Path:             targetPath,
+				IfExists:         codegen.ExistsOverwrite,
+				DisableSignature: true,
+				Contents:         contents,
+				Mutable:          tc.mutable,
+			}
+
+			opts := []codegen.WriteOption{}
+			if tc.useStore {
+				opts = append(opts, codegen.WithContentStore(newTestContentStore(t, targetDir)))
+			}
+
+			l := logger.CreateLogger()
+			require.NoError(t, codegen.WriteToFile(
+				t.Context(), l, venv.OSVenv(), "", &config, opts...,
+			))
+
+			info, err := os.Lstat(targetPath)
+			require.NoError(t, err)
+			assert.Zero(t, info.Mode()&os.ModeSymlink, "the dangling symlink must be replaced")
+
+			generated, err := os.ReadFile(targetPath)
+			require.NoError(t, err)
+			assert.Equal(t, contents, string(generated))
+		})
+	}
+}
+
+// TestWriteToFileSymlinkIsNotTerragruntGenerated verifies that the
+// terragrunt-only modes refuse a symlinked target. Terragrunt never generates a
+// symlink, and reading through one would check the destination's signature
+// while the write replaces the link.
+func TestWriteToFileSymlinkIsNotTerragruntGenerated(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("creating symlinks requires elevated privileges on Windows")
+	}
+
+	testDir := helpers.TmpDirWOSymlinks(t)
+	signature := codegen.DefaultCommentPrefix + codegen.TerragruntGeneratedSignature + "\n"
+
+	for _, tc := range []struct {
+		name        string
+		destination string
+		disable     bool
+	}{
+		{name: "overwrite-terragrunt-refuses-dangling"},
+		{name: "remove-terragrunt-refuses-dangling", disable: true},
+		{name: "overwrite-terragrunt-refuses-generated-destination", destination: signature},
+		{name: "remove-terragrunt-refuses-generated-destination", destination: signature, disable: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			targetDir := filepath.Join(testDir, tc.name)
+			require.NoError(t, os.MkdirAll(targetDir, 0755))
+
+			destinationPath := filepath.Join(targetDir, "destination.tf")
+			if tc.destination != "" {
+				require.NoError(t, os.WriteFile(destinationPath, []byte(tc.destination), 0644))
+			}
+
+			targetPath := filepath.Join(targetDir, "provider.tf")
+			require.NoError(t, os.Symlink(destinationPath, targetPath))
+
+			config := codegen.GenerateConfig{
+				Path:          targetPath,
+				IfExists:      codegen.ExistsOverwriteTerragrunt,
+				IfDisabled:    codegen.DisabledRemoveTerragrunt,
+				CommentPrefix: codegen.DefaultCommentPrefix,
+				Contents:      "provider \"null\" {\n}\n",
+				Disable:       tc.disable,
+			}
+
+			l := logger.CreateLogger()
+			writeErr := codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config)
+
+			if tc.disable {
+				var removeErr codegen.GenerateFileRemoveError
+
+				require.ErrorAs(t, writeErr, &removeErr)
+			}
+
+			if !tc.disable {
+				var existsErr codegen.GenerateFileExistsError
+
+				require.ErrorAs(t, writeErr, &existsErr)
+			}
+
+			info, err := os.Lstat(targetPath)
+			require.NoError(t, err)
+			assert.NotZero(t, info.Mode()&os.ModeSymlink, "the symlink must be left alone")
+
+			if tc.destination != "" {
+				destination, err := os.ReadFile(destinationPath)
+				require.NoError(t, err)
+				assert.Equal(t, tc.destination, string(destination), "the destination must stay intact")
+			}
+		})
+	}
 }
 
 // newTestContentStore returns a store rooted under dir so tests never touch the

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -103,6 +103,11 @@ const (
 	BlockIteration = "block-iteration"
 	// BrowseTUI gates the interactive Miller-columns browser for `terragrunt browse`.
 	BrowseTUI = "browse-tui"
+	// MutableGenerate gates the mutable attribute on the generate block and the
+	// default it changes: generated files are deduplicated through
+	// content-addressable storage and hard-linked into each working directory
+	// rather than written per unit.
+	MutableGenerate = "mutable-generate"
 )
 
 const (
@@ -214,6 +219,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: BrowseTUI,
+		},
+		{
+			Name: MutableGenerate,
 		},
 	}
 }

--- a/internal/experiment/experiment_test.go
+++ b/internal/experiment/experiment_test.go
@@ -74,6 +74,19 @@ func TestVersionAttributeIsOngoing(t *testing.T) {
 	assert.True(t, got.Evaluate(), "version-attribute must be enabled once explicitly requested")
 }
 
+func TestMutableGenerateIsOngoing(t *testing.T) {
+	t.Parallel()
+
+	exps := experiment.NewExperiments()
+	got := exps.Find(experiment.MutableGenerate)
+	require.NotNil(t, got, "mutable-generate experiment must be registered in NewExperiments()")
+	assert.Equal(t, experiment.StatusOngoing, got.Status, "mutable-generate must be ongoing")
+	assert.False(t, got.Evaluate(), "mutable-generate must be disabled by default")
+
+	require.NoError(t, exps.EnableExperiment(experiment.MutableGenerate))
+	assert.True(t, got.Evaluate(), "mutable-generate must be enabled once explicitly requested")
+}
+
 func TestEvaluate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/prepare/prepare.go
+++ b/internal/prepare/prepare.go
@@ -194,12 +194,13 @@ func PrepareSource(
 // PrepareGenerate handles code generation configs, both generate blocks and generate attribute of remote_state.
 // It requires PrepareSource to have been called first.
 func PrepareGenerate(
+	ctx context.Context,
 	l log.Logger,
 	v *venv.Venv,
 	opts *options.TerragruntOptions,
 	cfg *runcfg.RunConfig,
 ) error {
-	return run.GenerateConfig(l, v.FS, configbridge.NewRunOptions(opts), cfg)
+	return run.GenerateConfig(ctx, l, v, configbridge.NewRunOptions(opts), cfg)
 }
 
 // PrepareInputsAsEnvVars sets terragrunt inputs as environment variables.

--- a/internal/remotestate/config.go
+++ b/internal/remotestate/config.go
@@ -1,6 +1,7 @@
 package remotestate
 
 import (
+	"context"
 	"fmt"
 
 	"errors"
@@ -8,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/codegen"
 	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -61,7 +63,9 @@ func (cfg *Config) Validate() error {
 
 // GenerateOpenTofuCode generates the OpenTofu/Terraform code for configuring remote state backend.
 func (cfg *Config) GenerateOpenTofuCode(
+	ctx context.Context,
 	l log.Logger,
+	v *venv.Venv,
 	workingDir string,
 	backendConfig map[string]any,
 ) error {
@@ -104,7 +108,7 @@ func (cfg *Config) GenerateOpenTofuCode(
 		CommentPrefix: codegen.DefaultCommentPrefix,
 	}
 
-	return codegen.WriteToFile(l, workingDir, &codegenConfig)
+	return codegen.WriteToFile(ctx, l, v, workingDir, &codegenConfig)
 }
 
 type ConfigFileGenerate struct {

--- a/internal/remotestate/remote_state.go
+++ b/internal/remotestate/remote_state.go
@@ -218,10 +218,15 @@ func (remote *RemoteState) GetTFInitArgs() []string {
 }
 
 // GenerateOpenTofuCode generates the OpenTofu/Terraform code for configuring remote state backend.
-func (remote *RemoteState) GenerateOpenTofuCode(l log.Logger, workingDir string) error {
+func (remote *RemoteState) GenerateOpenTofuCode(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+	workingDir string,
+) error {
 	backendConfig := remote.backend.GetTFInitArgs(remote.BackendConfig)
 
-	return remote.Config.GenerateOpenTofuCode(l, workingDir, backendConfig)
+	return remote.Config.GenerateOpenTofuCode(ctx, l, v, workingDir, backendConfig)
 }
 
 func (remote *RemoteState) pullState(

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -18,7 +18,9 @@ import (
 
 	"errors"
 
+	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/codegen"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
 	"github.com/gruntwork-io/terragrunt/internal/iam"
 	"github.com/gruntwork-io/terragrunt/internal/multierror"
@@ -183,7 +185,7 @@ func Run(
 
 	// Handle code generation configs, both generate blocks and generate attribute of remote_state.
 	// Note that relative paths are relative to the terragrunt working dir (where terraform is called).
-	if err = GenerateConfig(l, v.FS, updatedOpts, cfg); err != nil {
+	if err = GenerateConfig(ctx, l, v, updatedOpts, cfg); err != nil {
 		return err
 	}
 
@@ -209,28 +211,36 @@ func Run(
 }
 
 // GenerateConfig handles code generation using config types (for backwards compatibility).
-func GenerateConfig(l log.Logger, fs vfs.FS, opts *Options, cfg *runcfg.RunConfig) error {
+func GenerateConfig(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+	opts *Options,
+	cfg *runcfg.RunConfig,
+) error {
 	rawActualLock, _ := sourceChangeLocks.LoadOrStore(opts.DownloadDir, &sync.Mutex{})
 
 	actualLock := rawActualLock.(*sync.Mutex)
 	actualLock.Lock()
 	defer actualLock.Unlock()
 
+	writeOpts := generateWriteOptions(l, opts)
+
 	for _, genCfg := range cfg.GenerateConfigs {
-		if err := codegen.WriteToFile(l, opts.CacheDir, &genCfg); err != nil {
+		if err := codegen.WriteToFile(ctx, l, v, opts.CacheDir, &genCfg, writeOpts...); err != nil {
 			return err
 		}
 	}
 
 	if cfg.RemoteState.Config != nil && cfg.RemoteState.Generate != nil {
-		if err := cfg.RemoteState.GenerateOpenTofuCode(l, opts.CacheDir); err != nil {
+		if err := cfg.RemoteState.GenerateOpenTofuCode(ctx, l, v, opts.CacheDir); err != nil {
 			return err
 		}
 	} else if cfg.RemoteState.Config != nil {
 		// We use else if here because we don't need to check the backend configuration is defined when the remote state
 		// block has a `generate` attribute configured.
 		if err := checkTerraformCodeDefinesBackend(
-			fs,
+			v.FS,
 			opts,
 			cfg.RemoteState.BackendName,
 		); err != nil {
@@ -239,6 +249,26 @@ func GenerateConfig(l log.Logger, fs vfs.FS, opts *Options, cfg *runcfg.RunConfi
 	}
 
 	return nil
+}
+
+// generateWriteOptions decides whether generated files are deduplicated through
+// the CAS store.
+//
+// A CAS that cannot be initialized is not fatal: generation falls back to direct
+// writes, matching how source downloads degrade.
+func generateWriteOptions(l log.Logger, opts *Options) []codegen.WriteOption {
+	if opts.NoCAS || !opts.Experiments.Evaluate(experiment.MutableGenerate) {
+		return nil
+	}
+
+	c, err := cas.New()
+	if err != nil {
+		l.Warnf("Failed to initialize CAS: %v. Generated files will not be deduplicated.", err)
+
+		return nil
+	}
+
+	return []codegen.WriteOption{codegen.WithContentStore(cas.NewContent(c.BlobStore()))}
 }
 
 // Runs tofu/terraform with the given options and CLI args.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -512,6 +512,10 @@ func (cfg *TerragruntConfig) WriteTo(w io.Writer) (int64, error) {
 			genBody.SetAttributeValue("hcl_fmt", goboolToCty(*gen.HclFmt))
 		}
 
+		if gen.Mutable != nil {
+			genBody.SetAttributeValue("mutable", goboolToCty(*gen.Mutable))
+		}
+
 		rootBody.AppendBlock(genBlock)
 	}
 
@@ -814,6 +818,7 @@ type terragruntGenerateBlock struct {
 	DisableSignature *bool   `hcl:"disable_signature,attr" mapstructure:"disable_signature"`
 	Disable          *bool   `hcl:"disable,attr"           mapstructure:"disable"`
 	HclFmt           *bool   `hcl:"hcl_fmt,attr"           mapstructure:"hcl_fmt"`
+	Mutable          *bool   `hcl:"mutable,attr"           mapstructure:"mutable"`
 	Name             string  `hcl:",label"                 mapstructure:",omitempty"`
 	Path             string  `hcl:"path,attr"              mapstructure:"path"`
 	IfExists         string  `hcl:"if_exists,attr"         mapstructure:"if_exists"`
@@ -2089,8 +2094,18 @@ func convertToTerragruntConfig(
 			return nil, err
 		}
 
+		if block.Mutable != nil && !pctx.Experiments.Evaluate(experiment.MutableGenerate) {
+			errs = append(errs, MutableGenerateRequiresExperimentError{
+				ConfigPath: configPath,
+				BlockName:  block.Name,
+			})
+
+			continue
+		}
+
 		genConfig := codegen.GenerateConfig{
 			HclFmt:        block.HclFmt,
+			Mutable:       block.Mutable,
 			Path:          block.Path,
 			IfExists:      ifExists,
 			IfExistsStr:   block.IfExists,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2147,6 +2147,102 @@ func TestParseConfigGenerateAttrWithHclFmt(t *testing.T) {
 	assert.False(t, *generateConfig.HclFmt)
 }
 
+// TestParseConfigGenerateBlockWithMutable verifies that mutable is parsed from generate blocks
+// once the gating experiment is enabled.
+func TestParseConfigGenerateBlockWithMutable(t *testing.T) {
+	t.Parallel()
+
+	cfg := `generate "test" {
+  path = "test.tf"
+  if_exists = "overwrite"
+  contents = "test = 1"
+  mutable = true
+}`
+
+	l := createLogger()
+	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MutableGenerate))
+
+	terragruntConfig, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		l,
+		config.DefaultTerragruntConfigPath,
+		cfg,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, terragruntConfig)
+
+	generateConfig, ok := terragruntConfig.GenerateConfigs["test"]
+	require.True(t, ok)
+	require.NotNil(t, generateConfig.Mutable)
+	assert.True(t, *generateConfig.Mutable)
+}
+
+// TestParseConfigGenerateAttrWithMutable verifies that mutable is parsed from generate attribute maps.
+func TestParseConfigGenerateAttrWithMutable(t *testing.T) {
+	t.Parallel()
+
+	cfg := `generate = {
+  test = {
+    path = "test.tf"
+    if_exists = "overwrite"
+    contents = "test = 1"
+    mutable = false
+  }
+}`
+
+	l := createLogger()
+	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MutableGenerate))
+
+	terragruntConfig, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		l,
+		config.DefaultTerragruntConfigPath,
+		cfg,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, terragruntConfig)
+
+	generateConfig, ok := terragruntConfig.GenerateConfigs["test"]
+	require.True(t, ok)
+	require.NotNil(t, generateConfig.Mutable)
+	assert.False(t, *generateConfig.Mutable)
+}
+
+// TestParseConfigGenerateBlockMutableRequiresExperiment verifies that mutable is rejected
+// until the experiment that gates it is enabled.
+func TestParseConfigGenerateBlockMutableRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	cfg := `generate "test" {
+  path = "test.tf"
+  if_exists = "overwrite"
+  contents = "test = 1"
+  mutable = false
+}`
+
+	l := createLogger()
+	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+
+	_, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		l,
+		config.DefaultTerragruntConfigPath,
+		cfg,
+		nil,
+	)
+
+	var experimentErr config.MutableGenerateRequiresExperimentError
+	require.ErrorAs(t, err, &experimentErr)
+	assert.Equal(t, "test", experimentErr.BlockName)
+}
+
 // TestParseConfigWithMissingIfExists verifies that generate blocks require the if_exists attribute.
 func TestParseConfigWithMissingIfExists(t *testing.T) {
 	t.Parallel()

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1592,7 +1592,7 @@ func getTerragruntOutputJSONFromRemoteState(
 		}
 	}
 
-	if err := remoteState.GenerateOpenTofuCode(l, tempWorkDir); err != nil {
+	if err := remoteState.GenerateOpenTofuCode(ctx, l, pctx.Venv, tempWorkDir); err != nil {
 		return nil, err
 	}
 

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -440,6 +440,21 @@ func (err VersionAttributeRequiresExperimentError) Error() string {
 	)
 }
 
+// MutableGenerateRequiresExperimentError is returned when a generate block sets the
+// mutable attribute without the mutable-generate experiment enabled.
+type MutableGenerateRequiresExperimentError struct {
+	ConfigPath string
+	BlockName  string
+}
+
+func (err MutableGenerateRequiresExperimentError) Error() string {
+	return fmt.Sprintf(
+		"the generate block %q in %s sets the mutable attribute, which requires the 'mutable-generate' experiment; enable it with --experiment mutable-generate",
+		err.BlockName,
+		err.ConfigPath,
+	)
+}
+
 // VersionAttributeNonRegistrySourceError is returned when the terraform block sets the
 // version attribute but its source is not a tfr:// registry URL, where a version
 // constraint has no meaning.

--- a/test/fixtures/codegen/mutable-generate/unit-a/terragrunt.hcl
+++ b/test/fixtures/codegen/mutable-generate/unit-a/terragrunt.hcl
@@ -1,0 +1,8 @@
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite"
+  contents  = <<EOF
+provider "null" {
+}
+EOF
+}

--- a/test/fixtures/codegen/mutable-generate/unit-b/terragrunt.hcl
+++ b/test/fixtures/codegen/mutable-generate/unit-b/terragrunt.hcl
@@ -1,0 +1,8 @@
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite"
+  contents  = <<EOF
+provider "null" {
+}
+EOF
+}

--- a/test/fixtures/codegen/mutable-generate/unit-mutable/terragrunt.hcl
+++ b/test/fixtures/codegen/mutable-generate/unit-mutable/terragrunt.hcl
@@ -1,0 +1,9 @@
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite"
+  mutable   = true
+  contents  = <<EOF
+provider "null" {
+}
+EOF
+}

--- a/test/integration_debug_test.go
+++ b/test/integration_debug_test.go
@@ -249,6 +249,7 @@ func TestRenderJSONConfigWithIncludesDependenciesAndLocals(t *testing.T) {
 					"if_exists":         "overwrite",
 					"if_disabled":       "skip",
 					"hcl_fmt":           nil,
+					"mutable":           nil,
 					"contents":          "# This is just a test",
 				},
 			},

--- a/test/integration_debug_tf_test.go
+++ b/test/integration_debug_tf_test.go
@@ -200,6 +200,7 @@ func TestTFRenderJSONConfig(t *testing.T) {
 					"if_exists":         "overwrite_terragrunt",
 					"if_disabled":       "skip",
 					"hcl_fmt":           nil,
+					"mutable":           nil,
 					"contents": `provider "aws" {
   region = "us-east-1"
 }

--- a/test/integration_json_test.go
+++ b/test/integration_json_test.go
@@ -180,6 +180,7 @@ func TestRenderJsonMetadataIncludes(t *testing.T) {
 					"if_exists":         "overwrite",
 					"if_disabled":       "skip",
 					"hcl_fmt":           nil,
+					"mutable":           nil,
 					"path":              "provider.tf",
 				},
 			},

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -933,6 +933,10 @@ func TestTerragruntMutableGenerateBlock(t *testing.T) {
 func TestTerragruntMutableGenerateBlockRequiresExperiment(t *testing.T) {
 	t.Parallel()
 
+	if helpers.IsExperimentMode(t) {
+		t.Skip("Skipping: TG_EXPERIMENT_MODE forces all experiments on, so the experiment-disabled error this test pins cannot occur")
+	}
+
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
 	unitPath := filepath.Join(
 		tmpEnvPath,

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -885,4 +886,101 @@ func TestNoDefaultForwardingUnknownCommand(t *testing.T) {
 		"terragrunt workspace list --non-interactive --working-dir "+rootPath,
 	)
 	require.Error(t, err, "expected error when invoking unknown top-level command without 'run'")
+}
+
+// TestTerragruntMutableGenerateBlock verifies that units generating identical
+// contents share one read-only file, and that a block asking to stay mutable
+// gets its own writable copy.
+func TestTerragruntMutableGenerateBlock(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("read-only permission bits are not meaningfully observable on Windows")
+	}
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	fixtureRoot := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "mutable-generate")
+
+	generated := map[string]os.FileInfo{}
+
+	for _, unit := range []string{"unit-a", "unit-b", "unit-mutable"} {
+		unitPath := filepath.Join(fixtureRoot, unit)
+		helpers.CleanupTerraformFolder(t, unitPath)
+		helpers.CleanupTerragruntFolder(t, unitPath)
+
+		_, _, err := helpers.RunTerragruntCommandWithOutput(
+			t,
+			"terragrunt exec --experiment mutable-generate --working-dir "+unitPath+" -- true",
+		)
+		require.NoError(t, err)
+
+		generated[unit] = statGeneratedFile(t, unitPath, "provider.tf")
+	}
+
+	assert.True(t, os.SameFile(generated["unit-a"], generated["unit-b"]),
+		"units generating identical contents must share one file")
+	assert.Equal(t, os.FileMode(0444), generated["unit-a"].Mode().Perm(),
+		"deduplicated files must be read-only so an edit cannot reach the shared store")
+
+	assert.False(t, os.SameFile(generated["unit-a"], generated["unit-mutable"]),
+		"a mutable generate block must get its own file")
+	assert.NotZero(t, generated["unit-mutable"].Mode().Perm()&0200,
+		"a mutable generate block must stay writable")
+}
+
+// TestTerragruntMutableGenerateBlockRequiresExperiment verifies that the mutable
+// attribute is rejected until the experiment gating it is enabled.
+func TestTerragruntMutableGenerateBlockRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+	unitPath := filepath.Join(
+		tmpEnvPath,
+		testFixtureCodegenPath,
+		"mutable-generate",
+		"unit-mutable",
+	)
+	helpers.CleanupTerraformFolder(t, unitPath)
+	helpers.CleanupTerragruntFolder(t, unitPath)
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt exec --working-dir "+unitPath+" -- true",
+	)
+
+	var experimentErr config.MutableGenerateRequiresExperimentError
+	require.ErrorAs(t, err, &experimentErr)
+}
+
+// statGeneratedFile locates a generated file inside the unit's cache dir, which
+// is nested under content-addressed directory names the test cannot predict.
+func statGeneratedFile(t *testing.T, unitPath, name string) os.FileInfo {
+	t.Helper()
+
+	var found os.FileInfo
+
+	require.NoError(t, filepath.WalkDir(
+		filepath.Join(unitPath, util.TerragruntCacheDir),
+		func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if d.IsDir() || d.Name() != name {
+				return nil
+			}
+
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+
+			found = info
+
+			return nil
+		},
+	))
+	require.NotNil(t, found, "expected %s to be generated under %s", name, unitPath)
+
+	return found
 }

--- a/test/integration_tf_test.go
+++ b/test/integration_tf_test.go
@@ -3129,6 +3129,7 @@ func TestTFReadTerragruntConfigFull(t *testing.T) {
 				"path":              "provider.tf",
 				"if_exists":         "overwrite_terragrunt",
 				"hcl_fmt":           nil,
+				"mutable":           nil,
 				"if_disabled":       "skip",
 				"comment_prefix":    "# ",
 				"disable_signature": false,

--- a/test/integration_tofu_aws_state_encryption_test.go
+++ b/test/integration_tofu_aws_state_encryption_test.go
@@ -177,6 +177,7 @@ func TestAwsTofuRenderJSONConfigWithEncryption(t *testing.T) {
 					"if_exists":         "overwrite_terragrunt",
 					"if_disabled":       "skip",
 					"hcl_fmt":           nil,
+					"mutable":           nil,
 					"contents": `provider "aws" {
   region = "us-east-1"
 }
@@ -301,6 +302,7 @@ func TestAwsTofuRenderJSONConfigWithEncryptionExp(t *testing.T) {
 					"if_exists":         "overwrite_terragrunt",
 					"if_disabled":       "skip",
 					"hcl_fmt":           nil,
+					"mutable":           nil,
 					"contents": `provider "aws" {
   region = "us-east-1"
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Closes #6559

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the experimental `mutable` attribute for `generate` blocks.
  * Generated files are deduplicated through CAS and shared as read-only links by default.
  * Set `mutable = true` to create a writable generated file; `--no-cas` continues to produce writable files.
  * Added documentation covering configuration, experiment enablement, CAS behavior, and limitations.

* **Bug Fixes**
  * Improved cancellation and virtual filesystem handling during generated and remote-state file creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->