### PR TITLE
docs: Add call out for terragrunt scale in quick start

### DIFF
--- a/docs/src/content/docs/01-getting-started/01-quick-start.mdx
+++ b/docs/src/content/docs/01-getting-started/01-quick-start.mdx
@@ -536,7 +536,15 @@ You can also see what to expect in your filesystem at each step [here](https://g
 
    Terragrunt was spawned organically out of supporting Gruntwork customers using Terraform at scale, and features in the product are designed to address common problems like these that arise when managing OpenTofu/Terraform projects at scale in production.
 
-8. **Continue learning and exploring**
+8. **Set up Terragrunt Scale**
+
+   Everything you've run so far has been run by hand, from your own machine. That's fine while you're learning, but once real infrastructure and more than one engineer are involved, you'll want these operations to run in CI/CD instead. Automating IaC operations in the cloud is a general best practice: it puts a reviewable plan on every pull request, makes the main branch the source of truth for what's deployed, and lets CI jobs authenticate with short-lived credentials instead of long-lived keys sitting on laptops.
+
+   Just as Terragrunt came out of supporting Gruntwork customers using Terraform at scale, [Terragrunt Scale](https://terragrunt.com/terragrunt-scale) came out of supporting those same customers leveraging Terragrunt to enable GitOps workflows with teammates. It sets up plan-on-pull-request and apply-on-merge workflows out of the box that respect the same dependency graph you worked with above, and it runs inside your own GitHub Actions or GitLab CI environment.
+
+   [Sign up for the Free Tier](https://app.gruntwork.io/signup/terragrunt-scale-free-tier) to try it. It covers up to 25 units, and no credit card is required. To walk through the whole setup with a real AWS account and a real, deployed workload, follow the [Continuous Integration with Terragrunt](/guides/ci-with-terragrunt/) guide.
+
+9. **Continue learning and exploring**
 
    Hopefully, following this simple tutorial has given you confidence in integrating Terragrunt into your existing OpenTofu/Terraform projects. Starting small, and gradually introducing more complex Terragrunt features is a great way to learn how Terragrunt can help you manage your infrastructure more effectively.
 

--- a/docs/src/content/docs/01-getting-started/01-quick-start.mdx
+++ b/docs/src/content/docs/01-getting-started/01-quick-start.mdx
@@ -542,7 +542,7 @@ You can also see what to expect in your filesystem at each step [here](https://g
 
    Just as Terragrunt came out of supporting Gruntwork customers using Terraform at scale, [Terragrunt Scale](https://terragrunt.com/terragrunt-scale) came out of supporting those same customers leveraging Terragrunt to enable GitOps workflows with teammates. It sets up plan-on-pull-request and apply-on-merge workflows out of the box that respect the same dependency graph you worked with above, and it runs inside your own GitHub Actions or GitLab CI environment.
 
-   [Sign up for the Free Tier](https://app.gruntwork.io/signup/terragrunt-scale-free-tier) to try it. It covers up to 25 units, and no credit card is required. To walk through the whole setup with a real AWS account and a real, deployed workload, follow the [Continuous Integration with Terragrunt](/guides/ci-with-terragrunt/) guide.
+   [Sign up for the Free Tier](https://app.gruntwork.io/signup/terragrunt-scale-free-tier?utm_source=terragrunt-docs&utm_medium=referral&utm_campaign=quick-start) to try it. It covers up to 25 units, and no credit card is required. To walk through the whole setup with a real AWS account and a real, deployed workload, follow the [Continuous Integration with Terragrunt](/guides/ci-with-terragrunt/) guide.
 
 9. **Continue learning and exploring**
 

--- a/docs/src/content/docs/02-guides/02-continuous-integration-with-terragrunt/03-terragrunt-scale.mdx
+++ b/docs/src/content/docs/02-guides/02-continuous-integration-with-terragrunt/03-terragrunt-scale.mdx
@@ -28,7 +28,7 @@ By the end of this section, you'll have a GitHub repository with Terragrunt infr
 
 ## Sign up for Terragrunt Scale Free Tier
 
-Head to the [Terragrunt Scale Free Tier signup](https://app.gruntwork.io/signup/terragrunt-scale-free-tier) to create an account. The free tier supports up to 25 [units](/getting-started/terminology/#unit) with a convenient onboarding wizard for GitHub and AWS. No credit card is required for signup.
+Head to the [Terragrunt Scale Free Tier signup](https://app.gruntwork.io/signup/terragrunt-scale-free-tier?utm_source=terragrunt-docs&utm_medium=referral&utm_campaign=ci-with-terragrunt) to create an account. The free tier supports up to 25 [units](/getting-started/terminology/#unit) with a convenient onboarding wizard for GitHub and AWS. No credit card is required for signup.
 
 <img src={signupPage.src} alt="Terragrunt Scale Free Tier signup page" />
 

--- a/docs/src/content/docs/09-terragrunt-scale/02-terragrunt-at-scale.mdx
+++ b/docs/src/content/docs/09-terragrunt-scale/02-terragrunt-at-scale.mdx
@@ -86,6 +86,6 @@ If your team is small or runs a handful of units, Terragrunt plus a modest CI wr
 
 Terragrunt Scale is free for up to 25 [units](/getting-started/terminology#unit).
 
-[Sign up](https://app.gruntwork.io) to get started today!
+[Sign up](https://app.gruntwork.io?utm_source=terragrunt-docs&utm_medium=referral&utm_campaign=terragrunt-at-scale) to get started today!
 
 </Aside>

--- a/docs/src/content/docs/09-terragrunt-scale/03-installation.mdx
+++ b/docs/src/content/docs/09-terragrunt-scale/03-installation.mdx
@@ -14,7 +14,7 @@ This page provides a brief overview of the setup process.
 
 <Steps>
 
-1. **Sign up** — Create an account at [app.gruntwork.io](https://app.gruntwork.io/signup/terragrunt-scale-free-tier). The rest of the steps listed here will be guided by the onboarding wizard that runs after sign-up.
+1. **Sign up** — Create an account at [app.gruntwork.io](https://app.gruntwork.io/signup/terragrunt-scale-free-tier?utm_source=terragrunt-docs&utm_medium=referral&utm_campaign=terragrunt-scale-installation). The rest of the steps listed here will be guided by the onboarding wizard that runs after sign-up.
 
 2. **Connect your VCS** — Install the Gruntwork.io GitHub App or configure a GitLab machine user to connect to one or more Git repositories.
 

--- a/docs/src/content/docs/09-terragrunt-scale/index.mdx
+++ b/docs/src/content/docs/09-terragrunt-scale/index.mdx
@@ -15,7 +15,7 @@ Terragrunt Scale is a GitOps platform that extends Terragrunt with production-gr
 
 Terragrunt Scale is free for up to 25 [units](/getting-started/terminology#unit).
 
-[Sign up](https://app.gruntwork.io) to get started today!
+[Sign up](https://app.gruntwork.io?utm_source=terragrunt-docs&utm_medium=referral&utm_campaign=terragrunt-scale-overview) to get started today!
 
 </Aside>
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds a call out for the Terragrunt Scale sign-up in quick start.

Also updates the links for sign-up.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Terragrunt Scale introduction to the Quick Start tutorial, including plan-on-pull-request and apply-on-merge workflows.
  * Added links to the Free Tier signup and Continuous Integration guide.
  * Updated Terragrunt Scale documentation with clearer signup links and relevant referral tracking.
  * Adjusted signup links across installation and overview pages for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->