### PR TITLE
chore: Addressing feedback from #6365 and #6355

### DIFF
--- a/docs/src/data/changelog/v1.1.3/bounded-discovery.mdx
+++ b/docs/src/data/changelog/v1.1.3/bounded-discovery.mdx
@@ -5,7 +5,7 @@ category: "experiments-added"
 
 #### `bounded-discovery` experiment encloses graph traversal within a directory
 
-Filter expressions that traverse the dependency graph reach beyond the working directory: dependents (`--filter '...{unit}'`) by walking up to the git repository root, dependencies (`--filter '{unit}...'`) by following declared paths. Either way, Terragrunt reads and parses every configuration it touches. In monorepos with isolated environments, that traversal can fail or do wasted work reading sibling environments.
+Filter expressions that traverse the dependency graph reach beyond the working directory: dependents (`--filter '...{unit}'`) by walking up to the Git repository root, dependencies (`--filter '{unit}...'`) by following declared paths. Either way, Terragrunt reads and parses every configuration it touches. In monorepos with isolated environments, that traversal can fail or do wasted work reading sibling environments.
 
 Enable the new [`bounded-discovery`](/reference/experiments/active#bounded-discovery) experiment to unlock an inline `(dir)` boundary operand. It occupies the same slot as a traversal depth, so it bounds discovery by location the way a number bounds it by graph hops:
 
@@ -14,4 +14,6 @@ cd environments/staging
 terragrunt run --all plan --experiment bounded-discovery --filter '(.)...{vpc}'
 ```
 
-Any configuration that resolves outside the boundary, whether a dependent or a dependency, is neither read nor parsed nor returned; configurations inside it are discovered as usual. The boundary must be an existing directory, resolved against the working directory.
+Any configuration that resolves outside the boundary, whether a dependent or a dependency, is not read, parsed, or returned; configurations inside it are discovered as usual. The boundary must be an existing directory, resolved against the working directory.
+
+Reserving `(` and `)` for the boundary operand changes how `--filter` reads those characters everywhere, not only when the experiment is enabled. An expression such as `--filter '1...(foo | bar)'` previously matched a unit literally named `(foo` or `bar)`; it is now rejected as a malformed boundary. Wrap a name or path containing parentheses in braces (e.g. `--filter '{./weird(name)}'`) to keep it literal.

--- a/docs/src/data/experiments/bounded-discovery.mdx
+++ b/docs/src/data/experiments/bounded-discovery.mdx
@@ -3,11 +3,11 @@ name: bounded-discovery
 since: "1.1.3"
 ---
 
-Enclose graph traversal for a `--filter` expression within a directory using an inline `(dir)` operand, instead of the git repository root.
+Enclose graph traversal for a `--filter` expression within a directory using an inline `(dir)` operand, instead of the Git repository root.
 
 ### `bounded-discovery` - What it does
 
-Graph-traversing filter expressions reach beyond the working directory. Dependent discovery (`...{unit}`) requires searching from the working directory of the given component up to the Git repository root (if the unit is within a Git repository). Dependency discovery (`{unit}...`) requires recursive parsing of dependencies to find the terminal dependency. Either way, Terragrunt has to read and parses every configuration it touches along the way for accuracy. In monorepos where sibling environments cannot be parsed independently of each other, that traversal fails or wastes work reaching into them.
+Graph-traversing filter expressions reach beyond the working directory. Dependent discovery (`...{unit}`) requires searching from the working directory of the given component up to the Git repository root (if the unit is within a Git repository). Dependency discovery (`{unit}...`) requires recursive parsing of dependencies to find the terminal dependency. Either way, Terragrunt has to read and parse every configuration it touches along the way for accuracy. In monorepos where sibling environments cannot be parsed independently of each other, that traversal fails or wastes work reaching into them.
 
 When enabled, this experiment unlocks an inline `(dir)` boundary operand. It sits in the same operand slot as a traversal depth (e.g. `1...{vpc}`):
 
@@ -27,9 +27,11 @@ terragrunt find --experiment bounded-discovery --filter '(.)...{vpc}'
 (../shared)...{vpc}...(.)
 ```
 
-Any configuration that is discovered outside the boundary, whether a dependent or a dependency, is not read, parsed nor returned. The boundary must be an existing directory. Relative paths are resolved against the working directory, and a dependent-direction boundary must contain the working directory.
+Any configuration that is discovered outside the boundary, whether a dependent or a dependency, is not read, parsed, or returned. The boundary must be an existing directory. Relative paths are resolved against the working directory, and a dependent-direction boundary must contain the working directory.
 
-A boundary bounds discovery traversal rather than filtering results, so an in-boundary unit reachable only by passing through an out-of-boundary unit is intentionally excluded (e.g. `a` --> `b` --> `c`, and yo`b` is not part of the boundary, will prevent graph traversal from `a` to reach `c` and vice-versa).
+A boundary bounds discovery traversal rather than filtering results, so an in-boundary unit reachable only by passing through an out-of-boundary unit is intentionally excluded. Given `a` --> `b` --> `c`, if `b` is outside the boundary, traversal from `a` cannot reach `c`, and vice-versa.
+
+Because the boundary operand claims `(` and `)`, those characters are no longer read as part of a unit name or path. Wrap a name or path that contains them in braces (e.g. `{./weird(name)}`) to keep it literal.
 
 The experiment also unlocks the [`--discovery-boundary`](/reference/cli/commands/find#discovery-boundary) flag (env: `TG_DISCOVERY_BOUNDARY`), which applies one boundary to every `--filter` expression on the command, in both directions:
 

--- a/internal/cli/commands/find/find.go
+++ b/internal/cli/commands/find/find.go
@@ -27,7 +27,7 @@ import (
 
 // Run runs the find command.
 func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *Options) error {
-	d, err := discovery.NewForDiscoveryCommand(l, &discovery.DiscoveryCommandOptions{
+	d, err := discovery.NewForDiscoveryCommand(l, v.FS, &discovery.DiscoveryCommandOptions{
 		WorkingDir:        opts.WorkingDir,
 		QueueConstructAs:  opts.QueueConstructAs,
 		NoHidden:          opts.NoHidden,

--- a/internal/cli/commands/hcl/validate/validate.go
+++ b/internal/cli/commands/hcl/validate/validate.go
@@ -105,7 +105,7 @@ func RunValidate(
 	opts.NonInteractive = true
 
 	// Create discovery with filter support if experiment enabled
-	d, err := discovery.NewForHCLCommand(l, discovery.HCLCommandOptions{
+	d, err := discovery.NewForHCLCommand(l, v.FS, discovery.HCLCommandOptions{
 		WorkingDir:        opts.WorkingDir,
 		DiscoveryBoundary: opts.DiscoveryBoundary,
 		Filters:           opts.Filters,
@@ -301,7 +301,7 @@ func RunValidateInputs(
 	opts.SkipOutput = true
 	opts.NonInteractive = true
 
-	d, err := discovery.NewForHCLCommand(l, discovery.HCLCommandOptions{
+	d, err := discovery.NewForHCLCommand(l, v.FS, discovery.HCLCommandOptions{
 		WorkingDir:        opts.WorkingDir,
 		DiscoveryBoundary: opts.DiscoveryBoundary,
 		Filters:           opts.Filters,

--- a/internal/cli/commands/list/list.go
+++ b/internal/cli/commands/list/list.go
@@ -31,7 +31,7 @@ import (
 
 // Run runs the list command.
 func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *Options) error {
-	d, err := discovery.NewForDiscoveryCommand(l, &discovery.DiscoveryCommandOptions{
+	d, err := discovery.NewForDiscoveryCommand(l, v.FS, &discovery.DiscoveryCommandOptions{
 		WorkingDir:        opts.WorkingDir,
 		QueueConstructAs:  opts.QueueConstructAs,
 		NoHidden:          opts.NoHidden,

--- a/internal/cli/flags/shared/filter_test.go
+++ b/internal/cli/flags/shared/filter_test.go
@@ -1,7 +1,6 @@
 package shared_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags/shared"
@@ -21,7 +20,7 @@ func TestDiscoveryBoundaryFlagRequiresExperiment(t *testing.T) {
 
 	require.NoError(t, flags.Parse(clihelper.Args{"--discovery-boundary", "."}))
 
-	err := flags.RunActions(context.Background(), &clihelper.Context{})
+	err := flags.RunActions(t.Context(), &clihelper.Context{})
 
 	require.ErrorIs(t, err, shared.ErrDiscoveryBoundaryRequiresExperiment)
 }
@@ -34,6 +33,6 @@ func TestDiscoveryBoundaryFlagAllowedWithExperiment(t *testing.T) {
 	flags := shared.NewFilterFlags(logger.CreateLogger(), opts)
 
 	require.NoError(t, flags.Parse(clihelper.Args{"--discovery-boundary", "."}))
-	require.NoError(t, flags.RunActions(context.Background(), &clihelper.Context{}))
+	require.NoError(t, flags.RunActions(t.Context(), &clihelper.Context{}))
 	assert.Equal(t, ".", opts.DiscoveryBoundary)
 }

--- a/internal/discovery/constructor.go
+++ b/internal/discovery/constructor.go
@@ -39,7 +39,7 @@ type StackGenerateOptions struct {
 }
 
 // NewForDiscoveryCommand creates a Discovery configured for discovery commands (find/list).
-func NewForDiscoveryCommand(l log.Logger, opts *DiscoveryCommandOptions) (*Discovery, error) {
+func NewForDiscoveryCommand(l log.Logger, fs vfs.FS, opts *DiscoveryCommandOptions) (*Discovery, error) {
 	d := NewDiscovery(opts.WorkingDir).
 		WithSuppressParseErrors().
 		WithBreakCycles()
@@ -98,7 +98,7 @@ func NewForDiscoveryCommand(l log.Logger, opts *DiscoveryCommandOptions) (*Disco
 	}
 
 	if opts.DiscoveryBoundary != "" {
-		boundary, err := resolveDiscoveryBoundary(vfs.NewOSFS(), opts.WorkingDir, opts.DiscoveryBoundary)
+		boundary, err := resolveDiscoveryBoundary(fs, opts.WorkingDir, opts.DiscoveryBoundary)
 		if err != nil {
 			return nil, err
 		}
@@ -110,7 +110,7 @@ func NewForDiscoveryCommand(l log.Logger, opts *DiscoveryCommandOptions) (*Disco
 }
 
 // NewForHCLCommand creates a Discovery configured for HCL commands (hcl validate/format).
-func NewForHCLCommand(l log.Logger, opts HCLCommandOptions) (*Discovery, error) {
+func NewForHCLCommand(l log.Logger, fs vfs.FS, opts HCLCommandOptions) (*Discovery, error) {
 	d := NewDiscovery(opts.WorkingDir)
 
 	if len(opts.Filters) > 0 {
@@ -118,7 +118,7 @@ func NewForHCLCommand(l log.Logger, opts HCLCommandOptions) (*Discovery, error) 
 	}
 
 	if opts.DiscoveryBoundary != "" {
-		boundary, err := resolveDiscoveryBoundary(vfs.NewOSFS(), opts.WorkingDir, opts.DiscoveryBoundary)
+		boundary, err := resolveDiscoveryBoundary(fs, opts.WorkingDir, opts.DiscoveryBoundary)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 
@@ -35,7 +34,7 @@ func (d *Discovery) Discover(
 	l.Debugf("Discovery: %d filter(s) configured: %s", len(d.filters), d.filters)
 
 	if d.discoveryBoundary != "" {
-		boundary, boundaryErr := resolveDiscoveryBoundary(vfs.NewOSFS(), d.workingDir, d.discoveryBoundary)
+		boundary, boundaryErr := resolveDiscoveryBoundary(v.FS, d.workingDir, d.discoveryBoundary)
 		if boundaryErr != nil {
 			return nil, boundaryErr
 		}

--- a/internal/discovery/discovery_boundary_test.go
+++ b/internal/discovery/discovery_boundary_test.go
@@ -1,8 +1,6 @@
 package discovery_test
 
 import (
-	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -14,13 +12,11 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
-	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
 
-// boundaryFixture is a git repository mimicking a monorepo with sibling
-// environments. The working directory is environments/staging, and the graph
-// crosses out of it in both directions:
+// boundaryFixture is an in-memory monorepo whose graph crosses out of the
+// working directory (environments/staging) in both directions:
 //
 //	environments/staging/vpc          (dependent-direction target)
 //	environments/staging/app          depends on ../vpc
@@ -28,7 +24,7 @@ import (
 //	environments/production/consumer  depends on ../../staging/vpc
 //	environments/production/external  (dependency-direction target's external dep)
 type boundaryFixture struct {
-	tmpDir      string
+	repoRoot    string
 	stagingDir  string
 	vpcDir      string
 	appDir      string
@@ -37,54 +33,49 @@ type boundaryFixture struct {
 	externalDir string
 }
 
-func newBoundaryFixture(t *testing.T) boundaryFixture {
+func newBoundaryFixture(t *testing.T) (boundaryFixture, *venv.Venv) {
 	t.Helper()
 
-	tmpDir := helpers.TmpDirWOSymlinks(t)
+	repoRoot := string(filepath.Separator) + "repo"
 
-	// Initialize a git repository so graph traversal bounds to the repo root
-	// when no discovery boundary is configured.
-	cmd := exec.CommandContext(t.Context(), "git", "init")
-	cmd.Dir = tmpDir
-	cmd.Env = os.Environ()
-	require.NoError(t, cmd.Run())
+	// The venv answers the git top-level probe with repoRoot, so traversal
+	// bounds to the repository root when no discovery boundary is configured.
+	v := memGitTopLevelVenv(t, repoRoot)
 
 	f := boundaryFixture{
-		tmpDir:      tmpDir,
-		stagingDir:  filepath.Join(tmpDir, "environments", "staging"),
-		vpcDir:      filepath.Join(tmpDir, "environments", "staging", "vpc"),
-		appDir:      filepath.Join(tmpDir, "environments", "staging", "app"),
-		edgeDir:     filepath.Join(tmpDir, "environments", "staging", "edge"),
-		consumerDir: filepath.Join(tmpDir, "environments", "production", "consumer"),
-		externalDir: filepath.Join(tmpDir, "environments", "production", "external"),
+		repoRoot:    repoRoot,
+		stagingDir:  filepath.Join(repoRoot, "environments", "staging"),
+		vpcDir:      filepath.Join(repoRoot, "environments", "staging", "vpc"),
+		appDir:      filepath.Join(repoRoot, "environments", "staging", "app"),
+		edgeDir:     filepath.Join(repoRoot, "environments", "staging", "edge"),
+		consumerDir: filepath.Join(repoRoot, "environments", "production", "consumer"),
+		externalDir: filepath.Join(repoRoot, "environments", "production", "external"),
 	}
 
-	for _, dir := range []string{f.vpcDir, f.appDir, f.edgeDir, f.consumerDir, f.externalDir} {
-		require.NoError(t, os.MkdirAll(dir, 0o755))
-	}
-
-	require.NoError(t, os.WriteFile(filepath.Join(f.vpcDir, "terragrunt.hcl"), []byte(``), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(f.externalDir, "terragrunt.hcl"), []byte(``), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(f.appDir, "terragrunt.hcl"), []byte(`
+	writeUnits(t, v.FS, map[string]string{
+		f.vpcDir:      ``,
+		f.externalDir: ``,
+		f.appDir: `
 dependency "vpc" {
   config_path = "../vpc"
 }
-`), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(f.consumerDir, "terragrunt.hcl"), []byte(`
+`,
+		f.consumerDir: `
 dependency "vpc" {
   config_path = "../../staging/vpc"
 }
-`), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(f.edgeDir, "terragrunt.hcl"), []byte(`
+`,
+		f.edgeDir: `
 dependency "external" {
   config_path = "../../production/external"
 }
-`), 0o644))
+`,
+	})
 
-	return f
+	return f, v
 }
 
-func (f *boundaryFixture) discover(t *testing.T, query, boundary string) (component.Components, error) {
+func (f *boundaryFixture) discover(t *testing.T, v *venv.Venv, query, boundary string) (component.Components, error) {
 	t.Helper()
 
 	opts := options.NewTerragruntOptions()
@@ -100,7 +91,7 @@ func (f *boundaryFixture) discover(t *testing.T, query, boundary string) (compon
 		d = d.WithDiscoveryBoundary(boundary)
 	}
 
-	return d.Discover(t.Context(), logger.CreateLogger(), venv.OSVenv(), opts)
+	return d.Discover(t.Context(), logger.CreateLogger(), v, opts)
 }
 
 // Test that a discovery boundary encloses graph discovery in both directions,
@@ -139,7 +130,7 @@ func TestDiscoveryBoundary_EnclosesGraphDiscovery(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			f := newBoundaryFixture(t)
+			f, v := newBoundaryFixture(t)
 
 			byName := map[string]string{
 				"vpc": f.vpcDir, "app": f.appDir, "edge": f.edgeDir,
@@ -161,12 +152,12 @@ func TestDiscoveryBoundary_EnclosesGraphDiscovery(t *testing.T) {
 			// into the sibling production environment. This pins the fixture as
 			// actually exercising cross-boundary traversal, so the bounded
 			// assertion below is meaningful.
-			configs, err := f.discover(t, query, "")
+			configs, err := f.discover(t, v, query, "")
 			require.NoError(t, err)
 			assert.ElementsMatch(t, resolve(tc.unbounded), configs.Filter(component.UnitKind).Paths())
 
 			// "." resolves against the working directory (staging).
-			configs, err = f.discover(t, query, ".")
+			configs, err = f.discover(t, v, query, ".")
 			require.NoError(t, err)
 			assert.ElementsMatch(t, resolve(tc.bounded), configs.Filter(component.UnitKind).Paths())
 		})
@@ -179,7 +170,7 @@ func TestDiscoveryBoundary_EnclosesGraphDiscovery(t *testing.T) {
 func TestDiscoveryBoundary_DiscoverValidatesBoundary(t *testing.T) {
 	t.Parallel()
 
-	f := newBoundaryFixture(t)
+	f, v := newBoundaryFixture(t)
 
 	testCases := []struct {
 		errAs    any
@@ -188,7 +179,7 @@ func TestDiscoveryBoundary_DiscoverValidatesBoundary(t *testing.T) {
 	}{
 		{
 			name:     "nonexistent boundary",
-			boundary: filepath.Join(f.tmpDir, "does-not-exist"),
+			boundary: filepath.Join(f.repoRoot, "does-not-exist"),
 			errAs:    &discovery.DiscoveryBoundaryDirError{},
 		},
 		{
@@ -207,7 +198,7 @@ func TestDiscoveryBoundary_DiscoverValidatesBoundary(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := f.discover(t, "...{"+f.vpcDir+"}", tc.boundary)
+			_, err := f.discover(t, v, "...{"+f.vpcDir+"}", tc.boundary)
 			require.ErrorAs(t, err, tc.errAs)
 		})
 	}
@@ -218,7 +209,7 @@ func TestDiscoveryBoundary_DiscoverValidatesBoundary(t *testing.T) {
 func TestNewForDiscoveryCommand_DiscoveryBoundaryValidation(t *testing.T) {
 	t.Parallel()
 
-	f := newBoundaryFixture(t)
+	f, v := newBoundaryFixture(t)
 
 	testCases := []struct {
 		errAs    any
@@ -227,7 +218,7 @@ func TestNewForDiscoveryCommand_DiscoveryBoundaryValidation(t *testing.T) {
 	}{
 		{
 			name:     "nonexistent boundary",
-			boundary: filepath.Join(f.tmpDir, "does-not-exist"),
+			boundary: filepath.Join(f.repoRoot, "does-not-exist"),
 			errAs:    &discovery.DiscoveryBoundaryDirError{},
 		},
 		{
@@ -241,7 +232,7 @@ func TestNewForDiscoveryCommand_DiscoveryBoundaryValidation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := discovery.NewForDiscoveryCommand(logger.CreateLogger(), &discovery.DiscoveryCommandOptions{
+			_, err := discovery.NewForDiscoveryCommand(logger.CreateLogger(), v.FS, &discovery.DiscoveryCommandOptions{
 				WorkingDir:        f.stagingDir,
 				DiscoveryBoundary: tc.boundary,
 			})
@@ -252,7 +243,7 @@ func TestNewForDiscoveryCommand_DiscoveryBoundaryValidation(t *testing.T) {
 	t.Run("valid boundary", func(t *testing.T) {
 		t.Parallel()
 
-		d, err := discovery.NewForDiscoveryCommand(logger.CreateLogger(), &discovery.DiscoveryCommandOptions{
+		d, err := discovery.NewForDiscoveryCommand(logger.CreateLogger(), v.FS, &discovery.DiscoveryCommandOptions{
 			WorkingDir:        f.stagingDir,
 			DiscoveryBoundary: "..",
 		})

--- a/internal/filter/doc.go
+++ b/internal/filter/doc.go
@@ -96,7 +96,7 @@
 // ## Graph Boundary
 //
 // A boundary encloses graph traversal within a directory, in place of the
-// default outer limit (the git repository root for dependents, the declared
+// default outer limit (the Git repository root for dependents, the declared
 // path for dependencies). It occupies the same operand slot as depth, written
 // as a parenthesized directory:
 //
@@ -109,6 +109,14 @@
 // read nor returned, the same way a too-deep node is excluded by a depth bound.
 // The value must be an existing directory, resolved against the working
 // directory. This syntax is gated behind the bounded-discovery experiment.
+//
+// A dependent-direction boundary must be the working directory or one of its
+// parents, since the dependent walk starts at the working directory and moves
+// outward. A boundary that does not contain it is rejected before traversal.
+//
+// Reserving "(" and ")" for this operand means neither character can appear
+// bare in a name or path. Brace a value that contains one, as in
+// "{./weird(name)}".
 //
 // ## Numeric Directory Disambiguation
 //

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -66,6 +66,8 @@ func (f *Filter) HasGraphBoundary() bool {
 	WalkExpressions(f.expr, func(e Expression) bool {
 		if g, ok := e.(*GraphExpression); ok && (g.Dependents.Boundary != "" || g.Dependencies.Boundary != "") {
 			found = true
+
+			return false
 		}
 
 		return true

--- a/internal/filter/parser_boundary_test.go
+++ b/internal/filter/parser_boundary_test.go
@@ -57,6 +57,26 @@ func TestParser_GraphBoundaryOperand(t *testing.T) {
 				Dependents: filter.GraphBound{Include: true, Boundary: "."},
 			},
 		},
+		{
+			// The dependent prefix is parsed before the caret, so the two
+			// operands have to compose.
+			name:  "boundary with excluded target",
+			input: "(./a)...^{./apps/foo}",
+			expected: &filter.GraphExpression{
+				Target:        mustPath(t, "./apps/foo"),
+				Dependents:    filter.GraphBound{Include: true, Boundary: "./a"},
+				ExcludeTarget: true,
+			},
+		},
+		{
+			// A Git filter is a separate target arm from paths and names.
+			name:  "boundary with git target",
+			input: "(./a)...[main...HEAD]",
+			expected: &filter.GraphExpression{
+				Target:     filter.NewGitExpression("main", "HEAD"),
+				Dependents: filter.GraphBound{Include: true, Boundary: "./a"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -86,6 +106,8 @@ func TestParser_GraphBoundaryRoundTrip(t *testing.T) {
 		"{./envs/prod/edge}...(./envs/prod)",
 		"(./a)...{./apps/foo}...(./b)",
 		"(.)...{./apps/foo}",
+		"(./a)...^{./apps/foo}",
+		"(./a)...[main...HEAD]",
 	}
 
 	for _, input := range inputs {
@@ -100,13 +122,16 @@ func TestParser_GraphBoundaryRoundTrip(t *testing.T) {
 			second, err := filter.NewParser(filter.NewLexer(rendered)).ParseExpression()
 			require.NoError(t, err)
 
+			assert.Equal(t, rendered, second.String(), "rendering must be idempotent")
+
 			firstGraph, ok := first.(*filter.GraphExpression)
 			require.True(t, ok)
 			secondGraph, ok := second.(*filter.GraphExpression)
 			require.True(t, ok)
 
-			assert.Equal(t, firstGraph.Dependents.Boundary, secondGraph.Dependents.Boundary)
-			assert.Equal(t, firstGraph.Dependencies.Boundary, secondGraph.Dependencies.Boundary)
+			assert.Equal(t, firstGraph.Dependents, secondGraph.Dependents)
+			assert.Equal(t, firstGraph.Dependencies, secondGraph.Dependencies)
+			assert.Equal(t, firstGraph.ExcludeTarget, secondGraph.ExcludeTarget)
 		})
 	}
 }
@@ -205,19 +230,40 @@ func TestParser_GraphBoundaryErrors(t *testing.T) {
 	t.Parallel()
 
 	// A boundary "(dir)" must sit in the operand slot adjacent to "...", be
-	// non-empty, and be closed.
-	inputs := []string{
-		"(./bound)",           // no ellipsis follows the boundary
-		"()...{./apps/foo}",   // empty boundary
-		"(./a...{./apps/foo}", // unclosed boundary
+	// non-empty, and be closed. Each violation reports its own diagnostic, so
+	// the title is asserted to keep the three paths from collapsing into one.
+	tests := []struct {
+		name  string
+		input string
+		title string
+	}{
+		{
+			name:  "no ellipsis follows the boundary",
+			input: "(./bound)",
+			title: "Invalid boundary operand",
+		},
+		{
+			name:  "empty boundary",
+			input: "()...{./apps/foo}",
+			title: "Empty boundary",
+		},
+		{
+			name:  "unclosed boundary",
+			input: "(./a...{./apps/foo}",
+			title: "Unclosed boundary",
+		},
 	}
 
-	for _, input := range inputs {
-		t.Run(input, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := filter.NewParser(filter.NewLexer(input)).ParseExpression()
+			_, err := filter.NewParser(filter.NewLexer(tt.input)).ParseExpression()
 			require.Error(t, err)
+
+			var parseErr filter.ParseError
+			require.ErrorAs(t, err, &parseErr)
+			assert.Equal(t, tt.title, parseErr.Title)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses feedback from #6365 and #6355

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discovery now consistently respects the active virtual filesystem when running find, list, and HCL validation commands.
  * Graph-boundary evaluation stops traversing once a boundary is reached, preventing out-of-boundary configurations from being read, parsed, or returned.
  * Improved handling and validation of boundary expressions, including excluded targets and names or paths containing parentheses.

* **Documentation**
  * Clarified repository traversal, boundary behavior, configuration parsing, and boundary-expression syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->