### PR TITLE
chore: Adding expansion blocks to the configs that accept expansion

### DIFF
--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -62,6 +62,8 @@ type dependencyOutputCache struct {
 }
 
 type Dependency struct {
+	Expansion *hclparse.ExpansionBlock `hcl:"expansion,block"`
+
 	ConfigPath                          cty.Value  `hcl:"config_path,attr"                             cty:"config_path"`
 	Enabled                             *bool      `hcl:"enabled,attr"                                 cty:"enabled"`
 	SkipOutputs                         *bool      `hcl:"skip_outputs,attr"                            cty:"skip"`

--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 )
 
 const dependencyWithExpansionHCL = `
@@ -315,6 +317,256 @@ func TestExpansionRequiresExperimentErrorNamesTheFlag(t *testing.T) {
 	}
 	assert.Contains(t, unlabeled.Error(), experiment.BlockIteration)
 	assert.NotContains(t, unlabeled.Error(), `""`)
+}
+
+func TestDependencyDecodesExpansionBlock(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyString(t, dependencyWithExpansionHCL)
+	require.NoError(t, err)
+	require.Len(t, cfg.TerragruntDependencies, 1)
+
+	dep := cfg.TerragruntDependencies[0]
+	require.NotNil(t, dep.Expansion)
+	require.NotNil(t, dep.Expansion.ForEach)
+
+	assert.Equal(
+		t,
+		cty.SetVal([]cty.Value{cty.StringVal("web"), cty.StringVal("api")}),
+		*dep.Expansion.ForEach,
+	)
+	assert.Nil(t, dep.Expansion.Count)
+}
+
+func TestUnitAndStackDecodeExpansionBlock(t *testing.T) {
+	t.Parallel()
+
+	stackCfg, err := parseStackString(t, unitWithExpansionHCL+stackWithExpansionHCL)
+	require.NoError(t, err)
+	require.Len(t, stackCfg.Units, 1)
+	require.Len(t, stackCfg.Stacks, 1)
+
+	unitExpansion := stackCfg.Units[0].Expansion
+	require.NotNil(t, unitExpansion)
+	require.NotNil(t, unitExpansion.ForEach)
+	assert.Equal(
+		t,
+		cty.SetVal([]cty.Value{cty.StringVal("web"), cty.StringVal("api")}),
+		*unitExpansion.ForEach,
+	)
+
+	stackExpansion := stackCfg.Stacks[0].Expansion
+	require.NotNil(t, stackExpansion)
+	require.NotNil(t, stackExpansion.Count)
+	// Decoding and the literal build the number at different big.Float precisions,
+	// which assert.Equal reads as a diff.
+	assert.True(t, stackExpansion.Count.RawEquals(cty.NumberIntVal(2)))
+}
+
+func TestBlocksWithoutExpansionDecodeUnchanged(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyString(t, `
+dependency "vpc" {
+  config_path = "../vpc"
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, cfg.TerragruntDependencies, 1)
+
+	dep := cfg.TerragruntDependencies[0]
+	assert.Nil(t, dep.Expansion)
+	assert.Equal(t, cty.StringVal("../vpc"), dep.ConfigPath)
+
+	stackCfg, err := parseStackString(t, `
+unit "app" {
+  source = "./modules/app"
+  path   = "app"
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, stackCfg.Units, 1)
+
+	assert.Nil(t, stackCfg.Units[0].Expansion)
+	assert.Equal(t, "app", stackCfg.Units[0].Path)
+}
+
+func TestExpansionBlockRejectsMistypedAttribute(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		parse func(testing.TB, string) error
+		name  string
+		cfg   string
+	}{
+		{
+			name:  "dependency",
+			parse: parseDependencyErr,
+			cfg: `
+dependency "aurora" {
+  expansion {
+    foreach = toset(["web"])
+  }
+
+  config_path = "../aurora"
+}
+`,
+		},
+		{
+			name:  "unit",
+			parse: parseStackErr,
+			cfg: `
+unit "app" {
+  expansion {
+    foreach = toset(["web"])
+  }
+
+  source = "./modules/app"
+  path   = "app"
+}
+`,
+		},
+		{
+			name:  "stack",
+			parse: parseStackErr,
+			cfg: `
+stack "team" {
+  expansion {
+    cuont = 2
+  }
+
+  source = "./stacks/team"
+  path   = "team"
+}
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Error(t, tc.parse(t, tc.cfg))
+		})
+	}
+}
+
+func TestIterationKeysAreNotSettableFromHCL(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseDependencyString(t, `
+dependency "aurora" {
+  each_key = "web"
+
+  config_path = "../aurora"
+}
+`)
+	require.Error(t, err)
+
+	stackCfg, err := parseStackString(t, `
+unit "app" {
+  each_key    = "web"
+  count_index = 0
+
+  source = "./modules/app"
+  path   = "app"
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, stackCfg.Units, 1)
+
+	// A unit absorbs unknown attributes into its remainder rather than rejecting them,
+	// so what it can be held to is that writing them leaves no expansion state.
+	assert.Nil(t, stackCfg.Units[0].Expansion)
+}
+
+// TestDependencyCtyShapeExcludesExpansionMetadata pins the attribute set a dependency
+// exposes to read_terragrunt_config and render, which a cty tag on expansion metadata
+// would widen for every user, experiment or not.
+func TestDependencyCtyShapeExcludesExpansionMetadata(t *testing.T) {
+	t.Parallel()
+
+	value, err := config.GoTypeToCty(config.Dependency{
+		Name:       "vpc",
+		ConfigPath: cty.StringVal("../vpc"),
+	})
+	require.NoError(t, err)
+
+	attrs := make([]string, 0, len(value.Type().AttributeTypes()))
+	for name := range value.Type().AttributeTypes() {
+		attrs = append(attrs, name)
+	}
+
+	assert.ElementsMatch(t, []string{
+		"name",
+		"config_path",
+		"enabled",
+		"skip",
+		"mock_outputs",
+		"mock_outputs_allowed_terraform_commands",
+		"mock_outputs_merge_with_state",
+		"mock_outputs_merge_strategy_with_state",
+		"outputs",
+		"inputs",
+	}, attrs)
+}
+
+func parseDependencyString(tb testing.TB, cfg string) (*config.TerragruntConfig, error) {
+	tb.Helper()
+
+	ctx, pctx := newExpansionParsingContext(tb, config.DefaultTerragruntConfigPath)
+
+	return config.PartialParseConfigString(
+		ctx,
+		pctx.WithDecodeList(config.DependencyBlock),
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		cfg,
+		nil,
+	)
+}
+
+func parseDependencyErr(tb testing.TB, cfg string) error {
+	tb.Helper()
+
+	_, err := parseDependencyString(tb, cfg)
+
+	return err
+}
+
+func parseStackString(tb testing.TB, cfg string) (*config.StackConfig, error) {
+	tb.Helper()
+
+	ctx, pctx := newExpansionParsingContext(tb, config.DefaultStackFile)
+
+	return config.ReadStackConfigString(
+		ctx,
+		logger.CreateLogger(),
+		pctx,
+		config.DefaultStackFile,
+		cfg,
+		nil,
+	)
+}
+
+func parseStackErr(tb testing.TB, cfg string) error {
+	tb.Helper()
+
+	_, err := parseStackString(tb, cfg)
+
+	return err
+}
+
+func newExpansionParsingContext(
+	tb testing.TB,
+	configPath string,
+) (context.Context, *config.ParsingContext) {
+	tb.Helper()
+
+	ctx, pctx := newTestParsingContext(tb, configPath)
+	require.NoError(tb, pctx.Experiments.EnableExperiment(experiment.BlockIteration))
+
+	return ctx, pctx
 }
 
 func parseHCLString(tb testing.TB, cfg, configPath string) *hclparse.File {

--- a/pkg/config/hclparse/expansion.go
+++ b/pkg/config/hclparse/expansion.go
@@ -46,10 +46,18 @@ func WithMaxInstances(maxInstances int) ExpandOption {
 	}
 }
 
-// Instance is one decoded product of expanding a block. A block with no expansion
-// block yields a single Instance with both keys nil.
-type Instance struct {
-	Value      any
+// ExpansionBlock is the decoded expansion sub-block of a dependency, unit, or stack
+// block. It stays nil unless the block declares expansion.
+type ExpansionBlock struct {
+	ForEach *cty.Value `hcl:"for_each,attr"`
+	Count   *cty.Value `hcl:"count,attr"`
+
+	InstanceKey
+}
+
+// InstanceKey identifies which expansion element produced a decoded block. It carries
+// no hcl tags: expansion assigns it, so a config cannot write it.
+type InstanceKey struct {
 	EachKey    *string
 	CountIndex *int
 }
@@ -61,15 +69,22 @@ type Instance struct {
 // Addresses are built from this in more than one place (the dependency cty map,
 // stack output), so keeping the stringification here is what stops those surfaces
 // from drifting apart.
-func (inst Instance) Key() string {
+func (key InstanceKey) Key() string {
 	switch {
-	case inst.EachKey != nil:
-		return *inst.EachKey
-	case inst.CountIndex != nil:
-		return strconv.Itoa(*inst.CountIndex)
+	case key.EachKey != nil:
+		return *key.EachKey
+	case key.CountIndex != nil:
+		return strconv.Itoa(*key.CountIndex)
 	default:
 		return ""
 	}
+}
+
+// Instance is one decoded product of expanding a block. A block with no expansion
+// block yields a single Instance with both keys nil.
+type Instance struct {
+	Value any
+	InstanceKey
 }
 
 // ExpandBlock decodes block once per iteration element, returning one Instance per
@@ -226,7 +241,10 @@ func expandCount(
 			return nil, err
 		}
 
-		instances = append(instances, Instance{Value: value, CountIndex: new(index)})
+		instances = append(instances, Instance{
+			Value:       value,
+			InstanceKey: InstanceKey{CountIndex: new(index)},
+		})
 	}
 
 	return instances, nil
@@ -292,7 +310,10 @@ func expandForEach(
 			return nil, err
 		}
 
-		instances = append(instances, Instance{Value: value, EachKey: new(key)})
+		instances = append(instances, Instance{
+			Value:       value,
+			InstanceKey: InstanceKey{EachKey: new(key)},
+		})
 	}
 
 	return instances, nil

--- a/pkg/config/hclparse/expansion_test.go
+++ b/pkg/config/hclparse/expansion_test.go
@@ -11,16 +11,9 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// testBlock mirrors the shape the real dependency/unit/stack structs take once
-// OSS-3968 lands: an expansion block field plus ordinary attributes.
 type testBlock struct {
-	Expansion *testExpansion `hcl:"expansion,block"`
-	Path      string         `hcl:"path,attr"`
-}
-
-type testExpansion struct {
-	ForEach *cty.Value `hcl:"for_each,attr"`
-	Count   *cty.Value `hcl:"count,attr"`
+	Expansion *hclparse.ExpansionBlock `hcl:"expansion,block"`
+	Path      string                   `hcl:"path,attr"`
 }
 
 func TestExpandBlockUnexpanded(t *testing.T) {

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -69,7 +69,10 @@ type StackConfig struct {
 
 // Unit represents unit from a stack file.
 type Unit struct {
-	Remain              hcl.Body   `hcl:",remain"`
+	Remain hcl.Body `hcl:",remain"`
+
+	Expansion *hclparse.ExpansionBlock `hcl:"expansion,block"`
+
 	UpdateSourceWithCAS *bool      `hcl:"update_source_with_cas,attr"`
 	Mutable             *bool      `hcl:"mutable,attr"`
 	NoStack             *bool      `hcl:"no_dot_terragrunt_stack,attr"`
@@ -87,7 +90,10 @@ func (u *Unit) GeneratedPath(stackDir string) string {
 
 // Stack represents the stack block in the configuration.
 type Stack struct {
-	Remain              hcl.Body   `hcl:",remain"`
+	Remain hcl.Body `hcl:",remain"`
+
+	Expansion *hclparse.ExpansionBlock `hcl:"expansion,block"`
+
 	UpdateSourceWithCAS *bool      `hcl:"update_source_with_cas,attr"`
 	Mutable             *bool      `hcl:"mutable,attr"`
 	NoStack             *bool      `hcl:"no_dot_terragrunt_stack,attr"`


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds expansion block to the `dependency`, `unit` and `stack` blocks.

Isn't used yet, but the block and requisite `Remain` is now registered.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `expansion` blocks on dependencies, units, and stacks.
  - Configurations can now create multiple instances using count-based or collection-based expansion.
  - Expansion instance keys are available for identifying generated instances.

- **Bug Fixes**
  - Invalid expansion attributes are rejected with validation errors.
  - Expansion metadata is protected from unintended configuration assignment and excluded from dependency output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->