### PR TITLE
perf: O(1) path lookup for ThreadSafeComponents

### DIFF
--- a/internal/component/component.go
+++ b/internal/component/component.go
@@ -241,45 +241,50 @@ func (c Components) CycleCheck() (Component, error) {
 
 // ThreadSafeComponents provides thread-safe access to a Components slice.
 // It uses an RWMutex to allow concurrent reads and serialized writes.
-// Resolved paths are cached to avoid repeated filepath.EvalSymlinks syscalls
-// and ensure consistent symlink-aware comparisons across all methods.
+//
+// Membership and FindByPath use a map keyed by resolved path (via
+// util.ResolvePath / EvalSymlinks) so set membership is O(1) in the number of
+// registered components (each call still pays path resolution). The slice
+// preserves insertion order for ToComponents.
+//
+// Contract: a component's Path() is treated as identity after it is registered.
+// Path() must not change for components already in the set (SetPath after
+// registration would leave the index stale).
 type ThreadSafeComponents struct {
-	resolvedPaths map[string]string
-	components    Components
-	mu            sync.RWMutex
+	// byResolvedPath maps util.ResolvePath(component.Path()) -> first component
+	// seen for that resolved path. First-wins matches historical IndexFunc
+	// behavior when the seed slice contains duplicate resolved paths.
+	byResolvedPath map[string]Component
+	components     Components
+	mu             sync.RWMutex
 }
 
 // NewThreadSafeComponents creates a new ThreadSafeComponents instance with the given components.
+// The seed slice is kept as-is (including any duplicate paths). Lookups index by
+// resolved path with first-wins identity.
 func NewThreadSafeComponents(components Components) *ThreadSafeComponents {
 	tsc := &ThreadSafeComponents{
-		components:    components,
-		resolvedPaths: make(map[string]string, len(components)),
+		components:     components,
+		byResolvedPath: make(map[string]Component, len(components)),
 	}
 
-	// Pre-populate resolved paths cache for initial components
 	for _, c := range components {
-		tsc.resolvedPaths[c.Path()] = util.ResolvePath(c.Path())
+		resolved := util.ResolvePath(c.Path())
+		if _, exists := tsc.byResolvedPath[resolved]; !exists {
+			tsc.byResolvedPath[resolved] = c
+		}
 	}
 
 	return tsc
-}
-
-// resolvedPathFor returns the cached resolved path for a component path if present,
-// otherwise resolves the path on the fly without mutating the cache.
-// Caller must hold at least a read lock.
-func (tsc *ThreadSafeComponents) resolvedPathFor(path string) string {
-	if resolved, ok := tsc.resolvedPaths[path]; ok {
-		return resolved
-	}
-
-	return util.ResolvePath(path)
 }
 
 // EnsureComponent adds a component to the components list if it's not already present.
 // This method is TOCTOU-safe (Time-Of-Check-Time-Of-Use) by using a double-check pattern.
 // Path comparison uses resolved symlink paths for consistency.
 //
-// It returns the component if it was added, and a boolean indicating if it was added.
+// It returns the registered component (the new instance if added, or the
+// existing first-wins instance if a component with the same resolved path was
+// already present) and whether a new entry was inserted.
 func (tsc *ThreadSafeComponents) EnsureComponent(c Component) (Component, bool) {
 	found, ok := tsc.findComponent(c)
 	if !ok {
@@ -289,47 +294,36 @@ func (tsc *ThreadSafeComponents) EnsureComponent(c Component) (Component, bool) 
 	return found, false
 }
 
-// findComponent checks if a component is in the components slice using resolved paths.
-// If it is, it returns the component and true.
-// If it is not, it returns nil and false.
+// findComponent checks if a component is already indexed by resolved path.
+// Path resolution runs outside the lock so concurrent lookups do not serialize
+// on filesystem I/O.
 func (tsc *ThreadSafeComponents) findComponent(c Component) (Component, bool) {
+	searchResolved := util.ResolvePath(c.Path())
+
 	tsc.mu.RLock()
 	defer tsc.mu.RUnlock()
 
-	searchResolved := util.ResolvePath(c.Path())
+	found, ok := tsc.byResolvedPath[searchResolved]
 
-	idx := slices.IndexFunc(tsc.components, func(cc Component) bool {
-		return tsc.resolvedPathFor(cc.Path()) == searchResolved
-	})
-
-	if idx == -1 {
-		return nil, false
-	}
-
-	return tsc.components[idx], true
+	return found, ok
 }
 
 // addComponent adds a component to the components list, acquiring a write lock.
-// Uses a double-check pattern to avoid TOCTOU race conditions.
-// Caches the resolved path for the new component.
+// Uses a double-check pattern to avoid TOCTOU race conditions. Path resolution
+// runs before taking the write lock.
 func (tsc *ThreadSafeComponents) addComponent(c Component) (Component, bool) {
+	searchResolved := util.ResolvePath(c.Path())
+
 	tsc.mu.Lock()
 	defer tsc.mu.Unlock()
 
-	searchResolved := util.ResolvePath(c.Path())
-
-	// Do one last check to see if the component is already in the components list
-	// to avoid a TOCTOU race condition. Uses resolved paths for comparison.
-	idx := slices.IndexFunc(tsc.components, func(cc Component) bool {
-		return tsc.resolvedPathFor(cc.Path()) == searchResolved
-	})
-
-	if idx != -1 {
-		return tsc.components[idx], false
+	// Double-check under the write lock so concurrent EnsureComponent calls
+	// for the same resolved path collapse to a single insert.
+	if found, ok := tsc.byResolvedPath[searchResolved]; ok {
+		return found, false
 	}
 
-	// Cache resolved path and add component
-	tsc.resolvedPaths[c.Path()] = searchResolved
+	tsc.byResolvedPath[searchResolved] = c
 	tsc.components = append(tsc.components, c)
 
 	return c, true
@@ -337,20 +331,13 @@ func (tsc *ThreadSafeComponents) addComponent(c Component) (Component, bool) {
 
 // FindByPath searches for a component by its path and returns it if found, otherwise returns nil.
 // Paths are resolved to handle symlinks consistently across platforms (e.g., macOS /var -> /private/var).
-// Uses cached resolved paths to avoid repeated syscalls.
 func (tsc *ThreadSafeComponents) FindByPath(path string) Component {
+	resolvedSearchPath := util.ResolvePath(path)
+
 	tsc.mu.RLock()
 	defer tsc.mu.RUnlock()
 
-	resolvedSearchPath := util.ResolvePath(path)
-
-	for _, c := range tsc.components {
-		if tsc.resolvedPathFor(c.Path()) == resolvedSearchPath {
-			return c
-		}
-	}
-
-	return nil
+	return tsc.byResolvedPath[resolvedSearchPath]
 }
 
 // ToComponents returns a copy of the components slice.

--- a/internal/component/component_test.go
+++ b/internal/component/component_test.go
@@ -1,6 +1,9 @@
 package component_test
 
 import (
+	"os"
+	"path/filepath"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -213,11 +216,14 @@ func TestThreadSafeComponentsConcurrentAccess(t *testing.T) {
 
 	const goroutines = 10
 
-	// Concurrent writes tests
-	for range goroutines {
+	results := make([]component.Component, goroutines)
+
+	// Concurrent writes for the same path
+	for i := range goroutines {
 		wg.Go(func() {
 			unit := component.NewUnit("/test/path")
-			tsc.EnsureComponent(unit)
+			added, _ := tsc.EnsureComponent(unit)
+			results[i] = added
 		})
 	}
 
@@ -236,6 +242,124 @@ func TestThreadSafeComponentsConcurrentAccess(t *testing.T) {
 
 	// Should have exactly one component despite concurrent adds
 	assert.Equal(t, 1, tsc.Len(), "should have exactly one component after concurrent adds")
+
+	canonical := tsc.FindByPath("/test/path")
+	require.NotNil(t, canonical)
+
+	for i := range goroutines {
+		assert.Same(t, canonical, results[i], "all concurrent Ensures should return the same instance")
+	}
+}
+
+func TestThreadSafeComponentsManyUniqueEnsure(t *testing.T) {
+	t.Parallel()
+
+	tsc := component.NewThreadSafeComponents(component.Components{})
+
+	const n = 200
+
+	units := make([]*component.Unit, n)
+	for i := range n {
+		// Unique absolute-style paths; ResolvePath falls back to the string when
+		// the path is not present on disk (no symlink resolution).
+		units[i] = component.NewUnit("/test/unit/" + strconv.Itoa(i))
+
+		added, wasAdded := tsc.EnsureComponent(units[i])
+		require.True(t, wasAdded)
+		assert.Same(t, units[i], added)
+	}
+
+	require.Equal(t, n, tsc.Len())
+
+	// Re-ensure returns the original instance and does not grow the set.
+	for i := range n {
+		added, wasAdded := tsc.EnsureComponent(component.NewUnit(units[i].Path()))
+		assert.False(t, wasAdded)
+		assert.Same(t, units[i], added)
+		assert.Same(t, units[i], tsc.FindByPath(units[i].Path()))
+	}
+
+	require.Equal(t, n, tsc.Len())
+
+	// Insertion order preserved.
+	got := tsc.ToComponents()
+	require.Len(t, got, n)
+	for i := range n {
+		assert.Same(t, units[i], got[i])
+	}
+}
+
+func TestThreadSafeComponentsSeedFirstWinsOnDuplicatePath(t *testing.T) {
+	t.Parallel()
+
+	first := component.NewUnit("/test/shared")
+	second := component.NewUnit("/test/shared")
+	tsc := component.NewThreadSafeComponents(component.Components{first, second})
+
+	// Seed keeps both entries in the slice (no silent seed dedupe).
+	require.Equal(t, 2, tsc.Len())
+	require.Len(t, tsc.ToComponents(), 2)
+
+	// Lookups and Ensure return the first seeded instance (IndexFunc / first-wins).
+	assert.Same(t, first, tsc.FindByPath("/test/shared"))
+
+	added, wasAdded := tsc.EnsureComponent(component.NewUnit("/test/shared"))
+	assert.False(t, wasAdded)
+	assert.Same(t, first, added)
+}
+
+func TestThreadSafeComponentsConcurrentDistinctPaths(t *testing.T) {
+	t.Parallel()
+
+	tsc := component.NewThreadSafeComponents(component.Components{})
+
+	var wg sync.WaitGroup
+
+	const n = 100
+
+	for i := range n {
+		wg.Go(func() {
+			unit := component.NewUnit("/test/distinct/" + strconv.Itoa(i))
+			tsc.EnsureComponent(unit)
+		})
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, n, tsc.Len())
+
+	for i := range n {
+		assert.NotNil(t, tsc.FindByPath("/test/distinct/"+strconv.Itoa(i)))
+	}
+}
+
+func TestThreadSafeComponentsSymlinkIdentity(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	realDir := filepath.Join(dir, "real")
+	require.NoError(t, os.Mkdir(realDir, 0o755))
+
+	linkDir := filepath.Join(dir, "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlinks not supported: %v", err)
+	}
+
+	realUnit := component.NewUnit(realDir)
+	tsc := component.NewThreadSafeComponents(component.Components{})
+
+	added, wasAdded := tsc.EnsureComponent(realUnit)
+	require.True(t, wasAdded)
+	require.Same(t, realUnit, added)
+
+	// Second registration via the symlink path must collapse to the same identity.
+	viaLink, wasAdded := tsc.EnsureComponent(component.NewUnit(linkDir))
+	assert.False(t, wasAdded)
+	assert.Same(t, realUnit, viaLink)
+	assert.Equal(t, 1, tsc.Len())
+
+	assert.Same(t, realUnit, tsc.FindByPath(linkDir))
+	assert.Same(t, realUnit, tsc.FindByPath(realDir))
 }
 
 // TestUnitGuardConfigParseWithRacing verifies the parse runs exactly once when


### PR DESCRIPTION
## Description

`ThreadSafeComponents.EnsureComponent` and `FindByPath` previously scanned the full component slice on every call. Discovery and graph phases call these while registering monorepo units, so membership cost grew with the number of components already registered.

This change indexes components by resolved path (`util.ResolvePath`) in a map while keeping the insertion-order slice for `ToComponents`. Public API and semantics are unchanged (symlink-aware dedup, first-wins on seed duplicates, write-lock double-check, path resolution outside the mutex).

Fixes #6588

Related follow-ups:
- #6585 negative filter membership
- #6586 per-node dependency ensure via `slices.Contains`

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.

## Verification

```text
go test ./internal/component/ -count=1   # ok
go test ./internal/discovery/ -count=1   # ok
```

## Related Issues

Fixes #6588