### PR TITLE
chore: Cleaning up profile tests per feedback in #6553

### DIFF
--- a/docs/src/content/docs/05-community/01-contributing.mdx
+++ b/docs/src/content/docs/05-community/01-contributing.mdx
@@ -219,7 +219,13 @@ The largest group of opt-in tests are the ones that drive a real OpenTofu or Ter
 go test -tags=tf -run '^TestTF' ./...
 ```
 
-Without that tag, `go test ./...` only runs the tests that Terragrunt can satisfy on its own, so the suite stays green in an environment with no OpenTofu or Terraform installed. Add the tag whenever you touch behavior that reaches the binary.
+Tests that depend on OpenTofu specifically, rather than on whichever binary `tf-path` points at, are prefixed with `TestTofu*` and tagged with the `tofu` build tag. Run them alongside the `TestTF*` tests, the way CI does:
+
+```bash
+go test -tags=tofu,tf -run '^(TestTF|TestTofu)' ./...
+```
+
+Without those tags, `go test ./...` only runs the tests that Terragrunt can satisfy on its own, so the suite stays green in an environment with no OpenTofu or Terraform installed. Add the tag whenever you touch behavior that reaches the binary.
 
 Terragrunt also includes integration tests for Google Cloud Platform (GCP). These tests are prefixed with `TestGcp*` and are tagged with the `gcp` build tag. To run these tests, you can use the `-tags` flag set in the `GOFLAGS` environment variable, similar to AWS tests:
 

--- a/test/integration_profile_test.go
+++ b/test/integration_profile_test.go
@@ -3,14 +3,10 @@ package test_test
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
-	"slices"
-	"sync"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,27 +63,6 @@ func TestProfileFlagsCreateProfileFiles(t *testing.T) {
 			requireNonEmptyFile(t, profilePath)
 		})
 	}
-}
-
-func TestTGProfileCPUDoesNotPropagateToTofu(t *testing.T) {
-	helpers.CleanupTerraformFolder(t, testFixtureInputs)
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureInputs)
-	rootPath := filepath.Join(tmpEnvPath, testFixtureInputs)
-
-	tmpDir := helpers.TmpDirWOSymlinks(t)
-	profilePath := filepath.Join(tmpDir, "terragrunt_cpu.prof")
-
-	t.Setenv("TG_EXPERIMENT", "profiling")
-	t.Setenv("TG_PROFILE_CPU", profilePath)
-
-	helpers.RunTerragrunt(t, "terragrunt plan --non-interactive --working-dir "+rootPath)
-
-	requireNonEmptyFile(t, profilePath)
-
-	assert.Empty(t, findProfileFiles(t, tmpEnvPath),
-		"TG_PROFILE_CPU alone should not produce OpenTofu profiles anywhere under the working dir")
-	assert.Equal(t, []string{profilePath}, findProfileFiles(t, tmpDir),
-		"the Terragrunt profile should be the only profile produced")
 }
 
 func TestTGProfileDirDoesNotOverrideExplicitTofuCPUProfile(t *testing.T) {
@@ -323,34 +298,4 @@ func requireNonEmptyFile(t *testing.T, path string) {
 	info, err := os.Stat(path)
 	require.NoError(t, err, "profile %s should exist", path)
 	assert.Positive(t, info.Size(), "profile %s should be non-empty", path)
-}
-
-// findProfileFiles returns all *.prof files under root, recursively.
-func findProfileFiles(t *testing.T, root string) []string {
-	t.Helper()
-
-	var (
-		mu       sync.Mutex
-		profiles []string
-	)
-
-	err := vfs.WalkDirParallel(vfs.NewOSFS(), root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if !d.IsDir() && filepath.Ext(path) == ".prof" {
-			mu.Lock()
-			defer mu.Unlock()
-
-			profiles = append(profiles, path)
-		}
-
-		return nil
-	})
-	require.NoError(t, err)
-
-	slices.Sort(profiles)
-
-	return profiles
 }

--- a/test/integration_profile_tf_test.go
+++ b/test/integration_profile_tf_test.go
@@ -1,0 +1,68 @@
+//go:build tf
+
+//nolint:paralleltest // CPU profiling is process-global (pprof.StartCPUProfile), so this test must not run in parallel with the rest of the profiling suite.
+package test_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTFProfileCPUDoesNotPropagateToTofu(t *testing.T) {
+	helpers.CleanupTerraformFolder(t, testFixtureInputs)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureInputs)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureInputs)
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+	profilePath := filepath.Join(tmpDir, "terragrunt_cpu.prof")
+
+	t.Setenv("TG_EXPERIMENT", "profiling")
+	t.Setenv("TG_PROFILE_CPU", profilePath)
+
+	helpers.RunTerragrunt(t, "terragrunt plan --non-interactive --working-dir "+rootPath)
+
+	requireNonEmptyFile(t, profilePath)
+
+	assert.Empty(t, findProfileFiles(t, tmpEnvPath),
+		"TG_PROFILE_CPU alone should not produce OpenTofu profiles anywhere under the working dir")
+	assert.Equal(t, []string{profilePath}, findProfileFiles(t, tmpDir),
+		"the Terragrunt profile should be the only profile produced")
+}
+
+// findProfileFiles returns all *.prof files under root, recursively.
+func findProfileFiles(t *testing.T, root string) []string {
+	t.Helper()
+
+	var (
+		mu       sync.Mutex
+		profiles []string
+	)
+
+	err := vfs.WalkDirParallel(vfs.NewOSFS(), root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() && filepath.Ext(path) == ".prof" {
+			mu.Lock()
+			defer mu.Unlock()
+
+			profiles = append(profiles, path)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	slices.Sort(profiles)
+
+	return profiles
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses feedback in #6553 ensuring that we don't require tofu/terraform installed for profiling tests.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified integration testing guidance for OpenTofu-specific tests, Terraform-selected tests, and required build tags.

- **Tests**
  - Added coverage confirming CPU profiling creates only the expected Terraform profile without propagating to OpenTofu.
  - Removed outdated profiling coverage from the general integration test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->