### PR TITLE
fix: Fixing bug with `negation | positive` expression in the same query.

### DIFF
--- a/docs/src/content/docs/03-features/08-filter/07-combining.mdx
+++ b/docs/src/content/docs/03-features/08-filter/07-combining.mdx
@@ -11,7 +11,7 @@ import FileTree from '@components/vendored/starlight/FileTree.astro';
 
 ## Negated Expressions
 
-Negate filter expressions using the `!` prefix. Negated expressions are always evaluated after all positive expressions have been evaluated.
+Negate filter expressions using the `!` prefix. A query that does nothing but negate is always evaluated after every other filter has been evaluated.
 
 ```bash
 # Exclude by name
@@ -153,7 +153,7 @@ terragrunt find --filter stack2 --filter '!./envs/prod/**' --filter '!./envs/sta
 
 ### Unions of negated filters
 
-When a filter query starts with a negation (`!`), the result is applied after _all_ positive filters have been applied.
+When every expression in a filter query is negated, the query is applied after _all_ other filters, removing from their combined results.
 
 This means that if you have a filter query like this:
 
@@ -164,6 +164,13 @@ terragrunt find --filter '!type=unit' --filter 'name=unit1'
 The result will be the components that are not units _and_ are named `unit1`.
 
 This means that you should be able to expect negative filters to take effect regardless of how other positive filters may result in the addition of results.
+
+A query that mixes a negation with a positive expression, like `'!./prod/** | type=stack'`, is not one of these. The `|` operator refines from left to right, so the query selects the stacks outside `./prod/**`, and it unions with the other filters the same way any other query does.
+
+```bash
+# Stacks outside ./prod/**, plus everything named 'unit1'
+terragrunt find --filter '!./prod/** | type=stack' --filter 'name=unit1'
+```
 
 <Aside type="tip" title="Using Negated Expressions">
 If you have infrastructure that you _never_ want to run, you can consider leveraging the [`--filters-file`](/features/filter/filters-file) to automatically negate them.

--- a/docs/src/data/changelog/v1.1.3/filter-compound-negation.mdx
+++ b/docs/src/data/changelog/v1.1.3/filter-compound-negation.mdx
@@ -1,0 +1,20 @@
+---
+version: "v1.1.3"
+category: "bug-fixes"
+---
+
+#### Apply the positive half of a filter that begins with a negation
+
+A `--filter` query like `'!name=foo | name=bar'` now returns only the components named `bar` that are not named `foo`. Previously the whole query was treated as an exclusion of `foo`, so the `name=bar` restriction was dropped and components matching neither term came back in the results.
+
+```bash
+# Three units: foo, bar and baz
+$ terragrunt list --filter '!name=foo | name=bar'
+bar
+```
+
+This follows the left-to-right refinement that `|` has everywhere else: each expression narrows what the one before it selected. A query is only treated as an exclusion when every one of its expressions is negated, such as `'!name=foo'` or `'!name=foo | !name=bar'`.
+
+If you were relying on a query like `'!./prod/** | type=stack'` to mean "everything except the stacks under `./prod/**`", there is no grouping syntax to negate a chain as a whole, so write the exclusion you want on its own, such as `'!./prod/**'` to drop that path entirely.
+
+See [Combining Expressions](/features/filter/combining) for how negation, intersection and union interact.

--- a/internal/filter/ast.go
+++ b/internal/filter/ast.go
@@ -23,8 +23,6 @@ type Expression interface {
 	RequiresParse() (Expression, bool)
 	// IsRestrictedToStacks returns true if the expression is restricted to stacks.
 	IsRestrictedToStacks() bool
-	// Negated returns the equivalent expression with negation flipped.
-	Negated() Expression
 }
 
 // Expressions is a slice of expressions.
@@ -59,8 +57,6 @@ func (p *PathExpression) String() string                        { return p.Value
 func (p *PathExpression) RequiresDiscovery() (Expression, bool) { return p, false }
 func (p *PathExpression) RequiresParse() (Expression, bool)     { return p, false }
 func (p *PathExpression) IsRestrictedToStacks() bool            { return false }
-
-func (p *PathExpression) Negated() Expression { return NewPrefixExpression("!", p) }
 
 // AttributeExpression represents a key-value attribute filter (e.g., "name=my-app").
 type AttributeExpression struct {
@@ -130,9 +126,6 @@ func (a *AttributeExpression) RequiresParse() (Expression, bool) {
 func (a *AttributeExpression) IsRestrictedToStacks() bool {
 	return a.Key == "type" && a.Value == "stack"
 }
-func (a *AttributeExpression) Negated() Expression {
-	return NewPrefixExpression("!", a)
-}
 
 // PrefixExpression represents a prefix operator expression (e.g., "!name=foo").
 type PrefixExpression struct {
@@ -169,14 +162,6 @@ func (p *PrefixExpression) IsRestrictedToStacks() bool {
 		}
 	default:
 		return false
-	}
-}
-func (p *PrefixExpression) Negated() Expression {
-	switch p.Operator {
-	case "!":
-		return p.Right
-	default:
-		return NewPrefixExpression("!", p.Right)
 	}
 }
 
@@ -224,14 +209,6 @@ func (i *InfixExpression) IsRestrictedToStacks() bool {
 		return i.Left.IsRestrictedToStacks() || i.Right.IsRestrictedToStacks()
 	default:
 		return false
-	}
-}
-func (i *InfixExpression) Negated() Expression {
-	switch i.Operator {
-	case "|":
-		return NewInfixExpression(i.Left.Negated(), i.Operator, i.Right)
-	default:
-		return NewInfixExpression(i.Left.Negated(), i.Operator, i.Right)
 	}
 }
 
@@ -324,9 +301,6 @@ func (g *GraphExpression) RequiresParse() (Expression, bool) {
 	return g, true
 }
 func (g *GraphExpression) IsRestrictedToStacks() bool { return false }
-func (g *GraphExpression) Negated() Expression {
-	return NewPrefixExpression("!", g)
-}
 
 // GitExpression represents a Git-based filter expression (e.g., "[main...HEAD]" or "[main]").
 // It filters components based on changes between Git references.
@@ -352,9 +326,6 @@ func (g *GitExpression) RequiresParse() (Expression, bool) {
 	return nil, false
 }
 func (g *GitExpression) IsRestrictedToStacks() bool { return false }
-func (g *GitExpression) Negated() Expression {
-	return NewPrefixExpression("!", g)
-}
 
 // GitExpressions is a slice of Git expressions.
 type GitExpressions []*GitExpression

--- a/internal/filter/candidacy.go
+++ b/internal/filter/candidacy.go
@@ -30,13 +30,17 @@ func (d GraphDirection) String() string {
 	}
 }
 
-// IsNegated returns true if the expression starts with a negation operator.
-func IsNegated(expr Expression) bool {
+// IsPureNegation returns true if every operand of the expression is negated, meaning the
+// filter can only subtract components and never selects any of its own.
+//
+// A compound expression such as "!foo | bar" is not a pure negation. The "|" operator
+// intersects left to right, so the expression still selects the components matching "bar".
+func IsPureNegation(expr Expression) bool {
 	switch node := expr.(type) {
 	case *PrefixExpression:
 		return node.Operator == "!"
 	case *InfixExpression:
-		return IsNegated(node.Left)
+		return IsPureNegation(node.Left) && IsPureNegation(node.Right)
 	default:
 		return false
 	}

--- a/internal/filter/candidacy_test.go
+++ b/internal/filter/candidacy_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsNegated(t *testing.T) {
+func TestIsPureNegation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -54,7 +54,7 @@ func TestIsNegated(t *testing.T) {
 					mustPath(t, "./bar"),
 				)
 			},
-			expected: true,
+			expected: false,
 		},
 		{
 			name: "infix with non-negated left",
@@ -69,13 +69,26 @@ func TestIsNegated(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "infix with both operands negated",
+			exprFn: func(t *testing.T) filter.Expression {
+				t.Helper()
+
+				return filter.NewInfixExpression(
+					filter.NewPrefixExpression("!", mustPath(t, "./foo")),
+					"|",
+					filter.NewPrefixExpression("!", mustPath(t, "./bar")),
+				)
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := filter.IsNegated(tt.exprFn(t))
+			result := filter.IsPureNegation(tt.exprFn(t))
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/filter/classifier.go
+++ b/internal/filter/classifier.go
@@ -128,7 +128,7 @@ func NewClassifier(filters Filters) *Classifier {
 			continue
 		}
 
-		if !IsNegated(expr) {
+		if !IsPureNegation(expr) {
 			c.hasPositiveFilters = true
 		}
 

--- a/internal/filter/classifier_test.go
+++ b/internal/filter/classifier_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -452,9 +453,18 @@ func TestClassifier_Classify(t *testing.T) {
 			expectedIdx:    -1,
 		},
 		{
-			name:           "compound_negation_filter_does_not_force_exclude_by_default",
+			name:           "compound_negation_filter_excludes_what_its_positive_operand_misses",
 			filterStrs:     []string{"!./_stacks | type=stack"},
 			componentPath:  "./unit1",
+			expectedStatus: filter.StatusExcluded,
+			expectedReason: filter.CandidacyReasonNone,
+			expectedIdx:    -1,
+		},
+		{
+			name:           "compound_negation_filter_keeps_what_its_positive_operand_matches",
+			filterStrs:     []string{"!./_stacks | type=stack"},
+			componentPath:  "./stack1",
+			componentKind:  component.StackKind,
 			expectedStatus: filter.StatusReadyForFilter,
 			expectedReason: filter.CandidacyReasonNone,
 			expectedIdx:    -1,
@@ -588,4 +598,61 @@ func newTestComponentWithRef(path, ref string) component.Component {
 		WorkingDir: ".",
 		Ref:        ref,
 	})
+}
+
+// TestClassifier_AgreesWithEvaluateOnSingleFilters holds the classifier's early exclusion to the
+// evaluator it exists to short-circuit: for any single filter query, nothing that survives
+// evaluation may be dropped before evaluation ever runs. Compound queries mixing a negation with
+// a positive operand are the shapes that used to disagree, because the negation was treated as if
+// it stood alone.
+func TestClassifier_AgreesWithEvaluateOnSingleFilters(t *testing.T) {
+	t.Parallel()
+
+	operands := []string{
+		"./apps/*", "name=app1", "type=unit", "type=stack",
+		"!./apps/*", "!name=app1", "!type=unit", "!type=stack",
+	}
+
+	queries := make([]string, 0, len(operands)*(len(operands)+1))
+
+	for _, left := range operands {
+		queries = append(queries, left)
+
+		for _, right := range operands {
+			queries = append(queries, left+" | "+right)
+		}
+	}
+
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			l := logger.CreateLogger()
+
+			filters, err := filter.ParseFilterQueries(l, []string{query})
+			require.NoError(t, err)
+
+			components := component.Components{
+				newTestComponent("./apps/app1"),
+				newTestComponent("./apps/app2"),
+				newTestComponent("./libs/db"),
+				newTestStack("./apps/stack1"),
+				newTestStack("./stacks/stack2"),
+			}
+
+			kept, err := filters.Evaluate(l, components)
+			require.NoError(t, err)
+
+			classifier := filter.NewClassifier(filters)
+
+			for _, c := range kept {
+				status, _, _ := classifier.Classify(c, filter.ClassificationContext{
+					ParseDataAvailable: true,
+				})
+
+				assert.NotEqual(t, filter.StatusExcluded, status,
+					"%s survives evaluation, so the classifier must not exclude it first", c.Path())
+			}
+		})
+	}
 }

--- a/internal/filter/doc.go
+++ b/internal/filter/doc.go
@@ -194,16 +194,20 @@
 //	// Returns: all components in ./apps/* OR components named "db"
 //
 // Multiple filters are evaluated in two phases:
-//  1. Positive filters (non-negated) are evaluated and their results are unioned
-//  2. Negative filters (starting with !) are applied to remove matching components
+//  1. Selecting filters are evaluated and their results are unioned
+//  2. Filters that only exclude are applied to remove matching components
 //
-// The ExcludeByDefault() method signals whether filters operate in exclude-by-default
-// mode. This is true if ANY filter doesn't start with a negation expression:
+// A filter only excludes when every one of its operands is negated, such as !foo or
+// !foo | !bar. A filter like !foo | bar selects, because | intersects left to right and
+// the expression still has to match bar.
 //
-//	filters.ExcludeByDefault() // true if any filter is positive
+// The HasPositiveFilter() method signals whether filters operate in exclude-by-default
+// mode. This is true if ANY filter selects components:
+//
+//	filters.HasPositiveFilter() // true if any filter selects
 //
 // When true, discovery should start with an empty set and add matches.
-// When false (all filters are negated), discovery should start with all components
+// When false (every filter only excludes), discovery should start with all components
 // and remove matches.
 //
 // ## One-Shot Usage

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -76,27 +76,6 @@ func (f *Filter) HasGraphBoundary() bool {
 	return found
 }
 
-// Negated returns the equivalent filter with negation flipped.
-//
-// If the filter is already negated, it will return the non-negated filter.
-func (f *Filter) Negated() *Filter {
-	switch node := f.expr.(type) {
-	case *PrefixExpression:
-		return NewFilter(node.Right, f.originalQuery)
-	case *InfixExpression:
-		return NewFilter(
-			NewInfixExpression(
-				node.Left.Negated(),
-				node.Operator,
-				node.Right,
-			),
-			f.originalQuery,
-		)
-	default:
-		return f
-	}
-}
-
 // Apply is a convenience function that parses and evaluates a filter in one step.
 // It's equivalent to calling Parse followed by Evaluate.
 func Apply(

--- a/internal/filter/filters.go
+++ b/internal/filter/filters.go
@@ -3,7 +3,6 @@ package filter
 import (
 	"encoding/json"
 	"fmt"
-	"slices"
 	"strings"
 
 	"errors"
@@ -69,10 +68,11 @@ func ParseFilterQueries(l log.Logger, filterStrings []string) (Filters, error) {
 	return result, nil
 }
 
-// HasPositiveFilter returns true if the filters have any positive filters.
+// HasPositiveFilter returns true if any filter selects components, rather than only
+// subtracting them.
 func (f Filters) HasPositiveFilter() bool {
 	for _, filter := range f {
-		if !IsNegated(filter.expr) {
+		if !IsPureNegation(filter.expr) {
 			return true
 		}
 	}
@@ -205,9 +205,14 @@ func (f Filters) RestrictToStacks() Filters {
 }
 
 // Evaluate applies all filters with union (OR) semantics in two phases:
-//  1. Positive filters (non-negated) are evaluated and their results are unioned
-//  2. Negative filters (starting with negation) are evaluated against the combined
-//     results and remove matching components
+//  1. Selecting filters are evaluated and their results are unioned
+//  2. Pure negations are evaluated against that union, keeping only what they don't reject
+//
+// A filter only subtracts when every one of its operands is negated, because such a filter
+// would otherwise swallow the union it is meant to narrow. A compound filter like "!foo | bar"
+// selects instead: "|" intersects left to right, so the expression still has to match "bar",
+// and subtracting it would drop that restriction and let components matching neither operand
+// through.
 //
 // If logger is provided, it will be used for logging warnings during evaluation.
 func (f Filters) Evaluate(
@@ -224,7 +229,7 @@ func (f Filters) Evaluate(
 	)
 
 	for _, filter := range f {
-		if IsNegated(filter.expr) {
+		if IsPureNegation(filter.expr) {
 			negativeFilters = append(negativeFilters, filter)
 
 			continue
@@ -243,33 +248,41 @@ func (f Filters) Evaluate(
 		return combined, nil
 	}
 
-	// Phase 2: Apply negative filters to find components to remove
-	toRemove := make(component.Components, 0, len(combined))
+	// Phase 2: Collect what the negations reject. Evaluating a negation returns what it keeps,
+	// so its rejects are the rest of the set, which spares us a complement of the filter that
+	// the language couldn't express for a chain like "!foo | !bar" anyway. Each negation is
+	// measured against the same initial set rather than against the previous one's leftovers,
+	// so that removing a component cannot rob a later negation of a graph traversal target.
+	rejected := make(map[string]struct{}, len(combined))
 
 	for _, filter := range negativeFilters {
-		removed, err := filter.Negated().Evaluate(l, combined)
+		kept, err := filter.Evaluate(l, combined)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, c := range removed {
-			if !slices.Contains(toRemove, c) {
-				toRemove = append(toRemove, c)
+		keptPaths := make(map[string]struct{}, len(kept))
+		for _, c := range kept {
+			keptPaths[c.Path()] = struct{}{}
+		}
+
+		for _, c := range combined {
+			if _, ok := keptPaths[c.Path()]; !ok {
+				rejected[c.Path()] = struct{}{}
 			}
 		}
 	}
 
-	if len(toRemove) == 0 {
+	if len(rejected) == 0 {
 		return combined, nil
 	}
 
-	// Phase 3: Remove components from the initial set
+	// We don't use slices.DeleteFunc here because we don't want the members of the original
+	// components slice to be zeroed.
+	results := make(component.Components, 0, len(combined)-len(rejected))
 
-	// We don't use slices.DeleteFunc here because we don't want the members of the original components slice to be
-	// zeroed.
-	results := make(component.Components, 0, len(combined)-len(toRemove))
 	for _, c := range combined {
-		if slices.Contains(toRemove, c) {
+		if _, ok := rejected[c.Path()]; ok {
 			continue
 		}
 

--- a/internal/filter/filters_test.go
+++ b/internal/filter/filters_test.go
@@ -1,6 +1,7 @@
 package filter_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
@@ -321,6 +322,155 @@ func TestFilters_Evaluate(t *testing.T) {
 
 		assert.ElementsMatch(t, expected, result)
 	})
+}
+
+// TestFilters_EvaluateCompoundNegation pins compound filters to the left-to-right intersection
+// documented for "|", so that a leading negation narrows the filter instead of turning the whole
+// query into a bare exclusion that lets unrelated components through.
+func TestFilters_EvaluateCompoundNegation(t *testing.T) {
+	t.Parallel()
+
+	newComponents := func() component.Components {
+		components := component.Components{
+			component.NewUnit("./apps/app1"),
+			component.NewUnit("./apps/app2"),
+			component.NewUnit("./apps/legacy"),
+			component.NewUnit("./libs/db"),
+			component.NewUnit("./libs/api"),
+		}
+
+		for _, c := range components {
+			c.SetDiscoveryContext(&component.DiscoveryContext{WorkingDir: "."})
+		}
+
+		return components
+	}
+
+	tests := []struct {
+		name     string
+		filters  []string
+		expected []string
+	}{
+		{
+			name:     "negation on the left still narrows to the right operand",
+			filters:  []string{"!name=app1 | ./apps/*"},
+			expected: []string{"./apps/app2", "./apps/legacy"},
+		},
+		{
+			name:     "operands that share no components select nothing",
+			filters:  []string{"!./apps/* | name=app1"},
+			expected: []string{},
+		},
+		{
+			name:     "negation on the right",
+			filters:  []string{"./apps/* | !name=legacy"},
+			expected: []string{"./apps/app1", "./apps/app2"},
+		},
+		{
+			name:     "negation on both operands",
+			filters:  []string{"!name=app1 | !name=app2"},
+			expected: []string{"./apps/legacy", "./libs/db", "./libs/api"},
+		},
+		{
+			name:     "three operands chained left to right",
+			filters:  []string{"!name=app1 | ./apps/* | !name=legacy"},
+			expected: []string{"./apps/app2"},
+		},
+		{
+			name:     "compound filter unions with another compound filter",
+			filters:  []string{"!name=app1 | ./apps/*", "!name=db | ./libs/*"},
+			expected: []string{"./apps/app2", "./apps/legacy", "./libs/api"},
+		},
+		{
+			name:     "bare negation subtracts from a compound filter's selection",
+			filters:  []string{"!name=app1 | ./apps/*", "!name=legacy"},
+			expected: []string{"./apps/app2"},
+		},
+		{
+			name:     "bare negation alone still starts from every component",
+			filters:  []string{"!name=app1"},
+			expected: []string{"./apps/app2", "./apps/legacy", "./libs/db", "./libs/api"},
+		},
+		{
+			name:     "chained negations subtract from another filter's selection",
+			filters:  []string{"./apps/*", "!name=legacy | !name=app2"},
+			expected: []string{"./apps/app1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := testLogger()
+
+			filters, err := filter.ParseFilterQueries(l, tt.filters)
+			require.NoError(t, err)
+
+			result, err := filters.Evaluate(l, newComponents())
+			require.NoError(t, err)
+
+			assert.ElementsMatch(t, tt.expected, paths(result))
+
+			if len(tt.filters) != 1 {
+				return
+			}
+
+			// A single filter has no union or subtraction to arrange, so Filters.Evaluate owes
+			// the same answer as walking the filter's own AST.
+			direct, err := filters[0].Evaluate(l, newComponents())
+			require.NoError(t, err)
+
+			assert.ElementsMatch(t, paths(direct), paths(result))
+		})
+	}
+}
+
+// TestFilters_EvaluateNegationsAreOrderIndependent pins that two filters that only exclude reach
+// the same result whichever order they arrive in. A negated graph expression can only find the
+// dependents to remove while its target is still in the set, so measuring each negation against
+// the leftovers of the last one would let the order of the flags change the answer.
+func TestFilters_EvaluateNegationsAreOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	orders := [][]string{
+		{"!name=db", "!...name=db"},
+		{"!...name=db", "!name=db"},
+	}
+
+	for _, order := range orders {
+		t.Run(strings.Join(order, " then "), func(t *testing.T) {
+			t.Parallel()
+
+			l := testLogger()
+
+			db := component.NewUnit("./libs/db")
+			app := component.NewUnit("./apps/app")
+			app.AddDependency(db)
+
+			components := component.Components{db, app}
+			for _, c := range components {
+				c.SetDiscoveryContext(&component.DiscoveryContext{WorkingDir: "."})
+			}
+
+			filters, err := filter.ParseFilterQueries(l, order)
+			require.NoError(t, err)
+
+			result, err := filters.Evaluate(l, components)
+			require.NoError(t, err)
+
+			assert.Empty(t, paths(result), "excluding db and its dependents leaves nothing")
+		})
+	}
+}
+
+func paths(components component.Components) []string {
+	result := make([]string, 0, len(components))
+	for _, c := range components {
+		result = append(result, c.Path())
+	}
+
+	return result
 }
 
 func TestFilters_HasPositiveFilter(t *testing.T) {

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -791,8 +791,6 @@ func worktreeStacksToGenerate(
 }
 
 // discoverStacks discovers stacks in a worktree.
-// User-provided filters from opts.Filters are included (restricted to stacks) so that
-// explicit exclusions like --filter '!./land-mine | type=stack' are respected.
 // When readFiles is true, all discovered stacks are parsed to populate their Reading
 // attribute (used by reading-affected detection).
 func discoverStacks(
@@ -803,11 +801,9 @@ func discoverStacks(
 	wt worktrees.Worktree,
 	readFiles bool,
 ) (component.Components, error) {
-	allFilters := slices.Concat(stackTypeFilter(), opts.Filters.RestrictToStacks())
-
 	d := discovery.NewDiscovery(wt.Path).
 		WithSuppressParseErrors().
-		WithFilters(allFilters)
+		WithFilters(StackDiscoveryFilters(opts.Filters))
 
 	if readFiles {
 		d = d.WithReadFiles()
@@ -891,6 +887,52 @@ func stacksReadingFiles(
 	}
 
 	return matched, nil
+}
+
+// StackDiscoveryFilters returns the filters that select which stacks a generation run
+// discovers, so that explicit exclusions like --filter '!./land-mine | type=stack' are
+// respected.
+//
+// Generation stays permissive until the user aims a filter at stacks, because a stack can
+// generate its units anywhere, so narrowing by a filter that never mentions stacks would drop
+// stacks the user still needs. Once a stack-targeted filter is present, every other filter is
+// narrowed to the stacks it matches and joins the union, rather than being dropped, which
+// would lose the stacks only that filter selects. Filters union, so a blanket type=stack
+// alongside them would select every stack and undo the exclusions.
+//
+// Git expressions are left out: they match on a component's Git reference, which discovery
+// only stamps on afterwards, so folding them in here would select nothing.
+func StackDiscoveryFilters(filters filter.Filters) filter.Filters {
+	stackFilters := filters.RestrictToStacks()
+	if len(stackFilters) == 0 {
+		return stackTypeFilter()
+	}
+
+	result := make(filter.Filters, 0, len(filters))
+	result = append(result, stackFilters...)
+
+	for _, f := range filters.ExcludingGitFilters() {
+		expr := f.Expression()
+		if expr.IsRestrictedToStacks() {
+			continue
+		}
+
+		// A filter that only excludes already subtracts from the union, so narrowing it to
+		// stacks would turn it into a selector and hand back what it set out to remove.
+		if filter.IsPureNegation(expr) {
+			result = append(result, f)
+
+			continue
+		}
+
+		attrExpr := filter.NewTypeExpression(component.StackKind)
+		result = append(result, filter.NewFilter(
+			filter.NewInfixExpression(expr, "|", attrExpr),
+			f.String(),
+		))
+	}
+
+	return result
 }
 
 // stackTypeFilter returns a filter.Filters that restricts to stack components.

--- a/internal/stacks/generate/generate_test.go
+++ b/internal/stacks/generate/generate_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -77,4 +79,83 @@ func TestGeneratorDefaultMaxLevel(t *testing.T) {
 		generate.DefaultMaxLevel,
 		"default level cap must stay generous so only genuine cycles reach it",
 	)
+}
+
+// TestStackDiscoveryFilters pins how a generation run composes its stack filters. A user
+// filter that already narrows to stacks must stand on its own, because unioning a blanket
+// type=stack alongside it would re-select the stacks it excludes.
+func TestStackDiscoveryFilters(t *testing.T) {
+	t.Parallel()
+
+	stacks := component.Components{
+		component.NewStack("./live/land-mine"),
+		component.NewStack("./live/normal"),
+	}
+
+	for _, c := range stacks {
+		c.SetDiscoveryContext(&component.DiscoveryContext{WorkingDir: "."})
+	}
+
+	tests := []struct {
+		name     string
+		filters  []string
+		expected []string
+	}{
+		{
+			name:     "no filters selects every stack",
+			filters:  nil,
+			expected: []string{"./live/land-mine", "./live/normal"},
+		},
+		{
+			name:     "stack filters that exclude keep excluding",
+			filters:  []string{"!./live/land-mine | type=stack"},
+			expected: []string{"./live/normal"},
+		},
+		{
+			name:     "filters that do not narrow to stacks fall back to every stack",
+			filters:  []string{"[HEAD~1...HEAD]"},
+			expected: []string{"./live/land-mine", "./live/normal"},
+		},
+		{
+			name:     "a path filter alone still leaves generation permissive",
+			filters:  []string{"./apps/*"},
+			expected: []string{"./live/land-mine", "./live/normal"},
+		},
+		{
+			name:     "another filter's stacks survive alongside a stack filter",
+			filters:  []string{"type=stack | name=normal", "name=land-mine"},
+			expected: []string{"./live/normal", "./live/land-mine"},
+		},
+		{
+			name:     "a git expression never narrows the stacks a stack filter selects",
+			filters:  []string{"[HEAD~1...HEAD]", "!./live/land-mine | type=stack"},
+			expected: []string{"./live/normal"},
+		},
+		{
+			name:     "a filter that only excludes keeps subtracting",
+			filters:  []string{"!./live/land-mine | type=stack", "!name=normal"},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := logger.CreateLogger()
+
+			parsed, err := filter.ParseFilterQueries(l, tt.filters)
+			require.NoError(t, err)
+
+			selected, err := generate.StackDiscoveryFilters(parsed).Evaluate(l, stacks)
+			require.NoError(t, err)
+
+			selectedPaths := make([]string, 0, len(selected))
+			for _, c := range selected {
+				selectedPaths = append(selectedPaths, c.Path())
+			}
+
+			assert.ElementsMatch(t, tt.expected, selectedPaths)
+		})
+	}
 }

--- a/test/integration_filter_test.go
+++ b/test/integration_filter_test.go
@@ -264,9 +264,35 @@ func TestFilterFlagWithList(t *testing.T) {
 			expectError:     false,
 		},
 		{
+			// Quoted so that shellwords keeps the pipe in the filter rather than cutting the
+			// command short at it.
 			name:            "filter with intersection - name and type",
-			filterQuery:     "a-unit | type=unit",
+			filterQuery:     "'a-unit | type=unit'",
 			expectedResults: []string{"a-unit"},
+			expectError:     false,
+		},
+		{
+			name:            "filter with intersection - negated name and type",
+			filterQuery:     "'!a-unit | type=unit'",
+			expectedResults: []string{"b-unit"},
+			expectError:     false,
+		},
+		{
+			name:            "filter with intersection - negated name and name",
+			filterQuery:     "'!a-unit | b-unit'",
+			expectedResults: []string{"b-unit"},
+			expectError:     false,
+		},
+		{
+			name:            "filter with intersection - operands that share nothing",
+			filterQuery:     "'!a-unit | a-unit'",
+			expectedResults: []string{},
+			expectError:     false,
+		},
+		{
+			name:            "filter with intersection - both operands negated",
+			filterQuery:     "'!a-unit | !b-unit'",
+			expectedResults: []string{},
 			expectError:     false,
 		},
 		{
@@ -1247,6 +1273,42 @@ func getJSONRunNames(recordsByUnit map[string]*report.JSONRun) []string {
 	sort.Strings(names)
 
 	return names
+}
+
+// TestFilterCompoundNegationDropsUnrelatedUnits pins that a filter whose negation comes first
+// still restricts on its positive operand. A unit matching neither operand used to survive,
+// because the whole query was treated as an exclusion of the negated operand alone.
+func TestFilterCompoundNegationDropsUnrelatedUnits(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	for _, name := range []string{"foo", "bar", "baz"} {
+		_ = createTestUnit(t, filepath.Join(tmpDir, name), "# "+name)
+	}
+
+	cmd := "terragrunt list --no-color --working-dir " + tmpDir + " --filter '!name=foo | name=bar'"
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"bar"}, strings.Fields(stdout))
+}
+
+// TestFilterExcludeByDefault pins that a filter which only excludes still starts from every
+// component, rather than emptying discovery out.
+func TestFilterExcludeByDefault(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureExcludeByDefault)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureExcludeByDefault)
+
+	helpers.CleanupTerraformFolder(t, rootPath)
+
+	cmd := "terragrunt list --no-color --working-dir " + rootPath + " --filter '!_stacks'"
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"unit1"}, strings.Fields(stdout))
 }
 
 func TestFilterFlagWithMarkAsRead(t *testing.T) {

--- a/test/integration_filter_tf_test.go
+++ b/test/integration_filter_tf_test.go
@@ -1260,7 +1260,11 @@ resource "null_resource" "unit_a" {}
 	require.NotEmpty(t, planFiles)
 }
 
-func TestTFFilterExcludeByDefault(t *testing.T) {
+// TestTFFilterCompoundNegation pins the left-to-right reading of "|" for a filter whose negation
+// comes first. Asking for stacks outside _stacks selects nothing in this fixture, so the run
+// finds no units. The run still has to succeed: the stack under _stacks holds no units and
+// would fail to generate, which is what shows the filter reached stack generation too.
+func TestTFFilterCompoundNegation(t *testing.T) {
 	t.Parallel()
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureExcludeByDefault)
@@ -1272,11 +1276,11 @@ func TestTFFilterExcludeByDefault(t *testing.T) {
 	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
 	require.NoError(t, err)
 
-	assert.NotContains(
+	assert.Contains(
 		t,
 		stderr,
 		"No units discovered",
-		"Filter should discover units, not result in empty discovery",
+		"Filter asking only for stacks should select no units",
 	)
 }
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

A bug in the logic for evaluating the "negativeness" of a filter expression resulted in queries like the following (where the estate had `foo`, `bar` and `baz` in the current working directory):

```
$ terragrunt find --filter '!foo | baz'
bar
baz
```

Results were not properly filtering left to right. This fixes that logic by evaluation whether all expressions in a filter are negated instead of just the leading filter.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compound filter evaluation when negated and positive expressions are combined.
  * Ensured mixed filters refine results left-to-right, while exclusion-only filters remain order-independent.
  * Improved stack discovery to preserve explicit exclusions and correctly handle combined filters.
  * Added regression coverage for compound negation, empty intersections, and quoted filters.

* **Documentation**
  * Clarified negation semantics, filter evaluation order, and exclusion-only queries.
  * Added a v1.1.3 changelog entry for the compound-negation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->