### PR TITLE
feat: Adding `catalog` `jsonl` format

### DIFF
--- a/docs/public/schemas/catalog/v1/schema.json
+++ b/docs/public/schemas/catalog/v1/schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.terragrunt.com/schemas/catalog/v1/schema.json",
+  "title": "Terragrunt Catalog Entry Schema",
+  "description": "Schema for a single catalog entry emitted by `terragrunt catalog --format=jsonl`. Each line of output is one entry, and each entry is validated against this schema on its own.",
+  "type": "object",
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": [
+        "module",
+        "template",
+        "unit",
+        "stack"
+      ],
+      "description": "What the entry is: an OpenTofu/Terraform module, a boilerplate template, a Terragrunt unit, or a Terragrunt stack."
+    },
+    "title": {
+      "type": "string",
+      "description": "Display title, taken from the README front matter or first heading, falling back to the directory name."
+    },
+    "description": {
+      "type": "string",
+      "description": "Short description, taken from the README front matter or the text under its headings."
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Tags declared in the README front matter, in authoring order. Absent when the entry declares none."
+    },
+    "source": {
+      "type": "string",
+      "description": "Repository the entry was discovered in, for example `github.com/gruntwork-io/terraform-aws-utilities`. Empty for a repository given as a local path."
+    },
+    "dir": {
+      "type": "string",
+      "description": "Slash-separated path of the entry within its repository. Absent when the repository root is itself the entry."
+    },
+    "version": {
+      "type": "string",
+      "description": "Latest release tag of the repository. Absent when the repository has no tags."
+    },
+    "url": {
+      "type": "string",
+      "description": "Browsable URL of the entry. Absent when one could not be derived from the repository."
+    },
+    "component_source": {
+      "type": "string",
+      "description": "Source string to use for the entry, in the form accepted by the `source` attribute of a `terraform` block."
+    },
+    "doc": {
+      "type": "string",
+      "description": "README body as written, with front matter removed. Absent when the entry has no README."
+    },
+    "copyable": {
+      "type": "boolean",
+      "description": "True when the entry is installed by copying its directory (units and stacks) rather than by scaffolding. Absent when false."
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "title",
+    "source",
+    "component_source"
+  ]
+}

--- a/docs/src/content/docs/03-features/06-catalog/04-non-interactive.mdx
+++ b/docs/src/content/docs/03-features/06-catalog/04-non-interactive.mdx
@@ -1,0 +1,61 @@
+---
+title: Non-interactive catalog
+description: Read the catalog from a script, one JSON object per line.
+slug: features/catalog/non-interactive
+sidebar:
+  order: 4
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Experimental">
+The `--format` flag is gated behind the [`catalog-format`](/reference/experiments/active#catalog-format) experiment. Enable it with `--experiment=catalog-format` or `TG_EXPERIMENT=catalog-format`.
+
+The examples below omit it for brevity.
+</Aside>
+
+The [catalog TUI](/features/catalog/tui) needs a terminal, which leaves scripts and CI jobs with no way to read what the catalog discovers. Pass `--format=jsonl` to write the same discovery to standard output as [JSON Lines](https://jsonlines.org/): one JSON object per line, and nothing else.
+
+```bash
+$ terragrunt catalog --format=jsonl | jq -c '{kind, title, component_source}'
+{"kind":"module","title":"VPC","component_source":"github.com/acme/infrastructure-modules//modules/vpc"}
+{"kind":"unit","title":"App","component_source":"github.com/acme/infrastructure-units//units/app"}
+```
+
+Every line is a catalog entry that you would normally see in the catalog TUI.
+
+## Streaming
+
+Entries are written as they are discovered, and each one is flushed as it is written, so results are readable while the remaining repositories are still being cloned. A consumer that stops reading ends the command:
+
+```bash
+terragrunt catalog --format=jsonl | head -5
+```
+
+Once the reader closes the pipe, Terragrunt stops loading, removes the repositories it cloned, and exits with status 0, writing nothing to standard error.
+
+## Keeping the streams apart
+
+Standard output carries entries and nothing else. Logs and diagnostics go to standard error, including the report of a repository that failed to load.
+
+Keep it that way when you parse the output. A `doc` field holding a large README makes a record longer than the operating system writes to a pipe in one go, so a log line merged into the same stream with `2>&1` can land in the middle of a record and break the parse.
+
+## Ordering
+
+Repositories are loaded concurrently, so entries interleave across them and appear in whatever order discovery produced. That order is not stable between runs, and nothing sorts it, because sorting would mean holding every entry until the slowest repository finished loading.
+
+Collect the stream first when you need a fixed order:
+
+```bash
+terragrunt catalog --format=jsonl | jq -s -c 'sort_by(.component_source)[]'
+```
+
+## Entry structure
+
+Entries are described by a [published JSON schema](https://docs.terragrunt.com/schemas/catalog/v1/schema.json). The schema covers a single entry, so validate each line on its own rather than the stream as a whole.
+
+The `doc` field holds the body of the component's README (which can be a lot of data) so drop it when the metadata is all you need:
+
+```bash
+terragrunt catalog --format=jsonl | jq -c 'del(.doc)'
+```

--- a/docs/src/content/docs/03-features/06-catalog/index.mdx
+++ b/docs/src/content/docs/03-features/06-catalog/index.mdx
@@ -16,6 +16,8 @@ Terragrunt's catalog ecosystem provides two complementary tools for working with
 
 You can use Scaffold standalone, or launch it directly from the Catalog TUI by pressing `S` on a selected module.
 
+Where a terminal is not available, the catalog can write what it discovers to standard output instead of drawing an interface. See [Non-interactive catalog](/features/catalog/non-interactive).
+
 ## Security Configuration
 
 The `catalog` block supports security-related configuration options:

--- a/docs/src/data/changelog/v1.1.3/catalog-jsonl-format.mdx
+++ b/docs/src/data/changelog/v1.1.3/catalog-jsonl-format.mdx
@@ -1,0 +1,34 @@
+---
+version: "v1.1.3"
+category: "experiments-updated"
+---
+
+import { Aside } from '@astrojs/starlight/components'
+
+#### `catalog-format` - Reading the catalog as JSON Lines
+
+The `catalog` command draws a terminal user interface, and refuses to start where there is no terminal to draw it on. With the [`catalog-format`](/reference/experiments/active#catalog-format) experiment enabled, `--format=jsonl` writes the same discovery to standard output instead, as one JSON object per line:
+
+```bash
+terragrunt catalog --experiment=catalog-format --format=jsonl | jq -c '{kind, title, component_source}'
+```
+
+Entries are written as they are discovered rather than collected first, so output is readable while the remaining repositories are still loading, and a reader that stops early ends the command quietly:
+
+```bash
+terragrunt catalog --experiment=catalog-format --format=jsonl | head -5
+```
+
+<Aside type="note" title="Closing the pipe">
+In this example, the `head` program exits after reading in five lines, and Terragrunt detects the `SIGPIPE` signal from the OS, and shuts down cleanly.
+</Aside>
+
+Entries appear in discovery order, which interleaves the repositories being loaded and differs between runs. Every entry carries the complete body of the component's README in the `doc` field. Combine usage of Terragrunt with other tools like `jq` to drop it.
+
+```bash
+terragrunt catalog --experiment=catalog-format --format=jsonl | jq -c 'del(.doc)'
+```
+
+Entries follow a [published JSON schema](https://docs.terragrunt.com/schemas/catalog/v1/schema.json). For the fields and their meanings, see [Non-interactive catalog](/features/catalog/non-interactive).
+
+`--format=tui` is the default, and leaves the terminal user interface exactly as it was.

--- a/docs/src/data/commands/catalog.mdx
+++ b/docs/src/data/commands/catalog.mdx
@@ -15,6 +15,7 @@ examples:
     code: |
       terragrunt catalog --root-file-name root.hcl
 flags:
+  - catalog-format
   - catalog-no-include-root
   - catalog-root-file-name
   - catalog-no-shell

--- a/docs/src/data/flags/catalog-format.mdx
+++ b/docs/src/data/flags/catalog-format.mdx
@@ -1,0 +1,48 @@
+---
+name: format
+description: |
+  Format the catalog as specified. Supported values (tui, jsonl). Default: tui.
+type: string
+env:
+  - TG_FORMAT
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Experimental">
+This flag is gated behind the [`catalog-format`](/reference/experiments/active#catalog-format) experiment. Enable it with `--experiment=catalog-format` or `TG_EXPERIMENT=catalog-format`.
+</Aside>
+
+## Formats
+
+- `tui` is the default format for the `catalog` command, and results in the catalog rendering as an interactive Terminal User Interface.
+- `jsonl` writes one JSON object per line to standard output, so a script can read the catalog where a terminal user interface cannot be used.
+
+## JSONL
+
+```bash
+$ terragrunt catalog --experiment=catalog-format --format=jsonl | head -1
+{"kind":"module","title":"VPC","description":"Creates a VPC.","tags":["networking"],"source":"github.com/acme/infrastructure-modules","dir":"modules/vpc","version":"v0.14.2","url":"https://github.com/acme/infrastructure-modules/tree/main/modules/vpc","component_source":"github.com/acme/infrastructure-modules//modules/vpc","doc":"Everything a VPC needs.\n"}
+```
+
+Each entry is emitted as it is discovered, so a consumer that only needs the first few results can stop reading before discovery finishes.
+
+Entries arrive in discovery order, which interleaves the repositories being loaded and differs between runs. Collect them before sorting when you need a stable order:
+
+```bash
+terragrunt catalog --experiment=catalog-format --format=jsonl | jq -s -c 'sort_by(.component_source)[]'
+```
+
+Every entry carries the body of the component's README in `doc`, and no flag suppresses it. Drop it when you only want the metadata:
+
+```bash
+terragrunt catalog --experiment=catalog-format --format=jsonl | jq -c 'del(.doc)'
+```
+
+Or keep only the fields you are after:
+
+```bash
+terragrunt catalog --experiment=catalog-format --format=jsonl | jq -c '{kind, title, component_source}'
+```
+
+Entries follow a [published JSON schema](https://docs.terragrunt.com/schemas/catalog/v1/schema.json), which describes the schema for each entry, not the stream as a whole.

--- a/internal/cli/commands/catalog/catalog.go
+++ b/internal/cli/commands/catalog/catalog.go
@@ -10,6 +10,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/format"
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
@@ -25,12 +26,39 @@ const urlChannelBufferSize = 10
 
 // Run is the main entry point for the catalog command.
 //
-// It launches the TUI immediately with a loading screen, then loads components
-// in the background. When an explicit repo URL is given, only that URL is
-// loaded; otherwise source discovery walks the configuration to find catalog
-// and source URLs. As components are found, the TUI transitions to the
-// component list, or shows a welcome screen when nothing is discovered.
+// When an explicit repo URL is given, only that URL is loaded; otherwise
+// source discovery walks the configuration to find catalog and source URLs.
+// The components that turn up are either browsed in the TUI or written to
+// standard output, depending on the requested format.
 func Run(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+	opts *Options,
+	repoURL string,
+) error {
+	if opts.Format == FormatTUI {
+		return runTUI(ctx, l, v, opts.TerragruntOptions, repoURL)
+	}
+
+	renderer, err := format.NewRenderer(opts.Format)
+	if err != nil {
+		return err
+	}
+
+	tempDirs := tui.NewTempDirTracker(v.FS)
+	defer tempDirs.Cleanup(l)
+
+	return Stream(
+		ctx, l, v.Writers.Writer, renderer,
+		newLoadFunc(l, v, opts.TerragruntOptions, tempDirs, repoURL),
+	)
+}
+
+// runTUI launches the TUI immediately with a loading screen, then loads
+// components in the background. As components are found, the TUI transitions
+// to the component list, or shows a welcome screen when nothing is discovered.
+func runTUI(
 	ctx context.Context,
 	l log.Logger,
 	v *venv.Venv,
@@ -48,17 +76,29 @@ func Run(
 
 	return tui.Run(
 		ctx, l, v, opts, v.Writers.ErrWriter,
-		func(
-			ctx context.Context, status tui.StatusFunc, componentCh chan<- *tui.ComponentEntry,
-		) error {
-			if repoURL != "" {
-				status("Loading " + repoURL + "...")
+		newLoadFunc(l, v, opts, tempDirs, repoURL),
+	)
+}
 
-				return tui.LoadURL(ctx, l, v, opts, tempDirs, repoURL, componentCh)
-			}
+// newLoadFunc returns the loader that every output format drives.
+func newLoadFunc(
+	l log.Logger,
+	v *venv.Venv,
+	opts *options.TerragruntOptions,
+	tempDirs *tui.TempDirTracker,
+	repoURL string,
+) tui.LoadFunc {
+	return func(
+		ctx context.Context, status tui.StatusFunc, componentCh chan<- *tui.ComponentEntry,
+	) error {
+		if repoURL != "" {
+			status("Loading " + repoURL + "...")
 
-			return discoverAndLoad(ctx, l, v, opts, tempDirs, status, componentCh)
-		})
+			return tui.LoadURL(ctx, l, v, opts, tempDirs, repoURL, componentCh)
+		}
+
+		return discoverAndLoad(ctx, l, v, opts, tempDirs, status, componentCh)
+	}
 }
 
 // discoverAndLoad runs the two concurrent URL discoverers and loads each

--- a/internal/cli/commands/catalog/cli.go
+++ b/internal/cli/commands/catalog/cli.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -20,12 +21,20 @@ const (
 	CommandName = "catalog"
 
 	IgnoreFileFlagName = "ignore-file"
+	FormatFlagName     = "format"
 )
 
-func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) clihelper.Flags {
+func NewFlags(opts *Options, prefix flags.Prefix) clihelper.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 
 	catalogFlags := clihelper.Flags{
+		flags.NewFlag(&clihelper.GenericFlag[string]{
+			Name:        FormatFlagName,
+			EnvVars:     tgPrefix.EnvVars(FormatFlagName),
+			Destination: &opts.Format,
+			Usage:       "Output format for the catalog. Valid values: tui, jsonl.",
+			DefaultText: FormatTUI,
+		}),
 		flags.NewFlag(&clihelper.GenericFlag[string]{
 			Name:        IgnoreFileFlagName,
 			EnvVars:     tgPrefix.EnvVars(IgnoreFileFlagName),
@@ -67,16 +76,36 @@ func NewFlags(opts *options.TerragruntOptions, prefix flags.Prefix) clihelper.Fl
 		}),
 	}
 
-	catalogFlags = catalogFlags.Add(shared.NewCASFlags(opts, prefix)...)
+	catalogFlags = catalogFlags.Add(shared.NewCASFlags(opts.TerragruntOptions, prefix)...)
 
-	return append(shared.NewScaffoldingFlags(opts, prefix), catalogFlags...)
+	return append(shared.NewScaffoldingFlags(opts.TerragruntOptions, prefix), catalogFlags...)
 }
 
 func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *clihelper.Command {
+	cmdOpts := NewOptions(opts)
+
 	return &clihelper.Command{
 		Name:  CommandName,
 		Usage: "Launch the user interface for searching and managing your module catalog.",
-		Flags: NewFlags(opts, nil),
+		Flags: NewFlags(cmdOpts, nil),
+		Before: func(_ context.Context, _ *clihelper.Context) error {
+			if err := cmdOpts.Validate(); err != nil {
+				return clihelper.NewExitError(err, clihelper.ExitCodeGeneralError)
+			}
+
+			if cmdOpts.Format == FormatTUI {
+				return nil
+			}
+
+			if !cmdOpts.Experiments.Evaluate(experiment.CatalogFormat) {
+				return clihelper.NewExitError(
+					ErrFormatRequiresExperiment,
+					clihelper.ExitCodeGeneralError,
+				)
+			}
+
+			return nil
+		},
 		Action: func(ctx context.Context, cliCtx *clihelper.Context) error {
 			var repoPath string
 
@@ -88,7 +117,10 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 				opts.ScaffoldRootFileName = scaffold.GetDefaultRootFileName(ctx, opts)
 			}
 
-			return Run(ctx, l, v, opts.OptionsFromContext(ctx), repoPath)
+			runOpts := *cmdOpts
+			runOpts.TerragruntOptions = opts.OptionsFromContext(ctx)
+
+			return Run(ctx, l, v, &runOpts, repoPath)
 		},
 	}
 }

--- a/internal/cli/commands/catalog/format/entry.go
+++ b/internal/cli/commands/catalog/format/entry.go
@@ -1,0 +1,42 @@
+package format
+
+import (
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+)
+
+// Entry is the serialized form of a discovered catalog component. Its shape
+// is published as a JSON schema at
+// https://docs.terragrunt.com/schemas/catalog/v1/schema.json, so field names
+// and meanings are part of what consumers can rely on.
+type Entry struct {
+	Kind            string   `json:"kind"`
+	Title           string   `json:"title"`
+	Description     string   `json:"description"`
+	Source          string   `json:"source"`
+	Dir             string   `json:"dir,omitempty"`
+	Version         string   `json:"version,omitempty"`
+	URL             string   `json:"url,omitempty"`
+	ComponentSource string   `json:"component_source"`
+	Doc             string   `json:"doc,omitempty"`
+	Tags            []string `json:"tags,omitempty"`
+	Copyable        bool     `json:"copyable,omitempty"`
+}
+
+// NewEntry converts a discovered component into its serialized form.
+func NewEntry(e *tui.ComponentEntry) *Entry {
+	c := e.Component
+
+	return &Entry{
+		Kind:            c.Kind.String(),
+		Title:           c.Title(),
+		Description:     c.Description(),
+		Source:          e.Source,
+		Dir:             c.Dir,
+		Version:         e.Version,
+		URL:             c.URL(),
+		ComponentSource: c.TerraformSourcePath(),
+		Doc:             c.Content(false),
+		Tags:            e.Tags(),
+		Copyable:        c.Kind.IsCopyable(),
+	}
+}

--- a/internal/cli/commands/catalog/format/format.go
+++ b/internal/cli/commands/catalog/format/format.go
@@ -1,0 +1,58 @@
+// Package format renders discovered catalog components in non-interactive
+// output formats. Renderers write each component as it arrives rather than
+// collecting them, so output reaches the consumer while discovery is still
+// running.
+package format
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+)
+
+// JSONL names the JSON Lines format: one JSON object per line.
+const JSONL = "jsonl"
+
+// ErrUnsupportedFormat is returned by [NewRenderer] for a format name that
+// has no renderer.
+var ErrUnsupportedFormat = errors.New("unsupported catalog output format")
+
+// Summary describes what a finished render covered: how many components were
+// written, and how many distinct sources they came from.
+type Summary struct {
+	Entries int
+	Sources int
+}
+
+// Renderer writes catalog components to w. Open runs once before the first
+// component and Close once after the last, so document-oriented formats can
+// wrap the stream in a header and a footer.
+type Renderer interface {
+	Open(w io.Writer) error
+	Entry(w io.Writer, e *tui.ComponentEntry) error
+	Close(w io.Writer, summary Summary) error
+}
+
+// NewRenderer returns the renderer for the named format.
+func NewRenderer(name string) (Renderer, error) {
+	switch name {
+	case JSONL:
+		return NewJSONLRenderer(), nil
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedFormat, name)
+	}
+}
+
+// flush pushes a buffering writer's contents through to the consumer, so a
+// reader on the other end of a pipe sees each component when it is rendered
+// rather than when the buffer happens to fill.
+func flush(w io.Writer) error {
+	f, ok := w.(interface{ Flush() error })
+	if !ok {
+		return nil
+	}
+
+	return f.Flush()
+}

--- a/internal/cli/commands/catalog/format/jsonl.go
+++ b/internal/cli/commands/catalog/format/jsonl.go
@@ -1,0 +1,55 @@
+package format
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+)
+
+// JSONLRenderer writes each component as a JSON object on its own line.
+type JSONLRenderer struct{}
+
+// NewJSONLRenderer returns a renderer that emits JSON Lines.
+func NewJSONLRenderer() *JSONLRenderer {
+	return &JSONLRenderer{}
+}
+
+// Open implements [Renderer]. JSON Lines has no document header.
+func (r *JSONLRenderer) Open(_ io.Writer) error {
+	return nil
+}
+
+// Entry implements [Renderer], writing e as one line.
+func (r *JSONLRenderer) Entry(w io.Writer, e *tui.ComponentEntry) error {
+	var buf bytes.Buffer
+
+	enc := json.NewEncoder(&buf)
+
+	// README bodies routinely contain angle brackets and ampersands, and
+	// escaping those would leave the documentation unreadable to anything
+	// that prints a record's `doc` field.
+	enc.SetEscapeHTML(false)
+
+	if err := enc.Encode(NewEntry(e)); err != nil {
+		return err
+	}
+
+	// Encode fully before writing, so a record reaches the stream in one Write
+	// rather than in fragments an interleaved writer could split. That is not
+	// atomicity: a README of a few megabytes exceeds PIPE_BUF, and os.File
+	// splits it across several write syscalls. What keeps records whole is
+	// that a single goroutine drains the component channel, so nothing else
+	// writes to this stream. Merging stderr into it (2>&1) forfeits that.
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		return err
+	}
+
+	return flush(w)
+}
+
+// Close implements [Renderer]. JSON Lines has no document footer.
+func (r *JSONLRenderer) Close(_ io.Writer, _ Summary) error {
+	return nil
+}

--- a/internal/cli/commands/catalog/format/jsonl_test.go
+++ b/internal/cli/commands/catalog/format/jsonl_test.go
@@ -1,0 +1,377 @@
+package format_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/format"
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+)
+
+// vpcReadme carries every piece of metadata an entry can pick up from a
+// README: a title, a description, tags, and a body.
+const vpcReadme = `---
+name: VPC
+description: Creates a VPC.
+tags:
+  - networking
+  - aws
+---
+
+Body text.
+`
+
+const rootReadme = `---
+name: Repo Root
+description: The repository itself is the component.
+---
+
+Root body.
+`
+
+// schemaPath locates the published schema. Tests read the file the docs site
+// serves so the renderer and the contract consumers validate against cannot
+// drift apart.
+var schemaPath = filepath.Join(
+	"..", "..", "..", "..", "..",
+	"docs", "public", "schemas", "catalog", "v1", "schema.json",
+)
+
+type entryCase struct {
+	entry *tui.ComponentEntry
+	name  string
+	want  format.Entry
+}
+
+func entryCases() []entryCase {
+	return []entryCase{
+		{
+			name: "module with full readme metadata",
+			entry: tui.NewComponentEntry(
+				tui.NewComponentForTest(
+					tui.ComponentKindModule,
+					"github.com/acme/repo",
+					"modules/vpc",
+					vpcReadme,
+				),
+			).WithSource("github.com/acme/repo").WithVersion("v1.2.3"),
+			want: format.Entry{
+				Kind:            "module",
+				Title:           "VPC",
+				Description:     "Creates a VPC.",
+				Tags:            []string{"networking", "aws"},
+				Source:          "github.com/acme/repo",
+				Dir:             "modules/vpc",
+				Version:         "v1.2.3",
+				ComponentSource: "github.com/acme/repo//modules/vpc",
+				Doc:             "Body text.\n",
+			},
+		},
+		{
+			name: "template without a readme",
+			entry: tui.NewComponentEntry(
+				tui.NewComponentForTest(
+					tui.ComponentKindTemplate,
+					"github.com/acme/repo?ref=v2",
+					"templates/service",
+					"",
+				),
+			).WithSource("github.com/acme/repo"),
+			want: format.Entry{
+				Kind:            "template",
+				Title:           "service",
+				Description:     "(no description found)",
+				Source:          "github.com/acme/repo",
+				Dir:             "templates/service",
+				ComponentSource: "github.com/acme/repo//templates/service?ref=v2",
+			},
+		},
+		{
+			name: "unit is copyable",
+			entry: tui.NewComponentEntry(
+				tui.NewComponentForTest(
+					tui.ComponentKindUnit,
+					"github.com/acme/repo",
+					"units/app",
+					"",
+				),
+			).WithSource("github.com/acme/repo"),
+			want: format.Entry{
+				Kind:            "unit",
+				Title:           "app",
+				Description:     "(no description found)",
+				Source:          "github.com/acme/repo",
+				Dir:             "units/app",
+				ComponentSource: "github.com/acme/repo//units/app",
+				Copyable:        true,
+			},
+		},
+		{
+			name: "stack is copyable",
+			entry: tui.NewComponentEntry(
+				tui.NewComponentForTest(
+					tui.ComponentKindStack,
+					"github.com/acme/repo",
+					"stacks/prod",
+					"",
+				),
+			).WithSource("github.com/acme/repo"),
+			want: format.Entry{
+				Kind:            "stack",
+				Title:           "prod",
+				Description:     "(no description found)",
+				Source:          "github.com/acme/repo",
+				Dir:             "stacks/prod",
+				ComponentSource: "github.com/acme/repo//stacks/prod",
+				Copyable:        true,
+			},
+		},
+		{
+			name: "repository root component",
+			entry: tui.NewComponentEntry(
+				tui.NewComponentForTest(
+					tui.ComponentKindModule,
+					"github.com/acme/repo",
+					"",
+					rootReadme,
+				),
+			).WithSource("github.com/acme/repo"),
+			want: format.Entry{
+				Kind:            "module",
+				Title:           "Repo Root",
+				Description:     "The repository itself is the component.",
+				Source:          "github.com/acme/repo",
+				ComponentSource: "github.com/acme/repo",
+				Doc:             "Root body.\n",
+			},
+		},
+	}
+}
+
+func TestJSONLRendererEntry(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range entryCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			require.NoError(t, format.NewJSONLRenderer().Entry(&buf, tc.entry))
+
+			line, ok := strings.CutSuffix(buf.String(), "\n")
+			require.True(t, ok, "a record must end with a newline")
+			require.NotContains(t, line, "\n", "a record must occupy a single line")
+
+			var got format.Entry
+
+			require.NoError(t, json.Unmarshal([]byte(line), &got))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestJSONLRendererOmitsUnsetFields(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		entry *tui.ComponentEntry
+		name  string
+		want  []string
+	}{
+		{
+			name: "entry without optional metadata",
+			entry: tui.NewComponentEntry(
+				tui.NewComponentForTest(
+					tui.ComponentKindModule,
+					"github.com/acme/repo",
+					"modules/vpc",
+					"",
+				),
+			).WithSource("github.com/acme/repo"),
+			want: []string{"component_source", "description", "dir", "kind", "source", "title"},
+		},
+		{
+			name: "entry with every field populated",
+			entry: tui.NewComponentEntry(
+				tui.NewComponentForTest(
+					tui.ComponentKindUnit,
+					"github.com/acme/repo",
+					"units/app",
+					vpcReadme,
+				),
+			).WithSource("github.com/acme/repo").WithVersion("v1.2.3"),
+			want: []string{
+				"component_source", "copyable", "description", "dir", "doc",
+				"kind", "source", "tags", "title", "version",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			require.NoError(t, format.NewJSONLRenderer().Entry(&buf, tc.entry))
+
+			var got map[string]any
+
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+			assert.Equal(t, tc.want, slices.Sorted(maps.Keys(got)))
+		})
+	}
+}
+
+func TestJSONLRendererKeepsReadmeMarkupUnescaped(t *testing.T) {
+	t.Parallel()
+
+	entry := tui.NewComponentEntry(
+		tui.NewComponentForTest(
+			tui.ComponentKindModule,
+			"github.com/acme/repo",
+			"modules/vpc",
+			"---\nname: VPC\n---\n\nUse a & b, and keep 1 < 2.\n",
+		),
+	).WithSource("github.com/acme/repo")
+
+	var buf bytes.Buffer
+
+	require.NoError(t, format.NewJSONLRenderer().Entry(&buf, entry))
+	assert.Contains(t, buf.String(), "Use a & b, and keep 1 < 2.")
+}
+
+// TestJSONLRendererKeepsReadmeBodyVerbatim pins the body against the TUI's
+// plain-text stripping, which deletes fenced code blocks and reads the
+// underscores in vpc_name as emphasis markers.
+func TestJSONLRendererKeepsReadmeBodyVerbatim(t *testing.T) {
+	t.Parallel()
+
+	const (
+		frontmatter = "---\nname: VPC\n---\n\n"
+		body        = "# VPC\n\nSet `vpc_name` and `cidr_block`.\n\n```hcl\ninputs = {\n  vpc_name = \"prod\"\n}\n```\n"
+	)
+
+	entry := tui.NewComponentEntry(
+		tui.NewComponentForTest(
+			tui.ComponentKindModule,
+			"github.com/acme/repo",
+			"modules/vpc",
+			frontmatter+body,
+		),
+	).WithSource("github.com/acme/repo")
+
+	var buf bytes.Buffer
+
+	require.NoError(t, format.NewJSONLRenderer().Entry(&buf, entry))
+
+	var got format.Entry
+
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, body, got.Doc)
+}
+
+func TestJSONLRendererFlushesEveryEntry(t *testing.T) {
+	t.Parallel()
+
+	w := &flushCountingWriter{}
+	renderer := format.NewJSONLRenderer()
+
+	require.NoError(t, renderer.Open(w))
+	assert.Equal(t, 0, w.flushes)
+
+	for i, tc := range entryCases() {
+		require.NoError(t, renderer.Entry(w, tc.entry))
+		assert.Equal(t, i+1, w.flushes, "every entry must be flushed as it is written")
+	}
+}
+
+func TestJSONLRendererSchemaConformance(t *testing.T) {
+	t.Parallel()
+
+	schemaBytes, err := os.ReadFile(schemaPath)
+	require.NoError(t, err)
+
+	schemaLoader := gojsonschema.NewBytesLoader(schemaBytes)
+
+	cases := entryCases()
+
+	var buf bytes.Buffer
+
+	renderer := format.NewJSONLRenderer()
+
+	require.NoError(t, renderer.Open(&buf))
+
+	for _, tc := range cases {
+		require.NoError(t, renderer.Entry(&buf, tc.entry))
+	}
+
+	require.NoError(t, renderer.Close(&buf, format.Summary{Entries: len(cases), Sources: 1}))
+
+	lines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
+	require.Len(t, lines, len(cases))
+
+	for i, line := range lines {
+		result, err := gojsonschema.Validate(schemaLoader, gojsonschema.NewStringLoader(line))
+		require.NoError(t, err)
+		assert.True(t, result.Valid(), "%s: %v", cases[i].name, result.Errors())
+	}
+}
+
+func TestNewRenderer(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		format  string
+		wantErr bool
+	}{
+		{name: "jsonl", format: "jsonl"},
+		{name: "markdown is not implemented yet", format: "md", wantErr: true},
+		{name: "the tui is not a renderer", format: "tui", wantErr: true},
+		{name: "unknown", format: "yaml", wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			renderer, err := format.NewRenderer(tc.format)
+
+			if tc.wantErr {
+				require.ErrorIs(t, err, format.ErrUnsupportedFormat)
+				assert.Nil(t, renderer)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotNil(t, renderer)
+		})
+	}
+}
+
+// flushCountingWriter records how many times a renderer asked for its output
+// to be pushed through to the consumer.
+type flushCountingWriter struct {
+	bytes.Buffer
+
+	flushes int
+}
+
+func (w *flushCountingWriter) Flush() error {
+	w.flushes++
+
+	return nil
+}

--- a/internal/cli/commands/catalog/options.go
+++ b/internal/cli/commands/catalog/options.go
@@ -1,0 +1,56 @@
+package catalog
+
+import (
+	"errors"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/format"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+)
+
+const (
+	// FormatTUI browses the catalog through the interactive terminal user
+	// interface. It is the default, and the only format that needs a terminal.
+	FormatTUI = "tui"
+
+	// FormatJSONL writes each discovered component to standard output as a
+	// JSON object on its own line.
+	FormatJSONL = format.JSONL
+)
+
+// ErrFormatRequiresExperiment is returned when a non-interactive format is
+// requested without the 'catalog-format' experiment.
+var ErrFormatRequiresExperiment = errors.New(
+	"non-interactive catalog formats require usage of the 'catalog-format' experiment" +
+		" (e.g., --experiment=catalog-format)",
+)
+
+// Options holds the settings of a single `terragrunt catalog` invocation.
+type Options struct {
+	*options.TerragruntOptions
+
+	Format string
+}
+
+// NewOptions returns catalog options defaulting to the terminal user interface.
+func NewOptions(opts *options.TerragruntOptions) *Options {
+	return &Options{
+		TerragruntOptions: opts,
+		Format:            FormatTUI,
+	}
+}
+
+// Validate reports whether the requested settings can be acted on.
+func (o *Options) Validate() error {
+	return o.validateFormat()
+}
+
+func (o *Options) validateFormat() error {
+	switch o.Format {
+	case FormatTUI:
+		return nil
+	case FormatJSONL:
+		return nil
+	default:
+		return errors.New("invalid format: " + o.Format)
+	}
+}

--- a/internal/cli/commands/catalog/options_test.go
+++ b/internal/cli/commands/catalog/options_test.go
@@ -1,0 +1,55 @@
+package catalog_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+)
+
+func TestOptionsDefaultToTheTUI(t *testing.T) {
+	t.Parallel()
+
+	opts := catalog.NewOptions(options.NewTerragruntOptions())
+
+	assert.Equal(t, catalog.FormatTUI, opts.Format)
+	require.NoError(t, opts.Validate())
+}
+
+func TestOptionsValidate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		format  string
+		wantErr bool
+	}{
+		{name: "tui", format: catalog.FormatTUI},
+		{name: "jsonl", format: catalog.FormatJSONL},
+		{name: "markdown is not implemented yet", format: "md", wantErr: true},
+		{name: "unknown format", format: "yaml", wantErr: true},
+		{name: "empty format", format: "", wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := catalog.NewOptions(options.NewTerragruntOptions())
+			opts.Format = tc.format
+
+			err := opts.Validate()
+
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/cli/commands/catalog/sigpipe_unix.go
+++ b/internal/cli/commands/catalog/sigpipe_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package catalog
+
+import (
+	"context"
+	"os"
+	"syscall"
+
+	"github.com/gruntwork-io/terragrunt/internal/os/signal"
+)
+
+// notifyBrokenPipe makes a write to a closed standard output fail with EPIPE
+// instead of killing the process.
+//
+// Go raises SIGPIPE for writes to file descriptors 1 and 2, and kills the
+// program with it, but only while the program is not receiving the signal.
+// Receiving it for the life of the stream is what lets the renderer stop on
+// its own and lets the command remove the repositories it cloned on the way
+// out, which a signal death skips.
+//
+// Cancelling from the callback ends discovery as soon as the reader goes
+// away, rather than at whichever write fails next. Registration is scoped to
+// ctx, so the rest of the process, the TUI included, keeps the default
+// disposition.
+func notifyBrokenPipe(ctx context.Context, cancel context.CancelFunc) {
+	signal.NotifierWithContext(ctx, func(_ os.Signal) { cancel() }, syscall.SIGPIPE)
+}

--- a/internal/cli/commands/catalog/sigpipe_windows.go
+++ b/internal/cli/commands/catalog/sigpipe_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package catalog
+
+import "context"
+
+// notifyBrokenPipe does nothing on Windows, which has no SIGPIPE. A write to
+// a pipe whose reader has gone fails with an error there, so the renderer
+// already learns about it the same way it does for any other write failure.
+func notifyBrokenPipe(_ context.Context, _ context.CancelFunc) {}

--- a/internal/cli/commands/catalog/stream.go
+++ b/internal/cli/commands/catalog/stream.go
@@ -1,0 +1,105 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"syscall"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/format"
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+)
+
+// componentChannelBufferSize absorbs short bursts from the concurrent loaders
+// without blocking them on the renderer.
+const componentChannelBufferSize = 10
+
+// Stream renders every component the loader discovers to w as it arrives.
+//
+// Components are written in discovery order, which interleaves across sources
+// and differs between runs. Sorting them would mean holding every component
+// until the slowest source finished loading, which is the opposite of what
+// this output is for.
+//
+// A consumer that stops reading, as in `terragrunt catalog --format=jsonl |
+// head -1`, ends the stream: the loader is cancelled and Stream returns
+// without an error, so the caller's cleanup still runs.
+func Stream(
+	ctx context.Context,
+	l log.Logger,
+	w io.Writer,
+	renderer format.Renderer,
+	load tui.LoadFunc,
+) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	notifyBrokenPipe(ctx, cancel)
+
+	componentCh := make(chan *tui.ComponentEntry, componentChannelBufferSize)
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		defer close(componentCh)
+
+		// Progress updates go to the log, never to w: every line written to
+		// w is a catalog component.
+		return load(gctx, func(msg string) { l.Debugf("%s", msg) }, componentCh)
+	})
+
+	renderErr := render(w, renderer, componentCh)
+
+	// A loader that is mid-send when rendering stops early parks on a channel
+	// nobody reads, so release it before waiting on the group.
+	cancel()
+
+	loadErr := g.Wait()
+
+	if renderErr != nil {
+		return renderErr
+	}
+
+	return loadErr
+}
+
+// render drains componentCh into renderer until the loader closes it.
+func render(w io.Writer, renderer format.Renderer, componentCh <-chan *tui.ComponentEntry) error {
+	if err := renderer.Open(w); err != nil {
+		return writeErr(err)
+	}
+
+	var (
+		entries int
+		sources = make(map[string]struct{})
+	)
+
+	for entry := range componentCh {
+		if err := renderer.Entry(w, entry); err != nil {
+			return writeErr(err)
+		}
+
+		entries++
+
+		sources[entry.Source] = struct{}{}
+	}
+
+	summary := format.Summary{Entries: entries, Sources: len(sources)}
+
+	return writeErr(renderer.Close(w, summary))
+}
+
+// writeErr reports which write failures the command should surface. A closed
+// pipe means the consumer read everything it wanted, so the stream ends
+// quietly instead of spraying write errors over the tail of the output.
+func writeErr(err error) error {
+	if errors.Is(err, syscall.EPIPE) || errors.Is(err, os.ErrClosed) {
+		return nil
+	}
+
+	return err
+}

--- a/internal/cli/commands/catalog/stream_test.go
+++ b/internal/cli/commands/catalog/stream_test.go
@@ -1,0 +1,304 @@
+package catalog_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog"
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/format"
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+func TestStreamWritesEveryDiscoveredComponent(t *testing.T) {
+	t.Parallel()
+
+	var buf strings.Builder
+
+	load := func(_ context.Context, status tui.StatusFunc, componentCh chan<- *tui.ComponentEntry) error {
+		status("Discovering catalog sources...")
+
+		componentCh <- testEntry("modules/vpc")
+
+		componentCh <- testEntry("modules/ecs")
+
+		return nil
+	}
+
+	require.NoError(t, catalog.Stream(
+		t.Context(), logger.CreateLogger(), &buf, format.NewJSONLRenderer(), load,
+	))
+
+	assert.Equal(t, []string{"modules/ecs", "modules/vpc"}, sortedDirs(t, buf.String()))
+}
+
+func TestStreamOnEmptyDiscovery(t *testing.T) {
+	t.Parallel()
+
+	var buf strings.Builder
+
+	load := func(_ context.Context, _ tui.StatusFunc, _ chan<- *tui.ComponentEntry) error {
+		return nil
+	}
+
+	require.NoError(t, catalog.Stream(
+		t.Context(), logger.CreateLogger(), &buf, format.NewJSONLRenderer(), load,
+	))
+
+	assert.Empty(t, buf.String())
+}
+
+// TestStreamWritesEntriesAsTheyArrive pins progressive output without timing:
+// the loader cannot send its second component until the test has observed the
+// first one reach the writer.
+func TestStreamWritesEntriesAsTheyArrive(t *testing.T) {
+	t.Parallel()
+
+	w := &blockingWriter{writes: make(chan string)}
+	releaseSecond := make(chan struct{})
+
+	load := func(_ context.Context, _ tui.StatusFunc, componentCh chan<- *tui.ComponentEntry) error {
+		componentCh <- testEntry("modules/first")
+
+		<-releaseSecond
+
+		componentCh <- testEntry("modules/second")
+
+		return nil
+	}
+
+	streamErr := make(chan error, 1)
+
+	go func() {
+		streamErr <- catalog.Stream(
+			t.Context(), logger.CreateLogger(), w, format.NewJSONLRenderer(), load,
+		)
+	}()
+
+	first := <-w.writes
+
+	close(releaseSecond)
+
+	second := <-w.writes
+
+	require.NoError(t, <-streamErr)
+	assert.Contains(t, first, "modules/first")
+	assert.Contains(t, second, "modules/second")
+}
+
+// TestStreamOnBrokenPipe covers `terragrunt catalog --format=jsonl | head -1`:
+// the reader is gone, so the command stops loading and exits quietly.
+func TestStreamOnBrokenPipe(t *testing.T) {
+	t.Parallel()
+
+	loaderCancelled := make(chan struct{})
+
+	load := func(ctx context.Context, _ tui.StatusFunc, componentCh chan<- *tui.ComponentEntry) error {
+		componentCh <- testEntry("modules/vpc")
+
+		<-ctx.Done()
+
+		close(loaderCancelled)
+
+		return nil
+	}
+
+	err := catalog.Stream(
+		t.Context(), logger.CreateLogger(), errWriter{err: syscall.EPIPE},
+		format.NewJSONLRenderer(), load,
+	)
+	require.NoError(t, err)
+
+	select {
+	case <-loaderCancelled:
+	default:
+		t.Fatal("the loader kept running after the consumer went away")
+	}
+}
+
+func TestStreamOnClosedWriter(t *testing.T) {
+	t.Parallel()
+
+	load := func(_ context.Context, _ tui.StatusFunc, componentCh chan<- *tui.ComponentEntry) error {
+		componentCh <- testEntry("modules/vpc")
+
+		return nil
+	}
+
+	require.NoError(t, catalog.Stream(
+		t.Context(), logger.CreateLogger(), errWriter{err: os.ErrClosed},
+		format.NewJSONLRenderer(), load,
+	))
+}
+
+func TestStreamReportsWriteFailures(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("disk is full")
+
+	load := func(_ context.Context, _ tui.StatusFunc, componentCh chan<- *tui.ComponentEntry) error {
+		componentCh <- testEntry("modules/vpc")
+
+		return nil
+	}
+
+	err := catalog.Stream(
+		t.Context(), logger.CreateLogger(), errWriter{err: wantErr},
+		format.NewJSONLRenderer(), load,
+	)
+	require.ErrorIs(t, err, wantErr)
+}
+
+// TestStreamReportsSourceFailures keeps the exit-code behavior of a source
+// that could not be loaded, which callers already depend on.
+func TestStreamReportsSourceFailures(t *testing.T) {
+	t.Parallel()
+
+	var buf strings.Builder
+
+	loadErr := &tui.SourceLoadError{
+		Failures:  []tui.SourceFailure{{URL: "github.com/acme/repo", Err: errors.New("clone failed")}},
+		Attempted: 1,
+	}
+
+	load := func(_ context.Context, _ tui.StatusFunc, componentCh chan<- *tui.ComponentEntry) error {
+		componentCh <- testEntry("modules/vpc")
+
+		return loadErr
+	}
+
+	err := catalog.Stream(
+		t.Context(), logger.CreateLogger(), &buf, format.NewJSONLRenderer(), load,
+	)
+
+	var sourceErr *tui.SourceLoadError
+
+	require.ErrorAs(t, err, &sourceErr)
+	assert.True(t, sourceErr.AllFailed())
+	assert.Equal(t, []string{"modules/vpc"}, sortedDirs(t, buf.String()))
+}
+
+// TestStreamConcurrentProducersWithRacing loads from several sources at once,
+// the way discovery does, and checks that no two components share a line.
+func TestStreamConcurrentProducersWithRacing(t *testing.T) {
+	t.Parallel()
+
+	const (
+		producers             = 8
+		componentsPerProducer = 25
+	)
+
+	w := &lockedWriter{}
+
+	load := func(ctx context.Context, _ tui.StatusFunc, componentCh chan<- *tui.ComponentEntry) error {
+		g, _ := errgroup.WithContext(ctx)
+
+		for producer := range producers {
+			g.Go(func() error {
+				for component := range componentsPerProducer {
+					componentCh <- testEntry(
+						"modules/" + strconv.Itoa(producer) + "/" + strconv.Itoa(component),
+					)
+				}
+
+				return nil
+			})
+		}
+
+		return g.Wait()
+	}
+
+	require.NoError(t, catalog.Stream(
+		t.Context(), logger.CreateLogger(), w, format.NewJSONLRenderer(), load,
+	))
+
+	assert.Len(t, sortedDirs(t, w.String()), producers*componentsPerProducer)
+}
+
+func testEntry(dir string) *tui.ComponentEntry {
+	component := tui.NewComponentForTest(
+		tui.ComponentKindModule, "github.com/acme/repo", dir, "",
+	)
+
+	return tui.NewComponentEntry(component).WithSource("github.com/acme/repo")
+}
+
+// sortedDirs parses every rendered line and returns the directories they
+// describe, sorted: components arrive in discovery order, which no test may
+// depend on.
+func sortedDirs(t *testing.T, out string) []string {
+	t.Helper()
+
+	trimmed := strings.TrimSuffix(out, "\n")
+	if trimmed == "" {
+		return nil
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	dirs := make([]string, 0, len(lines))
+
+	for _, line := range lines {
+		var entry format.Entry
+
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+
+		dirs = append(dirs, entry.Dir)
+	}
+
+	slices.Sort(dirs)
+
+	return dirs
+}
+
+// blockingWriter hands each write to a reader of writes and blocks until it
+// is taken, so a test can observe output without waiting on the clock.
+type blockingWriter struct {
+	writes chan string
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	w.writes <- string(p)
+
+	return len(p), nil
+}
+
+// errWriter fails every write with a fixed error.
+type errWriter struct {
+	err error
+}
+
+func (w errWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
+}
+
+// lockedWriter collects output from concurrent writers.
+type lockedWriter struct {
+	buf strings.Builder
+	mu  sync.Mutex
+}
+
+func (w *lockedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.buf.Write(p)
+}
+
+func (w *lockedWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.buf.String()
+}

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -1,9 +1,16 @@
 package test_test
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -13,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog"
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/format"
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/scaffold"
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
@@ -30,6 +38,15 @@ import (
 
 const (
 	testFixtureCatalogLocalTemplate = "fixtures/catalog/local-template"
+
+	// catalogPipeWorkDirEnv carries the working directory the catalog pipe
+	// child process renders, and marks the process as that child.
+	catalogPipeWorkDirEnv = "CATALOG_PIPE_WORKING_DIR"
+
+	// catalogEarlyExitModules is large enough that rendering every module
+	// outgrows a pipe buffer, so the child is still writing when the reader
+	// stops.
+	catalogEarlyExitModules = 400
 )
 
 func TestCatalogGitRepoUpdate(t *testing.T) {
@@ -433,13 +450,281 @@ func TestCatalogNonTTYFailsFast(t *testing.T) {
 	require.ErrorIs(t, err, tui.ErrNoTerminal)
 }
 
+// TestCatalogJSONLFormat renders a catalog non-interactively, one JSON object
+// per line, and checks the components it discovered.
+func TestCatalogJSONLFormat(t *testing.T) {
+	t.Parallel()
+
+	workDir := catalogJSONLFixture(t)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt catalog --experiment catalog-format --format jsonl --working-dir "+workDir)
+	require.NoError(t, err)
+
+	byDir := parseCatalogJSONL(t, stdout)
+
+	kinds := map[string]string{}
+	for dir, entry := range byDir {
+		kinds[dir] = entry.Kind
+	}
+
+	assert.Equal(t, map[string]string{
+		"modules/vpc":       "module",
+		"templates/service": "template",
+		"units/app":         "unit",
+		"stacks/prod":       "stack",
+	}, kinds)
+
+	vpc := byDir["modules/vpc"]
+	assert.Equal(t, "VPC", vpc.Title)
+	assert.Equal(t, "Creates a VPC.", vpc.Description)
+	assert.Equal(t, []string{"networking"}, vpc.Tags)
+	assert.Contains(t, vpc.Doc, "Everything a VPC needs.")
+	assert.False(t, vpc.Copyable)
+
+	assert.True(t, byDir["units/app"].Copyable)
+	assert.True(t, byDir["stacks/prod"].Copyable)
+}
+
+// TestCatalogJSONLFormatWithoutTTY guards the non-interactive path against the
+// terminal check that the TUI needs, which would make the command unusable in
+// CI. It mirrors the skip of [TestCatalogNonTTYFailsFast]: where a terminal is
+// available, a regression would launch the TUI and block instead of failing.
+func TestCatalogJSONLFormatWithoutTTY(t *testing.T) {
+	t.Parallel()
+
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		t.Skip("stdin is a terminal; a regression would launch the catalog TUI for real")
+	}
+
+	if in, out, err := tea.OpenTTY(); err == nil {
+		closeErr := in.Close()
+		if out != in {
+			closeErr = errors.Join(closeErr, out.Close())
+		}
+
+		require.NoError(t, closeErr)
+		t.Skip("a controlling terminal is available; a regression would launch the catalog TUI for real")
+	}
+
+	workDir := catalogJSONLFixture(t)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt catalog --experiment catalog-format --format jsonl --working-dir "+workDir)
+	require.NoError(t, err)
+	assert.Len(t, parseCatalogJSONL(t, stdout), 4)
+}
+
+func TestCatalogJSONLFormatRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsExperimentMode(t) {
+		t.Skip(
+			"Skipping: TG_EXPERIMENT_MODE forces all experiments on, opening the gate this test pins shut",
+		)
+	}
+
+	workDir := catalogJSONLFixture(t)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt catalog --format jsonl --working-dir "+workDir)
+
+	require.ErrorIs(t, err, catalog.ErrFormatRequiresExperiment)
+	assert.Empty(t, stdout)
+}
+
+// TestCatalogUnknownFormat uses a format nothing plans to implement, so that
+// adding a renderer never turns this into a failure that has to be chased.
+func TestCatalogUnknownFormat(t *testing.T) {
+	t.Parallel()
+
+	workDir := catalogJSONLFixture(t)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt catalog --experiment catalog-format --format pdf --working-dir "+workDir)
+
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+}
+
+// TestCatalogJSONLFormatCleansUpOnEarlyExit covers `terragrunt catalog
+// --format=jsonl | head -1`: the reader stops, and the command must still
+// remove the repositories it cloned into the temporary directory.
+//
+// It runs in a child process because standard output has to be a real pipe.
+// A write to a closed pipe on file descriptor 1 is the only thing that
+// reaches the path this guards, and the test process cannot produce one
+// without taking over its own standard output.
+func TestCatalogJSONLFormatCleansUpOnEarlyExit(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGPIPE, and the early exit it used to cause, do not exist on Windows")
+	}
+
+	workDir := catalogManyModulesFixture(t, catalogEarlyExitModules)
+	childTempDir := t.TempDir()
+
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestCatalogPipeHelper$")
+
+	cmd.Env = append(
+		os.Environ(),
+		catalogPipeWorkDirEnv+"="+workDir,
+		"TMPDIR="+childTempDir,
+	)
+
+	var childStderr bytes.Buffer
+
+	cmd.Stderr = &childStderr
+
+	childStdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+
+	require.NoError(t, cmd.Start())
+
+	// Reading one record and closing is what `head -1` does. The fixture is
+	// large enough that the child is still writing at that point.
+	line, err := bufio.NewReader(childStdout).ReadString('\n')
+	require.NoError(t, err)
+	require.NoError(t, childStdout.Close())
+
+	waitErr := cmd.Wait()
+
+	var entry format.Entry
+
+	require.NoError(t, json.Unmarshal([]byte(line), &entry))
+	assert.Equal(t, "module", entry.Kind)
+
+	leftovers, err := filepath.Glob(filepath.Join(childTempDir, "catalog-*"))
+	require.NoError(t, err)
+	assert.Empty(
+		t,
+		leftovers,
+		"clone directories survived the early exit (child exit: %v, child stderr: %s)",
+		waitErr,
+		childStderr.String(),
+	)
+}
+
+// TestCatalogPipeHelper renders a catalog to the process's own standard
+// output. It is the child of [TestCatalogJSONLFormatCleansUpOnEarlyExit] and
+// skips itself in every other run.
+func TestCatalogPipeHelper(t *testing.T) {
+	t.Parallel()
+
+	workDir := os.Getenv(catalogPipeWorkDirEnv)
+	if workDir == "" {
+		t.Skip("not the catalog pipe child process")
+	}
+
+	require.NoError(t, helpers.RunTerragruntCommand(t,
+		"terragrunt catalog --experiment catalog-format --format jsonl --working-dir "+workDir,
+		os.Stdout, os.Stderr))
+}
+
+// catalogManyModulesFixture builds a repository of count modules, each with a
+// README long enough that rendering them all outgrows a pipe buffer, and
+// returns a working directory whose catalog configuration points at it.
+func catalogManyModulesFixture(t *testing.T, count int) string {
+	t.Helper()
+
+	repoDir := helpers.TmpDirWOSymlinks(t)
+	body := strings.Repeat("Everything this module needs. ", 20)
+
+	for i := range count {
+		name := fmt.Sprintf("m%04d", i)
+
+		writeFixtureFile(t, filepath.Join(repoDir, "modules", name, "main.tf"), "# "+name)
+		writeFixtureFile(
+			t,
+			filepath.Join(repoDir, "modules", name, "README.md"),
+			"# "+name+"\n\n"+body+"\n",
+		)
+	}
+
+	seedFakeGit(t, repoDir)
+
+	workDir := helpers.TmpDirWOSymlinks(t)
+
+	writeFixtureFile(t, filepath.Join(workDir, "terragrunt.hcl"), `catalog {
+  urls = ["`+filepath.ToSlash(repoDir)+`"]
+}
+`)
+
+	return workDir
+}
+
+// catalogJSONLFixture builds a repository holding one component of each kind
+// and a working directory whose catalog configuration points at it, then
+// returns the working directory.
+func catalogJSONLFixture(t *testing.T) string {
+	t.Helper()
+
+	repoDir := helpers.TmpDirWOSymlinks(t)
+
+	writeFixtureFile(t, filepath.Join(repoDir, "modules", "vpc", "main.tf"), "# vpc module")
+	writeFixtureFile(t, filepath.Join(repoDir, "modules", "vpc", "README.md"), `---
+name: VPC
+description: Creates a VPC.
+tags:
+  - networking
+---
+
+Everything a VPC needs.
+`)
+	writeFixtureFile(
+		t,
+		filepath.Join(repoDir, "templates", "service", ".boilerplate", "boilerplate.yml"),
+		"variables: []\n",
+	)
+	writeFixtureFile(t, filepath.Join(repoDir, "units", "app", "terragrunt.hcl"), "# app unit")
+	writeFixtureFile(
+		t,
+		filepath.Join(repoDir, "stacks", "prod", "terragrunt.stack.hcl"),
+		"# prod stack",
+	)
+
+	seedFakeGit(t, repoDir)
+
+	workDir := helpers.TmpDirWOSymlinks(t)
+
+	writeFixtureFile(t, filepath.Join(workDir, "terragrunt.hcl"), `catalog {
+  urls = ["`+filepath.ToSlash(repoDir)+`"]
+}
+`)
+
+	return workDir
+}
+
+// parseCatalogJSONL parses each line of rendered output and keys the entries
+// by directory. Entries arrive in discovery order, so callers may not depend
+// on the order they were written in.
+func parseCatalogJSONL(t *testing.T, stdout string) map[string]*format.Entry {
+	t.Helper()
+
+	entries := map[string]*format.Entry{}
+
+	for line := range strings.SplitSeq(strings.TrimSuffix(stdout, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+
+		entry := &format.Entry{}
+		require.NoError(t, json.Unmarshal([]byte(line), entry))
+
+		entries[entry.Dir] = entry
+	}
+
+	return entries
+}
+
 func ignoreFileAction(
 	t *testing.T,
 	opts *options.TerragruntOptions,
 ) clihelper.FlagActionFunc[string] {
 	t.Helper()
 
-	flagList := catalog.NewFlags(opts, nil)
+	flagList := catalog.NewFlags(catalog.NewOptions(opts), nil)
 
 	flag := flagList.Get(catalog.IgnoreFileFlagName)
 	require.NotNil(t, flag, "--%s flag not registered", catalog.IgnoreFileFlagName)


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds a `jsonl` format for the `catalog` command.

Relates to #6579

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental `--format` flag to catalog command with `jsonl` output mode for non-interactive usage.
  * Catalog output can now be streamed and piped to tools like `jq` for filtering and sorting.
  * Added proper signal handling for broken-pipe scenarios during piped output.

* **Documentation**
  * Added JSON schema reference for catalog entries.
  * Added comprehensive guides for non-interactive catalog output and `jsonl` format options.

* **Tests**
  * Added extensive tests for JSON Lines rendering and streaming functionality with integration coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->