### PR TITLE
chore: Adding expansion detection and internal expansion logic

### DIFF
--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -233,7 +233,13 @@ func DecodeBaseBlocks(
 	// Feature defaults from includes must be visible while decoding base blocks like
 	// locals and exclude, but they must remain local to this parse instead of being
 	// stored in shared command options.
-	mergedFeatureFlags, err := mergeIncludedFeatureFlags(ctx, pctx, l, trackInclude, tgFlags.FeatureFlags)
+	mergedFeatureFlags, err := mergeIncludedFeatureFlags(
+		ctx,
+		pctx,
+		l,
+		trackInclude,
+		tgFlags.FeatureFlags,
+	)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -268,7 +274,13 @@ func DecodeBaseBlocks(
 }
 
 // mergeIncludedFeatureFlags merges feature defaults from included configs into the current parse.
-func mergeIncludedFeatureFlags(ctx context.Context, pctx *ParsingContext, l log.Logger, trackInclude *TrackInclude, childFlags FeatureFlags) (FeatureFlags, error) {
+func mergeIncludedFeatureFlags(
+	ctx context.Context,
+	pctx *ParsingContext,
+	l log.Logger,
+	trackInclude *TrackInclude,
+	childFlags FeatureFlags,
+) (FeatureFlags, error) {
 	if trackInclude == nil || len(trackInclude.CurrentList) == 0 {
 		return childFlags, nil
 	}
@@ -293,7 +305,12 @@ func mergeIncludedFeatureFlags(ctx context.Context, pctx *ParsingContext, l log.
 			return childFlags, err
 		}
 
-		mergedConfig, err := mergeFeatureFlagConfig(l, mergeStrategy, baseConfig, parsedIncludeConfig.FeatureFlags)
+		mergedConfig, err := mergeFeatureFlagConfig(
+			l,
+			mergeStrategy,
+			baseConfig,
+			parsedIncludeConfig.FeatureFlags,
+		)
 		if err != nil {
 			return childFlags, err
 		}
@@ -305,7 +322,12 @@ func mergeIncludedFeatureFlags(ctx context.Context, pctx *ParsingContext, l log.
 }
 
 // mergeFeatureFlagConfig applies an include merge strategy to feature defaults only.
-func mergeFeatureFlagConfig(l log.Logger, mergeStrategy MergeStrategyType, baseConfig *TerragruntConfig, includeFlags FeatureFlags) (*TerragruntConfig, error) {
+func mergeFeatureFlagConfig(
+	l log.Logger,
+	mergeStrategy MergeStrategyType,
+	baseConfig *TerragruntConfig,
+	includeFlags FeatureFlags,
+) (*TerragruntConfig, error) {
 	includeOnlyConfig := &TerragruntConfig{FeatureFlags: includeFlags}
 
 	switch mergeStrategy {
@@ -322,7 +344,13 @@ func mergeFeatureFlagConfig(l log.Logger, mergeStrategy MergeStrategyType, baseC
 	case DeepMergeMapOnly:
 		return nil, InvalidMergeStrategyTypeError(mergeStrategy)
 	default:
-		return nil, fmt.Errorf("you reached an impossible condition. This is most likely a bug in terragrunt. Please open an issue at github.com/gruntwork-io/terragrunt with this error message. Code: UNKNOWN_MERGE_STRATEGY_%s", mergeStrategy)
+		return nil, fmt.Errorf(
+			"you reached an impossible condition. "+
+				"This is most likely a bug in terragrunt. "+
+				"Please open an issue at github.com/gruntwork-io/terragrunt "+
+				"with this error message. Code: UNKNOWN_MERGE_STRATEGY_%s",
+			mergeStrategy,
+		)
 	}
 
 	return includeOnlyConfig, nil

--- a/pkg/config/expansion.go
+++ b/pkg/config/expansion.go
@@ -9,10 +9,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 )
 
-// ExpansionBlockName is the block that declares count/for_each iteration inside a
-// dependency, unit, or stack block.
-const ExpansionBlockName = "expansion"
-
 // expansionCapableBlocks are the block types an expansion block may appear in.
 var expansionCapableBlocks = []string{MetadataDependency, MetadataUnit, MetadataStack}
 
@@ -42,7 +38,7 @@ func ValidateExpansionExperiment(experiments experiment.Experiments, file *hclpa
 		}
 
 		if !slices.ContainsFunc(block.Body.Blocks, func(inner *hclsyntax.Block) bool {
-			return inner.Type == ExpansionBlockName
+			return inner.Type == hclparse.ExpansionBlockName
 		}) {
 			continue
 		}

--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -179,7 +179,10 @@ func TestValidateExpansionExperimentEnabled(t *testing.T) {
 
 			require.NoError(
 				t,
-				config.ValidateExpansionExperiment(experiments, parseHCLString(t, tc.cfg, tc.configPath)),
+				config.ValidateExpansionExperiment(
+					experiments,
+					parseHCLString(t, tc.cfg, tc.configPath),
+				),
 			)
 		})
 	}

--- a/pkg/config/hclparse/errors.go
+++ b/pkg/config/hclparse/errors.go
@@ -94,6 +94,29 @@ func (err NegativeCountError) Error() string {
 	)
 }
 
+// ExpansionLimitExceededError is returned when a meta-arg asks for more instances
+// than the configured ceiling allows.
+type ExpansionLimitExceededError struct {
+	Subject *hcl.Range
+	Attr    string
+	Size    int
+	Limit   int
+}
+
+func (err ExpansionLimitExceededError) Error() string {
+	return fmt.Sprintf(
+		"%s: %s expands to %d instances, which is above the limit of %d. "+
+			"Terragrunt maintainers are not aware of a legitimate use-case for an expansion "+
+			"this large. If you have one, please open an issue at "+
+			"https://github.com/gruntwork-io/terragrunt/issues describing it, so we can consider "+
+			"raising the limit or making it configurable",
+		err.Subject,
+		err.Attr,
+		err.Size,
+		err.Limit,
+	)
+}
+
 // UnknownExpansionValueError is returned when a meta-arg evaluates to an unknown
 // value, which cannot be iterated.
 type UnknownExpansionValueError struct {

--- a/pkg/config/hclparse/errors.go
+++ b/pkg/config/hclparse/errors.go
@@ -94,6 +94,31 @@ func (err NegativeCountError) Error() string {
 	)
 }
 
+// UnknownExpansionValueError is returned when a meta-arg evaluates to an unknown
+// value, which cannot be iterated.
+type UnknownExpansionValueError struct {
+	Subject *hcl.Range
+	Attr    string
+}
+
+func (err UnknownExpansionValueError) Error() string {
+	return fmt.Sprintf(
+		"%s: %s is not known at parse time; it must resolve to a concrete value",
+		err.Subject,
+		err.Attr,
+	)
+}
+
+// NullExpansionValueError is returned when a meta-arg evaluates to null.
+type NullExpansionValueError struct {
+	Subject *hcl.Range
+	Attr    string
+}
+
+func (err NullExpansionValueError) Error() string {
+	return fmt.Sprintf("%s: %s is null; it must resolve to a concrete value", err.Subject, err.Attr)
+}
+
 // UnsupportedForEachTypeError is returned when for_each evaluates to something other
 // than a set, map, or object.
 type UnsupportedForEachTypeError struct {

--- a/pkg/config/hclparse/errors.go
+++ b/pkg/config/hclparse/errors.go
@@ -3,6 +3,8 @@ package hclparse
 import (
 	"fmt"
 	"reflect"
+
+	"github.com/hashicorp/hcl/v2"
 )
 
 type PanicWhileParsingConfigError struct {
@@ -16,5 +18,110 @@ func (err PanicWhileParsingConfigError) Error() string {
 		err.ConfigFile,
 		reflect.TypeOf(err.RecoveredValue),
 		err.RecoveredValue,
+	)
+}
+
+// DuplicateExpansionBlockError is returned when a block declares more than one
+// expansion block.
+type DuplicateExpansionBlockError struct {
+	Subject   *hcl.Range
+	BlockType string
+}
+
+func (err DuplicateExpansionBlockError) Error() string {
+	return fmt.Sprintf(
+		"%s: the %s block declares more than one expansion block; a block may declare at most one",
+		err.Subject,
+		err.BlockType,
+	)
+}
+
+// ConflictingMetaArgsError is returned when an expansion block sets both for_each
+// and count.
+type ConflictingMetaArgsError struct {
+	Subject *hcl.Range
+}
+
+func (err ConflictingMetaArgsError) Error() string {
+	return fmt.Sprintf(
+		"%s: the expansion block sets both %s and %s; set exactly one",
+		err.Subject,
+		forEachAttrName,
+		countAttrName,
+	)
+}
+
+// MissingMetaArgError is returned when an expansion block sets neither for_each nor count.
+type MissingMetaArgError struct {
+	Subject *hcl.Range
+}
+
+func (err MissingMetaArgError) Error() string {
+	return fmt.Sprintf(
+		"%s: the expansion block sets neither %s nor %s; set exactly one",
+		err.Subject,
+		forEachAttrName,
+		countAttrName,
+	)
+}
+
+// InvalidCountError is returned when count does not evaluate to a whole number.
+type InvalidCountError struct {
+	Err     error
+	Subject *hcl.Range
+}
+
+func (err InvalidCountError) Error() string {
+	return fmt.Sprintf("%s: %s must be a whole number: %v", err.Subject, countAttrName, err.Err)
+}
+
+func (err InvalidCountError) Unwrap() error {
+	return err.Err
+}
+
+// NegativeCountError is returned when count evaluates to a negative number.
+type NegativeCountError struct {
+	Subject *hcl.Range
+	Count   int
+}
+
+func (err NegativeCountError) Error() string {
+	return fmt.Sprintf(
+		"%s: %s is %d; it must not be negative",
+		err.Subject,
+		countAttrName,
+		err.Count,
+	)
+}
+
+// UnsupportedForEachTypeError is returned when for_each evaluates to something other
+// than a set, map, or object.
+type UnsupportedForEachTypeError struct {
+	Subject *hcl.Range
+	Type    string
+}
+
+func (err UnsupportedForEachTypeError) Error() string {
+	return fmt.Sprintf(
+		"%s: %s must be a set or a map, but got %s",
+		err.Subject,
+		forEachAttrName,
+		err.Type,
+	)
+}
+
+// UnsupportedForEachKeyTypeError is returned when a for_each element key is neither
+// a string nor a number.
+type UnsupportedForEachKeyTypeError struct {
+	Subject *hcl.Range
+	Type    string
+}
+
+func (err UnsupportedForEachKeyTypeError) Error() string {
+	return fmt.Sprintf(
+		"%s: %s keys must be strings or numbers, but got %s",
+		err.Subject,
+		forEachAttrName,
+		err.Type,
 	)
 }

--- a/pkg/config/hclparse/expansion.go
+++ b/pkg/config/hclparse/expansion.go
@@ -26,6 +26,26 @@ const (
 	countIndexAttrName = "index"
 )
 
+// DefaultMaxInstances bounds how many instances a single block may expand into,
+// whether through count or for_each. The ceiling exists so a runaway expression
+// cannot make Terragrunt allocate and decode without limit.
+const DefaultMaxInstances = 1_000_000
+
+type expandConfig struct {
+	maxInstances int
+}
+
+// ExpandOption adjusts how [ExpandBlock] expands a block.
+type ExpandOption func(*expandConfig)
+
+// WithMaxInstances overrides the expansion ceiling. Tests use this to exercise the
+// bound without decoding [DefaultMaxInstances] instances.
+func WithMaxInstances(maxInstances int) ExpandOption {
+	return func(cfg *expandConfig) {
+		cfg.maxInstances = maxInstances
+	}
+}
+
 // Instance is one decoded product of expanding a block. A block with no expansion
 // block yields a single Instance with both keys nil.
 type Instance struct {
@@ -63,10 +83,20 @@ func (inst Instance) Key() string {
 // read before the surrounding body is evaluated. That ordering is what lets the
 // body reference each.value at all: the references are still unevaluated here, and
 // only resolve in the per-element decode below.
-func ExpandBlock(block *hcl.Block, out any, ctx *hcl.EvalContext) ([]Instance, error) {
+func ExpandBlock(
+	block *hcl.Block,
+	out any,
+	ctx *hcl.EvalContext,
+	opts ...ExpandOption,
+) ([]Instance, error) {
 	outType := reflect.TypeOf(out)
 	if outType == nil || outType.Kind() != reflect.Pointer {
 		panic("hclparse.ExpandBlock: out must be a non-nil pointer")
+	}
+
+	cfg := expandConfig{maxInstances: DefaultMaxInstances}
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 
 	expansion, err := expansionBlock(block)
@@ -89,10 +119,10 @@ func ExpandBlock(block *hcl.Block, out any, ctx *hcl.EvalContext) ([]Instance, e
 	}
 
 	if count != nil {
-		return expandCount(block, outType, ctx, count)
+		return expandCount(block, outType, ctx, count, cfg.maxInstances)
 	}
 
-	return expandForEach(block, outType, ctx, forEach)
+	return expandForEach(block, outType, ctx, forEach, cfg.maxInstances)
 }
 
 // expansionBlock returns the block's expansion sub-block, or nil when it declares none.
@@ -151,6 +181,7 @@ func expandCount(
 	outType reflect.Type,
 	ctx *hcl.EvalContext,
 	count *hcl.Attribute,
+	maxInstances int,
 ) ([]Instance, error) {
 	value, diags := count.Expr.Value(ctx)
 	if diags.HasErrors() {
@@ -168,6 +199,16 @@ func expandCount(
 
 	if total < 0 {
 		return nil, NegativeCountError{Count: total, Subject: &count.Range}
+	}
+
+	// Checked before the allocation below, which is what the ceiling protects.
+	if total > maxInstances {
+		return nil, ExpansionLimitExceededError{
+			Attr:    countAttrName,
+			Size:    total,
+			Limit:   maxInstances,
+			Subject: &count.Range,
+		}
 	}
 
 	instances := make([]Instance, 0, total)
@@ -196,6 +237,7 @@ func expandForEach(
 	outType reflect.Type,
 	ctx *hcl.EvalContext,
 	forEach *hcl.Attribute,
+	maxInstances int,
 ) ([]Instance, error) {
 	collection, diags := forEach.Expr.Value(ctx)
 	if diags.HasErrors() {
@@ -217,7 +259,17 @@ func expandForEach(
 		}
 	}
 
-	instances := make([]Instance, 0, collection.LengthInt())
+	size := collection.LengthInt()
+	if size > maxInstances {
+		return nil, ExpansionLimitExceededError{
+			Attr:    forEachAttrName,
+			Size:    size,
+			Limit:   maxInstances,
+			Subject: &forEach.Range,
+		}
+	}
+
+	instances := make([]Instance, 0, size)
 
 	for it := collection.ElementIterator(); it.Next(); {
 		elementKey, elementValue := it.Element()

--- a/pkg/config/hclparse/expansion.go
+++ b/pkg/config/hclparse/expansion.go
@@ -157,6 +157,10 @@ func expandCount(
 		return nil, diags
 	}
 
+	if err := requireConcrete(value, countAttrName, &count.Range); err != nil {
+		return nil, err
+	}
+
 	var total int
 	if err := gocty.FromCtyValue(value, &total); err != nil {
 		return nil, InvalidCountError{Subject: &count.Range, Err: err}
@@ -198,6 +202,12 @@ func expandForEach(
 		return nil, diags
 	}
 
+	// LengthInt and ElementIterator panic on unknown or null values, so these are
+	// rejected before the collection is touched rather than after the type check.
+	if err := requireConcrete(collection, forEachAttrName, &forEach.Range); err != nil {
+		return nil, err
+	}
+
 	collectionType := collection.Type()
 	if !collectionType.IsSetType() && !collectionType.IsMapType() &&
 		!collectionType.IsObjectType() {
@@ -234,6 +244,19 @@ func expandForEach(
 	}
 
 	return instances, nil
+}
+
+// requireConcrete rejects meta-arg values that cannot be iterated or converted.
+func requireConcrete(value cty.Value, attr string, subject *hcl.Range) error {
+	if !value.IsKnown() {
+		return UnknownExpansionValueError{Attr: attr, Subject: subject}
+	}
+
+	if value.IsNull() {
+		return NullExpansionValueError{Attr: attr, Subject: subject}
+	}
+
+	return nil
 }
 
 // expansionKey renders a for_each element key as the string used in addresses.

--- a/pkg/config/hclparse/expansion.go
+++ b/pkg/config/hclparse/expansion.go
@@ -1,0 +1,264 @@
+package hclparse
+
+import (
+	"reflect"
+	"strconv"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/gocty"
+)
+
+const (
+	// ExpansionBlockName is the block that declares count/for_each iteration inside a
+	// dependency, unit, or stack block.
+	ExpansionBlockName = "expansion"
+
+	forEachAttrName = "for_each"
+	countAttrName   = "count"
+
+	eachVarName  = "each"
+	countVarName = "count"
+
+	eachKeyAttrName    = "key"
+	eachValueAttrName  = "value"
+	countIndexAttrName = "index"
+)
+
+// Instance is one decoded product of expanding a block. A block with no expansion
+// block yields a single Instance with both keys nil.
+type Instance struct {
+	Value      any
+	EachKey    *string
+	CountIndex *int
+}
+
+// Key returns the address segment identifying this instance: the each.key for
+// for_each, the stringified index for count, and the empty string when the block
+// was not expanded.
+//
+// Addresses are built from this in more than one place (the dependency cty map,
+// stack output), so keeping the stringification here is what stops those surfaces
+// from drifting apart.
+func (inst Instance) Key() string {
+	switch {
+	case inst.EachKey != nil:
+		return *inst.EachKey
+	case inst.CountIndex != nil:
+		return strconv.Itoa(*inst.CountIndex)
+	default:
+		return ""
+	}
+}
+
+// ExpandBlock decodes block once per iteration element, returning one Instance per
+// element. out is a prototype pointer supplying the type to decode into; a fresh
+// value of that type backs every returned Instance.
+//
+// A block with no expansion block decodes to exactly one Instance, so callers can
+// route expanded and unexpanded blocks through the same path.
+//
+// Expansion is driven by the presence of the statically-known expansion sub-block,
+// read before the surrounding body is evaluated. That ordering is what lets the
+// body reference each.value at all: the references are still unevaluated here, and
+// only resolve in the per-element decode below.
+func ExpandBlock(block *hcl.Block, out any, ctx *hcl.EvalContext) ([]Instance, error) {
+	outType := reflect.TypeOf(out)
+	if outType == nil || outType.Kind() != reflect.Pointer {
+		panic("hclparse.ExpandBlock: out must be a non-nil pointer")
+	}
+
+	expansion, err := expansionBlock(block)
+	if err != nil {
+		return nil, err
+	}
+
+	if expansion == nil {
+		instance, err := decodeInstance(block, outType, ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return []Instance{{Value: instance}}, nil
+	}
+
+	forEach, count, err := expansionMetaArg(expansion)
+	if err != nil {
+		return nil, err
+	}
+
+	if count != nil {
+		return expandCount(block, outType, ctx, count)
+	}
+
+	return expandForEach(block, outType, ctx, forEach)
+}
+
+// expansionBlock returns the block's expansion sub-block, or nil when it declares none.
+func expansionBlock(block *hcl.Block) (*hcl.Block, error) {
+	content, _, diags := block.Body.PartialContent(&hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{{Type: ExpansionBlockName}},
+	})
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	if len(content.Blocks) == 0 {
+		return nil, nil
+	}
+
+	if len(content.Blocks) > 1 {
+		return nil, DuplicateExpansionBlockError{
+			BlockType: block.Type,
+			Subject:   &content.Blocks[1].DefRange,
+		}
+	}
+
+	return content.Blocks[0], nil
+}
+
+// expansionMetaArg returns whichever of for_each/count the expansion block sets.
+// Exactly one is non-nil on success.
+func expansionMetaArg(expansion *hcl.Block) (forEach, count *hcl.Attribute, err error) {
+	// Content rather than PartialContent so a typo inside the expansion block is a
+	// loud "unsupported argument" rather than a silently ignored attribute.
+	content, diags := expansion.Body.Content(&hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{Name: forEachAttrName},
+			{Name: countAttrName},
+		},
+	})
+	if diags.HasErrors() {
+		return nil, nil, diags
+	}
+
+	forEach = content.Attributes[forEachAttrName]
+	count = content.Attributes[countAttrName]
+
+	switch {
+	case forEach != nil && count != nil:
+		return nil, nil, ConflictingMetaArgsError{Subject: &expansion.DefRange}
+	case forEach == nil && count == nil:
+		return nil, nil, MissingMetaArgError{Subject: &expansion.DefRange}
+	}
+
+	return forEach, count, nil
+}
+
+func expandCount(
+	block *hcl.Block,
+	outType reflect.Type,
+	ctx *hcl.EvalContext,
+	count *hcl.Attribute,
+) ([]Instance, error) {
+	value, diags := count.Expr.Value(ctx)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	var total int
+	if err := gocty.FromCtyValue(value, &total); err != nil {
+		return nil, InvalidCountError{Subject: &count.Range, Err: err}
+	}
+
+	if total < 0 {
+		return nil, NegativeCountError{Count: total, Subject: &count.Range}
+	}
+
+	instances := make([]Instance, 0, total)
+
+	for index := range total {
+		child := ctx.NewChild()
+		child.Variables = map[string]cty.Value{
+			countVarName: cty.ObjectVal(map[string]cty.Value{
+				countIndexAttrName: cty.NumberIntVal(int64(index)),
+			}),
+		}
+
+		value, err := decodeInstance(block, outType, child)
+		if err != nil {
+			return nil, err
+		}
+
+		instances = append(instances, Instance{Value: value, CountIndex: new(index)})
+	}
+
+	return instances, nil
+}
+
+func expandForEach(
+	block *hcl.Block,
+	outType reflect.Type,
+	ctx *hcl.EvalContext,
+	forEach *hcl.Attribute,
+) ([]Instance, error) {
+	collection, diags := forEach.Expr.Value(ctx)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	collectionType := collection.Type()
+	if !collectionType.IsSetType() && !collectionType.IsMapType() &&
+		!collectionType.IsObjectType() {
+		return nil, UnsupportedForEachTypeError{
+			Type:    collectionType.FriendlyName(),
+			Subject: &forEach.Range,
+		}
+	}
+
+	instances := make([]Instance, 0, collection.LengthInt())
+
+	for it := collection.ElementIterator(); it.Next(); {
+		elementKey, elementValue := it.Element()
+
+		key, err := expansionKey(elementKey, &forEach.Range)
+		if err != nil {
+			return nil, err
+		}
+
+		child := ctx.NewChild()
+		child.Variables = map[string]cty.Value{
+			eachVarName: cty.ObjectVal(map[string]cty.Value{
+				eachKeyAttrName:   cty.StringVal(key),
+				eachValueAttrName: elementValue,
+			}),
+		}
+
+		value, err := decodeInstance(block, outType, child)
+		if err != nil {
+			return nil, err
+		}
+
+		instances = append(instances, Instance{Value: value, EachKey: new(key)})
+	}
+
+	return instances, nil
+}
+
+// expansionKey renders a for_each element key as the string used in addresses.
+func expansionKey(key cty.Value, subject *hcl.Range) (string, error) {
+	switch key.Type() {
+	case cty.String:
+		return key.AsString(), nil
+	case cty.Number:
+		return key.AsBigFloat().Text('f', -1), nil
+	default:
+		return "", UnsupportedForEachKeyTypeError{
+			Type:    key.Type().FriendlyName(),
+			Subject: subject,
+		}
+	}
+}
+
+// decodeInstance decodes the whole block body, expansion sub-block included, into a
+// fresh value of outType.
+func decodeInstance(block *hcl.Block, outType reflect.Type, ctx *hcl.EvalContext) (any, error) {
+	instance := reflect.New(outType.Elem()).Interface()
+
+	if diags := gohcl.DecodeBody(block.Body, ctx, instance); diags.HasErrors() {
+		return nil, diags
+	}
+
+	return instance, nil
+}

--- a/pkg/config/hclparse/expansion_test.go
+++ b/pkg/config/hclparse/expansion_test.go
@@ -346,6 +346,90 @@ dependency "a" {
 	}
 }
 
+// TestExpandBlockInstanceLimit pins the expansion ceiling for both meta-args. The
+// limit is injected so the bound is exercised without decoding DefaultMaxInstances
+// instances, and the boundary itself is checked in both directions.
+func TestExpandBlockInstanceLimit(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		attr    string
+		limit   int
+		want    int
+		wantErr bool
+	}{
+		{name: "count at the limit", attr: "count = 3", limit: 3, want: 3},
+		{name: "count above the limit", attr: "count = 4", limit: 3, wantErr: true},
+		{name: "for_each at the limit", attr: "for_each = local.services", limit: 2, want: 2},
+		{name: "for_each above the limit", attr: "for_each = local.services", limit: 1, wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			instances, err := expand(t, `
+dependency "a" {
+  expansion {
+    `+tc.attr+`
+  }
+
+  path = "../x"
+}
+`, hclparse.WithMaxInstances(tc.limit))
+
+			if !tc.wantErr {
+				require.NoError(t, err)
+				assert.Len(t, instances, tc.want)
+
+				return
+			}
+
+			var typed hclparse.ExpansionLimitExceededError
+			require.ErrorAs(t, err, &typed)
+			assert.Equal(t, tc.limit, typed.Limit)
+		})
+	}
+}
+
+// TestExpandBlockDefaultInstanceLimit pins that the ceiling applies to callers that
+// pass no options. The check runs before any allocation, so asking for more than a
+// million instances costs nothing to reject.
+func TestExpandBlockDefaultInstanceLimit(t *testing.T) {
+	t.Parallel()
+
+	_, err := expand(t, `
+dependency "a" {
+  expansion {
+    count = 1000001
+  }
+
+  path = "../x"
+}
+`)
+
+	var typed hclparse.ExpansionLimitExceededError
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, hclparse.DefaultMaxInstances, typed.Limit)
+}
+
+// TestExpansionLimitExceededErrorGuidesTheUser pins that the message tells the user
+// why the ceiling exists and how to ask for it to change, rather than just refusing.
+func TestExpansionLimitExceededErrorGuidesTheUser(t *testing.T) {
+	t.Parallel()
+
+	msg := hclparse.ExpansionLimitExceededError{
+		Attr:  "count",
+		Size:  2_000_000,
+		Limit: hclparse.DefaultMaxInstances,
+	}.Error()
+
+	assert.Contains(t, msg, "2000000")
+	assert.Contains(t, msg, "1000000")
+	assert.Contains(t, msg, "github.com/gruntwork-io/terragrunt/issues")
+}
+
 // TestExpandBlockNumericForEachKeys pins how a numeric each.key renders into an
 // address, since OSS-3971 builds the dependency cty map from the same string.
 func TestExpandBlockNumericForEachKeys(t *testing.T) {
@@ -435,7 +519,11 @@ dependency "a" {
 	}
 }
 
-func expand(tb testing.TB, cfg string) ([]hclparse.Instance, error) {
+func expand(
+	tb testing.TB,
+	cfg string,
+	opts ...hclparse.ExpandOption,
+) ([]hclparse.Instance, error) {
 	tb.Helper()
 
 	file, diags := hclsyntax.ParseConfig([]byte(cfg), "terragrunt.hcl", hcl.InitialPos)
@@ -473,7 +561,7 @@ func expand(tb testing.TB, cfg string) ([]hclparse.Instance, error) {
 		},
 	}
 
-	return hclparse.ExpandBlock(body.Blocks[0].AsHCLBlock(), new(testBlock), ctx)
+	return hclparse.ExpandBlock(body.Blocks[0].AsHCLBlock(), new(testBlock), ctx, opts...)
 }
 
 func keysOf(instances []hclparse.Instance) []string {

--- a/pkg/config/hclparse/expansion_test.go
+++ b/pkg/config/hclparse/expansion_test.go
@@ -1,0 +1,329 @@
+package hclparse_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// testBlock mirrors the shape the real dependency/unit/stack structs take once
+// OSS-3968 lands: an expansion block field plus ordinary attributes.
+type testBlock struct {
+	Expansion *testExpansion `hcl:"expansion,block"`
+	Path      string         `hcl:"path,attr"`
+}
+
+type testExpansion struct {
+	ForEach *cty.Value `hcl:"for_each,attr"`
+	Count   *cty.Value `hcl:"count,attr"`
+}
+
+func TestExpandBlockUnexpanded(t *testing.T) {
+	t.Parallel()
+
+	instances, err := expand(t, `
+dependency "a" {
+  path = "../vpc"
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+
+	assert.Nil(t, instances[0].EachKey)
+	assert.Nil(t, instances[0].CountIndex)
+	assert.Empty(t, instances[0].Key())
+	assert.Equal(t, "../vpc", instances[0].Value.(*testBlock).Path)
+}
+
+func TestExpandBlockForEachSet(t *testing.T) {
+	t.Parallel()
+
+	instances, err := expand(t, `
+dependency "a" {
+  expansion {
+    for_each = local.services
+  }
+
+  path = "../${each.value}"
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, instances, 2)
+
+	keys := make([]string, 0, len(instances))
+	paths := make([]string, 0, len(instances))
+
+	for _, inst := range instances {
+		require.NotNil(t, inst.EachKey)
+		assert.Nil(t, inst.CountIndex)
+
+		keys = append(keys, inst.Key())
+		paths = append(paths, inst.Value.(*testBlock).Path)
+	}
+
+	assert.ElementsMatch(t, []string{"web", "api"}, keys)
+	assert.ElementsMatch(t, []string{"../web", "../api"}, paths)
+}
+
+// TestExpandBlockForEachMap pins that a map exposes distinct each.key and each.value,
+// unlike a set where the two coincide.
+func TestExpandBlockForEachMap(t *testing.T) {
+	t.Parallel()
+
+	instances, err := expand(t, `
+dependency "a" {
+  expansion {
+    for_each = local.service_map
+  }
+
+  path = "../${each.key}/${each.value}"
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, instances, 2)
+
+	paths := make([]string, 0, len(instances))
+	for _, inst := range instances {
+		paths = append(paths, inst.Value.(*testBlock).Path)
+	}
+
+	assert.ElementsMatch(t, []string{"../web/frontend", "../api/backend"}, paths)
+}
+
+func TestExpandBlockCount(t *testing.T) {
+	t.Parallel()
+
+	instances, err := expand(t, `
+dependency "a" {
+  expansion {
+    count = 3
+  }
+
+  path = "../${count.index}"
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, instances, 3)
+
+	for index, inst := range instances {
+		require.NotNil(t, inst.CountIndex)
+		assert.Nil(t, inst.EachKey)
+		assert.Equal(t, index, *inst.CountIndex)
+	}
+
+	assert.Equal(t, []string{"0", "1", "2"}, keysOf(instances))
+	assert.Equal(t, "../2", instances[2].Value.(*testBlock).Path)
+}
+
+// TestExpandBlockEmptyExpansions pins that an empty collection and a zero count are
+// legitimate no-ops rather than errors, so a config can expand to nothing.
+func TestExpandBlockEmptyExpansions(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		cfg  string
+	}{
+		{
+			name: "empty for_each",
+			cfg: `
+dependency "a" {
+  expansion {
+    for_each = local.no_services
+  }
+
+  path = "../x"
+}
+`,
+		},
+		{
+			name: "zero count",
+			cfg: `
+dependency "a" {
+  expansion {
+    count = 0
+  }
+
+  path = "../x"
+}
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			instances, err := expand(t, tc.cfg)
+			require.NoError(t, err)
+			assert.Empty(t, instances)
+		})
+	}
+}
+
+func TestExpandBlockValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		target any
+		name   string
+		cfg    string
+	}{
+		{
+			name: "both meta-args",
+			cfg: `
+dependency "a" {
+  expansion {
+    for_each = local.services
+    count    = 2
+  }
+
+  path = "../x"
+}
+`,
+			target: new(hclparse.ConflictingMetaArgsError),
+		},
+		{
+			name: "neither meta-arg",
+			cfg: `
+dependency "a" {
+  expansion {}
+
+  path = "../x"
+}
+`,
+			target: new(hclparse.MissingMetaArgError),
+		},
+		{
+			name: "more than one expansion block",
+			cfg: `
+dependency "a" {
+  expansion {
+    count = 1
+  }
+
+  expansion {
+    count = 2
+  }
+
+  path = "../x"
+}
+`,
+			target: new(hclparse.DuplicateExpansionBlockError),
+		},
+		{
+			name: "negative count",
+			cfg: `
+dependency "a" {
+  expansion {
+    count = -1
+  }
+
+  path = "../x"
+}
+`,
+			target: new(hclparse.NegativeCountError),
+		},
+		{
+			name: "unsupported for_each type",
+			cfg: `
+dependency "a" {
+  expansion {
+    for_each = local.not_a_collection
+  }
+
+  path = "../x"
+}
+`,
+			target: new(hclparse.UnsupportedForEachTypeError),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := expand(t, tc.cfg)
+			require.Error(t, err)
+			require.ErrorAs(t, err, tc.target)
+		})
+	}
+}
+
+// TestExpandBlockRejectsUnknownExpansionAttribute pins that the expansion block has
+// no catch-all, so a mistyped meta-arg fails loudly instead of expanding zero times.
+// each_key is the case that matters most: it is engine-assigned metadata, and letting
+// a config set it would let the address disagree with the iteration key.
+func TestExpandBlockRejectsUnknownExpansionAttribute(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		attr string
+	}{
+		{name: "mistyped for_each", attr: `for_eech = local.services`},
+		{name: "engine-assigned each_key", attr: `each_key = "web"`},
+		{name: "engine-assigned count_index", attr: `count_index = 0`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := expand(t, `
+dependency "a" {
+  expansion {
+    `+tc.attr+`
+  }
+
+  path = "../x"
+}
+`)
+			require.Error(t, err)
+		})
+	}
+}
+
+func expand(tb testing.TB, cfg string) ([]hclparse.Instance, error) {
+	tb.Helper()
+
+	file, diags := hclsyntax.ParseConfig([]byte(cfg), "terragrunt.hcl", hcl.InitialPos)
+	require.False(tb, diags.HasErrors(), "fixture failed to parse: %v", diags)
+
+	body, ok := file.Body.(*hclsyntax.Body)
+	require.True(tb, ok)
+	require.Len(tb, body.Blocks, 1)
+
+	ctx := &hcl.EvalContext{
+		Variables: map[string]cty.Value{
+			"local": cty.ObjectVal(map[string]cty.Value{
+				"services": cty.SetVal([]cty.Value{
+					cty.StringVal("web"),
+					cty.StringVal("api"),
+				}),
+				"service_map": cty.MapVal(map[string]cty.Value{
+					"web": cty.StringVal("frontend"),
+					"api": cty.StringVal("backend"),
+				}),
+				"no_services":      cty.SetValEmpty(cty.String),
+				"not_a_collection": cty.StringVal("nope"),
+			}),
+		},
+	}
+
+	return hclparse.ExpandBlock(body.Blocks[0].AsHCLBlock(), new(testBlock), ctx)
+}
+
+func keysOf(instances []hclparse.Instance) []string {
+	keys := make([]string, 0, len(instances))
+	for _, inst := range instances {
+		keys = append(keys, inst.Key())
+	}
+
+	return keys
+}

--- a/pkg/config/hclparse/expansion_test.go
+++ b/pkg/config/hclparse/expansion_test.go
@@ -242,6 +242,45 @@ dependency "a" {
 `,
 			target: new(hclparse.UnsupportedForEachTypeError),
 		},
+		{
+			name: "for_each element key is not a string or number",
+			cfg: `
+dependency "a" {
+  expansion {
+    for_each = local.object_set
+  }
+
+  path = "../x"
+}
+`,
+			target: new(hclparse.UnsupportedForEachKeyTypeError),
+		},
+		{
+			name: "fractional count",
+			cfg: `
+dependency "a" {
+  expansion {
+    count = 1.5
+  }
+
+  path = "../x"
+}
+`,
+			target: new(hclparse.InvalidCountError),
+		},
+		{
+			name: "non-numeric count",
+			cfg: `
+dependency "a" {
+  expansion {
+    count = "two"
+  }
+
+  path = "../x"
+}
+`,
+			target: new(hclparse.InvalidCountError),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -253,6 +292,113 @@ dependency "a" {
 			require.ErrorAs(t, err, tc.target)
 		})
 	}
+}
+
+// TestExpandBlockRejectsNonConcreteValues pins that unknown and null meta-args are
+// reported rather than crashing. cty's LengthInt and ElementIterator panic on both,
+// and a for_each fed from a dependency output can be either.
+func TestExpandBlockRejectsNonConcreteValues(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		target any
+		name   string
+		attr   string
+	}{
+		{
+			name:   "unknown for_each",
+			attr:   "for_each = local.unknown_services",
+			target: new(hclparse.UnknownExpansionValueError),
+		},
+		{
+			name:   "null for_each",
+			attr:   "for_each = local.null_services",
+			target: new(hclparse.NullExpansionValueError),
+		},
+		{
+			name:   "unknown count",
+			attr:   "count = local.unknown_count",
+			target: new(hclparse.UnknownExpansionValueError),
+		},
+		{
+			name:   "null count",
+			attr:   "count = local.null_count",
+			target: new(hclparse.NullExpansionValueError),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := expand(t, `
+dependency "a" {
+  expansion {
+    `+tc.attr+`
+  }
+
+  path = "../x"
+}
+`)
+			require.Error(t, err)
+			require.ErrorAs(t, err, tc.target)
+		})
+	}
+}
+
+// TestExpandBlockNumericForEachKeys pins how a numeric each.key renders into an
+// address, since OSS-3971 builds the dependency cty map from the same string.
+func TestExpandBlockNumericForEachKeys(t *testing.T) {
+	t.Parallel()
+
+	instances, err := expand(t, `
+dependency "a" {
+  expansion {
+    for_each = local.numeric_keys
+  }
+
+  path = "../${each.key}"
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, instances, 2)
+
+	assert.ElementsMatch(t, []string{"1", "2"}, keysOf(instances))
+}
+
+// TestExpandBlockRejectsEachUnderCount pins that the two iteration namespaces stay
+// separate: count exposes count.index only, so a stray each reference is an error
+// rather than a silently empty interpolation.
+func TestExpandBlockRejectsEachUnderCount(t *testing.T) {
+	t.Parallel()
+
+	_, err := expand(t, `
+dependency "a" {
+  expansion {
+    count = 2
+  }
+
+  path = "../${each.value}"
+}
+`)
+	require.Error(t, err)
+}
+
+// TestExpandBlockRejectsLabeledExpansionBlock pins that expansion takes no label, so
+// a stray one fails instead of being read as a differently-named block.
+func TestExpandBlockRejectsLabeledExpansionBlock(t *testing.T) {
+	t.Parallel()
+
+	_, err := expand(t, `
+dependency "a" {
+  expansion "extra" {
+    count = 2
+  }
+
+  path = "../x"
+}
+`)
+	require.Error(t, err)
 }
 
 // TestExpandBlockRejectsUnknownExpansionAttribute pins that the expansion block has
@@ -312,6 +458,17 @@ func expand(tb testing.TB, cfg string) ([]hclparse.Instance, error) {
 				}),
 				"no_services":      cty.SetValEmpty(cty.String),
 				"not_a_collection": cty.StringVal("nope"),
+				"numeric_keys": cty.SetVal([]cty.Value{
+					cty.NumberIntVal(1),
+					cty.NumberIntVal(2),
+				}),
+				"object_set": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{"name": cty.StringVal("web")}),
+				}),
+				"unknown_services": cty.UnknownVal(cty.Set(cty.String)),
+				"null_services":    cty.NullVal(cty.Set(cty.String)),
+				"unknown_count":    cty.UnknownVal(cty.Number),
+				"null_count":       cty.NullVal(cty.Number),
 			}),
 		},
 	}

--- a/pkg/config/hclparse/expansion_test.go
+++ b/pkg/config/hclparse/expansion_test.go
@@ -362,7 +362,12 @@ func TestExpandBlockInstanceLimit(t *testing.T) {
 		{name: "count at the limit", attr: "count = 3", limit: 3, want: 3},
 		{name: "count above the limit", attr: "count = 4", limit: 3, wantErr: true},
 		{name: "for_each at the limit", attr: "for_each = local.services", limit: 2, want: 2},
-		{name: "for_each above the limit", attr: "for_each = local.services", limit: 1, wantErr: true},
+		{
+			name:    "for_each above the limit",
+			attr:    "for_each = local.services",
+			limit:   1,
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -1243,7 +1243,12 @@ func injectStackComponentRefs(
 	// stack.<name>.path can resolve against the base components, matching how the full decode resolves them.
 	setStackComponentRefVars(evalCtx, stackDir, headers.Units, headers.Stacks)
 
-	autoUnits, autoStacks, err := stackAutoIncludeComponentHeaders(fsys, stackDir, evalCtx, parserOpts)
+	autoUnits, autoStacks, err := stackAutoIncludeComponentHeaders(
+		fsys,
+		stackDir,
+		evalCtx,
+		parserOpts,
+	)
 	if err != nil {
 		return err
 	}
@@ -1421,7 +1426,12 @@ func pruneOverriddenStackAutoIncludes(
 		return nil
 	}
 
-	unitNames, stackNames, err := stackAutoIncludeComponentNames(fsys, stackDir, evalCtx, parserOpts)
+	unitNames, stackNames, err := stackAutoIncludeComponentNames(
+		fsys,
+		stackDir,
+		evalCtx,
+		parserOpts,
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds the core logic for expanding HCL blocks based on the `expansion` block. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for expanding configuration blocks with `count` and `for_each`.
  * Supports sets, maps, and objects, with per-instance values and indexes available during evaluation.
  * Added configurable limits to prevent excessive block expansion.
* **Bug Fixes**
  * Added clear validation errors for invalid, conflicting, missing, unknown, null, negative, duplicate, or unsupported expansion settings.
* **Tests**
  * Added comprehensive coverage for expansion behavior, limits, iteration values, and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->