### PR TITLE
chore: Registring `catalog-format` experiment

### DIFF
--- a/docs/src/data/experiments/catalog-format.mdx
+++ b/docs/src/data/experiments/catalog-format.mdx
@@ -1,0 +1,36 @@
+---
+name: catalog-format
+since: "1.1.3"
+---
+
+Non-interactive output formats for the `catalog` command.
+
+### `catalog-format` - What it does
+
+The `catalog` command renders an interactive terminal user interface, which leaves scripts, CI jobs, and agents with no way to read what it discovers. This experiment adds a `--format` flag that writes results to standard output instead: `jsonl` emits one JSON object per catalog entry, and `md` emits a Markdown document.
+
+Both formats render progressively, as entries are discovered, so a consumer that only needs the first few can stop reading before discovery finishes. Entries appear in discovery order, which is not stable between runs.
+
+The `jsonl` records follow a published JSON schema, so consumers can validate what they read.
+
+Interactivity stays in the terminal user interface. Scaffolding a module and copying a unit or stack are not available in the non-interactive formats, which report the command to run instead.
+
+### `catalog-format` - How to provide feedback
+
+Track and discuss this experiment in [gruntwork-io/terragrunt#6579](https://github.com/gruntwork-io/terragrunt/issues/6579). When reporting issues or providing feedback, please include:
+
+- How you consume catalog output (shell script, CI job, agent tooling).
+- The format you are using, and any entry fields you need that are missing.
+- Whether you depend on reading output before the command exits.
+
+### `catalog-format` - Criteria for stabilization
+
+To transition the `catalog-format` feature to a stable release, the following must be addressed, at a minimum:
+
+- [ ] A `--format` flag on `catalog` accepting `jsonl` and `md`.
+- [ ] Progressive rendering of both formats, so output is usable before discovery completes.
+- [ ] A published JSON schema for `jsonl` records.
+- [ ] A default format derived from what the output stream supports, so piping `catalog` does not require passing `--format`.
+- [ ] Documentation covering each format and the stability guarantees of the record structure.
+- [ ] Integration test coverage for each format.
+- [ ] Community feedback on real-world usage.

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -88,6 +88,10 @@ const (
 	// records through the configured logs exporter and correlating them with
 	// traces via the active span.
 	OtelLogs = "otel-logs"
+	// CatalogFormat enables non-interactive output formats for the catalog
+	// command, rendering discovered components as JSON Lines or Markdown on
+	// standard output instead of launching the terminal user interface.
+	CatalogFormat = "catalog-format"
 )
 
 const (
@@ -187,6 +191,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: OtelLogs,
+		},
+		{
+			Name: CatalogFormat,
 		},
 	}
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Registers a new `catalog-format` experiment as part of #6579

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `catalog-format` experiment for planned non-interactive catalog output in JSON Lines and Markdown formats.
  * Documented progressive rendering, output behavior when piping results, and differences from the interactive terminal view.

* **Documentation**
  * Added guidance on output schemas, discovery order, stabilization criteria, integration testing, and feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->