### PR TITLE
fix(providercache): log -lockfile=readonly skip at debug level

### DIFF
--- a/docs/src/data/changelog/v1.1.2/lockfile-readonly-log-level.mdx
+++ b/docs/src/data/changelog/v1.1.2/lockfile-readonly-log-level.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.2"
+category: "bug-fixes"
+---
+
+#### Log `-lockfile=readonly` handling at debug level
+
+When `-lockfile=readonly` is set, Terragrunt logs that it is leaving `.terraform.lock.hcl` untouched at debug level instead of warning. Skipping the lock file is the behaviour the flag asks for, so warning about it once per unit made plan output noisy without telling you anything you did not already ask for.
+
+Run with `--log-level debug` to see the message.

--- a/docs/src/data/changelog/v1.1.3/lockfile-readonly-log-level.mdx
+++ b/docs/src/data/changelog/v1.1.3/lockfile-readonly-log-level.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.1.2"
+version: "v1.1.3"
 category: "bug-fixes"
 ---
 

--- a/internal/providercache/providercache.go
+++ b/internal/providercache/providercache.go
@@ -353,7 +353,7 @@ func (pc *ProviderCache) warmUpCache(
 	// wrote the lock file here, that check would always pass, silently defeating the
 	// flag. Leave the lock file untouched and let OpenTofu/Terraform enforce it.
 	if lockfileReadonly {
-		l.Warnf(
+		l.Debugf(
 			"`%s=%s` is set, so Terragrunt will not generate or update %s in %s. "+
 				"OpenTofu/Terraform will fail if the lock file is missing or incomplete.",
 			tf.FlagNameLockfile,

--- a/test/integration_provider_cache_lockfile_readonly_test.go
+++ b/test/integration_provider_cache_lockfile_readonly_test.go
@@ -12,7 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testFixtureProviderCacheLockfileReadonly = "fixtures/provider-cache/lockfile-readonly"
+const (
+	testFixtureProviderCacheLockfileReadonly = "fixtures/provider-cache/lockfile-readonly"
+
+	// lockfileReadonlyLogMessage is a distinctive fragment of the message Terragrunt logs
+	// when it leaves the lock file untouched because `-lockfile=readonly` is set.
+	lockfileReadonlyLogMessage = "so Terragrunt will not generate or update"
+)
 
 // TestTerragruntProviderCacheLockfileReadonly is a regression test for GitHub issue
 // #6349. With the provider cache enabled, Terragrunt used to generate
@@ -43,7 +49,7 @@ func TestTerragruntProviderCacheLockfileReadonly(t *testing.T) {
 		appPath := copyProviderCacheLockfileReadonlyFixture(t)
 		providerCacheDir := helpers.TmpDirWOSymlinks(t)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
+		_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
 			"terragrunt run --provider-cache --provider-cache-dir %s "+
 				"--non-interactive --working-dir %s -- init -lockfile=readonly",
 			providerCacheDir, appPath,
@@ -52,6 +58,23 @@ func TestTerragruntProviderCacheLockfileReadonly(t *testing.T) {
 		require.Error(t, err, "init must fail because the lock file is missing and read-only")
 		assert.False(t, util.FileExists(filepath.Join(appPath, lockfileName)),
 			"provider cache must not generate the lock file when -lockfile=readonly is set")
+		assert.NotContains(t, stderr, lockfileReadonlyLogMessage,
+			"skipping the lock file is the requested behaviour, so it must not be logged above debug level")
+	})
+
+	t.Run("readonly is logged at debug level", func(t *testing.T) {
+		appPath := copyProviderCacheLockfileReadonlyFixture(t)
+		providerCacheDir := helpers.TmpDirWOSymlinks(t)
+
+		_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
+			"terragrunt run --provider-cache --provider-cache-dir %s "+
+				"--non-interactive --log-level debug --working-dir %s -- init -lockfile=readonly",
+			providerCacheDir, appPath,
+		))
+
+		require.Error(t, err, "init must fail because the lock file is missing and read-only")
+		assert.Contains(t, stderr, lockfileReadonlyLogMessage,
+			"debug logging must still explain why the lock file was left untouched")
 	})
 
 	t.Run("readonly via TF_CLI_ARGS_init is enforced", func(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes #6573.

`-lockfile=readonly` asks OpenTofu/Terraform to verify that every provider is already recorded in `.terraform.lock.hcl` and to fail otherwise. When it is set, Terragrunt correctly leaves the lock file alone while warming the provider cache — but it also logs a `WARN` saying so, once per unit.

Skipping the lock file is exactly what the flag asks for, so on a `run --all plan` in CI this reports intended behaviour as something worth flagging, once for every unit.

This downgrades that single message from `l.Warnf` to `l.Debugf`, as suggested in the issue. The wording is unchanged and it is still there under `--log-level debug`.

### Tests

Two subtests in `TestTerragruntProviderCacheLockfileReadonly`:

- `readonly_via_flag_is_enforced` (extended) — asserts the message is absent from stderr at the default log level.
- `readonly_is_logged_at_debug_level` (new) — asserts it is still present under `--log-level debug`.

Test output, including a control run with the change backed out to show the new assertion fails without it:
https://gist.github.com/bryanhorstmann/f889b0dc48ade0da55138cba02ca12bd

```
--- PASS: TestTerragruntProviderCacheLockfileReadonly (10.74s)
    --- PASS: TestTerragruntProviderCacheLockfileReadonly/cache_writes_lock_file_without_readonly (2.88s)
    --- PASS: TestTerragruntProviderCacheLockfileReadonly/readonly_via_flag_is_enforced (2.39s)
    --- PASS: TestTerragruntProviderCacheLockfileReadonly/readonly_is_logged_at_debug_level (3.09s)
    --- PASS: TestTerragruntProviderCacheLockfileReadonly/readonly_via_TF_CLI_ARGS_init_is_enforced (2.38s)
PASS
ok  	github.com/gruntwork-io/terragrunt/test	12.318s
```

`golangci-lint run` reports 0 issues on both changed packages, and pre-commit passes.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.

Notes on the unticked boxes: no dependencies are added or changed, and there are no prose docs describing this message to update — a changelog entry under `v1.1.2` is included. The change is forwards and backwards compatible; it only lowers a log level.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced lockfile-readonly messages from warning level to debug level, preventing unnecessary warnings during normal operation.
  * The message remains available when debug logging is enabled.

* **Documentation**
  * Added a changelog entry describing the updated lockfile-readonly logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->