### PR TITLE
chore: Pin exact provider versions for terralith to terragrunt guide

### DIFF
--- a/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/04-step-1-starting-the-terralith.mdx
+++ b/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/04-step-1-starting-the-terralith.mdx
@@ -31,7 +31,9 @@ import providersTf from '../../../../fixtures/terralith-to-terragrunt/walkthroug
 
 Don't worry about that `var.aws_region` bit there. We'll define it later. When we do, we'll be defining the region in which AWS will have resources provisioned.
 
-It's best practice to tell OpenTofu what your version constraints are, so that your IaC is reliably reusable. You'll pin version `>= 1.10` of OpenTofu here, as you're going to be using an OpenTofu 1.10+ feature later on, and you'll pin version `~> 6.0` because any change that makes the `resource` definitions we define here break *should* be in a future major release of the `aws` provider.
+It's best practice to tell OpenTofu what your version constraints are, so that your IaC is reliably reusable. You'll pin version `>= 1.10` of OpenTofu here, as you're going to be using an OpenTofu 1.10+ feature later on, and you'll pin the `aws` provider to exactly `6.56.0`.
+
+A range like `~> 6.0` accepts any 6.x release, which means a provider published after you wrote your code can change what `tofu apply` does. Pinning an exact version means the only way the provider changes is when you change it. Once you run `tofu init`, OpenTofu records the resolved version and its checksums in a `.terraform.lock.hcl` file, which you commit alongside your code so that everyone, including CI, installs the same provider build.
 
 import versionsTf from '../../../../fixtures/terralith-to-terragrunt/walkthrough/step-1-starting-the-terralith/live/versions.tf?raw';
 

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-1-starting-the-terralith/live/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-1-starting-the-terralith/live/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-1-starting-the-terralith/live/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-1-starting-the-terralith/live/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-2-refactoring/catalog/modules/ddb/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-2-refactoring/catalog/modules/ddb/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-2-refactoring/catalog/modules/iam/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-2-refactoring/catalog/modules/iam/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-2-refactoring/catalog/modules/lambda/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-2-refactoring/catalog/modules/lambda/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-2-refactoring/catalog/modules/s3/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-2-refactoring/catalog/modules/s3/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-2-refactoring/live/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-2-refactoring/live/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-2-refactoring/live/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-2-refactoring/live/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-3-adding-dev/catalog/modules/ddb/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-3-adding-dev/catalog/modules/ddb/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-3-adding-dev/catalog/modules/iam/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-3-adding-dev/catalog/modules/iam/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-3-adding-dev/catalog/modules/lambda/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-3-adding-dev/catalog/modules/lambda/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-3-adding-dev/catalog/modules/s3/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-3-adding-dev/catalog/modules/s3/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-3-adding-dev/live/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-3-adding-dev/live/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-3-adding-dev/live/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-3-adding-dev/live/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/catalog/modules/ddb/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/catalog/modules/ddb/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/catalog/modules/iam/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/catalog/modules/iam/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/catalog/modules/lambda/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/catalog/modules/lambda/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/catalog/modules/s3/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/catalog/modules/s3/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/live/dev/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/live/dev/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/live/dev/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/live/dev/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/live/prod/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/live/prod/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/live/prod/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-4-breaking-the-terralith/live/prod/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-5-adding-terragrunt/catalog/modules/ddb/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-5-adding-terragrunt/catalog/modules/ddb/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-5-adding-terragrunt/catalog/modules/iam/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-5-adding-terragrunt/catalog/modules/iam/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-5-adding-terragrunt/catalog/modules/lambda/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-5-adding-terragrunt/catalog/modules/lambda/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-5-adding-terragrunt/catalog/modules/s3/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-5-adding-terragrunt/catalog/modules/s3/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-5-adding-terragrunt/live/dev/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-5-adding-terragrunt/live/dev/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-5-adding-terragrunt/live/prod/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-5-adding-terragrunt/live/prod/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/catalog/modules/ddb/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/catalog/modules/ddb/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/catalog/modules/iam/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/catalog/modules/iam/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/catalog/modules/lambda/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/catalog/modules/lambda/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/catalog/modules/s3/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/catalog/modules/s3/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/dev/ddb/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/dev/ddb/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/dev/iam/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/dev/iam/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/dev/lambda/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/dev/lambda/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/dev/s3/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/dev/s3/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/prod/ddb/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/prod/ddb/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/prod/iam/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/prod/iam/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/prod/lambda/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/prod/lambda/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/prod/s3/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-6-breaking-the-terralith-further/live/prod/s3/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/modules/ddb/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/modules/ddb/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/modules/iam/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/modules/iam/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/modules/lambda/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/modules/lambda/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/modules/s3/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/modules/s3/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/units/ddb/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/units/ddb/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/units/iam/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/units/iam/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/units/lambda/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/units/lambda/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/units/s3/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-7-taking-advantage-of-terragrunt-stacks/catalog/units/s3/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/modules/ddb/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/modules/ddb/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/modules/iam/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/modules/iam/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/modules/lambda/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/modules/lambda/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/modules/s3/versions.tf
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/modules/s3/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.56.0"
     }
   }
 }

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/units/ddb/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/units/ddb/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/units/iam/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/units/iam/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/units/lambda/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/units/lambda/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/units/s3/.terraform.lock.hcl
+++ b/docs/src/fixtures/terralith-to-terragrunt/walkthrough/step-8-refactoring-state-with-terragrunt-stacks/catalog/units/s3/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}

--- a/test/fixtures/assume-role/flag-env-creds/.terraform.lock.hcl
+++ b/test/fixtures/assume-role/flag-env-creds/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/assume-role/flag-env-creds/main.tf
+++ b/test/fixtures/assume-role/flag-env-creds/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "test_file" {
   content  = "test_file"
   filename = "${path.module}/test_file.txt"

--- a/test/fixtures/assume-role/iam-role-attr-env-creds/.terraform.lock.hcl
+++ b/test/fixtures/assume-role/iam-role-attr-env-creds/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/assume-role/iam-role-attr-env-creds/main.tf
+++ b/test/fixtures/assume-role/iam-role-attr-env-creds/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "test_file" {
   content  = "test_file"
   filename = "${path.module}/test_file.txt"

--- a/test/fixtures/auto-provider-cache-dir/basic/unit/main.tf
+++ b/test/fixtures/auto-provider-cache-dir/basic/unit/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.0"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/auto-provider-cache-dir/heavy/unit/main.tf
+++ b/test/fixtures/auto-provider-cache-dir/heavy/unit/main.tf
@@ -2,55 +2,55 @@ terraform {
   required_providers {
     aws = {
       source  = "registry.opentofu.org/hashicorp/aws"
-      version = "~> 6.0"
+      version = "6.28.0"
     }
     google = {
       source  = "registry.opentofu.org/hashicorp/google"
-      version = "~> 6.0"
+      version = "6.50.0"
     }
     azurerm = {
       source  = "registry.opentofu.org/hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "4.58.0"
     }
     kubernetes = {
       source  = "registry.opentofu.org/hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "2.38.0"
     }
     helm = {
       source  = "registry.opentofu.org/hashicorp/helm"
-      version = "~> 3.0"
+      version = "3.1.1"
     }
     vault = {
       source  = "registry.opentofu.org/hashicorp/vault"
-      version = "~> 5.0"
+      version = "5.6.0"
     }
     consul = {
       source  = "registry.opentofu.org/hashicorp/consul"
-      version = "~> 2.0"
+      version = "2.22.1"
     }
     nomad = {
       source  = "registry.opentofu.org/hashicorp/nomad"
-      version = "~> 2.0"
+      version = "2.5.2"
     }
     datadog = {
       source  = "registry.opentofu.org/DataDog/datadog"
-      version = "~> 3.0"
+      version = "3.85.0"
     }
     github = {
       source  = "registry.opentofu.org/integrations/github"
-      version = "~> 6.0"
+      version = "6.10.2"
     }
     tls = {
       source  = "registry.opentofu.org/hashicorp/tls"
-      version = "~> 4.0"
+      version = "4.1.0"
     }
     random = {
       source  = "registry.opentofu.org/hashicorp/random"
-      version = "~> 3.0"
+      version = "3.8.0"
     }
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.0"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/buffer-module-output/app/main.tf
+++ b/test/fixtures/buffer-module-output/app/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/buffer-module-output/app2/main.tf
+++ b/test/fixtures/buffer-module-output/app2/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/buffer-module-output/app3/main.tf
+++ b/test/fixtures/buffer-module-output/app3/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/destroy-order/hello/main.tf
+++ b/test/fixtures/destroy-order/hello/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = ">= 3.0.0"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/dirs/main.tf
+++ b/test/fixtures/dirs/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/docs/02-overview/step-01-terragrunt.hcl/.terraform.lock.hcl
+++ b/test/fixtures/docs/02-overview/step-01-terragrunt.hcl/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 5.46.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}
+
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 5.46.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/test/fixtures/docs/02-overview/step-02-dependencies/ec2/.terraform.lock.hcl
+++ b/test/fixtures/docs/02-overview/step-02-dependencies/ec2/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 6.28.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}
+
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 6.28.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/test/fixtures/docs/02-overview/step-02-dependencies/vpc/.terraform.lock.hcl
+++ b/test/fixtures/docs/02-overview/step-02-dependencies/vpc/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 5.46.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}
+
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 5.46.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/test/fixtures/docs/02-overview/step-03-mock-outputs/ec2/.terraform.lock.hcl
+++ b/test/fixtures/docs/02-overview/step-03-mock-outputs/ec2/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 6.28.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}
+
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 6.28.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/test/fixtures/docs/02-overview/step-03-mock-outputs/vpc/.terraform.lock.hcl
+++ b/test/fixtures/docs/02-overview/step-03-mock-outputs/vpc/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 5.46.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}
+
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 5.46.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/test/fixtures/docs/02-overview/step-04-configuration-hierarchy/us-east-1/ec2/.terraform.lock.hcl
+++ b/test/fixtures/docs/02-overview/step-04-configuration-hierarchy/us-east-1/ec2/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 6.28.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}
+
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 6.28.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/test/fixtures/docs/02-overview/step-04-configuration-hierarchy/us-east-1/vpc/.terraform.lock.hcl
+++ b/test/fixtures/docs/02-overview/step-04-configuration-hierarchy/us-east-1/vpc/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 5.46.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}
+
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 5.46.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/test/fixtures/docs/02-overview/step-05-exposed-includes/us-east-1/ec2/.terraform.lock.hcl
+++ b/test/fixtures/docs/02-overview/step-05-exposed-includes/us-east-1/ec2/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 6.28.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}
+
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 6.28.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/test/fixtures/docs/02-overview/step-05-exposed-includes/us-east-1/vpc/.terraform.lock.hcl
+++ b/test/fixtures/docs/02-overview/step-05-exposed-includes/us-east-1/vpc/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 5.46.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}
+
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 5.46.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/test/fixtures/docs/02-overview/step-05-exposed-includes/us-west-2/ec2/.terraform.lock.hcl
+++ b/test/fixtures/docs/02-overview/step-05-exposed-includes/us-west-2/ec2/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 6.28.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}
+
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 6.28.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/test/fixtures/docs/02-overview/step-05-exposed-includes/us-west-2/vpc/.terraform.lock.hcl
+++ b/test/fixtures/docs/02-overview/step-05-exposed-includes/us-west-2/vpc/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 5.46.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}
+
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = ">= 5.46.0"
+  hashes = [
+    "h1:741DoGPD40A9X3e/30UA/TBlhhJFQwC6+1aLqM/v6r8=",
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
+    "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
+    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
+    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
+    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
+    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
+    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
+    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
+    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
+    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
+    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
+    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
+    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
+    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
+    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
+    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
+  ]
+}

--- a/test/fixtures/download/hello-world-no-remote/main.tf
+++ b/test/fixtures/download/hello-world-no-remote/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/download/hello-world-with-backend/main.tf
+++ b/test/fixtures/download/hello-world-with-backend/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/download/hello-world/main.tf
+++ b/test/fixtures/download/hello-world/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/download/local-windows/JZwoL6Viko8bzuRvTOQFx3Jh8vs/3mU4huxMLOXOW5ZgJOFXGUFDKc8/main.tf
+++ b/test/fixtures/download/local-windows/JZwoL6Viko8bzuRvTOQFx3Jh8vs/3mU4huxMLOXOW5ZgJOFXGUFDKc8/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/download/stdout/main.tf
+++ b/test/fixtures/download/stdout/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/fail-fast-early-exit/failing-unit/main.tf
+++ b/test/fixtures/fail-fast-early-exit/failing-unit/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = ">= 3.2"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/gcs-byo-bucket/main.tf
+++ b/test/fixtures/gcs-byo-bucket/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/gcs/main.tf
+++ b/test/fixtures/gcs/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/after-only/main.tf
+++ b/test/fixtures/hooks/after-only/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/all/after-only/main.tf
+++ b/test/fixtures/hooks/all/after-only/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/all/before-only/main.tf
+++ b/test/fixtures/hooks/all/before-only/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/bad-arg-action/empty-command-list/main.tf
+++ b/test/fixtures/hooks/bad-arg-action/empty-command-list/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/bad-arg-action/empty-string-command/main.tf
+++ b/test/fixtures/hooks/bad-arg-action/empty-string-command/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/before-after-and-error-merge/qa/my-app/main.tf
+++ b/test/fixtures/hooks/before-after-and-error-merge/qa/my-app/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/before-after-and-on-error/main.tf
+++ b/test/fixtures/hooks/before-after-and-on-error/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/before-and-after/main.tf
+++ b/test/fixtures/hooks/before-and-after/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/before-only/main.tf
+++ b/test/fixtures/hooks/before-only/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/hook-context-env/modules/foo/main.tf
+++ b/test/fixtures/hooks/hook-context-env/modules/foo/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/init-once/base-module/main.tf
+++ b/test/fixtures/hooks/init-once/base-module/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/init-once/no-source-no-backend/main.tf
+++ b/test/fixtures/hooks/init-once/no-source-no-backend/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/init-once/no-source-with-backend/main.tf
+++ b/test/fixtures/hooks/init-once/no-source-with-backend/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/interpolations/main.tf
+++ b/test/fixtures/hooks/interpolations/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/one-arg-action/main.tf
+++ b/test/fixtures/hooks/one-arg-action/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/hooks/skip-on-error/main.tf
+++ b/test/fixtures/hooks/skip-on-error/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/include/qa/my-app/main.tf
+++ b/test/fixtures/include/qa/my-app/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/include/stage/my-app/main.tf
+++ b/test/fixtures/include/stage/my-app/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/main.tf
+++ b/test/fixtures/parent-folders/terragrunt-in-root/child/sub-child/sub-sub-child/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/provider-cache/filesystem-mirror/app/main.tf
+++ b/test/fixtures/provider-cache/filesystem-mirror/app/main.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     null = {
-      source = "registry.opentofu.org/hashicorp/null"
+      source  = "registry.opentofu.org/hashicorp/null"
+      version = "3.2.4"
     }
     aws = {
       source  = "example.com/hashicorp/aws"

--- a/test/fixtures/provider-cache/windows-remote-url/.terraform.lock.hcl
+++ b/test/fixtures/provider-cache/windows-remote-url/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = "3.2.4"
+  hashes = [
+    "h1:346niW/SBt/jtCZctHefjkQGqtX9YgxSkCAKeCzQhXw=",
+    "h1:8V2yVD20zG5UkKm5VgZLtao3vsiS09pTU4AyFuf6/iA=",
+    "h1:8ghdTVY6mALCeMuACnbrTmPaEzgamIYlgvunvqI2ZSY=",
+    "h1:8p8ONHguBmR8LKTmj8WhhuBt7ygWU3h7tZRboLDvv6k=",
+    "h1:BMHnZHUn7rdS/54e2NFPQFXYILPL8HoFvcVg2Q7bBxI=",
+    "h1:i+WKhUHL2REY5EGmiHjfUljJB8UKZ9QdhdM5uTeUhC4=",
+    "h1:jsKjBiLb+v3OIC3xuDiY4sR0r1OHUMSWPYKult9MhT0=",
+    "h1:mpBlahl9+yfbJQnUG18KTczWZrKM8uo2c9xus2OpvP8=",
+    "h1:wg0cxqzzWFNnEzw0LSlPL9Ovqy1VFW44A7ayHEU/A1I=",
+    "h1:ykZBLguRjDzDBEDZFIyd3cIHFDItYMrVtqN2nbQ9Wq4=",
+    "zh:1769783386610bed8bb1e861a119fe25058be41895e3996d9216dd6bb8a7aee3",
+    "zh:32c62a9387ad0b861b5262b41c5e9ed6e940eda729c2a0e58100e6629af27ddb",
+    "zh:339bf8c2f9733fce068eb6d5612701144c752425cebeafab36563a16be460fb2",
+    "zh:36731f23343aee12a7e078067a98644c0126714c4fe9ac930eecb0f2361788c4",
+    "zh:3d106c7e32a929e2843f732625a582e562ff09120021e510a51a6f5d01175b8d",
+    "zh:74bcb3567708171ad83b234b92c9d63ab441ef882b770b0210c2b14fdbe3b1b6",
+    "zh:90b55bdbffa35df9204282251059e62c178b0ac7035958b93a647839643c0072",
+    "zh:ae24c0e5adc692b8f94cb23a000f91a316070fdc19418578dcf2134ff57cf447",
+    "zh:b5c10d4ad860c4c21273203d1de6d2f0286845edf1c64319fa2362df526b5f58",
+    "zh:e05bbd88e82e1d6234988c85db62fd66f11502645838fff594a2ec25352ecd80",
+  ]
+}

--- a/test/fixtures/regressions/auto-init-marker-with-cached-modules/src/main.tf
+++ b/test/fixtures/regressions/auto-init-marker-with-cached-modules/src/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/report/first-failure/main.tf
+++ b/test/fixtures/report/first-failure/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/report/second-failure/main.tf
+++ b/test/fixtures/report/second-failure/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/s3-encryption/custom-key/main.tf
+++ b/test/fixtures/s3-encryption/custom-key/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.0"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/s3-encryption/sse-aes/main.tf
+++ b/test/fixtures/s3-encryption/sse-aes/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.0"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/s3-encryption/sse-kms/main.tf
+++ b/test/fixtures/s3-encryption/sse-kms/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.0"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/stack/mgmt/bastion-host/main.tf
+++ b/test/fixtures/stack/mgmt/bastion-host/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/stack/mgmt/kms-master-key/main.tf
+++ b/test/fixtures/stack/mgmt/kms-master-key/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/stack/mgmt/vpc/main.tf
+++ b/test/fixtures/stack/mgmt/vpc/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/stack/stage/backend-app/main.tf
+++ b/test/fixtures/stack/stage/backend-app/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/stack/stage/frontend-app/main.tf
+++ b/test/fixtures/stack/stage/frontend-app/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/stack/stage/mysql/main.tf
+++ b/test/fixtures/stack/stage/mysql/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/stack/stage/redis/main.tf
+++ b/test/fixtures/stack/stage/redis/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/stack/stage/search-app/main.tf
+++ b/test/fixtures/stack/stage/search-app/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/stack/stage/vpc/main.tf
+++ b/test/fixtures/stack/stage/vpc/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/stacks/dependencies/units/app-with-dependency/main.tf
+++ b/test/fixtures/stacks/dependencies/units/app-with-dependency/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "registry.opentofu.org/hashicorp/local"
-      version = ">= 2.5.2"
+      version = "2.6.1"
     }
   }
 }

--- a/test/fixtures/stacks/dependencies/units/app/main.tf
+++ b/test/fixtures/stacks/dependencies/units/app/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "registry.opentofu.org/hashicorp/local"
-      version = ">= 2.5.2"
+      version = "2.6.1"
     }
   }
 }

--- a/test/fixtures/stacks/stack-deps-apply-no-mocks/catalog/units/consumer/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-apply-no-mocks/catalog/units/consumer/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-apply-no-mocks/catalog/units/consumer/main.tf
+++ b/test/fixtures/stacks/stack-deps-apply-no-mocks/catalog/units/consumer/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 variable "producer_val" {
   type = string
 }

--- a/test/fixtures/stacks/stack-deps-apply-no-mocks/catalog/units/producer/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-apply-no-mocks/catalog/units/producer/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-apply-no-mocks/catalog/units/producer/main.tf
+++ b/test/fixtures/stacks/stack-deps-apply-no-mocks/catalog/units/producer/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "producer"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-arbitrary-override/catalog/units/gen/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-arbitrary-override/catalog/units/gen/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-arbitrary-override/catalog/units/gen/main.tf
+++ b/test/fixtures/stacks/stack-deps-arbitrary-override/catalog/units/gen/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "gen"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-autoinclude-complex-siblings/catalog/units/idp/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-autoinclude-complex-siblings/catalog/units/idp/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-autoinclude-complex-siblings/catalog/units/idp/main.tf
+++ b/test/fixtures/stacks/stack-deps-autoinclude-complex-siblings/catalog/units/idp/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "idp-applied"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-autoinclude-complex-siblings/catalog/units/roles/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-autoinclude-complex-siblings/catalog/units/roles/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-autoinclude-complex-siblings/catalog/units/roles/main.tf
+++ b/test/fixtures/stacks/stack-deps-autoinclude-complex-siblings/catalog/units/roles/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 variable "val" {
   type    = string
   default = "missing"

--- a/test/fixtures/stacks/stack-deps-basic/catalog/units/unit-w-inputs/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-basic/catalog/units/unit-w-inputs/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-basic/catalog/units/unit-w-inputs/main.tf
+++ b/test/fixtures/stacks/stack-deps-basic/catalog/units/unit-w-inputs/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 variable "val" {
   type        = string
   description = "Value received from the dependency unit"

--- a/test/fixtures/stacks/stack-deps-basic/catalog/units/unit-w-outputs/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-basic/catalog/units/unit-w-outputs/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-basic/catalog/units/unit-w-outputs/main.tf
+++ b/test/fixtures/stacks/stack-deps-basic/catalog/units/unit-w-outputs/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "output_marker" {
   content  = "Hello from unit-w-outputs!"
   filename = "${path.module}/output.txt"

--- a/test/fixtures/stacks/stack-deps-chain/catalog/units/unit-a/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-chain/catalog/units/unit-a/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-chain/catalog/units/unit-a/main.tf
+++ b/test/fixtures/stacks/stack-deps-chain/catalog/units/unit-a/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 variable "val_from_b" {
   type = string
 }

--- a/test/fixtures/stacks/stack-deps-chain/catalog/units/unit-b/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-chain/catalog/units/unit-b/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-chain/catalog/units/unit-b/main.tf
+++ b/test/fixtures/stacks/stack-deps-chain/catalog/units/unit-b/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 variable "val_from_c" {
   type = string
 }

--- a/test/fixtures/stacks/stack-deps-chain/catalog/units/unit-c/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-chain/catalog/units/unit-c/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-chain/catalog/units/unit-c/main.tf
+++ b/test/fixtures/stacks/stack-deps-chain/catalog/units/unit-c/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "unit-c"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/consumer/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/consumer/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/consumer/main.tf
+++ b/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/consumer/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 variable "val" {
   type = string
 }

--- a/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/producer/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/producer/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/producer/main.tf
+++ b/test/fixtures/stacks/stack-deps-cross-level-values/catalog/units/producer/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "producer"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-cross-stack/units/app/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-cross-stack/units/app/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-cross-stack/units/app/main.tf
+++ b/test/fixtures/stacks/stack-deps-cross-stack/units/app/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 variable "vpc_id" {
   type = string
 }

--- a/test/fixtures/stacks/stack-deps-cross-stack/units/subnets/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-cross-stack/units/subnets/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-cross-stack/units/subnets/main.tf
+++ b/test/fixtures/stacks/stack-deps-cross-stack/units/subnets/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "subnets"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-cross-stack/units/vpc/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-cross-stack/units/vpc/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-cross-stack/units/vpc/main.tf
+++ b/test/fixtures/stacks/stack-deps-cross-stack/units/vpc/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "vpc"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-merge-precedence/catalog/units/target/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-merge-precedence/catalog/units/target/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-merge-precedence/catalog/units/target/main.tf
+++ b/test/fixtures/stacks/stack-deps-merge-precedence/catalog/units/target/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 variable "val" {
   type = string
 }

--- a/test/fixtures/stacks/stack-deps-no-deps/catalog/units/alpha/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-no-deps/catalog/units/alpha/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-no-deps/catalog/units/alpha/main.tf
+++ b/test/fixtures/stacks/stack-deps-no-deps/catalog/units/alpha/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "alpha"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-no-deps/catalog/units/beta/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-no-deps/catalog/units/beta/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-no-deps/catalog/units/beta/main.tf
+++ b/test/fixtures/stacks/stack-deps-no-deps/catalog/units/beta/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "beta"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-remote-state-dep/catalog/units/unit-w-inputs/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-remote-state-dep/catalog/units/unit-w-inputs/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-remote-state-dep/catalog/units/unit-w-inputs/main.tf
+++ b/test/fixtures/stacks/stack-deps-remote-state-dep/catalog/units/unit-w-inputs/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "input_marker" {
   content  = "input-marker"
   filename = "${path.module}/input.txt"

--- a/test/fixtures/stacks/stack-deps-remote-state-dep/catalog/units/unit-w-outputs/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-remote-state-dep/catalog/units/unit-w-outputs/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-remote-state-dep/catalog/units/unit-w-outputs/main.tf
+++ b/test/fixtures/stacks/stack-deps-remote-state-dep/catalog/units/unit-w-outputs/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "output_marker" {
   content  = "Hello from unit-w-outputs!"
   filename = "${path.module}/output.txt"

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/deep/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/deep/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/deep/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/deep/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "deep"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/vpc/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/vpc/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/vpc/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-nested/units/vpc/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "vpc"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/added/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/added/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/added/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/added/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "added"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/sibling/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/sibling/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/sibling/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/sibling/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 variable "ok" {
   type    = string
   default = ""

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/vpc-base/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/vpc-base/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/vpc-base/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/vpc-base/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "vpc-base"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/vpc-override/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/vpc-override/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/vpc-override/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude-override/units/vpc-override/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "vpc-override"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude/units/extra/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude/units/extra/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude/units/extra/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude/units/extra/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "extra"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude/units/vpc/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude/units/vpc/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-stack-autoinclude/units/vpc/main.tf
+++ b/test/fixtures/stacks/stack-deps-stack-autoinclude/units/vpc/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "vpc"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-a/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-a/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-a/main.tf
+++ b/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-a/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 variable "val_from_b" {
   type = string
 }

--- a/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-b/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-b/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-b/main.tf
+++ b/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-b/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 variable "val_from_d" {
   type = string
 }

--- a/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-c/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-c/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-c/main.tf
+++ b/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-c/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "unit-c"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-d/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-d/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-d/main.tf
+++ b/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-d/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "unit-d"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-e/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-e/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-e/main.tf
+++ b/test/fixtures/stacks/stack-deps-tree/catalog/units/unit-e/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "unit-e"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/consumer/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/consumer/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/consumer/main.tf
+++ b/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/consumer/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 variable "val" {
   type = string
 }

--- a/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/producer/.terraform.lock.hcl
+++ b/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/producer/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/producer/main.tf
+++ b/test/fixtures/stacks/stack-deps-values-sibling-autoinclude/catalog/units/producer/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "2.6.1"
+    }
+  }
+}
+
 resource "local_file" "marker" {
   content  = "producer"
   filename = "${path.module}/marker.txt"

--- a/test/fixtures/streaming/unit1/main.tf
+++ b/test/fixtures/streaming/unit1/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/streaming/unit2/main.tf
+++ b/test/fixtures/streaming/unit2/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/tflint/issues-found/main.tf
+++ b/test/fixtures/tflint/issues-found/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     random = {
-      version = ">= 3.4.0"
+      version = "3.8.0"
     }
   }
 

--- a/test/fixtures/tflint/module-found/dummy_module/main.tf
+++ b/test/fixtures/tflint/module-found/dummy_module/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     null = {
       source  = "registry.opentofu.org/hashicorp/null"
-      version = "~> 3.2.4"
+      version = "3.2.4"
     }
   }
 }

--- a/test/fixtures/tflint/no-config-file/main.tf
+++ b/test/fixtures/tflint/no-config-file/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     random = {
-      version = ">= 3.4.0"
+      version = "3.8.0"
       source  = "registry.opentofu.org/hashicorp/random"
     }
   }

--- a/test/fixtures/tflint/no-issues-found/main.tf
+++ b/test/fixtures/tflint/no-issues-found/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     random = {
-      version = ">= 3.4.0"
+      version = "3.8.0"
     }
   }
 

--- a/test/fixtures/tflint/no-tf-source/main.tf
+++ b/test/fixtures/tflint/no-tf-source/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     random = {
-      version = ">= 3.4.0"
+      version = "3.8.0"
     }
   }
 

--- a/test/fixtures/tofu-http-encryption/app/.terraform.lock.hcl
+++ b/test/fixtures/tofu-http-encryption/app/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/tofu-http-encryption/app/main.tf
+++ b/test/fixtures/tofu-http-encryption/app/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.1"
+      version = "2.6.1"
     }
   }
 }

--- a/test/fixtures/tofu-http-encryption/dep/.terraform.lock.hcl
+++ b/test/fixtures/tofu-http-encryption/dep/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = "2.6.1"
+  hashes = [
+    "h1:+XfQ7VmNtYMp0eOnoQH6cZpSMk12IP1X6tEkMoMGQ/A=",
+    "h1:/+kH/83i8qMcwVzJIxeB+SvUEH2EIW69qwrSoCxMiYg=",
+    "h1:Dd5MP04TnE9qaFD8BQkJYkluiJCOsL7fwUTJx26KIP0=",
+    "h1:QH/Ay/SWVoOLgvFacjcvQcrw2WfEktZHxCcIQG0A9/w=",
+    "h1:R+vBQV89rxRk4aUDiVvYmVRB7OFYq5xczMdekhRPGF0=",
+    "h1:XiN9d3xRg1Xy//8c7j5b7s7/SHqKJM/iKhtXYQhdaQw=",
+    "h1:daBdyjOru1A6DZzjMfIg2o/3oOk0135tNUk9klcN5Rs=",
+    "h1:dhy8EXPk8bfoDPjS2lQiHIWp7imC6sn189fPXjtqnU4=",
+    "h1:vU6J/kywp/JfQdwwYjx84UiwKsVX79uPGZyRMkU61Rs=",
+    "zh:0416d7bf0b459a995cf48f202af7b7ffa252def7d23386fc05b34f67347a22ba",
+    "zh:24743d559026b59610eb3d9fa9ec7fbeb06399c0ef01272e46fe5c313eb5c6ff",
+    "zh:2561cdfbc90090fee7f844a5cb5cbed8472ce264f5d505acb18326650a5b563f",
+    "zh:3ebc3f2dc7a099bd83e5c4c2b6918e5b56ec746766c58a31a3f5d189cb837db5",
+    "zh:490e0ce925fc3848027e10017f960e9e19e7f9c3b620524f67ce54217d1c6390",
+    "zh:bf08934295877f831f2e5f17a0b3ebb51dd608b2509077f7b22afa7722e28950",
+    "zh:c298c0f72e1485588a73768cb90163863b6c3d4c71982908c219e9b87904f376",
+    "zh:cedbaed4967818903ef378675211ed541c8243c4597304161363e828c7dc3d36",
+    "zh:edda76726d7874128cf1e182640c332c5a5e6a66a053c0aa97e2a0e4267b3b92",
+  ]
+}

--- a/test/fixtures/tofu-http-encryption/dep/main.tf
+++ b/test/fixtures/tofu-http-encryption/dep/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.1"
+      version = "2.6.1"
     }
   }
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Explicitly pins all the providers we use to a fixed version so that we can cache this more reliably and dodge issues like the borked AWS provider being released.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
