### PR TITLE
fix: prevent auto-init env vars from leaking into main command

### DIFF
--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -324,7 +324,7 @@ func runTerragruntWithConfig(
 		cfg,
 		r,
 		func(childCtx context.Context) error {
-			// Set the per-command downstream profile path here so auto-init and the main command, which share v.Env, do not clobber each other.
+			// Set the per-command downstream profile path here so auto-init and the main command can use distinct profiles.
 			if err := SetTofuCPUProfileEnv(l, v, opts); err != nil {
 				return err
 			}
@@ -835,7 +835,7 @@ func runTerraformInitRunCfg(
 		return err
 	}
 
-	initV := v
+	initV := v.WithEnvCloned()
 	if suppressInitStdout {
 		initV = initV.WithWriter(io.Discard)
 	}

--- a/internal/runner/run/run_e2e_test.go
+++ b/internal/runner/run/run_e2e_test.go
@@ -79,6 +79,60 @@ func TestRunPipelineEndToEndPlan(t *testing.T) {
 	assert.Contains(t, calls[0].Args, "plan")
 }
 
+// TestRunPipelineEndToEndAutoInitEnvVarsDoNotLeakIntoApply pins the
+// contract that command-specific environment variables set for auto-init
+// do not overwrite those set for the requested command.
+func TestRunPipelineEndToEndAutoInitEnvVarsDoNotLeakIntoApply(t *testing.T) {
+	t.Parallel()
+
+	s := setupRunE2EScaffold(t)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(s.dir, run.ModuleInitRequiredFile),
+		nil,
+		0o600,
+	))
+
+	rec := &recorder{}
+	exec := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		rec.record(&inv)
+
+		return vexec.Result{}
+	})
+
+	v := venvtest.New().WithExec(exec).WithFS(vfs.NewOSFS())
+	opts := newRunE2EOpts(t, s, "apply", "-auto-approve")
+	opts.AutoInit = true
+
+	cfg := &runcfg.RunConfig{
+		Terraform: runcfg.TerraformConfig{
+			ExtraArgs: []runcfg.TerraformExtraArguments{
+				{
+					Name:     "apply",
+					Commands: []string{"apply"},
+					EnvVars:  map[string]string{"MARKER": "apply"},
+				},
+				{
+					Name:     "init",
+					Commands: []string{"init"},
+					EnvVars:  map[string]string{"MARKER": "init"},
+				},
+			},
+		},
+	}
+
+	require.NoError(
+		t,
+		run.Run(t.Context(), logger.CreateLogger(), v, opts, report.NewReport(), cfg, creds.NewGetter()),
+	)
+
+	calls := rec.snapshot()
+	require.Len(t, calls, 2)
+	assert.Contains(t, calls[0].Args, "init")
+	assert.Contains(t, calls[0].Env, "MARKER=init")
+	assert.Contains(t, calls[1].Args, "apply")
+	assert.Contains(t, calls[1].Env, "MARKER=apply")
+}
+
 // TestRunPipelineEndToEndPropagatesPlanFailure pins the contract that
 // a non-zero terraform exit causes run.Run to return an error. The mem
 // backend lets us trigger the failure deterministically without


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6575.

When `apply` triggered auto-init, the nested `init` reused the requested command's `Venv.Env` map. As a result, init-specific `extra_arguments.env_vars` could overwrite the environment later used by `apply`.

This change restores previous behavior by giving auto-init a cloned environment so its mutations remain isolated while preserving the environment available when auto-init begins. It also adds an end-to-end regression test that verifies `init` and `apply` receive their respective command-specific environment variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented environment variables set during automatic Terraform initialization from leaking into the subsequent apply command.
  - Improved command separation so initialization and apply can use distinct runtime settings.

- **Tests**
  - Added an end-to-end test that verifies init-specific environment variables are only applied to the initialization step and not to apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->