### PR TITLE
fix: Fixing the `--config=` form of flags used in the tflint hook

### DIFF
--- a/docs/src/data/changelog/v1.1.3/tflint-config-flag-forms.mdx
+++ b/docs/src/data/changelog/v1.1.3/tflint-config-flag-forms.mdx
@@ -1,0 +1,19 @@
+---
+version: "v1.1.3"
+category: "bug-fixes"
+---
+
+#### Fixed `--config=` being ignored by the `tflint` hook
+
+The built-in `tflint` hook reads the configuration file out of the arguments you give it, then uses that path for `tflint init` and for the lint run. It only recognized the space-separated `--config <path>` spelling, so a hook written as:
+
+```hcl
+before_hook "tflint" {
+  commands = ["plan"]
+  execute  = ["tflint", "--config=custom.tflint.hcl"]
+}
+```
+
+was treated as though no configuration file had been named at all. Terragrunt searched the unit directory and its parents for a `.tflint.hcl` file instead, and either failed with a config-not-found error or ran `tflint init` against whatever unrelated configuration the search turned up. Terragrunt now recognizes `--config <path>`, `--config=<path>`, `-c <path>`, and `-c=<path>`.
+
+The hook also builds `--var` arguments from the unit's `inputs` and from `TF_VAR_` entries in `extra_arguments` blocks. Those arguments came out in a different order on every run, which made the logged command line, and anything comparing it between runs, needlessly unstable. They are now ordered by variable name.

--- a/internal/tflint/tflint.go
+++ b/internal/tflint/tflint.go
@@ -5,6 +5,7 @@ package tflint
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -133,8 +134,9 @@ func RunTflintWithOpts(
 func InputsToTflintVar(inputs map[string]any) ([]string, error) {
 	variables := make([]string, 0, len(inputs))
 
-	for key, value := range inputs {
-		varValue, err := util.AsTerraformEnvVarJSONValue(value)
+	// Sorted so that repeated runs produce the same command line.
+	for _, key := range slices.Sorted(maps.Keys(inputs)) {
+		varValue, err := util.AsTerraformEnvVarJSONValue(inputs[key])
 		if err != nil {
 			return nil, err
 		}
@@ -206,12 +208,12 @@ func TFArgumentsToVar(l log.Logger, fs vfs.FS, hook *runcfg.Hook,
 		}
 
 		if len(arg.EnvVars) > 0 {
-			// extract env_vars
-			for name, value := range arg.EnvVars {
+			// extract env_vars, sorted so that repeated runs produce the same command line
+			for _, name := range slices.Sorted(maps.Keys(arg.EnvVars)) {
 				if after, ok := strings.CutPrefix(name, tfVarPrefix); ok {
 					varName := after
 
-					varValue, err := util.AsTerraformEnvVarJSONValue(value)
+					varValue, err := util.AsTerraformEnvVarJSONValue(arg.EnvVars[name])
 					if err != nil {
 						return nil, err
 					}
@@ -316,7 +318,7 @@ func FindConfigInProject(l log.Logger, fs vfs.FS, opts *TFLintOptions) (string, 
 	}
 }
 
-// ConfigFilePath returns the configuration file specified in --config argument,
+// ConfigFilePath returns the configuration file specified in the --config argument,
 // or the result of walking parents to find a .tflint.hcl file.
 func ConfigFilePath(
 	l log.Logger,
@@ -324,9 +326,18 @@ func ConfigFilePath(
 	opts *TFLintOptions,
 	arguments []string,
 ) (string, error) {
+	// The spellings tflint accepts for the flag that names its configuration file.
+	configFlags := []string{"--config", "-c"}
+
 	for i, arg := range arguments {
-		if arg == "--config" && len(arguments) > i+1 {
-			return arguments[i+1], nil
+		for _, flag := range configFlags {
+			if arg == flag && len(arguments) > i+1 {
+				return arguments[i+1], nil
+			}
+
+			if after, ok := strings.CutPrefix(arg, flag+"="); ok {
+				return after, nil
+			}
 		}
 	}
 	// find .tflint.hcl configuration in project files if it is not provided in arguments

--- a/internal/tflint/tflint_test.go
+++ b/internal/tflint/tflint_test.go
@@ -30,7 +30,22 @@ func TestInputsToTflintVar(t *testing.T) {
 		{
 			name:     "strings",
 			inputs:   map[string]any{"region": "eu-central-1", "instance_count": 3},
-			expected: []string{"--var=region=eu-central-1", "--var=instance_count=3"},
+			expected: []string{"--var=instance_count=3", "--var=region=eu-central-1"},
+		},
+		{
+			name: "keys are emitted in sorted order",
+			inputs: map[string]any{
+				"zeta":  1,
+				"alpha": 2,
+				"mu":    3,
+				"beta":  4,
+			},
+			expected: []string{
+				"--var=alpha=2",
+				"--var=beta=4",
+				"--var=mu=3",
+				"--var=zeta=1",
+			},
 		},
 		{
 			name:     "strings and arrays",
@@ -56,7 +71,7 @@ func TestInputsToTflintVar(t *testing.T) {
 
 			actual, err := tflint.InputsToTflintVar(tc.inputs)
 			require.NoError(t, err)
-			assert.ElementsMatch(t, tc.expected, actual)
+			assert.Equal(t, tc.expected, actual)
 		})
 	}
 }
@@ -99,6 +114,27 @@ func TestTFArgumentsToVar(t *testing.T) {
 				},
 			}},
 			expected: []string{"--var='region=us-east-1'"},
+		},
+		{
+			name: "TF_VAR_ env vars are emitted in sorted order",
+			hook: runcfg.Hook{Commands: []string{"plan"}},
+			cfg: runcfg.TerraformConfig{ExtraArgs: []runcfg.TerraformExtraArguments{
+				{
+					Commands: []string{"plan"},
+					EnvVars: map[string]string{
+						"TF_VAR_zeta":  "1",
+						"TF_VAR_alpha": "2",
+						"TF_VAR_mu":    "3",
+						"TF_VAR_beta":  "4",
+					},
+				},
+			}},
+			expected: []string{
+				"--var='alpha=2'",
+				"--var='beta=4'",
+				"--var='mu=3'",
+				"--var='zeta=1'",
+			},
 		},
 		{
 			name: "-var= and -var-file= arguments split correctly",
@@ -168,35 +204,103 @@ func TestTFArgumentsToVar(t *testing.T) {
 func TestConfigFilePath_ShortCircuitsOnConfigFlag(t *testing.T) {
 	t.Parallel()
 
-	fs := vfs.NewMemMapFS()
-	l := logger.CreateLogger()
+	const explicit = "/explicit/.tflint.hcl"
 
-	got, err := tflint.ConfigFilePath(l, fs, &tflint.TFLintOptions{
-		WorkingDir:        "/work/unit",
-		RootWorkingDir:    "/work",
-		MaxFoldersToCheck: 5,
-	}, []string{"tflint", "--config", "/explicit/.tflint.hcl"})
+	testCases := []struct {
+		name      string
+		arguments []string
+	}{
+		{
+			name:      "long flag, space separated",
+			arguments: []string{"tflint", "--config", explicit},
+		},
+		{
+			name:      "long flag, equals separated",
+			arguments: []string{"tflint", "--config=" + explicit},
+		},
+		{
+			name:      "short flag, space separated",
+			arguments: []string{"tflint", "-c", explicit},
+		},
+		{
+			name:      "short flag, equals separated",
+			arguments: []string{"tflint", "-c=" + explicit},
+		},
+		{
+			name:      "flag follows unrelated arguments",
+			arguments: []string{"tflint", "--minimum-failure-severity=error", "--config=" + explicit},
+		},
+		{
+			name:      "earliest of several config flags is used",
+			arguments: []string{"tflint", "--config=" + explicit, "--config=/other/.tflint.hcl"},
+		},
+	}
 
-	require.NoError(t, err)
-	assert.Equal(t, "/explicit/.tflint.hcl", got)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// An empty FS makes the parent walk impossible, so a successful
+			// return can only have come from the arguments.
+			fs := vfs.NewMemMapFS()
+			l := logger.CreateLogger()
+
+			got, err := tflint.ConfigFilePath(l, fs, &tflint.TFLintOptions{
+				WorkingDir:        "/work/unit",
+				RootWorkingDir:    "/work",
+				MaxFoldersToCheck: 5,
+			}, tc.arguments)
+
+			require.NoError(t, err)
+			assert.Equal(t, explicit, got)
+		})
+	}
 }
 
-func TestConfigFilePath_FallsBackToProjectWalk(t *testing.T) {
+func TestConfigFilePath_IgnoresNonConfigArguments(t *testing.T) {
 	t.Parallel()
 
-	fs := vfs.NewMemMapFS()
-	require.NoError(t, vfs.WriteFile(fs, "/work/.tflint.hcl", []byte("config {}"), 0o644))
+	testCases := []struct {
+		name      string
+		arguments []string
+	}{
+		{
+			name:      "no config flag at all",
+			arguments: []string{"tflint"},
+		},
+		{
+			name:      "flag names sharing the config prefix",
+			arguments: []string{"tflint", "--config-file=/other/.tflint.hcl", "--chdir=/other"},
+		},
+		{
+			name:      "long flag with no value to consume",
+			arguments: []string{"tflint", "--config"},
+		},
+		{
+			name:      "short flag with no value to consume",
+			arguments: []string{"tflint", "-c"},
+		},
+	}
 
-	l := logger.CreateLogger()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	got, err := tflint.ConfigFilePath(l, fs, &tflint.TFLintOptions{
-		WorkingDir:        "/work/unit",
-		RootWorkingDir:    "/work",
-		MaxFoldersToCheck: 5,
-	}, []string{"tflint"})
+			fs := vfs.NewMemMapFS()
+			require.NoError(t, vfs.WriteFile(fs, "/work/.tflint.hcl", []byte("config {}"), 0o644))
 
-	require.NoError(t, err)
-	assert.Equal(t, "/work/.tflint.hcl", got)
+			l := logger.CreateLogger()
+
+			got, err := tflint.ConfigFilePath(l, fs, &tflint.TFLintOptions{
+				WorkingDir:        "/work/unit",
+				RootWorkingDir:    "/work",
+				MaxFoldersToCheck: 5,
+			}, tc.arguments)
+
+			require.NoError(t, err)
+			assert.Equal(t, "/work/.tflint.hcl", got)
+		})
+	}
 }
 
 func TestFindConfigInProject(t *testing.T) {
@@ -320,12 +424,13 @@ func TestRunTflintWithOpts_HappyPath(t *testing.T) {
 		Commands: []string{"plan"},
 		Execute:  []string{"tflint"},
 	}, &runcfg.RunConfig{
-		Inputs: map[string]any{"region": "us-east-1"},
+		Inputs: map[string]any{"region": "us-east-1", "instance_count": 3},
 		Terraform: runcfg.TerraformConfig{
 			ExtraArgs: []runcfg.TerraformExtraArguments{
 				{
 					Commands:  []string{"plan"},
 					Arguments: []string{"-var=foo=bar"},
+					EnvVars:   map[string]string{"TF_VAR_zone": "a", "TF_VAR_ami": "b"},
 				},
 			},
 		},
@@ -345,12 +450,45 @@ func TestRunTflintWithOpts_HappyPath(t *testing.T) {
 		calls[0].Args,
 	)
 
-	// lint call: the fixed prefix is deterministic; --var/--var-file order is
-	// map-iteration dependent so check membership separately.
-	require.GreaterOrEqual(t, len(calls[1].Args), 5)
-	assert.Equal(t, []string{"--config", "./.tflint.hcl", "--chdir", "./unit"}, calls[1].Args[:4])
-	assert.Contains(t, calls[1].Args, "--var=region=us-east-1")
-	assert.Contains(t, calls[1].Args, "--var='foo=bar'")
+	assert.Equal(t, []string{
+		"--config", "./.tflint.hcl",
+		"--chdir", "./unit",
+		"--var=instance_count=3",
+		"--var=region=us-east-1",
+		"--var='ami=b'",
+		"--var='zone=a'",
+		"--var='foo=bar'",
+	}, calls[1].Args)
+}
+
+func TestRunTflintWithOpts_HonorsConfigFlagInHook(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	// Deliberately not seeded anywhere the parent walk would reach, so the
+	// run can only succeed by reading the path out of the hook arguments.
+	require.NoError(t, vfs.WriteFile(fs, "/elsewhere/custom.tflint.hcl", []byte("config {}"), 0o644))
+
+	var calls []vexec.Invocation
+
+	exec := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		calls = append(calls, cloneInvocation(&inv))
+
+		return vexec.Result{}
+	})
+
+	require.NoError(t, runWithOpts(t, fs, exec, &runcfg.Hook{
+		Name:     "tflint",
+		Commands: []string{"plan"},
+		Execute:  []string{"tflint", "--config=/elsewhere/custom.tflint.hcl"},
+	}, &runcfg.RunConfig{}))
+
+	require.Len(t, calls, 2)
+	assert.Equal(t, []string{
+		"--init",
+		"--config", "../../elsewhere/custom.tflint.hcl",
+		"--chdir", "./unit",
+	}, calls[0].Args)
 }
 
 func TestRunTflintWithOpts_StripsExternalTflintFlag(t *testing.T) {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

The `--config=` form of flags weren't properly recognized by the special integration Terragrunt has with `tflint`.

This fixes that.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The built-in TFLint hook now recognizes all supported `--config` and `-c` argument formats.
  * Generated Terraform variable arguments now appear in a consistent, deterministic order.
  * Explicit TFLint configuration paths are honored more reliably.

* **Documentation**
  * Added release notes covering these TFLint improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->