### PR TITLE
fix: Fixing fast-copy ancestor directory permissions

### DIFF
--- a/docs/src/data/changelog/v1.1.3/fast-copy-hidden-dir-permissions.mdx
+++ b/docs/src/data/changelog/v1.1.3/fast-copy-hidden-dir-permissions.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.3"
+category: "bug-fixes"
+---
+
+#### Keep source permissions on hidden directories copied for `include_in_copy`
+
+With the `fast-copy` strict control enabled, a hidden directory that Terragrunt copied only because `include_in_copy` matched something inside it took the permissions of whatever landed in it first, instead of the permissions it has in the source. Those directories now keep their source permissions, matching the copy Terragrunt performs with the control disabled.

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -632,6 +633,11 @@ func copyFolderContentsFast(
 	// concurrent writes, so AddFile is guarded.
 	var manifestMu sync.Mutex
 
+	var (
+		ancestorMu    sync.Mutex
+		ancestorModes = map[string]fs.FileMode{}
+	)
+
 	walkFn := func(absolutePath string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -689,6 +695,15 @@ func copyFolderContentsFast(
 			// still be descended into even when TerragruntExcludes
 			// would reject it.
 			if isDir && include.isAncestor(rel) {
+				info, err := os.Stat(absolutePath)
+				if err != nil {
+					return err
+				}
+
+				ancestorMu.Lock()
+				ancestorModes[rel] = info.Mode().Perm()
+				ancestorMu.Unlock()
+
 				return nil
 			}
 
@@ -743,6 +758,31 @@ func copyFolderContentsFast(
 		vfs.WithFollowSymlinks(),
 	); err != nil {
 		return err
+	}
+
+	return applyDirModes(destination, ancestorModes)
+}
+
+// applyDirModes sets the mode of each source-relative directory in modes,
+// skipping those that never made it into destination. Deeper directories
+// are handled first, so a mode that drops traversal on a parent cannot
+// lock out the children still waiting for theirs.
+func applyDirModes(destination string, modes map[string]fs.FileMode) error {
+	rels := slices.SortedFunc(maps.Keys(modes), func(a, b string) int {
+		return strings.Count(b, "/") - strings.Count(a, "/")
+	})
+
+	for _, rel := range rels {
+		err := os.Chmod(filepath.Join(destination, rel), modes[rel])
+
+		// Nothing under the directory was copied, so it does not exist.
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -986,6 +986,74 @@ func TestExcludeIncludeBehaviourPriority(t *testing.T) {
 	}
 }
 
+func TestFastCopyPreservesModeOfDirsHoldingIncludes(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("Skipping test on Windows since it does not carry POSIX permission bits")
+	}
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	source := filepath.Join(tempDir, "source")
+	destination := filepath.Join(tempDir, "destination")
+
+	// Dot-prefixed dirs are excluded by default, so the walk only descends
+	// into them to reach the includes below. Modes are set after the tree
+	// is written so the assertions hold under any umask.
+	dirModes := map[string]os.FileMode{
+		".hidden":            0o751,
+		".hidden/.nested":    0o705,
+		".hidden/.nested/in": 0o755,
+		".hidden/.no-match":  0o711,
+		".deep":              0o703,
+		".deep/keep":         0o750,
+	}
+
+	for dir := range dirModes {
+		require.NoError(t, os.MkdirAll(filepath.Join(source, dir), 0o755))
+	}
+
+	for _, file := range []string{
+		".hidden/.nested/in/file.txt",
+		".hidden/.no-match/other.txt",
+		".deep/keep/file.txt",
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(source, file), []byte("source file"), 0o644))
+	}
+
+	for dir, mode := range dirModes {
+		require.NoError(t, os.Chmod(filepath.Join(source, dir), mode))
+	}
+
+	require.NoError(t, util.CopyFolderContents(
+		logger.CreateLogger(),
+		source,
+		destination,
+		testManifestName,
+		// The second pattern makes every dir a candidate ancestor, so the
+		// walk descends into dirs it ends up copying nothing from.
+		util.WithIncludeInCopy(".hidden/.nested/in", "**/keep"),
+		util.WithFastCopy(),
+	))
+
+	for _, dir := range []string{
+		".hidden",
+		".hidden/.nested",
+		".hidden/.nested/in",
+		".deep",
+		".deep/keep",
+	} {
+		info, err := os.Lstat(filepath.Join(destination, dir))
+		require.NoError(t, err)
+		assert.Equal(t, dirModes[dir], info.Mode().Perm(), "Unexpected mode for %s", dir)
+	}
+
+	// A dot-prefixed dir with no include match below it stays out of the
+	// destination entirely.
+	_, err := os.Lstat(filepath.Join(destination, ".hidden/.no-match"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestEmptyDir(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes bug where directories could be copied with the wrong file permissions when using the `fast-copy` strict control.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fast folder copies now preserve source permissions for included hidden directories and their ancestor directories when strict controls are enabled.
  - Unmatched hidden directories remain excluded as expected.

- **Documentation**
  - Added a changelog entry describing the permission-preservation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->