### PR TITLE
feat: Adding `md` format for `catalog`

### DIFF
--- a/docs/public/schemas/catalog/v1/schema.json
+++ b/docs/public/schemas/catalog/v1/schema.json
@@ -28,7 +28,7 @@
       "items": {
         "type": "string"
       },
-      "description": "Tags declared in the README front matter, in authoring order. Absent when the entry declares none."
+      "description": "Tags declared in the README front matter, in authoring order. Omitted rather than emitted as an empty array when the entry declares none."
     },
     "source": {
       "type": "string",
@@ -53,10 +53,6 @@
     "doc": {
       "type": "string",
       "description": "README body as written, with front matter removed. Absent when the entry has no README."
-    },
-    "copyable": {
-      "type": "boolean",
-      "description": "True when the entry is installed by copying its directory (units and stacks) rather than by scaffolding. Absent when false."
     }
   },
   "additionalProperties": false,

--- a/docs/src/content/docs/03-features/06-catalog/04-non-interactive.mdx
+++ b/docs/src/content/docs/03-features/06-catalog/04-non-interactive.mdx
@@ -1,6 +1,6 @@
 ---
 title: Non-interactive catalog
-description: Read the catalog from a script, one JSON object per line.
+description: Read the catalog from a script or an agent, as JSON Lines or Markdown.
 slug: features/catalog/non-interactive
 sidebar:
   order: 4
@@ -14,7 +14,16 @@ The `--format` flag is gated behind the [`catalog-format`](/reference/experiment
 The examples below omit it for brevity.
 </Aside>
 
-The [catalog TUI](/features/catalog/tui) needs a terminal, which leaves scripts and CI jobs with no way to read what the catalog discovers. Pass `--format=jsonl` to write the same discovery to standard output as [JSON Lines](https://jsonlines.org/): one JSON object per line, and nothing else.
+The [catalog TUI](/features/catalog/tui) needs a terminal, which leaves scripts, CI jobs, and agents with no way to read what the catalog discovers. The `--format` flag writes the same discovery to standard output instead, in one of two formats:
+
+- `jsonl` for a program that parses what it reads.
+- `md` for a person or an agent that reads prose.
+
+Both carry the same information, and neither is interactive. Scaffolding stays in the TUI.
+
+## JSON Lines
+
+`--format=jsonl` writes [JSON Lines](https://jsonlines.org/): one JSON object per line, and nothing else.
 
 ```bash
 $ terragrunt catalog --format=jsonl | jq -c '{kind, title, component_source}'
@@ -23,6 +32,58 @@ $ terragrunt catalog --format=jsonl | jq -c '{kind, title, component_source}'
 ```
 
 Every line is a catalog entry that you would normally see in the catalog TUI.
+
+## Markdown
+
+`--format=md` writes one document, with a section per entry.
+
+```bash
+terragrunt catalog --format=md > catalog.md
+```
+
+The document opens with a header describing what it holds, and gives each entry a section:
+
+````markdown
+## VPC
+
+Creates a VPC.
+
+| Field | Value |
+| --- | --- |
+| Kind | `module` |
+| Source | `github.com/acme/infrastructure-modules` |
+| Directory | `modules/vpc` |
+| Version | `v0.14.2` |
+| URL | <https://github.com/acme/infrastructure-modules/tree/main/modules/vpc> |
+| Component source | `github.com/acme/infrastructure-modules//modules/vpc` |
+
+| Tag |
+| --- |
+| `networking` |
+
+```markdown
+Everything a VPC needs.
+```
+````
+
+The description leads the section as prose, and the rest of the entry follows as a table. The rows hold the fields described under [Entry structure](#entry-structure). The `Component source` row identifies where the component is scaffolded from: hand it to [`terragrunt scaffold`](/features/catalog/scaffold) for a module or a template, or use the TUI for a unit or a stack, which are scaffolded by copying.
+
+Tags get a table of their own, a row each, and an entry that declares none has no tag table.
+
+Each README is reproduced inside a fenced block, so the headings a README carries are not read as sections of the catalog document. The fence is made longer than any fence inside the README, so a README that contains fenced code blocks of its own is still enclosed by one block.
+
+The document closes with a table of what it holds, and the count that marks it complete:
+
+```markdown
+| Component | Kind | Component source |
+| --- | --- | --- |
+| VPC | `module` | `github.com/acme/infrastructure-modules//modules/vpc` |
+| App | `unit` | `github.com/acme/infrastructure-units//units/app` |
+
+Discovered 2 components from 2 sources.
+```
+
+The table comes last because the content written to stdout is streamed in as components are discovered.
 
 ## Streaming
 
@@ -34,11 +95,13 @@ terragrunt catalog --format=jsonl | head -5
 
 Once the reader closes the pipe, Terragrunt stops loading, removes the repositories it cloned, and exits with status 0, writing nothing to standard error.
 
+Scripts and agents can use this to avoid waiting on a complete load of the catalog when they see the result they care about.
+
 ## Keeping the streams apart
 
-Standard output carries entries and nothing else. Logs and diagnostics go to standard error, including the report of a repository that failed to load.
+Standard output carries entries and nothing else. Logs and diagnostics go to standard error, including the report of any repository that fails to load.
 
-Keep it that way when you parse the output. A `doc` field holding a large README makes a record longer than the operating system writes to a pipe in one go, so a log line merged into the same stream with `2>&1` can land in the middle of a record and break the parse.
+Keep it that way when you parse the output. A large README makes an entry longer than the operating system writes to a pipe in one go, so a log line merged into the same stream with `2>&1` can land in the middle of an entry and break the parse.
 
 ## Ordering
 
@@ -52,7 +115,7 @@ terragrunt catalog --format=jsonl | jq -s -c 'sort_by(.component_source)[]'
 
 ## Entry structure
 
-Entries are described by a [published JSON schema](https://docs.terragrunt.com/schemas/catalog/v1/schema.json). The schema covers a single entry, so validate each line on its own rather than the stream as a whole.
+Entries are described by a [published JSON schema](https://docs.terragrunt.com/schemas/catalog/v1/schema.json). The schema covers a single entry, so validate each line of `jsonl` output on its own rather than the stream as a whole. The `md` format writes the same fields as rows of a table, under labels of their own, and is not covered by the schema.
 
 The `doc` field holds the body of the component's README (which can be a lot of data) so drop it when the metadata is all you need:
 

--- a/docs/src/data/changelog/v1.1.3/catalog-md-format.mdx
+++ b/docs/src/data/changelog/v1.1.3/catalog-md-format.mdx
@@ -1,0 +1,18 @@
+---
+version: "v1.1.3"
+category: "experiments-updated"
+---
+
+#### `catalog-format` - Reading the catalog as Markdown
+
+The [`catalog-format`](/reference/experiments/active#catalog-format) experiment gains a second non-interactive format. Where `--format=jsonl` writes a record per catalog entry for a program to parse, `--format=md` writes one Markdown document for a person or an agent to read:
+
+```bash
+terragrunt catalog --experiment=catalog-format --format=md > catalog.md
+```
+
+Each entry becomes a section holding the metadata the catalog user interface shows for it, the source the component is scaffolded from, and the component's README. Sections are written as entries are discovered, so the document is readable while the remaining repositories are still loading.
+
+READMEs are reproduced inside fenced blocks, so the headings one carries are not read as sections of the catalog document. The document closes with a table naming every component it holds and a count of what was discovered, which is how a reader tells a complete document from one that was cut short by a consumer that stopped reading.
+
+For the fields each section carries, see [Non-interactive catalog](/features/catalog/non-interactive).

--- a/docs/src/data/flags/catalog-format.mdx
+++ b/docs/src/data/flags/catalog-format.mdx
@@ -1,7 +1,7 @@
 ---
 name: format
 description: |
-  Format the catalog as specified. Supported values (tui, jsonl). Default: tui.
+  Format the catalog as specified. Supported values (tui, jsonl, md). Default: tui.
 type: string
 env:
   - TG_FORMAT
@@ -17,6 +17,7 @@ This flag is gated behind the [`catalog-format`](/reference/experiments/active#c
 
 - `tui` is the default format for the `catalog` command, and results in the catalog rendering as an interactive Terminal User Interface.
 - `jsonl` writes one JSON object per line to standard output, so a script can read the catalog where a terminal user interface cannot be used.
+- `md` writes a Markdown document to standard output, with a section per catalog entry, for reading by a person or by an agent.
 
 ## JSONL
 
@@ -46,3 +47,36 @@ terragrunt catalog --experiment=catalog-format --format=jsonl | jq -c '{kind, ti
 ```
 
 Entries follow a [published JSON schema](https://docs.terragrunt.com/schemas/catalog/v1/schema.json), which describes the schema for each entry, not the stream as a whole.
+
+## Markdown
+
+```bash
+terragrunt catalog --experiment=catalog-format --format=md > catalog.md
+```
+
+The document opens with a header describing what it holds, and gives each entry a section carrying the same metadata the `jsonl` format puts in a record:
+
+```markdown
+## VPC
+
+Creates a VPC.
+
+| Field | Value |
+| --- | --- |
+| Kind | `module` |
+| Source | `github.com/acme/infrastructure-modules` |
+| Directory | `modules/vpc` |
+| Version | `v0.14.2` |
+| URL | <https://github.com/acme/infrastructure-modules/tree/main/modules/vpc> |
+| Component source | `github.com/acme/infrastructure-modules//modules/vpc` |
+
+| Tag |
+| --- |
+| `networking` |
+```
+
+A row is written only when the entry has a value for it, and an entry that declares no tags has no tag table. The component's README follows, inside a fenced block, which keeps the headings a README carries from reading as sections of the catalog document.
+
+Sections are written as entries are discovered, so a reader gets the first ones while the remaining repositories are still being cloned, and their order differs between runs. The document closes with a table naming every entry it holds and a count of what was discovered, which is what tells a complete document from one that was cut short.
+
+See [Non-interactive catalog](/features/catalog/non-interactive) for the whole shape of the document.

--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/wI2L/jsondiff v0.7.1
 	github.com/xeipuuv/gojsonschema v1.2.0
+	github.com/yuin/goldmark v1.8.4
 	go.opentelemetry.io/contrib/bridges/otellogrus v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.20.0
@@ -289,7 +290,6 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
-	github.com/yuin/goldmark v1.8.4 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zclconf/go-cty-yaml v1.1.0 // indirect

--- a/internal/cli/commands/catalog/cli.go
+++ b/internal/cli/commands/catalog/cli.go
@@ -32,7 +32,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) clihelper.Flags {
 			Name:        FormatFlagName,
 			EnvVars:     tgPrefix.EnvVars(FormatFlagName),
 			Destination: &opts.Format,
-			Usage:       "Output format for the catalog. Valid values: tui, jsonl.",
+			Usage:       "Output format for the catalog. Valid values: tui, jsonl, md.",
 			DefaultText: FormatTUI,
 		}),
 		flags.NewFlag(&clihelper.GenericFlag[string]{

--- a/internal/cli/commands/catalog/format/entry.go
+++ b/internal/cli/commands/catalog/format/entry.go
@@ -11,7 +11,7 @@ import (
 type Entry struct {
 	Kind            string   `json:"kind"`
 	Title           string   `json:"title"`
-	Description     string   `json:"description"`
+	Description     string   `json:"description,omitempty"`
 	Source          string   `json:"source"`
 	Dir             string   `json:"dir,omitempty"`
 	Version         string   `json:"version,omitempty"`
@@ -19,7 +19,6 @@ type Entry struct {
 	ComponentSource string   `json:"component_source"`
 	Doc             string   `json:"doc,omitempty"`
 	Tags            []string `json:"tags,omitempty"`
-	Copyable        bool     `json:"copyable,omitempty"`
 }
 
 // NewEntry converts a discovered component into its serialized form.
@@ -29,7 +28,7 @@ func NewEntry(e *tui.ComponentEntry) *Entry {
 	return &Entry{
 		Kind:            c.Kind.String(),
 		Title:           c.Title(),
-		Description:     c.Description(),
+		Description:     c.DocDescription(),
 		Source:          e.Source,
 		Dir:             c.Dir,
 		Version:         e.Version,
@@ -37,6 +36,5 @@ func NewEntry(e *tui.ComponentEntry) *Entry {
 		ComponentSource: c.TerraformSourcePath(),
 		Doc:             c.Content(false),
 		Tags:            e.Tags(),
-		Copyable:        c.Kind.IsCopyable(),
 	}
 }

--- a/internal/cli/commands/catalog/format/format.go
+++ b/internal/cli/commands/catalog/format/format.go
@@ -12,8 +12,13 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
 )
 
-// JSONL names the JSON Lines format: one JSON object per line.
-const JSONL = "jsonl"
+const (
+	// JSONL names the JSON Lines format: one JSON object per line.
+	JSONL = "jsonl"
+
+	// MD names the Markdown format: one document, with a section per component.
+	MD = "md"
+)
 
 // ErrUnsupportedFormat is returned by [NewRenderer] for a format name that
 // has no renderer.
@@ -40,6 +45,8 @@ func NewRenderer(name string) (Renderer, error) {
 	switch name {
 	case JSONL:
 		return NewJSONLRenderer(), nil
+	case MD:
+		return NewMarkdownRenderer(), nil
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedFormat, name)
 	}

--- a/internal/cli/commands/catalog/format/jsonl_test.go
+++ b/internal/cli/commands/catalog/format/jsonl_test.go
@@ -91,14 +91,13 @@ func entryCases() []entryCase {
 			want: format.Entry{
 				Kind:            "template",
 				Title:           "service",
-				Description:     "(no description found)",
 				Source:          "github.com/acme/repo",
 				Dir:             "templates/service",
 				ComponentSource: "github.com/acme/repo//templates/service?ref=v2",
 			},
 		},
 		{
-			name: "unit is copyable",
+			name: "unit",
 			entry: tui.NewComponentEntry(
 				tui.NewComponentForTest(
 					component.KindUnit,
@@ -110,15 +109,13 @@ func entryCases() []entryCase {
 			want: format.Entry{
 				Kind:            "unit",
 				Title:           "app",
-				Description:     "(no description found)",
 				Source:          "github.com/acme/repo",
 				Dir:             "units/app",
 				ComponentSource: "github.com/acme/repo//units/app",
-				Copyable:        true,
 			},
 		},
 		{
-			name: "stack is copyable",
+			name: "stack",
 			entry: tui.NewComponentEntry(
 				tui.NewComponentForTest(
 					component.KindStack,
@@ -130,11 +127,9 @@ func entryCases() []entryCase {
 			want: format.Entry{
 				Kind:            "stack",
 				Title:           "prod",
-				Description:     "(no description found)",
 				Source:          "github.com/acme/repo",
 				Dir:             "stacks/prod",
 				ComponentSource: "github.com/acme/repo//stacks/prod",
-				Copyable:        true,
 			},
 		},
 		{
@@ -200,7 +195,7 @@ func TestJSONLRendererOmitsUnsetFields(t *testing.T) {
 					"",
 				),
 			).WithSource("github.com/acme/repo"),
-			want: []string{"component_source", "description", "dir", "kind", "source", "title"},
+			want: []string{"component_source", "dir", "kind", "source", "title"},
 		},
 		{
 			name: "entry with every field populated",
@@ -213,7 +208,7 @@ func TestJSONLRendererOmitsUnsetFields(t *testing.T) {
 				),
 			).WithSource("github.com/acme/repo").WithVersion("v1.2.3"),
 			want: []string{
-				"component_source", "copyable", "description", "dir", "doc",
+				"component_source", "description", "dir", "doc",
 				"kind", "source", "tags", "title", "version",
 			},
 		},
@@ -339,7 +334,7 @@ func TestNewRenderer(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "jsonl", format: "jsonl"},
-		{name: "markdown is not implemented yet", format: "md", wantErr: true},
+		{name: "md", format: "md"},
 		{name: "the tui is not a renderer", format: "tui", wantErr: true},
 		{name: "unknown", format: "yaml", wantErr: true},
 	}

--- a/internal/cli/commands/catalog/format/md.go
+++ b/internal/cli/commands/catalog/format/md.go
@@ -1,0 +1,313 @@
+package format
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+)
+
+// minFenceLength is the shortest code fence CommonMark recognizes.
+const minFenceLength = 3
+
+const (
+	// fieldTableHeader opens a component's table of metadata, one field per row.
+	fieldTableHeader = "| Field | Value |\n| --- | --- |\n"
+
+	// tagTableHeader opens a component's table of tags. Tags are a flat list
+	// today, so the table has the one column; a value column joins it the day
+	// they carry one.
+	tagTableHeader = "| Tag |\n| --- |\n"
+
+	// indexTableHeader opens the table of components the document closes with.
+	indexTableHeader = "| Component | Kind | Component source |\n| --- | --- | --- |\n"
+)
+
+// markdownHeader opens the document. It states what the reader is holding,
+// because the document is as likely to be piped into a tool or handed to an
+// agent as it is to be read by the person who ran the command.
+const markdownHeader = `# Terragrunt Catalog
+
+Every component that ` + "`terragrunt catalog`" + ` discovers has a section below, holding the metadata the catalog user interface shows for it, followed by the component's README.
+
+Each section records a component source, which is where the component is scaffolded from. ` + "`terragrunt scaffold`" + ` takes one for a module or a template; the catalog user interface scaffolds a unit or a stack by copying.
+
+Sections are written as components are discovered, so they interleave the repositories being loaded, and their order changes between runs. READMEs are reproduced inside fenced blocks, so a heading within one is not part of this document's structure.
+
+The document ends with an index of the components it holds and a count of what was discovered, which is how a reader tells a complete document from one that was cut short.
+
+`
+
+// MarkdownRenderer writes the catalog as a Markdown document: a header, a
+// section per component, and a closing index of everything it wrote.
+type MarkdownRenderer struct {
+	index []indexRow
+}
+
+// indexRow is what a component contributes to the closing index. Three fields
+// per component is what a table at the end of a streamed document costs; the
+// READMEs, which are the bulk of the output, are written and forgotten.
+type indexRow struct {
+	title  string
+	kind   string
+	source string
+}
+
+// NewMarkdownRenderer returns a renderer that emits Markdown.
+func NewMarkdownRenderer() *MarkdownRenderer {
+	return &MarkdownRenderer{}
+}
+
+// Open implements [Renderer], writing the document header.
+func (r *MarkdownRenderer) Open(w io.Writer) error {
+	if _, err := io.WriteString(w, markdownHeader); err != nil {
+		return err
+	}
+
+	return flush(w)
+}
+
+// Entry implements [Renderer], writing e as one section.
+func (r *MarkdownRenderer) Entry(w io.Writer, e *tui.ComponentEntry) error {
+	entry := NewEntry(e)
+	title := oneLine(entry.Title)
+
+	var buf bytes.Buffer
+
+	fmt.Fprintf(&buf, "## %s\n\n", title)
+
+	// The description is the component's own prose, so it opens the section as
+	// prose rather than as a row in the table of facts below it.
+	if entry.Description != "" {
+		fmt.Fprintf(&buf, "%s\n\n", paragraph(entry.Description))
+	}
+
+	buf.WriteString(fieldTableHeader)
+
+	for _, f := range entryFields(entry) {
+		// A row is written only when the component has a value for it, so the
+		// table carries what it has rather than a column of empty cells.
+		if f.value == "" {
+			continue
+		}
+
+		fmt.Fprintf(&buf, "| %s | %s |\n", f.label, f.value)
+	}
+
+	writeTags(&buf, entry.Tags)
+
+	if entry.Doc != "" {
+		buf.WriteString("\n")
+		writeDoc(&buf, entry.Doc, docLanguageOf(e.Component))
+	}
+
+	buf.WriteString("\n")
+
+	r.index = append(r.index, indexRow{
+		title:  title,
+		kind:   entry.Kind,
+		source: entry.ComponentSource,
+	})
+
+	// Build the whole section before writing, for the reasons given in
+	// [JSONLRenderer.Entry].
+	return writeAndFlush(w, &buf)
+}
+
+// Close implements [Renderer], writing the index of what the document holds
+// and the count that marks it complete.
+func (r *MarkdownRenderer) Close(w io.Writer, summary Summary) error {
+	var buf bytes.Buffer
+
+	buf.WriteString("---\n\n")
+
+	if summary.Entries == 0 {
+		buf.WriteString("No components were discovered.\n")
+
+		return writeAndFlush(w, &buf)
+	}
+
+	buf.WriteString(indexTableHeader)
+
+	for _, row := range r.index {
+		fmt.Fprintf(&buf, "| %s | %s | %s |\n", cell(row.title), code(row.kind), code(row.source))
+	}
+
+	fmt.Fprintf(
+		&buf, "\nDiscovered %s from %s.\n",
+		plural(summary.Entries, "component"),
+		plural(summary.Sources, "source"),
+	)
+
+	return writeAndFlush(w, &buf)
+}
+
+// writeAndFlush pushes a built-up chunk of the document to the consumer.
+func writeAndFlush(w io.Writer, buf *bytes.Buffer) error {
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		return err
+	}
+
+	return flush(w)
+}
+
+// field is one row of a component's metadata table.
+type field struct {
+	label string
+	value string
+}
+
+// entryFields returns a component's metadata rows in the order they are
+// written.
+func entryFields(e *Entry) []field {
+	return []field{
+		{label: "Kind", value: code(e.Kind)},
+		{label: "Source", value: code(e.Source)},
+		{label: "Directory", value: code(e.Dir)},
+		{label: "Version", value: code(e.Version)},
+		{label: "URL", value: autolink(e.URL)},
+		{label: "Component source", value: code(e.ComponentSource)},
+	}
+}
+
+// writeTags writes a component's tags as a table of their own. A component
+// can carry any number of them, and a row each stays readable where a single
+// cell holding the whole list would not.
+func writeTags(buf *bytes.Buffer, tags []string) {
+	if len(tags) == 0 {
+		return
+	}
+
+	buf.WriteString("\n" + tagTableHeader)
+
+	for _, tag := range tags {
+		fmt.Fprintf(buf, "| %s |\n", code(tag))
+	}
+}
+
+// docLanguage is the info string a README's fenced block carries.
+type docLanguage string
+
+const (
+	// docPlain leaves a README that isn't Markdown (AsciiDoc, today) with a
+	// bare fence, rather than an info string claiming a language it isn't
+	// written in.
+	docPlain docLanguage = ""
+
+	docMarkdown docLanguage = "markdown"
+)
+
+// docLanguageOf returns the info string to fence c's README with.
+func docLanguageOf(c *tui.Component) docLanguage {
+	if c.IsMarkDown() {
+		return docMarkdown
+	}
+
+	return docPlain
+}
+
+// writeDoc writes a component's README inside a fenced block, so that the
+// headings and thematic breaks a README carries cannot be read as part of the
+// surrounding document.
+func writeDoc(buf *bytes.Buffer, doc string, lang docLanguage) {
+	fence := docFence(doc)
+
+	buf.WriteString(fence)
+	buf.WriteString(string(lang))
+	buf.WriteString("\n")
+	buf.WriteString(doc)
+
+	if !strings.HasSuffix(doc, "\n") {
+		buf.WriteString("\n")
+	}
+
+	buf.WriteString(fence)
+	buf.WriteString("\n")
+}
+
+// docFence returns a fence long enough to hold doc. A fenced block ends at
+// the first fence at least as long as the one that opened it, so a README
+// containing fences of its own needs a longer one around it.
+func docFence(doc string) string {
+	longest, run := 0, 0
+
+	for _, r := range doc {
+		if r != '`' {
+			run = 0
+
+			continue
+		}
+
+		run++
+		longest = max(longest, run)
+	}
+
+	return strings.Repeat("`", max(minFenceLength, longest+1))
+}
+
+// oneLine collapses whitespace so that a value taken from README front matter
+// stays on the line the document put it on.
+func oneLine(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}
+
+// blockStarters open a block construct when they open a line: a heading, a
+// fence, a thematic break, a list, a quote, or raw HTML.
+const blockStarters = "#>`~<-_*+"
+
+// paragraph renders a value as prose of its own, escaping a leading character
+// that would otherwise open a block. A value the component wrote must not add
+// a section to the document, or a fence that swallows the rest of it.
+func paragraph(value string) string {
+	line := oneLine(value)
+	if line == "" {
+		return ""
+	}
+
+	if strings.ContainsAny(line[:1], blockStarters) {
+		return `\` + line
+	}
+
+	return line
+}
+
+// cell renders a value as the content of a table cell. A pipe would end the
+// cell, and a line break would end the row, so neither survives as itself.
+// Every value this file writes lands in a cell, so the wrappers below escape
+// as they wrap and nothing escapes twice. The escape holds inside a code span
+// too, which is where most of these values end up.
+func cell(value string) string {
+	return strings.ReplaceAll(oneLine(value), "|", `\|`)
+}
+
+// code wraps value in a code span, leaving an empty value empty so the caller
+// can drop its row.
+func code(value string) string {
+	if value == "" {
+		return ""
+	}
+
+	return "`" + cell(value) + "`"
+}
+
+// autolink wraps a URL in the angle brackets that make it a link without a
+// separate label.
+func autolink(url string) string {
+	if url == "" {
+		return ""
+	}
+
+	return "<" + cell(url) + ">"
+}
+
+// plural renders a count with the singular or plural form of unit.
+func plural(count int, unit string) string {
+	if count == 1 {
+		return "1 " + unit
+	}
+
+	return strconv.Itoa(count) + " " + unit + "s"
+}

--- a/internal/cli/commands/catalog/format/md_test.go
+++ b/internal/cli/commands/catalog/format/md_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/format"
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+	"github.com/gruntwork-io/terragrunt/internal/services/catalog/component"
 )
 
 func TestMarkdownRendererEntry(t *testing.T) {
@@ -30,7 +31,7 @@ func TestMarkdownRendererEntry(t *testing.T) {
 			name: "module with full readme metadata",
 			entry: tui.NewComponentEntry(
 				tui.NewComponentForTest(
-					tui.ComponentKindModule,
+					component.KindModule,
 					"github.com/acme/repo",
 					"modules/vpc",
 					vpcReadme,
@@ -63,7 +64,7 @@ Body text.
 			name: "unit without a readme has no description and no tags",
 			entry: tui.NewComponentEntry(
 				tui.NewComponentForTest(
-					tui.ComponentKindUnit,
+					component.KindUnit,
 					"github.com/acme/repo",
 					"units/app",
 					"",
@@ -84,7 +85,7 @@ Body text.
 			name: "repository root component",
 			entry: tui.NewComponentEntry(
 				tui.NewComponentForTest(
-					tui.ComponentKindModule,
+					component.KindModule,
 					"github.com/acme/repo",
 					"",
 					rootReadme,
@@ -128,7 +129,7 @@ func TestMarkdownRendererEntryTables(t *testing.T) {
 
 	entry := tui.NewComponentEntry(
 		tui.NewComponentForTest(
-			tui.ComponentKindModule,
+			component.KindModule,
 			"github.com/acme/repo",
 			"modules/vpc",
 			vpcReadme,
@@ -194,7 +195,7 @@ name: VPC
 
 	entry := tui.NewComponentEntry(
 		tui.NewComponentForTest(
-			tui.ComponentKindModule,
+			component.KindModule,
 			"github.com/acme/repo",
 			"modules/vpc",
 			readme,
@@ -237,7 +238,7 @@ func TestMarkdownRendererKeepsDescriptionOutOfTheDocumentStructure(t *testing.T)
 
 			entry := tui.NewComponentEntry(
 				tui.NewComponentForTest(
-					tui.ComponentKindModule,
+					component.KindModule,
 					"github.com/acme/repo",
 					"modules/vpc",
 					"---\nname: VPC\ndescription: \""+tc.description+"\"\n---\n\nBody.\n",
@@ -308,7 +309,7 @@ inputs = {}
 
 			entry := tui.NewComponentEntry(
 				tui.NewComponentForTest(
-					tui.ComponentKindModule,
+					component.KindModule,
 					"github.com/acme/repo",
 					"modules/vpc",
 					"---\nname: VPC\n---\n\n"+tc.body,
@@ -331,7 +332,7 @@ func TestMarkdownRendererFencesNonMarkdownReadme(t *testing.T) {
 	t.Parallel()
 
 	component := tui.NewComponentForTest(
-		tui.ComponentKindModule,
+		component.KindModule,
 		"github.com/acme/repo",
 		"modules/vpc",
 		"",
@@ -380,7 +381,7 @@ inputs = {
 
 	entry := tui.NewComponentEntry(
 		tui.NewComponentForTest(
-			tui.ComponentKindModule,
+			component.KindModule,
 			"github.com/acme/repo",
 			"modules/vpc",
 			frontmatter+body,
@@ -429,7 +430,7 @@ func TestMarkdownRendererIndexEscapesPipes(t *testing.T) {
 
 	entry := tui.NewComponentEntry(
 		tui.NewComponentForTest(
-			tui.ComponentKindModule,
+			component.KindModule,
 			"github.com/acme/repo",
 			"modules/vpc",
 			`---

--- a/internal/cli/commands/catalog/format/md_test.go
+++ b/internal/cli/commands/catalog/format/md_test.go
@@ -1,0 +1,605 @@
+package format_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	extast "github.com/yuin/goldmark/extension/ast"
+	"github.com/yuin/goldmark/text"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/format"
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+)
+
+func TestMarkdownRendererEntry(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		entry *tui.ComponentEntry
+		name  string
+		want  string
+	}{
+		{
+			name: "module with full readme metadata",
+			entry: tui.NewComponentEntry(
+				tui.NewComponentForTest(
+					tui.ComponentKindModule,
+					"github.com/acme/repo",
+					"modules/vpc",
+					vpcReadme,
+				),
+			).WithSource("github.com/acme/repo").WithVersion("v1.2.3"),
+			want: backticks(`## VPC
+
+Creates a VPC.
+
+| Field | Value |
+| --- | --- |
+| Kind | ~module~ |
+| Source | ~github.com/acme/repo~ |
+| Directory | ~modules/vpc~ |
+| Version | ~v1.2.3~ |
+| Component source | ~github.com/acme/repo//modules/vpc~ |
+
+| Tag |
+| --- |
+| ~networking~ |
+| ~aws~ |
+
+~~~markdown
+Body text.
+~~~
+
+`),
+		},
+		{
+			name: "unit without a readme has no description and no tags",
+			entry: tui.NewComponentEntry(
+				tui.NewComponentForTest(
+					tui.ComponentKindUnit,
+					"github.com/acme/repo",
+					"units/app",
+					"",
+				),
+			).WithSource("github.com/acme/repo"),
+			want: backticks(`## app
+
+| Field | Value |
+| --- | --- |
+| Kind | ~unit~ |
+| Source | ~github.com/acme/repo~ |
+| Directory | ~units/app~ |
+| Component source | ~github.com/acme/repo//units/app~ |
+
+`),
+		},
+		{
+			name: "repository root component",
+			entry: tui.NewComponentEntry(
+				tui.NewComponentForTest(
+					tui.ComponentKindModule,
+					"github.com/acme/repo",
+					"",
+					rootReadme,
+				),
+			).WithSource("github.com/acme/repo"),
+			want: backticks(`## Repo Root
+
+The repository itself is the component.
+
+| Field | Value |
+| --- | --- |
+| Kind | ~module~ |
+| Source | ~github.com/acme/repo~ |
+| Component source | ~github.com/acme/repo~ |
+
+~~~markdown
+Root body.
+~~~
+
+`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			require.NoError(t, format.NewMarkdownRenderer().Entry(&buf, tc.entry))
+			assert.Equal(t, tc.want, buf.String())
+		})
+	}
+}
+
+// TestMarkdownRendererEntryTables reads a section back with a table parser:
+// the fields parse as a two-column table, and the tags as a table of their
+// own, one column wide.
+func TestMarkdownRendererEntryTables(t *testing.T) {
+	t.Parallel()
+
+	entry := tui.NewComponentEntry(
+		tui.NewComponentForTest(
+			tui.ComponentKindModule,
+			"github.com/acme/repo",
+			"modules/vpc",
+			vpcReadme,
+		),
+	).WithSource("github.com/acme/repo").WithVersion("v1.2.3")
+
+	var buf bytes.Buffer
+
+	require.NoError(t, format.NewMarkdownRenderer().Entry(&buf, entry))
+
+	assert.Equal(
+		t,
+		[]int{2, 2, 2, 2, 2, 1, 1},
+		tableRows(t, buf.String()),
+		"five field rows of two cells, then a tag each in a table one cell wide",
+	)
+}
+
+// TestMarkdownRendererDocument renders every kind of component the catalog
+// discovers and reads the result back as Markdown: the sections of the
+// document are the components, and nothing else.
+func TestMarkdownRendererDocument(t *testing.T) {
+	t.Parallel()
+
+	cases := entryCases()
+
+	var buf bytes.Buffer
+
+	renderer := format.NewMarkdownRenderer()
+
+	require.NoError(t, renderer.Open(&buf))
+
+	for _, tc := range cases {
+		require.NoError(t, renderer.Entry(&buf, tc.entry))
+	}
+
+	require.NoError(t, renderer.Close(&buf, format.Summary{Entries: len(cases), Sources: 2}))
+
+	assert.Equal(
+		t,
+		[]string{"Terragrunt Catalog", "VPC", "service", "app", "prod", "Repo Root"},
+		headings(t, buf.String()),
+	)
+	assert.True(t, strings.HasSuffix(buf.String(), "Discovered 5 components from 2 sources.\n"))
+}
+
+// TestMarkdownRendererKeepsReadmeStructureOutOfTheDocument covers the reason
+// READMEs are fenced: a README carrying its own headings must not add
+// sections to the document that contains it.
+func TestMarkdownRendererKeepsReadmeStructureOutOfTheDocument(t *testing.T) {
+	t.Parallel()
+
+	const readme = `---
+name: VPC
+---
+
+# Not a component
+
+## Neither is this
+
+---
+`
+
+	entry := tui.NewComponentEntry(
+		tui.NewComponentForTest(
+			tui.ComponentKindModule,
+			"github.com/acme/repo",
+			"modules/vpc",
+			readme,
+		),
+	).WithSource("github.com/acme/repo")
+
+	var buf bytes.Buffer
+
+	renderer := format.NewMarkdownRenderer()
+
+	require.NoError(t, renderer.Open(&buf))
+	require.NoError(t, renderer.Entry(&buf, entry))
+	require.NoError(t, renderer.Close(&buf, format.Summary{Entries: 1, Sources: 1}))
+
+	assert.Equal(t, []string{"Terragrunt Catalog", "VPC"}, headings(t, buf.String()))
+}
+
+// TestMarkdownRendererKeepsDescriptionOutOfTheDocumentStructure covers the
+// other half of a README the component wrote: a description is prose in the
+// document rather than fenced, so one that opens with Markdown structure must
+// not add a section or open a fence of its own.
+func TestMarkdownRendererKeepsDescriptionOutOfTheDocumentStructure(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		description string
+	}{
+		{name: "heading", description: "# Not a component"},
+		{name: "fence", description: backticks("~~~")},
+		{name: "thematic break", description: "---"},
+		{name: "quote", description: "> Creates a VPC."},
+		{name: "list", description: "- Creates a VPC."},
+		{name: "html", description: "<p>Creates a VPC.</p>"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			entry := tui.NewComponentEntry(
+				tui.NewComponentForTest(
+					tui.ComponentKindModule,
+					"github.com/acme/repo",
+					"modules/vpc",
+					"---\nname: VPC\ndescription: \""+tc.description+"\"\n---\n\nBody.\n",
+				),
+			).WithSource("github.com/acme/repo")
+
+			var buf bytes.Buffer
+
+			renderer := format.NewMarkdownRenderer()
+
+			require.NoError(t, renderer.Open(&buf))
+			require.NoError(t, renderer.Entry(&buf, entry))
+			require.NoError(t, renderer.Close(&buf, format.Summary{Entries: 1, Sources: 1}))
+
+			assert.Equal(t, []string{"Terragrunt Catalog", "VPC"}, headings(t, buf.String()))
+			assert.Equal(
+				t,
+				ast.KindParagraph,
+				blockAfter(t, buf.String(), "VPC"),
+				"the description opens the section as prose",
+			)
+		})
+	}
+}
+
+func TestMarkdownRendererFencesReadmeContainingFences(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		body  string
+		fence string
+	}{
+		{
+			name: "no backticks",
+			body: `Body text.
+`,
+			fence: "```",
+		},
+		{
+			name: "inline code span",
+			body: backticks(`Set ~vpc_name~.
+`),
+			fence: "```",
+		},
+		{
+			name: "fenced block",
+			body: backticks(`~~~hcl
+inputs = {}
+~~~
+`),
+			fence: "````",
+		},
+		{
+			name: "fenced block holding a fence",
+			body: backticks(`~~~~md
+~~~hcl
+~~~
+~~~~
+`),
+			fence: "`````",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			entry := tui.NewComponentEntry(
+				tui.NewComponentForTest(
+					tui.ComponentKindModule,
+					"github.com/acme/repo",
+					"modules/vpc",
+					"---\nname: VPC\n---\n\n"+tc.body,
+				),
+			).WithSource("github.com/acme/repo")
+
+			var buf bytes.Buffer
+
+			require.NoError(t, format.NewMarkdownRenderer().Entry(&buf, entry))
+
+			assert.Contains(t, buf.String(), "\n"+tc.fence+"markdown\n"+tc.body+tc.fence+"\n")
+		})
+	}
+}
+
+// TestMarkdownRendererFencesNonMarkdownReadme pins the info string to what the
+// README is actually written in: an AsciiDoc README is fenced without one
+// rather than labelled as Markdown.
+func TestMarkdownRendererFencesNonMarkdownReadme(t *testing.T) {
+	t.Parallel()
+
+	component := tui.NewComponentForTest(
+		tui.ComponentKindModule,
+		"github.com/acme/repo",
+		"modules/vpc",
+		"",
+	)
+	component.Doc = tui.NewComponentDoc(`= VPC
+
+Body text.
+`, ".adoc")
+
+	entry := tui.NewComponentEntry(component).WithSource("github.com/acme/repo")
+
+	var buf bytes.Buffer
+
+	require.NoError(t, format.NewMarkdownRenderer().Entry(&buf, entry))
+	assert.Contains(t, buf.String(), backticks(`
+~~~
+= VPC
+
+Body text.
+~~~
+`))
+}
+
+// TestMarkdownRendererKeepsReadmeBodyVerbatim pins the body against the TUI's
+// plain-text stripping, which deletes fenced code blocks and reads the
+// underscores in vpc_name as emphasis markers.
+func TestMarkdownRendererKeepsReadmeBodyVerbatim(t *testing.T) {
+	t.Parallel()
+
+	const frontmatter = `---
+name: VPC
+---
+
+`
+
+	body := backticks(`# VPC
+
+Set ~vpc_name~ and ~cidr_block~.
+
+~~~hcl
+inputs = {
+  vpc_name = "prod"
+}
+~~~
+`)
+
+	entry := tui.NewComponentEntry(
+		tui.NewComponentForTest(
+			tui.ComponentKindModule,
+			"github.com/acme/repo",
+			"modules/vpc",
+			frontmatter+body,
+		),
+	).WithSource("github.com/acme/repo")
+
+	var buf bytes.Buffer
+
+	require.NoError(t, format.NewMarkdownRenderer().Entry(&buf, entry))
+	assert.Contains(t, buf.String(), body)
+}
+
+// TestMarkdownRendererIndex covers the document footer: a table naming every
+// component the document holds, and the count that marks it complete.
+func TestMarkdownRendererIndex(t *testing.T) {
+	t.Parallel()
+
+	cases := entryCases()
+
+	var buf bytes.Buffer
+
+	renderer := format.NewMarkdownRenderer()
+
+	for _, tc := range cases {
+		require.NoError(t, renderer.Entry(io.Discard, tc.entry))
+	}
+
+	require.NoError(t, renderer.Close(&buf, format.Summary{Entries: len(cases), Sources: 2}))
+
+	assert.Equal(t, backticks(`---
+
+| Component | Kind | Component source |
+| --- | --- | --- |
+| VPC | ~module~ | ~github.com/acme/repo//modules/vpc~ |
+| service | ~template~ | ~github.com/acme/repo//templates/service?ref=v2~ |
+| app | ~unit~ | ~github.com/acme/repo//units/app~ |
+| prod | ~stack~ | ~github.com/acme/repo//stacks/prod~ |
+| Repo Root | ~module~ | ~github.com/acme/repo~ |
+
+Discovered 5 components from 2 sources.
+`), buf.String())
+}
+
+func TestMarkdownRendererIndexEscapesPipes(t *testing.T) {
+	t.Parallel()
+
+	entry := tui.NewComponentEntry(
+		tui.NewComponentForTest(
+			tui.ComponentKindModule,
+			"github.com/acme/repo",
+			"modules/vpc",
+			`---
+name: A | B
+---
+`,
+		),
+	).WithSource("github.com/acme/repo")
+
+	var buf bytes.Buffer
+
+	renderer := format.NewMarkdownRenderer()
+
+	require.NoError(t, renderer.Entry(io.Discard, entry))
+	require.NoError(t, renderer.Close(&buf, format.Summary{Entries: 1, Sources: 1}))
+
+	assert.Contains(t, buf.String(), `| A \| B | `)
+	assert.Equal(t, []int{3}, tableRows(t, buf.String()), "one row of three cells")
+}
+
+func TestMarkdownRendererSummary(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		want    string
+		summary format.Summary
+	}{
+		{
+			name:    "nothing discovered",
+			summary: format.Summary{},
+			want: `---
+
+No components were discovered.
+`,
+		},
+		{
+			name:    "one component in one source",
+			summary: format.Summary{Entries: 1, Sources: 1},
+			want: `Discovered 1 component from 1 source.
+`,
+		},
+		{
+			name:    "many components across many sources",
+			summary: format.Summary{Entries: 12, Sources: 3},
+			want: `Discovered 12 components from 3 sources.
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			require.NoError(t, format.NewMarkdownRenderer().Close(&buf, tc.summary))
+			assert.True(t, strings.HasSuffix(buf.String(), tc.want), buf.String())
+		})
+	}
+}
+
+func TestMarkdownRendererFlushesEveryEntry(t *testing.T) {
+	t.Parallel()
+
+	w := &flushCountingWriter{}
+	renderer := format.NewMarkdownRenderer()
+
+	require.NoError(t, renderer.Open(w))
+	assert.Equal(t, 1, w.flushes, "the header must reach the consumer before the first entry")
+
+	cases := entryCases()
+
+	for i, tc := range cases {
+		require.NoError(t, renderer.Entry(w, tc.entry))
+		assert.Equal(t, i+2, w.flushes, "every entry must be flushed as it is written")
+	}
+
+	require.NoError(t, renderer.Close(w, format.Summary{Entries: len(cases), Sources: 1}))
+	assert.Equal(t, len(cases)+2, w.flushes)
+}
+
+// headings parses doc as Markdown and returns the text of every heading, so a
+// test can assert what the document is made of rather than which lines it
+// happens to contain.
+func headings(t *testing.T, doc string) []string {
+	t.Helper()
+
+	source := []byte(doc)
+
+	var titles []string
+
+	err := ast.Walk(
+		goldmark.DefaultParser().Parse(text.NewReader(source)),
+		func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+			heading, ok := n.(*ast.Heading)
+			if !ok || !entering {
+				return ast.WalkContinue, nil
+			}
+
+			titles = append(titles, string(heading.Lines().Value(source)))
+
+			return ast.WalkSkipChildren, nil
+		},
+	)
+	require.NoError(t, err)
+
+	return titles
+}
+
+// blockAfter parses doc as Markdown and names the kind of block that follows
+// the given heading, so a test can assert what a value became rather than
+// which characters it was written as.
+func blockAfter(t *testing.T, doc, heading string) ast.NodeKind {
+	t.Helper()
+
+	source := []byte(doc)
+	document := goldmark.DefaultParser().Parse(text.NewReader(source))
+
+	var found ast.Node
+
+	for n := document.FirstChild(); n != nil; n = n.NextSibling() {
+		h, ok := n.(*ast.Heading)
+		if !ok || string(h.Lines().Value(source)) != heading {
+			continue
+		}
+
+		found = n
+
+		break
+	}
+
+	require.NotNil(t, found, "no heading %q in %s", heading, doc)
+
+	next := found.NextSibling()
+	require.NotNil(t, next, "heading %q closes the document", heading)
+
+	return next.Kind()
+}
+
+// tableRows parses doc as GitHub-flavored Markdown and returns the number of
+// cells in each body row of its table, so a test can assert that a value
+// holding a pipe stayed inside the cell it was written to.
+func tableRows(t *testing.T, doc string) []int {
+	t.Helper()
+
+	parser := goldmark.New(goldmark.WithExtensions(extension.Table)).Parser()
+
+	var rows []int
+
+	err := ast.Walk(
+		parser.Parse(text.NewReader([]byte(doc))),
+		func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+			row, ok := n.(*extast.TableRow)
+			if !ok || !entering {
+				return ast.WalkContinue, nil
+			}
+
+			rows = append(rows, row.ChildCount())
+
+			return ast.WalkSkipChildren, nil
+		},
+	)
+	require.NoError(t, err)
+
+	return rows
+}
+
+// backticks turns the tildes of a raw string literal into the backticks the
+// renderer writes, which a raw string literal cannot hold.
+func backticks(s string) string {
+	return strings.ReplaceAll(s, "~", "`")
+}

--- a/internal/cli/commands/catalog/options.go
+++ b/internal/cli/commands/catalog/options.go
@@ -15,6 +15,10 @@ const (
 	// FormatJSONL writes each discovered component to standard output as a
 	// JSON object on its own line.
 	FormatJSONL = format.JSONL
+
+	// FormatMD writes the discovered components to standard output as a
+	// Markdown document, with a section per component.
+	FormatMD = format.MD
 )
 
 // ErrFormatRequiresExperiment is returned when a non-interactive format is
@@ -49,6 +53,8 @@ func (o *Options) validateFormat() error {
 	case FormatTUI:
 		return nil
 	case FormatJSONL:
+		return nil
+	case FormatMD:
 		return nil
 	default:
 		return errors.New("invalid format: " + o.Format)

--- a/internal/cli/commands/catalog/options_test.go
+++ b/internal/cli/commands/catalog/options_test.go
@@ -29,7 +29,7 @@ func TestOptionsValidate(t *testing.T) {
 	}{
 		{name: "tui", format: catalog.FormatTUI},
 		{name: "jsonl", format: catalog.FormatJSONL},
-		{name: "markdown is not implemented yet", format: "md", wantErr: true},
+		{name: "md", format: catalog.FormatMD},
 		{name: "unknown format", format: "yaml", wantErr: true},
 		{name: "empty format", format: "", wantErr: true},
 	}

--- a/internal/cli/commands/catalog/tui/component.go
+++ b/internal/cli/commands/catalog/tui/component.go
@@ -57,15 +57,25 @@ func (c *Component) Title() string {
 	return filepath.Base(c.Dir)
 }
 
-// Description returns a short description for the list view.
+// Description returns a short description for the list view, falling back to
+// a placeholder that fills the row a list item always reserves for it.
 func (c *Component) Description() string {
-	if c.Doc != nil {
-		if desc := c.Doc.Description(maxDescriptionLength); desc != "" {
-			return desc
-		}
+	if desc := c.DocDescription(); desc != "" {
+		return desc
 	}
 
 	return defaultDescription
+}
+
+// DocDescription returns the component's README description, or an empty
+// string when it has none. Output formats that have no row to fill use this
+// rather than writing the list view's placeholder into a document.
+func (c *Component) DocDescription() string {
+	if c.Doc == nil {
+		return ""
+	}
+
+	return c.Doc.Description(maxDescriptionLength)
 }
 
 // FilterValue is what the list fuzzy-matches against when the user filters.

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -399,7 +399,7 @@ func TestCatalogNonTTYFailsFast(t *testing.T) {
 func TestCatalogJSONLFormat(t *testing.T) {
 	t.Parallel()
 
-	workDir := catalogJSONLFixture(t)
+	workDir := catalogFixture(t)
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
 		"terragrunt catalog --experiment catalog-format --format jsonl --working-dir "+workDir)
@@ -424,10 +424,6 @@ func TestCatalogJSONLFormat(t *testing.T) {
 	assert.Equal(t, "Creates a VPC.", vpc.Description)
 	assert.Equal(t, []string{"networking"}, vpc.Tags)
 	assert.Contains(t, vpc.Doc, "Everything a VPC needs.")
-	assert.False(t, vpc.Copyable)
-
-	assert.True(t, byDir["units/app"].Copyable)
-	assert.True(t, byDir["stacks/prod"].Copyable)
 }
 
 // TestCatalogJSONLFormatWithoutTTY guards the non-interactive path against the
@@ -451,12 +447,66 @@ func TestCatalogJSONLFormatWithoutTTY(t *testing.T) {
 		t.Skip("a controlling terminal is available; a regression would launch the catalog TUI for real")
 	}
 
-	workDir := catalogJSONLFixture(t)
+	workDir := catalogFixture(t)
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
 		"terragrunt catalog --experiment catalog-format --format jsonl --working-dir "+workDir)
 	require.NoError(t, err)
 	assert.Len(t, parseCatalogJSONL(t, stdout), 4)
+}
+
+// TestCatalogMDFormat renders a catalog as a Markdown document and checks the
+// sections it wrote.
+func TestCatalogMDFormat(t *testing.T) {
+	t.Parallel()
+
+	workDir := catalogFixture(t)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt catalog --experiment catalog-format --format md --working-dir "+workDir)
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(stdout, "# Terragrunt Catalog\n"), "the header opens the document")
+
+	for _, want := range []string{
+		backticks(`## VPC
+
+Creates a VPC.
+
+| Field | Value |
+| --- | --- |
+| Kind | ~module~ |
+`),
+		backticks(`
+| Tag |
+| --- |
+| ~networking~ |
+`),
+		// A component with no README has no description, so its table opens the
+		// section.
+		backticks(`## service
+
+| Field | Value |
+`),
+		"## app",
+		"## prod",
+		backticks(`~~~markdown
+Everything a VPC needs.
+~~~
+`),
+		backticks(`| Component | Kind | Component source |
+| --- | --- | --- |
+`),
+		backticks("| VPC | ~module~ | "),
+	} {
+		assert.Contains(t, stdout, want)
+	}
+
+	assert.True(
+		t,
+		strings.HasSuffix(stdout, "\nDiscovered 4 components from 1 source.\n"),
+		"the count closes the document",
+	)
 }
 
 func TestCatalogJSONLFormatRequiresExperiment(t *testing.T) {
@@ -468,7 +518,7 @@ func TestCatalogJSONLFormatRequiresExperiment(t *testing.T) {
 		)
 	}
 
-	workDir := catalogJSONLFixture(t)
+	workDir := catalogFixture(t)
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
 		"terragrunt catalog --format jsonl --working-dir "+workDir)
@@ -482,7 +532,7 @@ func TestCatalogJSONLFormatRequiresExperiment(t *testing.T) {
 func TestCatalogUnknownFormat(t *testing.T) {
 	t.Parallel()
 
-	workDir := catalogJSONLFixture(t)
+	workDir := catalogFixture(t)
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t,
 		"terragrunt catalog --experiment catalog-format --format pdf --working-dir "+workDir)
@@ -614,10 +664,10 @@ func catalogManyModulesFixture(t *testing.T, count int) string {
 	return workDir
 }
 
-// catalogJSONLFixture builds a repository holding one component of each kind
+// catalogFixture builds a repository holding one component of each kind
 // and a working directory whose catalog configuration points at it, then
 // returns the working directory.
-func catalogJSONLFixture(t *testing.T) string {
+func catalogFixture(t *testing.T) string {
 	t.Helper()
 
 	repoDir := helpers.TmpDirWOSymlinks(t)
@@ -654,6 +704,12 @@ Everything a VPC needs.
 `)
 
 	return workDir
+}
+
+// backticks turns the tildes of a raw string literal into the backticks the
+// Markdown format writes, which a raw string literal cannot hold.
+func backticks(s string) string {
+	return strings.ReplaceAll(s, "~", "`")
 }
 
 // parseCatalogJSONL parses each line of rendered output and keys the entries


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds support for the `md` format to render `catalog` entries as streamed markdown content.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Markdown output support for catalog results with component sections, metadata, tags, README content, streaming, and a final completeness summary.
  * Added Markdown format validation and documentation for scripts, CI jobs, and agents.
* **Bug Fixes**
  * Improved JSON output by omitting empty descriptions and removed the obsolete `copyable` field.
  * Updated catalog descriptions and schema documentation to accurately reflect omitted tag fields.
* **Documentation**
  * Added changelog coverage for the new Markdown catalog format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->