### PR TITLE
fix: Fixing handling of `EOF` in `generate` blocks

### DIFF
--- a/docs/src/data/changelog/v1.1.3/codegen-unterminated-first-line.mdx
+++ b/docs/src/data/changelog/v1.1.3/codegen-unterminated-first-line.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.3"
+category: "bug-fixes"
+---
+
+#### Fix `overwrite_terragrunt` and `remove_terragrunt` on files with no trailing newline
+
+`generate` blocks using `if_exists = "overwrite_terragrunt"` or `if_disabled = "remove_terragrunt"` failed with a bare `EOF` error whenever the file already at the target path had no newline after its first line, an empty file included. Terragrunt now reads that first line up to the end of the file, so a file carrying the Terragrunt signature is overwritten or removed as configured, and a file without it produces the usual error naming the path Terragrunt would not touch.

--- a/internal/codegen/generate.go
+++ b/internal/codegen/generate.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -297,7 +298,7 @@ func fileWasGeneratedByTerragrunt(path string) (bool, error) {
 	reader := bufio.NewReader(file)
 
 	firstLine, err := reader.ReadString('\n')
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return false, err
 	}
 

--- a/internal/codegen/generate_test.go
+++ b/internal/codegen/generate_test.go
@@ -726,6 +726,135 @@ func TestWriteToFileDisabledRemovesReadOnlyFile(t *testing.T) {
 	assert.True(t, util.FileNotExists(targetPath))
 }
 
+// TestWriteToFileSignatureWithoutTrailingNewline verifies that a generated
+// file consisting of nothing but the signature line, with no trailing newline,
+// is still recognized as terragrunt-generated.
+func TestWriteToFileSignatureWithoutTrailingNewline(t *testing.T) {
+	t.Parallel()
+
+	testDir := helpers.TmpDirWOSymlinks(t)
+
+	signatureOnly := codegen.DefaultCommentPrefix + codegen.TerragruntGeneratedSignature
+
+	testCases := []struct {
+		name    string
+		disable bool
+	}{
+		{
+			name:    "overwrite-terragrunt-regenerates",
+			disable: false,
+		},
+		{
+			name:    "remove-terragrunt-removes",
+			disable: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(testDir, tc.name+".tf")
+			require.NoError(t, os.WriteFile(path, []byte(signatureOnly), 0644))
+
+			config := codegen.GenerateConfig{
+				Path:          path,
+				IfExists:      codegen.ExistsOverwriteTerragrunt,
+				IfDisabled:    codegen.DisabledRemoveTerragrunt,
+				CommentPrefix: codegen.DefaultCommentPrefix,
+				Contents:      "terraform {}\n",
+				Disable:       tc.disable,
+			}
+
+			l := logger.CreateLogger()
+			require.NoError(t, codegen.WriteToFile(l, "", &config))
+
+			if tc.disable {
+				assert.True(t, util.FileNotExists(path))
+
+				return
+			}
+
+			fileContent, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Contains(t, string(fileContent), "terraform {}")
+		})
+	}
+}
+
+// TestWriteToFileUnsignedFileWithoutTrailingNewline verifies that files
+// without the signature are still refused by the terragrunt-only modes, even
+// when they lack a trailing newline for the first line read to terminate on.
+func TestWriteToFileUnsignedFileWithoutTrailingNewline(t *testing.T) {
+	t.Parallel()
+
+	testDir := helpers.TmpDirWOSymlinks(t)
+
+	testCases := []struct {
+		name     string
+		contents string
+		disable  bool
+	}{
+		{
+			name:     "overwrite-terragrunt-rejects-empty-file",
+			contents: "",
+			disable:  false,
+		},
+		{
+			name:     "overwrite-terragrunt-rejects-foreign-file",
+			contents: "terraform {}",
+			disable:  false,
+		},
+		{
+			name:     "remove-terragrunt-rejects-empty-file",
+			contents: "",
+			disable:  true,
+		},
+		{
+			name:     "remove-terragrunt-rejects-foreign-file",
+			contents: "terraform {}",
+			disable:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(testDir, tc.name+".tf")
+			require.NoError(t, os.WriteFile(path, []byte(tc.contents), 0644))
+
+			config := codegen.GenerateConfig{
+				Path:          path,
+				IfExists:      codegen.ExistsOverwriteTerragrunt,
+				IfDisabled:    codegen.DisabledRemoveTerragrunt,
+				CommentPrefix: codegen.DefaultCommentPrefix,
+				Contents:      "terraform {\n  required_version = \">= 1.0.0\"\n}\n",
+				Disable:       tc.disable,
+			}
+
+			l := logger.CreateLogger()
+			writeErr := codegen.WriteToFile(l, "", &config)
+
+			if tc.disable {
+				var removeErr codegen.GenerateFileRemoveError
+
+				require.ErrorAs(t, writeErr, &removeErr)
+			}
+
+			if !tc.disable {
+				var existsErr codegen.GenerateFileExistsError
+
+				require.ErrorAs(t, writeErr, &existsErr)
+			}
+
+			fileContent, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, tc.contents, string(fileContent), "existing file must stay intact")
+		})
+	}
+}
+
 // writeFileWithPerms writes contents first and tightens permissions afterwards
 // so read-only fixtures still receive their contents.
 func writeFileWithPerms(t *testing.T, path, contents string, perms os.FileMode) {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

A bug broke proper handling of empty generated files with the `if_exists = "overwrite_terragrunt"` or `if_disabled = "remove_terragrunt"` attributes for the `generate` block. This properly handles the `EOF` sentinel error.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected overwrite and removal behavior for files without trailing newlines, including empty files.
  * Generated files are now recognized reliably even when their final line lacks a newline.
  * Non-matching or unsigned files remain protected and continue to report the appropriate error.

* **Documentation**
  * Added a changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->