### PR TITLE
chore: address review feedback from #6531

### DIFF
--- a/docs/src/data/changelog/v1.1.3/oci-tofu-credentials.mdx
+++ b/docs/src/data/changelog/v1.1.3/oci-tofu-credentials.mdx
@@ -5,12 +5,8 @@ category: "experiments-updated"
 
 #### `oci` - OpenTofu CLI-config credentials for OCI module sources
 
-`oci://` module downloads now read OpenTofu's CLI-config credentials, so one configuration serves both `tofu` and Terragrunt.
+`oci://` module downloads now read OpenTofu's CLI-config credentials, so one configuration serves both OpenTofu and Terragrunt.
 
 Terragrunt honors the `oci_credentials "<registry>[/<repo-prefix>]"` blocks (username and password, OAuth tokens, or a `docker_credentials_helper`, which like `tofu` may only be set on a whole registry) and the `oci_default_credentials` fallback helper. A `TF_CLI_CONFIG_FILE` or `TERRAFORM_CONFIG` value selects the config file outright; otherwise Terragrunt reads the first of `~/.tofurc` and `~/.terraformrc` that exists, and merges the `*.tfrc` and `*.tfrc.json` files in OpenTofu's config directory.
 
 Terragrunt picks the most specific matching source across CLI config and ambient Docker config; an explicit CLI-config entry wins when both match equally. Set `discover_ambient_credentials = false` in the `oci_default_credentials` block to use CLI config only.
-
-A missing CLI config is a normal discovery miss. A config file that exists but is invalid is reported as an error rather than skipped, so a typo can never quietly change which credentials Terragrunt sends.
-
-The interim `TG_TMP_OCI_*` environment variables introduced in v1.1.2 are removed. Move those credentials into an `oci_credentials` block, or rely on ambient Docker config.

--- a/docs/src/data/experiments/oci.mdx
+++ b/docs/src/data/experiments/oci.mdx
@@ -41,12 +41,10 @@ and `~/.terraformrc` that exists (on Windows, `%APPDATA%\tofu.rc` and
 `%APPDATA%\terraform.rc`). Unless one of those environment variables is set, it
 also merges the `*.tfrc` and `*.tfrc.json` files in OpenTofu's config directory. Terragrunt also reads ambient Docker and containers
 auth files (`~/.docker/config.json` and containers `auth.json`), following the
-containers-auth search order OpenTofu uses. Set `docker_style_config_files` in
+[containers-auth search order](https://opentofu.org/docs/cli/oci_registries/credentials/)
+OpenTofu uses as of OpenTofu 1.12. Set `docker_style_config_files` in
 `oci_default_credentials` to replace those default search paths, or an empty
 list to disable ambient discovery entirely.
-
-A CLI config that exists but is invalid is an error, matching `tofu`, rather
-than being skipped in a way that would change which credentials are sent.
 
 Terragrunt ranks every matching CLI-config and ambient credential together by how
 much of the repository path each one matches, and uses the single best match. A

--- a/internal/getter/errors.go
+++ b/internal/getter/errors.go
@@ -1,0 +1,125 @@
+package getter
+
+import (
+	"errors"
+	"fmt"
+)
+
+// The errors raised while resolving OCI credentials, from the OpenTofu CLI config and from ambient Docker config.
+
+// ErrOCIHelperMalformedOutput reports a credential helper whose output is not valid JSON.
+var ErrOCIHelperMalformedOutput = errors.New("oci credential helper returned malformed output")
+
+// ErrOCIAmbientConfigFile reports a docker_style_config_files entry that cannot be read.
+var ErrOCIAmbientConfigFile = errors.New("cannot read docker_style_config_files entry")
+
+// ErrOCIInvalidHelperName reports a helper name that is empty or contains a path separator.
+var ErrOCIInvalidHelperName = errors.New(
+	"credential helper name must be the suffix of a docker-credential-<name> program on PATH, not a path",
+)
+
+// ErrOCIMissingCredentialStyle reports an oci_credentials block configuring no credential at all.
+var ErrOCIMissingCredentialStyle = errors.New(
+	"oci_credentials block must configure basic auth, OAuth tokens, or a helper",
+)
+
+// ErrOCIMultipleCredentialStyles reports a block configuring more than one credential style.
+var ErrOCIMultipleCredentialStyles = errors.New("oci_credentials block must configure at most one credential style")
+
+// ErrOCIIncompleteBasicCredential reports an oci_credentials block missing a username or password.
+var ErrOCIIncompleteBasicCredential = errors.New("oci_credentials basic auth requires both a username and a password")
+
+// ErrOCIIncompleteOAuthCredential reports an oci_credentials block missing an access or refresh token.
+var ErrOCIIncompleteOAuthCredential = errors.New(
+	"oci_credentials oauth requires both an access_token and a refresh_token",
+)
+
+// ErrOCIHelperWithRepositoryPath reports a helper on a repository-scoped label, which tofu rejects.
+var ErrOCIHelperWithRepositoryPath = errors.New(
+	"oci_credentials docker_credentials_helper cannot be used with a repository path",
+)
+
+// ErrOCIAmbientFilesWithoutDiscovery reports docker_style_config_files set while ambient discovery is off.
+var ErrOCIAmbientFilesWithoutDiscovery = errors.New(
+	"oci_default_credentials docker_style_config_files requires discover_ambient_credentials to be enabled",
+)
+
+// ErrOCIDuplicateDefaultBlock reports a second oci_default_credentials block, which tofu rejects.
+var ErrOCIDuplicateDefaultBlock = errors.New("at most one oci_default_credentials block is allowed")
+
+// ErrOCIDuplicateRepoBlock reports two oci_credentials blocks sharing a label, which tofu rejects.
+var ErrOCIDuplicateRepoBlock = errors.New("duplicate oci_credentials block")
+
+// ErrOCIEmptyCredentialValue reports a credential argument set to an empty string.
+var ErrOCIEmptyCredentialValue = errors.New("oci_credentials values must not be empty")
+
+// ErrOCILabelNotRepositoryAddress reports a label that is not a bare registry domain and repository path.
+var ErrOCILabelNotRepositoryAddress = errors.New(
+	"oci_credentials label must be a registry domain with an optional repository path, without a URL scheme",
+)
+
+// OCICredentialHelperError reports a helper failure, carrying stderr diagnostics but never the secret stdout.
+type OCICredentialHelperError struct {
+	Err      error
+	Helper   string
+	Registry string
+	Stderr   string
+}
+
+func (err OCICredentialHelperError) Error() string {
+	if err.Stderr != "" {
+		return fmt.Sprintf("oci credential helper %q for %s: %v: %s", err.Helper, err.Registry, err.Err, err.Stderr)
+	}
+
+	return fmt.Sprintf("oci credential helper %q for %s: %v", err.Helper, err.Registry, err.Err)
+}
+
+func (err OCICredentialHelperError) Unwrap() error {
+	return err.Err
+}
+
+// OCIAmbientConfigFileError names the docker_style_config_files entry that could not be read.
+type OCIAmbientConfigFileError struct {
+	Err  error
+	Path string
+}
+
+func (err OCIAmbientConfigFileError) Error() string {
+	return fmt.Sprintf("%s %s: %v", ErrOCIAmbientConfigFile, err.Path, err.Err)
+}
+
+// Unwrap exposes both the class sentinel and the read failure, so either matches with errors.Is.
+func (err OCIAmbientConfigFileError) Unwrap() []error {
+	return []error{ErrOCIAmbientConfigFile, err.Err}
+}
+
+// OCIDuplicateRepoBlockError names the oci_credentials label declared twice, and the file redeclaring it.
+type OCIDuplicateRepoBlockError struct {
+	Label string
+	Path  string
+}
+
+func (err OCIDuplicateRepoBlockError) Error() string {
+	return fmt.Sprintf("%s %q in %s", ErrOCIDuplicateRepoBlock, err.Label, err.Path)
+}
+
+func (err OCIDuplicateRepoBlockError) Unwrap() error {
+	return ErrOCIDuplicateRepoBlock
+}
+
+// OCIDuplicateDefaultBlockError names the file declaring a second oci_default_credentials block.
+type OCIDuplicateDefaultBlockError struct {
+	Path string
+}
+
+func (err OCIDuplicateDefaultBlockError) Error() string {
+	if err.Path == "" {
+		return ErrOCIDuplicateDefaultBlock.Error()
+	}
+
+	return fmt.Sprintf("%s: %s", ErrOCIDuplicateDefaultBlock, err.Path)
+}
+
+func (err OCIDuplicateDefaultBlockError) Unwrap() error {
+	return ErrOCIDuplicateDefaultBlock
+}

--- a/internal/getter/oci_auth.go
+++ b/internal/getter/oci_auth.go
@@ -39,12 +39,6 @@ var ociDockerHubRegistries = []string{
 	"registry-1.docker.io",
 }
 
-// ErrOCIHelperMalformedOutput reports a credential helper whose output is not valid JSON.
-var ErrOCIHelperMalformedOutput = errors.New("oci credential helper returned malformed output")
-
-// ErrOCIAmbientConfigFile reports a docker_style_config_files entry that cannot be read.
-var ErrOCIAmbientConfigFile = errors.New("cannot read docker_style_config_files entry")
-
 const (
 	// ociCredentialHelperPrefix is the docker-credential binary name prefix.
 	ociCredentialHelperPrefix = "docker-credential-"
@@ -61,26 +55,6 @@ const (
 	// ociDockerHubIndexServer is the server address helpers store Docker Hub creds under.
 	ociDockerHubIndexServer = "https://index.docker.io/v1/"
 )
-
-// OCICredentialHelperError reports a helper failure, carrying stderr diagnostics but never the secret stdout.
-type OCICredentialHelperError struct {
-	Err      error
-	Helper   string
-	Registry string
-	Stderr   string
-}
-
-func (err OCICredentialHelperError) Error() string {
-	if err.Stderr != "" {
-		return fmt.Sprintf("oci credential helper %q for %s: %v: %s", err.Helper, err.Registry, err.Err, err.Stderr)
-	}
-
-	return fmt.Sprintf("oci credential helper %q for %s: %v", err.Helper, err.Registry, err.Err)
-}
-
-func (err OCICredentialHelperError) Unwrap() error {
-	return err.Err
-}
 
 // OCIRemoteStore adapts oras' by-value Fetch to the pointer-taking [OCIRepositoryStore] seam.
 type OCIRemoteStore struct {
@@ -276,75 +250,96 @@ func ociSelectCredentialCandidate(
 ) ociCredentialCandidate {
 	var best ociCredentialCandidate
 
-	// CLI-config oci_credentials blocks rank by repository-prefix specificity.
 	for i := range tofu.repos {
 		repo := &tofu.repos[i]
 		if !repo.matches(hostport, repositoryName) {
 			continue
 		}
 
-		if cand := ociTofuCandidate(repo, hostport); ociOutranks(&cand, &best) {
-			best = cand
-		}
+		cand := ociTofuCandidate(repo, hostport)
+		keepBestCandidate(&best, &cand)
 	}
 
-	// The oci_default_credentials helper is a global-specificity CLI source.
-	if tofu.defaultHelper != "" {
-		cand := ociCredentialCandidate{
-			helper: &ociHelperEntry{
-				suffix:        tofu.defaultHelper,
-				serverAddress: ociTofuHelperServerAddress(hostport),
-				explicit:      true,
-			},
-			specificity:   ociGlobalSpecificity,
-			fromCLIConfig: true,
-		}
-		if ociOutranks(&cand, &best) {
-			best = cand
-		}
-	}
+	defaultHelper := ociTofuDefaultHelperCandidate(tofu, hostport)
+	keepBestCandidate(&best, &defaultHelper)
 
 	for _, ambient := range stores {
-		// The most specific inline key that resolves in this file.
-		for _, key := range ociCredentialKeys(hostport, repositoryName) {
-			cred := ociCredentialFromAmbientStore(ctx, l, ambient, key)
-			if cred == auth.EmptyCredential {
-				continue
-			}
+		inline := ociAmbientInlineCandidate(ctx, l, ambient, hostport, repositoryName)
+		keepBestCandidate(&best, &inline)
 
-			cand := ociCredentialCandidate{static: cred, specificity: ociInlineSpecificity(key)}
-			if ociOutranks(&cand, &best) {
-				best = cand
-			}
+		helper := ociAmbientHelperCandidate(ambient, hostport)
+		keepBestCandidate(&best, &helper)
 
-			break
-		}
-
-		// A per-registry credHelpers entry wins a tie with a domain inline login.
-		entry, hasHelper := ambient.credHelpers[ociCanonicalAuthKey(hostport)]
-		if hasHelper {
-			winner := entry
-			cand := ociCredentialCandidate{helper: &winner, specificity: ociDomainSpecificity}
-
-			if ociOutranks(&cand, &best) {
-				best = cand
-			}
-		}
-
-		// The global credsStore is the least specific source.
-		if ambient.credsStore != "" {
-			cand := ociCredentialCandidate{
-				helper:      &ociHelperEntry{suffix: ambient.credsStore, serverAddress: ociHelperServerAddress(hostport)},
-				specificity: ociGlobalSpecificity,
-			}
-
-			if ociOutranks(&cand, &best) {
-				best = cand
-			}
-		}
+		credsStore := ociAmbientCredsStoreCandidate(ambient, hostport)
+		keepBestCandidate(&best, &credsStore)
 	}
 
 	return best
+}
+
+// keepBestCandidate replaces best with cand when cand outranks it, ignoring the no-source zero candidate.
+func keepBestCandidate(best, cand *ociCredentialCandidate) {
+	if cand.specificity != 0 && ociOutranks(cand, best) {
+		*best = *cand
+	}
+}
+
+// ociTofuDefaultHelperCandidate ranks the oci_default_credentials helper as a global-specificity CLI source.
+func ociTofuDefaultHelperCandidate(tofu *ociTofuCredentials, hostport string) ociCredentialCandidate {
+	if tofu.defaultHelper == "" {
+		return ociCredentialCandidate{}
+	}
+
+	return ociCredentialCandidate{
+		helper: &ociHelperEntry{
+			suffix:        tofu.defaultHelper,
+			serverAddress: ociTofuHelperServerAddress(hostport),
+			explicit:      true,
+		},
+		specificity:   ociGlobalSpecificity,
+		fromCLIConfig: true,
+	}
+}
+
+// ociAmbientInlineCandidate ranks the most specific inline login that resolves in one ambient file.
+func ociAmbientInlineCandidate(
+	ctx context.Context,
+	l log.Logger,
+	ambient ociAmbientStore,
+	hostport, repositoryName string,
+) ociCredentialCandidate {
+	for _, key := range ociCredentialKeys(hostport, repositoryName) {
+		cred := ociCredentialFromAmbientStore(ctx, l, ambient, key)
+		if cred == auth.EmptyCredential {
+			continue
+		}
+
+		return ociCredentialCandidate{static: cred, specificity: ociInlineSpecificity(key)}
+	}
+
+	return ociCredentialCandidate{}
+}
+
+// ociAmbientHelperCandidate ranks a per-registry credHelpers entry, which wins a tie with a domain inline login.
+func ociAmbientHelperCandidate(ambient ociAmbientStore, hostport string) ociCredentialCandidate {
+	entry, hasHelper := ambient.credHelpers[ociCanonicalAuthKey(hostport)]
+	if !hasHelper {
+		return ociCredentialCandidate{}
+	}
+
+	return ociCredentialCandidate{helper: &entry, specificity: ociDomainSpecificity}
+}
+
+// ociAmbientCredsStoreCandidate ranks the file's global credsStore, the least specific source.
+func ociAmbientCredsStoreCandidate(ambient ociAmbientStore, hostport string) ociCredentialCandidate {
+	if ambient.credsStore == "" {
+		return ociCredentialCandidate{}
+	}
+
+	return ociCredentialCandidate{
+		helper:      &ociHelperEntry{suffix: ambient.credsStore, serverAddress: ociHelperServerAddress(hostport)},
+		specificity: ociGlobalSpecificity,
+	}
 }
 
 // ociExecuteCredentialCandidate runs the winning source now, with an explicit helper fatal and credsStore best-effort.
@@ -383,7 +378,7 @@ func ociHelperServerAddress(hostport string) string {
 	return hostport
 }
 
-// ociTofuHelperServerAddress builds the CLI-config helper address: https:// plus the host, unrewritten.
+// ociTofuHelperServerAddress builds the fixed https:// address tofu sends; the registry client never speaks plain HTTP.
 func ociTofuHelperServerAddress(hostport string) string {
 	return "https://" + hostport
 }
@@ -395,12 +390,12 @@ func ociCredentialFromHelper(
 	entry ociHelperEntry,
 	timeout time.Duration,
 ) (auth.Credential, error) {
-	// A path separator would make exec.LookPath run a non-PATH binary.
+	// The name is only the suffix of docker-credential-<name>, so a separator would run a non-PATH binary.
 	if !ociValidHelperName(entry.suffix) {
 		return auth.EmptyCredential, OCICredentialHelperError{
 			Helper:   entry.suffix,
 			Registry: entry.serverAddress,
-			Err:      errOCIInvalidHelperName,
+			Err:      ErrOCIInvalidHelperName,
 		}
 	}
 
@@ -547,7 +542,7 @@ func loadOCIAmbientStores(l log.Logger, v *venv.Venv, tofu *ociTofuCredentials) 
 		file, err := ociAuthFile(v, candidate)
 		if err != nil {
 			if explicit {
-				return nil, fmt.Errorf("%w %s: %w", ErrOCIAmbientConfigFile, candidate, err)
+				return nil, OCIAmbientConfigFileError{Path: candidate, Err: err}
 			}
 
 			if !errors.Is(err, iofs.ErrNotExist) {

--- a/internal/getter/oci_toforc.go
+++ b/internal/getter/oci_toforc.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	iofs "io/fs"
 	"path/filepath"
 	"strings"
 
+	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -17,15 +19,6 @@ import (
 	"oras.land/oras-go/v2/registry/remote/auth"
 )
 
-// Env vars OpenTofu reads to locate its CLI config, in the order it checks them.
-const (
-	envTFCLIConfigFile = "TF_CLI_CONFIG_FILE"
-	envTerraformConfig = "TERRAFORM_CONFIG"
-)
-
-// windowsGOOS is the platform whose CLI config lives under %APPDATA%.
-const windowsGOOS = "windows"
-
 // ociTofuRepoCredential is one decoded oci_credentials block: registry, repository prefix, credential or helper.
 type ociTofuRepoCredential struct {
 	label            string
@@ -35,7 +28,7 @@ type ociTofuRepoCredential struct {
 	helper           string
 }
 
-// matches reports whether this block serves hostport/repositoryName, on a path-segment boundary.
+// matches reports whether this block serves hostport/repositoryName; the trailing "/" path.Join strips is the boundary.
 func (c *ociTofuRepoCredential) matches(hostport, repositoryName string) bool {
 	if c.registryDomain != ociCanonicalAuthKey(hostport) {
 		return false
@@ -49,13 +42,18 @@ func (c *ociTofuRepoCredential) matches(hostport, repositoryName string) bool {
 		strings.HasPrefix(repositoryName, c.repositoryPrefix+"/")
 }
 
-// specificity ranks this block: domain level plus one per repository-path segment the label pins.
+// specificity ranks this block by counting the repository-path segments the label pins, not by joining a path.
 func (c *ociTofuRepoCredential) specificity() int {
 	if c.repositoryPrefix == "" {
 		return ociDomainSpecificity
 	}
 
 	return ociDomainSpecificity + strings.Count(c.repositoryPrefix, "/") + 1
+}
+
+// dedupKey identifies the label a block claims; concatenation keeps it injective, which path cleaning would not.
+func (c *ociTofuRepoCredential) dedupKey() string {
+	return c.registryDomain + "/" + c.repositoryPrefix
 }
 
 // ociTofuCredentials is the decoded OCI subset of an OpenTofu CLI config.
@@ -77,52 +75,24 @@ type ociTofuDefaults struct {
 	configFilesSet  bool
 }
 
-// errOCIInvalidHelperName reports a helper name that is empty or contains a path separator.
-var errOCIInvalidHelperName = errors.New("credential helper name must not be empty or contain a path separator")
+// ociTofuRepoBody is the decoded argument set of one oci_credentials block.
+type ociTofuRepoBody struct {
+	Username     *string  `hcl:"username,optional"`
+	Password     *string  `hcl:"password,optional"`
+	AccessToken  *string  `hcl:"access_token,optional"`
+	RefreshToken *string  `hcl:"refresh_token,optional"`
+	Helper       *string  `hcl:"docker_credentials_helper,optional"`
+	Remain       hcl.Body `hcl:",remain"`
+}
 
-// errOCIMissingCredentialStyle reports an oci_credentials block configuring no credential at all.
-var errOCIMissingCredentialStyle = errors.New(
-	"oci_credentials block must configure basic auth, OAuth tokens, or a helper",
-)
-
-// errOCIMultipleCredentialStyles reports a block configuring more than one credential style.
-var errOCIMultipleCredentialStyles = errors.New("oci_credentials block must configure at most one credential style")
-
-// errOCIIncompleteBasicCredential reports an oci_credentials block missing a username or password.
-var errOCIIncompleteBasicCredential = errors.New("oci_credentials basic auth requires both a username and a password")
-
-// errOCIIncompleteOAuthCredential reports an oci_credentials block missing an access or refresh token.
-var errOCIIncompleteOAuthCredential = errors.New(
-	"oci_credentials oauth requires both an access_token and a refresh_token",
-)
-
-// errOCIHelperWithRepositoryPath reports a helper on a repository-scoped label, which tofu rejects.
-var errOCIHelperWithRepositoryPath = errors.New(
-	"oci_credentials docker_credentials_helper cannot be used with a repository path",
-)
-
-// errOCIAmbientFilesWithoutDiscovery reports docker_style_config_files set while ambient discovery is off.
-var errOCIAmbientFilesWithoutDiscovery = errors.New(
-	"oci_default_credentials docker_style_config_files requires discover_ambient_credentials to be enabled",
-)
-
-// errOCIDuplicateDefaultBlock reports a second oci_default_credentials block, which tofu rejects.
-var errOCIDuplicateDefaultBlock = errors.New("at most one oci_default_credentials block is allowed")
-
-// errOCIDuplicateRepoBlock reports two oci_credentials blocks sharing a label, which tofu rejects.
-var errOCIDuplicateRepoBlock = errors.New("duplicate oci_credentials block")
-
-// errOCIEmptyCredentialValue reports a credential argument set to an empty string.
-var errOCIEmptyCredentialValue = errors.New("oci_credentials values must not be empty")
-
-// errOCILabelNotRepositoryAddress reports a label that is not a bare registry domain and repository path.
-var errOCILabelNotRepositoryAddress = errors.New(
-	"oci_credentials label must be a registry domain with an optional repository path, without a URL scheme",
-)
-
-// ociValidHelperName reports whether name is a safe docker-credential suffix, matching tofu.
+// ociValidHelperName reports whether name is a docker-credential-<name> suffix run off PATH, never a path itself.
 func ociValidHelperName(name string) bool {
 	return name != "" && !strings.ContainsAny(name, `/\`)
+}
+
+// ociTofuConfigError attributes one problem to its CLI config file, so every joined line locates itself.
+func ociTofuConfigError(path string, err error) error {
+	return fmt.Errorf("reading OpenTofu CLI config %s: %w", path, err)
 }
 
 // loadOCITofuCredentials merges the CLI config's OCI blocks; a file that exists but is invalid is an error.
@@ -130,20 +100,36 @@ func loadOCITofuCredentials(l log.Logger, v *venv.Venv) (ociTofuCredentials, err
 	merged := ociTofuCredentials{discoverAmbient: true}
 	seenRepos := make(map[string]struct{})
 
-	for _, path := range ociTofuConfigSources(l, v) {
+	sources, err := ociTofuConfigSources(l, v)
+	if err != nil {
+		return ociTofuCredentials{}, err
+	}
+
+	var errs []error
+
+	for _, path := range sources {
 		data, err := vfs.ReadFile(v.FS, path)
 		if err != nil {
-			return ociTofuCredentials{}, fmt.Errorf("reading OpenTofu CLI config %s: %w", path, err)
+			errs = append(errs, ociTofuConfigError(path, err))
+
+			continue
 		}
 
 		one, err := decodeOCITofuCredentials(data, path)
 		if err != nil {
-			return ociTofuCredentials{}, fmt.Errorf("reading OpenTofu CLI config %s: %w", path, err)
+			errs = append(errs, err)
+
+			continue
 		}
 
 		if err := mergeOCITofuCredentials(&merged, &one, path, seenRepos); err != nil {
-			return ociTofuCredentials{}, err
+			errs = append(errs, err)
 		}
+	}
+
+	// Every source is reported at once, and no partial merge escapes alongside an error.
+	if err := errors.Join(errs...); err != nil {
+		return ociTofuCredentials{}, err
 	}
 
 	return merged, nil
@@ -155,12 +141,16 @@ func mergeOCITofuCredentials(
 	path string,
 	seenRepos map[string]struct{},
 ) error {
+	var errs []error
+
 	for i := range one.repos {
 		repo := &one.repos[i]
 
-		key := repo.registryDomain + "/" + repo.repositoryPrefix
+		key := repo.dedupKey()
 		if _, dup := seenRepos[key]; dup {
-			return fmt.Errorf("%w %q in %s", errOCIDuplicateRepoBlock, repo.label, path)
+			errs = append(errs, OCIDuplicateRepoBlockError{Label: repo.label, Path: path})
+
+			continue
 		}
 
 		seenRepos[key] = struct{}{}
@@ -168,63 +158,81 @@ func mergeOCITofuCredentials(
 		merged.repos = append(merged.repos, *repo)
 	}
 
-	if !one.hasDefault {
-		return nil
-	}
-
-	if merged.hasDefault {
-		return fmt.Errorf("%w: %s", errOCIDuplicateDefaultBlock, path)
-	}
-
-	merged.hasDefault = true
-	merged.defaultHelper = one.defaultHelper
-	merged.discoverAmbient = one.discoverAmbient
-	merged.configFiles = one.configFiles
-	merged.configFilesSet = one.configFilesSet
-	// Relative docker_style_config_files resolve against the declaring file.
-	merged.configDir = filepath.Dir(path)
-
-	return nil
-}
-
-// ociTofuConfigSources lists the CLI config files to read; an env override suppresses the fragments.
-func ociTofuConfigSources(l log.Logger, v *venv.Venv) []string {
-	var sources []string
-
-	if path := ociTofuConfigPath(l, v); path != "" {
-		if _, err := v.FS.Stat(path); err == nil {
-			sources = append(sources, path)
+	if one.hasDefault {
+		if merged.hasDefault {
+			errs = append(errs, OCIDuplicateDefaultBlockError{Path: path})
+		} else {
+			merged.hasDefault = true
+			merged.defaultHelper = one.defaultHelper
+			merged.discoverAmbient = one.discoverAmbient
+			merged.configFiles = one.configFiles
+			merged.configFilesSet = one.configFilesSet
+			// Relative docker_style_config_files resolve against the declaring file.
+			merged.configDir = filepath.Dir(path)
 		}
 	}
 
-	if v.Env[envTFCLIConfigFile] != "" || v.Env[envTerraformConfig] != "" {
-		return sources
+	return errors.Join(errs...)
+}
+
+// ociTofuConfigSources lists the CLI config files to read; an env override suppresses the fragments.
+func ociTofuConfigSources(l log.Logger, v *venv.Venv) ([]string, error) {
+	path, err := ociTofuConfigPath(l, v)
+	if err != nil {
+		return nil, err
 	}
 
-	return append(sources, ociTofuConfigFragments(l, v)...)
+	var sources []string
+
+	if path != "" {
+		sources = append(sources, path)
+	}
+
+	if override, _ := cliconfig.UserConfigOverride(v); override != "" {
+		return sources, nil
+	}
+
+	fragments, err := ociTofuConfigFragments(l, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(sources, fragments...), nil
 }
 
 // ociTofuConfigFragments returns the config directory's *.tfrc and *.tfrc.json files, in filename order.
-func ociTofuConfigFragments(l log.Logger, v *venv.Venv) []string {
-	dir := ociTofuConfigDir(v)
+func ociTofuConfigFragments(l log.Logger, v *venv.Venv) ([]string, error) {
+	dir, err := cliconfig.UserConfigDir(v)
+	if err != nil {
+		return nil, err
+	}
+
 	if dir == "" {
-		return nil
+		return nil, nil
 	}
 
+	// tofu reads no fragments when the config directory is absent, unreadable, or not a directory.
 	info, err := v.FS.Stat(dir)
-	if err != nil || !info.IsDir() {
-		return nil
+	if err != nil {
+		if !errors.Is(err, iofs.ErrNotExist) {
+			l.Warnf("Skipping unreadable OpenTofu CLI config directory %s: %v", dir, err)
+		}
+
+		return nil, nil
 	}
 
-	// ReadDirEntries sorts by name, so merging stays deterministic.
+	if !info.IsDir() {
+		return nil, nil
+	}
+
 	entries, err := vfs.ReadDirEntries(v.FS, dir)
 	if err != nil {
 		l.Warnf("Skipping unreadable OpenTofu CLI config directory %s: %v", dir, err)
 
-		return nil
+		return nil, nil
 	}
 
-	var fragments []string
+	fragments := make([]string, 0, len(entries))
 
 	for _, entry := range entries {
 		name := entry.Name()
@@ -235,64 +243,39 @@ func ociTofuConfigFragments(l log.Logger, v *venv.Venv) []string {
 		fragments = append(fragments, filepath.Join(dir, name))
 	}
 
-	return fragments
-}
-
-// ociTofuConfigDir resolves OpenTofu's CLI config directory for the platform.
-func ociTofuConfigDir(v *venv.Venv) string {
-	home, err := v.Platform.UserHomeDir()
-	if err != nil {
-		home = ""
-	}
-
-	if v.Platform.GOOS == windowsGOOS {
-		if appData := v.Env["APPDATA"]; appData != "" {
-			return filepath.Join(appData, "terraform.d")
-		}
-
-		return ""
-	}
-
-	if home != "" {
-		legacy := filepath.Join(home, ".terraform.d")
-		if _, statErr := v.FS.Stat(legacy); statErr == nil {
-			return legacy
-		}
-	}
-
-	if xdg := v.Env["XDG_CONFIG_HOME"]; xdg != "" {
-		return filepath.Join(xdg, "opentofu")
-	}
-
-	if home == "" {
-		return ""
-	}
-
-	return filepath.Join(home, ".terraform.d")
+	return fragments, nil
 }
 
 // ociTofuConfigPath resolves the CLI config path OpenTofu would use, honoring its env overrides.
-func ociTofuConfigPath(l log.Logger, v *venv.Venv) string {
-	for _, name := range []string{envTFCLIConfigFile, envTerraformConfig} {
-		override := v.Env[name]
-		if override == "" {
-			continue
+func ociTofuConfigPath(l log.Logger, v *venv.Venv) (string, error) {
+	if override, envName := cliconfig.UserConfigOverride(v); override != "" {
+		exists, err := vfs.FileExists(v.FS, override)
+		if err != nil {
+			return "", ociTofuConfigError(override, err)
 		}
 
-		if _, err := v.FS.Stat(override); err != nil {
-			l.Warnf("OpenTofu CLI config %s set by %s cannot be read: %v", override, name, err)
+		// tofu skips a named config file that is absent, so warn rather than fail, and read no other file.
+		if !exists {
+			l.Warnf("OpenTofu CLI config %s named by %s does not exist", override, envName)
+
+			return "", nil
 		}
 
-		return override
+		return override, nil
 	}
 
-	for _, candidate := range ociTofuConfigCandidates(v) {
-		if _, statErr := v.FS.Stat(candidate); statErr == nil {
-			return candidate
+	for _, candidate := range cliconfig.UserConfigCandidates(v) {
+		exists, err := vfs.FileExists(v.FS, candidate)
+		if err != nil {
+			return "", ociTofuConfigError(candidate, err)
+		}
+
+		if exists {
+			return candidate, nil
 		}
 	}
 
-	return ""
+	return "", nil
 }
 
 // parseOCITofuConfig parses the CLI config, detecting the JSON form from a leading brace as tofu does.
@@ -304,44 +287,11 @@ func parseOCITofuConfig(data []byte, path string) (*hcl.File, hcl.Diagnostics) {
 	return hclsyntax.ParseConfig(data, path, hcl.Pos{Line: 1, Column: 1})
 }
 
-// ociTofuConfigCandidates lists OpenTofu's default CLI-config locations for the injected platform.
-func ociTofuConfigCandidates(v *venv.Venv) []string {
-	home, err := v.Platform.UserHomeDir()
-	if err != nil {
-		home = ""
-	}
-
-	var paths []string
-
-	// On Windows tofu reads only tofu.rc and terraform.rc under %APPDATA%.
-	if v.Platform.GOOS == windowsGOOS {
-		if appData := v.Env["APPDATA"]; appData != "" {
-			return []string{
-				filepath.Join(appData, "tofu.rc"),
-				filepath.Join(appData, "terraform.rc"),
-			}
-		}
-
-		return nil
-	}
-
-	if home != "" {
-		paths = append(paths, filepath.Join(home, ".tofurc"), filepath.Join(home, ".terraformrc"))
-	}
-
-	// tofu falls back to XDG only when XDG_CONFIG_HOME is set.
-	if configDir := v.Env["XDG_CONFIG_HOME"]; configDir != "" {
-		paths = append(paths, filepath.Join(configDir, "opentofu", "tofurc"))
-	}
-
-	return paths
-}
-
 // decodeOCITofuCredentials extracts the OCI blocks; an invalid block is an error, as tofu reports.
 func decodeOCITofuCredentials(data []byte, path string) (ociTofuCredentials, error) {
 	file, diags := parseOCITofuConfig(data, path)
 	if diags.HasErrors() {
-		return ociTofuCredentials{}, diags
+		return ociTofuCredentials{}, ociTofuConfigError(path, diags)
 	}
 
 	schema := &hcl.BodySchema{
@@ -353,7 +303,7 @@ func decodeOCITofuCredentials(data []byte, path string) (ociTofuCredentials, err
 
 	content, _, diags := file.Body.PartialContent(schema)
 	if diags.HasErrors() {
-		return ociTofuCredentials{}, diags
+		return ociTofuCredentials{}, ociTofuConfigError(path, diags)
 	}
 
 	tofu := ociTofuCredentials{
@@ -361,35 +311,53 @@ func decodeOCITofuCredentials(data []byte, path string) (ociTofuCredentials, err
 		discoverAmbient: true,
 	}
 
+	var errs []error
+
 	for _, block := range content.Blocks {
 		if block.Type == "oci_default_credentials" {
-			if tofu.hasDefault {
-				return ociTofuCredentials{}, errOCIDuplicateDefaultBlock
+			if err := decodeOCITofuDefaultBlock(&tofu, block, path); err != nil {
+				errs = append(errs, err)
 			}
-
-			defaults, err := decodeOCITofuDefaultHelper(block.Body)
-			if err != nil {
-				return ociTofuCredentials{}, err
-			}
-
-			tofu.hasDefault = true
-			tofu.discoverAmbient = defaults.discoverAmbient
-			tofu.defaultHelper = defaults.helper
-			tofu.configFiles = defaults.configFiles
-			tofu.configFilesSet = defaults.configFilesSet
 
 			continue
 		}
 
 		repo, err := decodeOCITofuRepoBlock(block)
 		if err != nil {
-			return ociTofuCredentials{}, fmt.Errorf("oci_credentials %q: %w", block.Labels[0], err)
+			errs = append(errs, ociTofuConfigError(path, fmt.Errorf("oci_credentials %q: %w", block.Labels[0], err)))
+
+			continue
 		}
 
 		tofu.repos = append(tofu.repos, repo)
 	}
 
+	// Every bad block is reported at once, so a user fixes the whole file in one pass.
+	if err := errors.Join(errs...); err != nil {
+		return ociTofuCredentials{}, err
+	}
+
 	return tofu, nil
+}
+
+// decodeOCITofuDefaultBlock folds one oci_default_credentials block into tofu, rejecting a second one.
+func decodeOCITofuDefaultBlock(tofu *ociTofuCredentials, block *hcl.Block, path string) error {
+	if tofu.hasDefault {
+		return OCIDuplicateDefaultBlockError{Path: path}
+	}
+
+	defaults, err := decodeOCITofuDefaultHelper(block.Body)
+	if err != nil {
+		return ociTofuConfigError(path, err)
+	}
+
+	tofu.hasDefault = true
+	tofu.discoverAmbient = defaults.discoverAmbient
+	tofu.defaultHelper = defaults.helper
+	tofu.configFiles = defaults.configFiles
+	tofu.configFilesSet = defaults.configFilesSet
+
+	return nil
 }
 
 // decodeOCITofuDefaultHelper reads the fallback helper and the ambient-discovery switch, default true.
@@ -408,16 +376,16 @@ func decodeOCITofuDefaultHelper(body hcl.Body) (ociTofuDefaults, error) {
 	discoverAmbient := decoded.DiscoverAmbient == nil || *decoded.DiscoverAmbient
 
 	if decoded.Helper != nil && !ociValidHelperName(*decoded.Helper) {
-		return ociTofuDefaults{discoverAmbient: discoverAmbient}, errOCIInvalidHelperName
+		return ociTofuDefaults{discoverAmbient: discoverAmbient}, ErrOCIInvalidHelperName
 	}
 
 	// The file list only tunes ambient discovery, so tofu rejects it when discovery is off.
 	if !discoverAmbient && decoded.ConfigFiles != nil {
-		return ociTofuDefaults{discoverAmbient: discoverAmbient}, errOCIAmbientFilesWithoutDiscovery
+		return ociTofuDefaults{discoverAmbient: discoverAmbient}, ErrOCIAmbientFilesWithoutDiscovery
 	}
 
 	defaults := ociTofuDefaults{
-		helper:          derefString(decoded.Helper),
+		helper:          deref(decoded.Helper),
 		discoverAmbient: discoverAmbient,
 	}
 
@@ -430,16 +398,9 @@ func decodeOCITofuDefaultHelper(body hcl.Body) (ociTofuDefaults, error) {
 	return defaults, nil
 }
 
-// decodeOCITofuRepoBlock reads one oci_credentials block, requiring exactly one credential style.
+// decodeOCITofuRepoBlock reads one oci_credentials block; a rejected block yields no credential, never a partial one.
 func decodeOCITofuRepoBlock(block *hcl.Block) (ociTofuRepoCredential, error) {
-	var decoded struct {
-		Username     *string  `hcl:"username,optional"`
-		Password     *string  `hcl:"password,optional"`
-		AccessToken  *string  `hcl:"access_token,optional"`
-		RefreshToken *string  `hcl:"refresh_token,optional"`
-		Helper       *string  `hcl:"docker_credentials_helper,optional"`
-		Remain       hcl.Body `hcl:",remain"`
-	}
+	var decoded ociTofuRepoBody
 
 	if diags := gohcl.DecodeBody(block.Body, nil, &decoded); diags.HasErrors() {
 		return ociTofuRepoCredential{}, diags
@@ -450,73 +411,97 @@ func decodeOCITofuRepoBlock(block *hcl.Block) (ociTofuRepoCredential, error) {
 	oauth := decoded.AccessToken != nil || decoded.RefreshToken != nil
 	helper := decoded.Helper != nil
 
-	// Reject a username without a password, or the reverse, matching OpenTofu.
-	if basic && (decoded.Username == nil || decoded.Password == nil) {
-		return ociTofuRepoCredential{}, errOCIIncompleteBasicCredential
-	}
-
-	// OpenTofu requires the OAuth pair together, so reject a lone token.
-	if oauth && (decoded.AccessToken == nil || decoded.RefreshToken == nil) {
-		return ociTofuRepoCredential{}, errOCIIncompleteOAuthCredential
-	}
-
-	// tofu requires exactly one style; zero would shadow a valid ambient credential.
-	switch trueCount(basic, oauth, helper) {
-	case 1:
-	case 0:
-		return ociTofuRepoCredential{}, errOCIMissingCredentialStyle
-	default:
-		return ociTofuRepoCredential{}, errOCIMultipleCredentialStyles
-	}
-
-	if helper && !ociValidHelperName(*decoded.Helper) {
-		return ociTofuRepoCredential{}, errOCIInvalidHelperName
+	if err := validateOCITofuRepoStyle(&decoded, basic, oauth, helper); err != nil {
+		return ociTofuRepoCredential{}, err
 	}
 
 	// tofu parses the label as a bare repository address, so a URL scheme is invalid.
 	if strings.Contains(block.Labels[0], "://") {
-		return ociTofuRepoCredential{}, errOCILabelNotRepositoryAddress
+		return ociTofuRepoCredential{}, ErrOCILabelNotRepositoryAddress
 	}
 
 	registryDomain, repositoryPrefix := ociSplitRepositoryPrefix(block.Labels[0])
 
 	// Docker credential helpers key on a whole domain, so tofu rejects a repository path here.
 	if helper && repositoryPrefix != "" {
-		return ociTofuRepoCredential{}, errOCIHelperWithRepositoryPath
+		return ociTofuRepoCredential{}, ErrOCIHelperWithRepositoryPath
 	}
 
 	repo := ociTofuRepoCredential{
 		label:            block.Labels[0],
 		registryDomain:   ociCanonicalAuthKey(registryDomain),
 		repositoryPrefix: repositoryPrefix,
-		helper:           derefString(decoded.Helper),
+		helper:           deref(decoded.Helper),
 	}
 
-	if oauth {
-		if *decoded.AccessToken == "" || *decoded.RefreshToken == "" {
-			return ociTofuRepoCredential{}, errOCIEmptyCredentialValue
-		}
-
-		repo.cred = auth.Credential{
-			AccessToken:  *decoded.AccessToken,
-			RefreshToken: *decoded.RefreshToken,
-		}
-
+	// A helper block carries no inline secret, so it is complete once the helper name is validated.
+	if !oauth && !basic {
 		return repo, nil
 	}
 
-	if basic {
-		if *decoded.Username == "" || *decoded.Password == "" {
-			return ociTofuRepoCredential{}, errOCIEmptyCredentialValue
-		}
-
-		repo.cred = auth.Credential{
-			Username: *decoded.Username,
-			Password: *decoded.Password,
-		}
+	cred, err := ociTofuInlineCredential(&decoded, oauth)
+	if err != nil {
+		return ociTofuRepoCredential{}, err
 	}
 
+	repo.cred = cred
+
 	return repo, nil
+}
+
+// validateOCITofuRepoStyle enforces tofu's rule of exactly one complete credential style per block.
+func validateOCITofuRepoStyle(decoded *ociTofuRepoBody, basic, oauth, helper bool) error {
+	// Reject a username without a password, or the reverse, matching OpenTofu.
+	if basic && (decoded.Username == nil || decoded.Password == nil) {
+		return ErrOCIIncompleteBasicCredential
+	}
+
+	// OpenTofu requires the OAuth pair together, so reject a lone token.
+	if oauth && (decoded.AccessToken == nil || decoded.RefreshToken == nil) {
+		return ErrOCIIncompleteOAuthCredential
+	}
+
+	// tofu requires exactly one style; zero would shadow a valid ambient credential.
+	switch trueCount(basic, oauth, helper) {
+	case 1:
+	case 0:
+		return ErrOCIMissingCredentialStyle
+	default:
+		return ErrOCIMultipleCredentialStyles
+	}
+
+	if helper && !ociValidHelperName(*decoded.Helper) {
+		return ErrOCIInvalidHelperName
+	}
+
+	return nil
+}
+
+// ociTofuInlineCredential builds the credential for whichever inline style the block selected.
+func ociTofuInlineCredential(decoded *ociTofuRepoBody, oauth bool) (auth.Credential, error) {
+	if oauth {
+		return ociTofuOAuthCredential(*decoded.AccessToken, *decoded.RefreshToken)
+	}
+
+	return ociTofuBasicCredential(*decoded.Username, *decoded.Password)
+}
+
+// ociTofuOAuthCredential builds the OAuth pair, rejecting an empty token as tofu does.
+func ociTofuOAuthCredential(accessToken, refreshToken string) (auth.Credential, error) {
+	if accessToken == "" || refreshToken == "" {
+		return auth.EmptyCredential, ErrOCIEmptyCredentialValue
+	}
+
+	return auth.Credential{AccessToken: accessToken, RefreshToken: refreshToken}, nil
+}
+
+// ociTofuBasicCredential builds the basic-auth pair, rejecting an empty half as tofu does.
+func ociTofuBasicCredential(username, password string) (auth.Credential, error) {
+	if username == "" || password == "" {
+		return auth.EmptyCredential, ErrOCIEmptyCredentialValue
+	}
+
+	return auth.Credential{Username: username, Password: password}, nil
 }
 
 // trueCount returns how many of the given booleans are true.
@@ -539,11 +524,13 @@ func ociSplitRepositoryPrefix(label string) (registryDomain, repositoryPrefix st
 	return registryDomain, repositoryPrefix
 }
 
-// derefString returns the pointed-to string, or the empty string when nil.
-func derefString(s *string) string {
-	if s == nil {
-		return ""
+// deref returns the pointed-to value, or the zero value of T when nil.
+func deref[T any](v *T) T {
+	if v == nil {
+		var zero T
+
+		return zero
 	}
 
-	return *s
+	return *v
 }

--- a/internal/getter/oci_toforc_test.go
+++ b/internal/getter/oci_toforc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -107,7 +108,7 @@ oci_credentials "registry.example.com/team" {
 
 	err := newStoreErr(t, v, testRegistry, "team/vpc")
 	require.Error(t, err)
-	require.ErrorContains(t, err, "cannot be used with a repository path")
+	require.ErrorIs(t, err, getter.ErrOCIHelperWithRepositoryPath)
 	assert.EqualValues(t, 0, calls.Load(), "a repository-scoped helper block must never run")
 }
 
@@ -164,7 +165,7 @@ func TestOCITofuCredentialsSchemeLabelRejected(t *testing.T) {
 
 	err := newStoreErr(t, v, testRegistry, "team/vpc")
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "without a URL scheme")
+	assert.ErrorIs(t, err, getter.ErrOCILabelNotRepositoryAddress)
 }
 
 // TestOCITofuCredentialsIncompleteBasicRejected: either half of the basic-auth pair alone is rejected.
@@ -197,7 +198,7 @@ oci_credentials "registry.example.com" {
 
 			err := newStoreErr(t, v, testRegistry, "team/vpc")
 			require.Error(t, err)
-			assert.ErrorContains(t, err, "requires both a username and a password")
+			assert.ErrorIs(t, err, getter.ErrOCIIncompleteBasicCredential)
 		})
 	}
 }
@@ -369,7 +370,7 @@ oci_credentials "registry.example.com" {
 
 	err := newStoreErr(t, v, testRegistry, "team/vpc")
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "credential helper name must not be empty")
+	assert.ErrorIs(t, err, getter.ErrOCIInvalidHelperName)
 }
 
 // TestOCITofuCredentialsMultipleStylesRejected: a block with more than one credential style is rejected.
@@ -389,7 +390,7 @@ oci_credentials "registry.example.com" {
 
 	err := newStoreErr(t, v, testRegistry, "team/vpc")
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "at most one credential style")
+	assert.ErrorIs(t, err, getter.ErrOCIMultipleCredentialStyles)
 }
 
 // TestOCITofuCredentialsConfigPathResolution: TERRAFORM_CONFIG and the .terraformrc fallback resolve.
@@ -490,7 +491,7 @@ oci_credentials "registry.example.com" {
 
 	err := newStoreErr(t, v, testRegistry, "team/vpc")
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "requires both an access_token and a refresh_token",
+	assert.ErrorIs(t, err, getter.ErrOCIIncompleteOAuthCredential,
 		"an OAuth block missing refresh_token must be rejected")
 }
 
@@ -589,7 +590,7 @@ oci_credentials "registry.example.com" {
 
 	err := newStoreErr(t, v, testRegistry, "team/vpc")
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "at most one credential style",
+	assert.ErrorIs(t, err, getter.ErrOCIMultipleCredentialStyles,
 		"a block mixing a helper with basic auth must be rejected")
 }
 
@@ -679,7 +680,7 @@ oci_credentials "registry.example.com/team/vpc" {
 
 	err := newStoreErr(t, v, testRegistry, "team/vpc")
 	require.Error(t, err, "an empty oci_credentials block must be reported, as tofu reports it")
-	assert.ErrorContains(t, err, "must configure basic auth, OAuth tokens, or a helper")
+	assert.ErrorIs(t, err, getter.ErrOCIMissingCredentialStyle)
 }
 
 // TestOCITofuCredentialsWindowsIgnoresHomeDotfiles: on Windows only the APPDATA pair is read.
@@ -798,8 +799,14 @@ func TestOCITofuCredentialsDuplicateLabelAcrossFilesRejected(t *testing.T) {
 		tofuBasicAuth(testRegistry, "fragment", "fake-secret-fragment"))
 
 	err := newStoreErr(t, v, testRegistry, "team/vpc")
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "duplicate oci_credentials block")
+	require.ErrorIs(t, err, getter.ErrOCIDuplicateRepoBlock)
+
+	var dupErr getter.OCIDuplicateRepoBlockError
+
+	require.ErrorAs(t, err, &dupErr)
+	assert.Equal(t, testRegistry, dupErr.Label)
+	assert.Equal(t, filepath.Join(home, ".terraform.d", "extra.tfrc"), dupErr.Path,
+		"the error must name the file redeclaring the label")
 }
 
 // TestOCITofuCredentialsExplicitConfigFileMissingIsFatal: a named config file must not fail silently.
@@ -837,7 +844,7 @@ oci_default_credentials {
 
 	err := newStoreErr(t, v, testRegistry, "team/vpc")
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "credential helper name must not be empty",
+	assert.ErrorIs(t, err, getter.ErrOCIInvalidHelperName,
 		"an unusable default block must not widen credential exposure")
 }
 
@@ -887,7 +894,7 @@ oci_default_credentials {
 
 			err := newStoreErr(t, v, testRegistry, "team/vpc")
 			require.Error(t, err)
-			assert.ErrorContains(t, err, "requires discover_ambient_credentials to be enabled")
+			assert.ErrorIs(t, err, getter.ErrOCIAmbientFilesWithoutDiscovery)
 		})
 	}
 }
@@ -956,7 +963,7 @@ oci_credentials "registry.example.com" {
 
 			err := newStoreErr(t, v, testRegistry, "team/vpc")
 			require.Error(t, err, "an empty credential value must not fall through to ambient")
-			assert.ErrorContains(t, err, "must not be empty")
+			assert.ErrorIs(t, err, getter.ErrOCIEmptyCredentialValue)
 		})
 	}
 }
@@ -992,7 +999,7 @@ oci_default_credentials {
 
 	err := newStoreErr(t, v, testRegistry, "team/vpc")
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "at most one oci_default_credentials block")
+	assert.ErrorIs(t, err, getter.ErrOCIDuplicateDefaultBlock)
 }
 
 // TestOCITofuCredentialsDuplicateDefaultBlockAcrossFilesRejected: the one-default rule spans merged sources.
@@ -1014,7 +1021,7 @@ oci_default_credentials {
 
 	err := newStoreErr(t, v, testRegistry, "team/vpc")
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "at most one oci_default_credentials block")
+	assert.ErrorIs(t, err, getter.ErrOCIDuplicateDefaultBlock)
 }
 
 // TestOCITofuCredentialsRelativeConfigFileResolves: a relative entry resolves against the declaring file.
@@ -1119,4 +1126,110 @@ func TestOCITofuCredentialsDockerHubLabel(t *testing.T) {
 				"a docker.io label must serve every Docker Hub spelling")
 		})
 	}
+}
+
+// TestOCITofuCredentialsAllBlockErrorsReported: every invalid block in one file is reported at once.
+func TestOCITofuCredentialsAllBlockErrorsReported(t *testing.T) {
+	t.Parallel()
+
+	home := testHome
+	v := credentialVenv(home, nil)
+	writeTofuConfig(t, v.FS, filepath.Join(home, ".tofurc"), `
+oci_credentials "registry.example.com/a" {
+  username = "only-user"
+}
+
+oci_credentials "registry.example.com/b" {
+}
+`+tofuBasicAuth("https://"+testRegistry+"/c", "user", "fake-secret-c"))
+
+	err := newStoreErr(t, v, testRegistry, "team/vpc")
+	require.Error(t, err)
+	require.ErrorIs(t, err, getter.ErrOCIIncompleteBasicCredential)
+	require.ErrorIs(t, err, getter.ErrOCIMissingCredentialStyle)
+	require.ErrorIs(t, err, getter.ErrOCILabelNotRepositoryAddress,
+		"every invalid block must be reported, so a user fixes the file in one pass")
+}
+
+// TestOCITofuCredentialsAllSourceErrorsReported: a broken main config and a broken fragment are reported together.
+func TestOCITofuCredentialsAllSourceErrorsReported(t *testing.T) {
+	t.Parallel()
+
+	home := testHome
+	v := credentialVenv(home, nil)
+	writeTofuConfig(t, v.FS, filepath.Join(home, ".tofurc"), `
+oci_credentials "registry.example.com/a" {
+  username = "only-user"
+}
+`)
+	writeTofuConfig(t, v.FS, filepath.Join(home, ".terraform.d", "extra.tfrc"), `
+oci_credentials "registry.example.com/b" {
+  access_token = "fake-secret-token"
+}
+`)
+
+	err := newStoreErr(t, v, testRegistry, "team/vpc")
+	require.Error(t, err)
+	require.ErrorIs(t, err, getter.ErrOCIIncompleteBasicCredential)
+	require.ErrorIs(t, err, getter.ErrOCIIncompleteOAuthCredential,
+		"every config source must be reported, not just the first that fails")
+}
+
+// TestOCITofuCredentialsMissingOverrideIsSkipped: a named config file that is absent is skipped, as tofu skips it.
+func TestOCITofuCredentialsMissingOverrideIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	home := testHome
+	v := credentialVenv(home, map[string]string{envTFCLIConfigFileTest: "/virtual/absent.tofurc"})
+	writeAuthFile(t, v.FS, filepath.Join(home, ".docker", "config.json"), testRegistry, "ambient", "ambient-pass")
+
+	store := newStoreForRepo(t, v, testRegistry, "team/vpc")
+	assert.Equal(t, "ambient", credentialFor(t, store, testRegistry).Username,
+		"an absent named config file must not fail the pull, matching tofu")
+}
+
+// TestOCITofuCredentialsUnreadableOverrideIsFatal: a named config file that cannot be read must not widen credentials.
+func TestOCITofuCredentialsUnreadableOverrideIsFatal(t *testing.T) {
+	t.Parallel()
+
+	const override = "/virtual/unreadable.tofurc"
+
+	home := testHome
+	v := credentialVenv(home, map[string]string{envTFCLIConfigFileTest: override})
+	writeAuthFile(t, v.FS, filepath.Join(home, ".docker", "config.json"), testRegistry, "ambient", "ambient-pass")
+	v = v.WithFS(statErrorFS{FS: v.FS, failPath: override})
+
+	err := newStoreErr(t, v, testRegistry, "team/vpc")
+	require.ErrorIs(t, err, errStatFailed,
+		"a config file whose presence cannot be determined must not fall through to ambient credentials")
+}
+
+// TestOCITofuCredentialsUnreadableCandidateIsFatal: an unreadable default config location is an error, not a miss.
+func TestOCITofuCredentialsUnreadableCandidateIsFatal(t *testing.T) {
+	t.Parallel()
+
+	home := testHome
+	v := credentialVenv(home, nil)
+	writeAuthFile(t, v.FS, filepath.Join(home, ".docker", "config.json"), testRegistry, "ambient", "ambient-pass")
+	v = v.WithFS(statErrorFS{FS: v.FS, failPath: filepath.Join(home, ".tofurc")})
+
+	err := newStoreErr(t, v, testRegistry, "team/vpc")
+	require.ErrorIs(t, err, errStatFailed)
+}
+
+// errStatFailed stands in for a filesystem that cannot answer whether a path exists.
+var errStatFailed = errors.New("stat failed")
+
+// statErrorFS fails Stat for one exact path, so a test can tell an absent config from an unreadable one.
+type statErrorFS struct {
+	vfs.FS
+	failPath string
+}
+
+func (fsys statErrorFS) Stat(name string) (os.FileInfo, error) {
+	if name == fsys.failPath {
+		return nil, &os.PathError{Op: "stat", Path: name, Err: errStatFailed}
+	}
+
+	return fsys.FS.Stat(name)
 }

--- a/internal/getter/resolver_s3.go
+++ b/internal/getter/resolver_s3.go
@@ -161,27 +161,27 @@ func pickS3CacheKey(rawURL string, head *s3.HeadObjectOutput) (string, error) {
 		return "", cas.ErrNoVersionMetadata
 	}
 
-	if v := strPtr(head.ChecksumSHA256); v != "" {
+	if v := deref(head.ChecksumSHA256); v != "" {
 		return cas.ContentKey("sha256", v), nil
 	}
 
-	if v := strPtr(head.ChecksumCRC64NVME); v != "" {
+	if v := deref(head.ChecksumCRC64NVME); v != "" {
 		return cas.ContentKey("crc64nvme", v), nil
 	}
 
-	if v := strPtr(head.ChecksumSHA1); v != "" {
+	if v := deref(head.ChecksumSHA1); v != "" {
 		return cas.ContentKey("sha1", v), nil
 	}
 
-	if v := strPtr(head.ChecksumCRC32C); v != "" {
+	if v := deref(head.ChecksumCRC32C); v != "" {
 		return cas.ContentKey("crc32c", v), nil
 	}
 
-	if v := strPtr(head.ChecksumCRC32); v != "" {
+	if v := deref(head.ChecksumCRC32); v != "" {
 		return cas.ContentKey("crc32", v), nil
 	}
 
-	if etag := strings.TrimSpace(strPtr(head.ETag)); etag != "" {
+	if etag := strings.TrimSpace(deref(head.ETag)); etag != "" {
 		if normalized := normalizeETag(etag); normalized != "" {
 			return cas.OpaqueKey("s3", rawURL, normalized), nil
 		}
@@ -315,15 +315,6 @@ func s3RegionFromHostLabel(label string) (region string, ok bool) {
 	}
 
 	return "", false
-}
-
-// strPtr safely dereferences a *string.
-func strPtr(p *string) string {
-	if p == nil {
-		return ""
-	}
-
-	return *p
 }
 
 // canonicalAWSS3HTTPSURL returns the path-style HTTPS URL for an AWS S3

--- a/internal/tf/cliconfig/paths.go
+++ b/internal/tf/cliconfig/paths.go
@@ -1,0 +1,103 @@
+package cliconfig
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+)
+
+// EnvNameTFCLIConfigFile and EnvNameTerraformConfig name the CLI config file outright, in the order OpenTofu checks them.
+const (
+	EnvNameTFCLIConfigFile = "TF_CLI_CONFIG_FILE"
+	EnvNameTerraformConfig = "TERRAFORM_CONFIG"
+)
+
+// windowsGOOS is the platform whose CLI config lives under %APPDATA%.
+const windowsGOOS = "windows"
+
+// UserConfigOverride returns the CLI config path an env var names, and the var that named it.
+func UserConfigOverride(v *venv.Venv) (path, envName string) {
+	for _, name := range []string{EnvNameTFCLIConfigFile, EnvNameTerraformConfig} {
+		if override := v.Env[name]; override != "" {
+			return override, name
+		}
+	}
+
+	return "", ""
+}
+
+// UserConfigCandidates lists OpenTofu's default CLI-config file locations for the injected platform, most preferred first.
+func UserConfigCandidates(v *venv.Venv) []string {
+	home, err := v.Platform.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
+
+	// On Windows tofu reads only tofu.rc and terraform.rc under %APPDATA%.
+	if v.Platform.GOOS == windowsGOOS {
+		appData := v.Env["APPDATA"]
+		if appData == "" {
+			return nil
+		}
+
+		return []string{
+			filepath.Join(appData, "tofu.rc"),
+			filepath.Join(appData, "terraform.rc"),
+		}
+	}
+
+	var paths []string
+
+	if home != "" {
+		paths = append(paths, filepath.Join(home, ".tofurc"), filepath.Join(home, ".terraformrc"))
+	}
+
+	// tofu falls back to XDG only when XDG_CONFIG_HOME is set, and never synthesizes ~/.config.
+	if configDir := v.Env["XDG_CONFIG_HOME"]; configDir != "" {
+		paths = append(paths, filepath.Join(configDir, "opentofu", "tofurc"))
+	}
+
+	return paths
+}
+
+// UserConfigDir resolves OpenTofu's CLI config directory, whose *.tfrc fragments extend the CLI config.
+func UserConfigDir(v *venv.Venv) (string, error) {
+	home, err := v.Platform.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
+
+	if v.Platform.GOOS == windowsGOOS {
+		if appData := v.Env["APPDATA"]; appData != "" {
+			return filepath.Join(appData, "terraform.d"), nil
+		}
+
+		return "", nil
+	}
+
+	if home != "" {
+		legacy := filepath.Join(home, ".terraform.d")
+
+		exists, err := vfs.FileExists(v.FS, legacy)
+		if err != nil {
+			return "", fmt.Errorf("reading OpenTofu CLI config directory %s: %w", legacy, err)
+		}
+
+		if exists {
+			return legacy, nil
+		}
+	}
+
+	// tofu falls back to XDG only when XDG_CONFIG_HOME is set, and never synthesizes ~/.config.
+	if xdg := v.Env["XDG_CONFIG_HOME"]; xdg != "" {
+		return filepath.Join(xdg, "opentofu"), nil
+	}
+
+	if home == "" {
+		return "", nil
+	}
+
+	return filepath.Join(home, ".terraform.d"), nil
+}

--- a/internal/tf/cliconfig/paths_test.go
+++ b/internal/tf/cliconfig/paths_test.go
@@ -1,0 +1,236 @@
+package cliconfig_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The virtual locations the injected platform reports.
+const (
+	testHome    = "/virtual/home"
+	testAppData = "/virtual/appdata"
+	testXDG     = "/virtual/config"
+)
+
+// errStatFailed stands in for a filesystem that cannot answer whether a path exists.
+var errStatFailed = errors.New("stat failed")
+
+// statErrorFS fails Stat for one exact path and delegates every other call.
+type statErrorFS struct {
+	vfs.FS
+	failPath string
+}
+
+func (fsys statErrorFS) Stat(name string) (os.FileInfo, error) {
+	if name == fsys.failPath {
+		return nil, &os.PathError{Op: "stat", Path: name, Err: errStatFailed}
+	}
+
+	return fsys.FS.Stat(name)
+}
+
+// pathsVenv builds an in-memory venv reporting goos, home, and env.
+func pathsVenv(goos, home string, env map[string]string) *venv.Venv {
+	if env == nil {
+		env = map[string]string{}
+	}
+
+	return venvtest.New().
+		WithGOOS(goos).
+		WithUserHomeDir(func() (string, error) { return home, nil }).
+		WithEnv(env)
+}
+
+// TestUserConfigOverride: the env vars are read in OpenTofu's order, and neither being set is not an override.
+func TestUserConfigOverride(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		env      map[string]string
+		name     string
+		wantPath string
+		wantEnv  string
+	}{
+		{name: "unset"},
+		{
+			name:     "TF_CLI_CONFIG_FILE",
+			env:      map[string]string{cliconfig.EnvNameTFCLIConfigFile: "/virtual/custom.tofurc"},
+			wantPath: "/virtual/custom.tofurc",
+			wantEnv:  cliconfig.EnvNameTFCLIConfigFile,
+		},
+		{
+			name:     "TERRAFORM_CONFIG",
+			env:      map[string]string{cliconfig.EnvNameTerraformConfig: "/virtual/terraform.rc"},
+			wantPath: "/virtual/terraform.rc",
+			wantEnv:  cliconfig.EnvNameTerraformConfig,
+		},
+		{
+			name: "TF_CLI_CONFIG_FILE wins",
+			env: map[string]string{
+				cliconfig.EnvNameTFCLIConfigFile: "/virtual/custom.tofurc",
+				cliconfig.EnvNameTerraformConfig: "/virtual/terraform.rc",
+			},
+			wantPath: "/virtual/custom.tofurc",
+			wantEnv:  cliconfig.EnvNameTFCLIConfigFile,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path, envName := cliconfig.UserConfigOverride(pathsVenv("linux", testHome, tt.env))
+			assert.Equal(t, tt.wantPath, path)
+			assert.Equal(t, tt.wantEnv, envName)
+		})
+	}
+}
+
+// TestUserConfigCandidates: the default file locations follow OpenTofu's platform-specific search order.
+func TestUserConfigCandidates(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		env  map[string]string
+		name string
+		goos string
+		home string
+		want []string
+	}{
+		{
+			name: "unix dotfiles",
+			goos: "linux",
+			home: testHome,
+			want: []string{filepath.Join(testHome, ".tofurc"), filepath.Join(testHome, ".terraformrc")},
+		},
+		{
+			name: "unix XDG appended when set",
+			goos: "linux",
+			home: testHome,
+			env:  map[string]string{"XDG_CONFIG_HOME": testXDG},
+			want: []string{
+				filepath.Join(testHome, ".tofurc"),
+				filepath.Join(testHome, ".terraformrc"),
+				filepath.Join(testXDG, "opentofu", "tofurc"),
+			},
+		},
+		{
+			name: "unix without a home reads XDG only",
+			goos: "linux",
+			env:  map[string]string{"XDG_CONFIG_HOME": testXDG},
+			want: []string{filepath.Join(testXDG, "opentofu", "tofurc")},
+		},
+		{
+			name: "unix without a home or XDG has no candidate",
+			goos: "linux",
+		},
+		{
+			name: "windows reads APPDATA only",
+			goos: "windows",
+			home: testHome,
+			env:  map[string]string{"APPDATA": testAppData, "XDG_CONFIG_HOME": testXDG},
+			want: []string{filepath.Join(testAppData, "tofu.rc"), filepath.Join(testAppData, "terraform.rc")},
+		},
+		{
+			name: "windows without APPDATA has no candidate",
+			goos: "windows",
+			home: testHome,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, cliconfig.UserConfigCandidates(pathsVenv(tt.goos, tt.home, tt.env)))
+		})
+	}
+}
+
+// TestUserConfigDir: the config directory prefers the legacy directory, then XDG, then the legacy default.
+func TestUserConfigDir(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		env         map[string]string
+		name        string
+		goos        string
+		home        string
+		existingDir string
+		want        string
+	}{
+		{
+			name:        "existing legacy directory wins",
+			goos:        "linux",
+			home:        testHome,
+			env:         map[string]string{"XDG_CONFIG_HOME": testXDG},
+			existingDir: filepath.Join(testHome, ".terraform.d"),
+			want:        filepath.Join(testHome, ".terraform.d"),
+		},
+		{
+			name: "absent legacy directory falls back to XDG",
+			goos: "linux",
+			home: testHome,
+			env:  map[string]string{"XDG_CONFIG_HOME": testXDG},
+			want: filepath.Join(testXDG, "opentofu"),
+		},
+		{
+			name: "no XDG falls back to the legacy default",
+			goos: "linux",
+			home: testHome,
+			want: filepath.Join(testHome, ".terraform.d"),
+		},
+		{
+			name: "no home and no XDG has no directory",
+			goos: "linux",
+		},
+		{
+			name: "windows reads APPDATA",
+			goos: "windows",
+			home: testHome,
+			env:  map[string]string{"APPDATA": testAppData},
+			want: filepath.Join(testAppData, "terraform.d"),
+		},
+		{
+			name: "windows without APPDATA has no directory",
+			goos: "windows",
+			home: testHome,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := pathsVenv(tt.goos, tt.home, tt.env)
+			if tt.existingDir != "" {
+				require.NoError(t, v.FS.MkdirAll(tt.existingDir, 0o755))
+			}
+
+			dir, err := cliconfig.UserConfigDir(v)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, dir)
+		})
+	}
+}
+
+// TestUserConfigDirStatFailure: a directory whose presence cannot be determined is an error, not a fallback.
+func TestUserConfigDirStatFailure(t *testing.T) {
+	t.Parallel()
+
+	legacy := filepath.Join(testHome, ".terraform.d")
+	v := pathsVenv("linux", testHome, map[string]string{"XDG_CONFIG_HOME": testXDG})
+	v = v.WithFS(statErrorFS{FS: v.FS, failPath: legacy})
+
+	_, err := cliconfig.UserConfigDir(v)
+	require.ErrorIs(t, err, errStatFailed, "an unreadable config directory must not silently fall through to XDG")
+}

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -808,7 +808,7 @@ func fetchComponentSource(
 		return nil
 	}
 
-	// CAS is git-backed, so an oci:// source goes straight to the getter.
+	// oci:// has no git remote, so the CAS clone can only fail; other non-git schemes still fall through to the getter.
 	if opts.casEnabled && !isOCI {
 		casErr := fetchViaCAS(ctx, l, v, opts, cmp.sourceDir, kindStr, source, dest)
 		if casErr == nil {
@@ -835,7 +835,8 @@ func fetchComponentSource(
 		})
 	}
 
-	if err := copyFiles(ctx, l, v, opts, cmp.name, cmp.sourceDir, source, dest); err != nil {
+	cp := componentCopy{identifier: cmp.name, sourceDir: cmp.sourceDir, src: source, dest: dest}
+	if err := copyFiles(ctx, l, v, opts, cp); err != nil {
 		return fmt.Errorf(
 			"failed to fetch %s %s\n"+
 				"  Source:      %s\n"+
@@ -866,7 +867,7 @@ func fetchViaCAS(
 	opts *generateOpts,
 	sourceDir, kindStr, source, dest string,
 ) error {
-	resolvedSource := resolveLocalCASSource(l, sourceDir, source)
+	resolvedSource := resolveLocalCASSource(v.FS, sourceDir, source)
 
 	result, err := opts.casInstance.ProcessStackComponent(ctx, l, v, resolvedSource, kindStr)
 	if err != nil {
@@ -903,13 +904,13 @@ func fetchViaCAS(
 // rather than the process CWD. Remote sources, absolute paths, and any source
 // that doesn't look like a local path are returned unchanged. The "//" subdir
 // suffix used by go-getter is preserved.
-func resolveLocalCASSource(l log.Logger, sourceDir, source string) string {
+func resolveLocalCASSource(fsys vfs.FS, sourceDir, source string) string {
 	if source == "" || sourceDir == "" {
 		return source
 	}
 
 	basePath, subdir := getter.SourceDirSubdir(source)
-	if filepath.IsAbs(basePath) || !isLocal(l, sourceDir, basePath) {
+	if filepath.IsAbs(basePath) || !isLocal(fsys, sourceDir, basePath) {
 		return source
 	}
 
@@ -930,6 +931,14 @@ func isCASProtocol(source string) bool {
 	return strings.HasPrefix(source, cas.CASProtocolPrefix)
 }
 
+// componentCopy names one component fetch: its identifier, source directory, source, and destination.
+type componentCopy struct {
+	identifier string
+	sourceDir  string
+	src        string
+	dest       string
+}
+
 // copyFiles copies files or directories from a source to a destination path.
 //
 // The function checks if the source is local or remote. If local, it copies the
@@ -940,24 +949,24 @@ func copyFiles(
 	l log.Logger,
 	v *venv.Venv,
 	opts *generateOpts,
-	identifier, sourceDir, src, dest string,
+	cp componentCopy,
 ) error {
-	if !isLocal(l, sourceDir, src) {
-		if err := os.MkdirAll(dest, os.ModePerm); err != nil {
-			return fmt.Errorf("failed to create directory %s for %s %w", dest, identifier, err)
+	if !isLocal(v.FS, cp.sourceDir, cp.src) {
+		if err := v.FS.MkdirAll(cp.dest, os.ModePerm); err != nil {
+			return fmt.Errorf("failed to create directory %s for %s %w", cp.dest, cp.identifier, err)
 		}
 
-		if _, err := getter.GetAny(ctx, dest, src, stackGetterOptions(l, v, opts)...); err != nil {
-			return fmt.Errorf("failed to fetch %s %s for %s %w", src, dest, identifier, err)
+		if _, err := getter.GetAny(ctx, cp.dest, cp.src, stackGetterOptions(l, v, opts)...); err != nil {
+			return fmt.Errorf("failed to fetch %s %s for %s %w", cp.src, cp.dest, cp.identifier, err)
 		}
 
 		return nil
 	}
 
-	localSrc := src
+	localSrc := cp.src
 
-	if !filepath.IsAbs(src) {
-		localSrc = filepath.Join(sourceDir, src)
+	if !filepath.IsAbs(cp.src) {
+		localSrc = filepath.Join(cp.sourceDir, cp.src)
 	}
 
 	localSrc = filepath.Clean(localSrc)
@@ -965,13 +974,13 @@ func copyFiles(
 	if err := util.CopyFolderContentsWithFilter(
 		l,
 		localSrc,
-		dest,
+		cp.dest,
 		manifestName,
 		func(absolutePath string) bool {
 			return true
 		},
 	); err != nil {
-		return fmt.Errorf("failed to copy %s to %s %w", localSrc, dest, err)
+		return fmt.Errorf("failed to copy %s to %s %w", localSrc, cp.dest, err)
 	}
 
 	return nil
@@ -1021,13 +1030,11 @@ func stackGetterOptions(l log.Logger, v *venv.Venv, opts *generateOpts) []getter
 // looks like an absolute path but does not exist is treated as remote so the
 // caller can produce a meaningful fetch error rather than silently copying
 // from an empty directory.
-func isLocal(_ log.Logger, workingDir, src string) bool {
-	if util.FileExists(src) {
-		return true
-	}
-
-	if util.FileExists(filepath.Join(workingDir, src)) {
-		return true
+func isLocal(fsys vfs.FS, workingDir, src string) bool {
+	for _, candidate := range []string{src, filepath.Join(workingDir, src)} {
+		if exists, err := vfs.FileExists(fsys, candidate); err == nil && exists {
+			return true
+		}
 	}
 
 	return strings.HasPrefix(src, "file://")

--- a/pkg/config/stack_oci_test.go
+++ b/pkg/config/stack_oci_test.go
@@ -3,57 +3,56 @@ package config_test
 import (
 	"bytes"
 	"errors"
-	"net/http"
-	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/worker"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// The virtual paths and registry the in-memory stack fixtures use.
+const (
+	ociTestStackDir = "/virtual/stack"
+	ociTestHome     = "/virtual/home"
+	ociTestRegistry = "registry.example.com"
+)
+
 // ociStackFixture writes a terragrunt.stack.hcl whose single unit or stack is served from an oci:// registry.
-func ociStackFixture(t *testing.T, kind, source string) string {
+func ociStackFixture(t *testing.T, fsys vfs.FS, kind, source string) string {
 	t.Helper()
 
-	dir := t.TempDir()
 	body := kind + ` "vpc" {
   source = "` + source + `"
   path   = "vpc"
 }
 `
 
-	stackPath := filepath.Join(dir, "terragrunt.stack.hcl")
-	require.NoError(t, os.WriteFile(stackPath, []byte(body), 0o644))
+	stackPath := filepath.Join(ociTestStackDir, "terragrunt.stack.hcl")
+	require.NoError(t, vfs.WriteFile(fsys, stackPath, []byte(body), 0o644))
 
 	return stackPath
 }
 
-// generateOCIStack runs stack generation for an oci:// component against a registry the test owns.
+// generateOCIStack runs stack generation for an oci:// component against an unreachable registry.
 func generateOCIStack(t *testing.T, kind, sourceScheme string, ociEnabled bool) (string, error) {
 	t.Helper()
 
-	// A TLS server the test owns, whose self-signed cert the client always rejects.
-	registry := httptest.NewTLSServer(http.NotFoundHandler())
-	t.Cleanup(registry.Close)
+	// An in-memory venv: no disk, and a fail-closed client so no fetch can leave the test.
+	v := venvtest.New().
+		WithEnv(map[string]string{"HOME": ociTestHome}).
+		WithUserHomeDir(func() (string, error) { return ociTestHome, nil })
 
-	source := sourceScheme + registry.Listener.Addr().String() + "/terraform-modules/vpc?tag=1.0.0"
-	stackPath := ociStackFixture(t, kind, source)
-
-	// Hermetic home so a developer's own credentials cannot influence the result.
-	hermeticHome := t.TempDir()
-	v := venv.OSVenv().
-		WithEnv(map[string]string{"HOME": hermeticHome}).
-		WithUserHomeDir(func() (string, error) { return hermeticHome, nil })
+	source := sourceScheme + ociTestRegistry + "/terraform-modules/vpc?tag=1.0.0"
+	stackPath := ociStackFixture(t, v.FS, kind, source)
 
 	var logBuf bytes.Buffer
 
@@ -123,7 +122,7 @@ func TestGenerateStackOCIReachesGetter(t *testing.T) {
 			t.Parallel()
 
 			logs, err := generateOCIStack(t, kind, "oci://", true)
-			require.Error(t, err, "the fake registry's cert is untrusted, so every fetch fails")
+			require.Error(t, err, "the venv's fail-closed HTTP client rejects every fetch")
 
 			var resolutionErr getter.OCIReferenceResolutionError
 			require.ErrorAs(


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description


- Typed OCI credential errors, aggregated and reported together
- CLI-config path discovery extracted into internal/tf/cliconfig, with tests
- Hermetic in-memory stack tests, errors.Is assertions, reworded docs


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved OCI credential discovery using OpenTofu CLI configuration files, overrides, fragments, and platform-specific paths.
  * Added clearer handling for credential conflicts, invalid settings, unreadable files, and aggregated configuration errors.
  * Improved OCI credential validation, deduplication, and repository matching.

* **Documentation**
  * Updated OCI documentation and changelog terminology to consistently reference OpenTofu.
  * Clarified OpenTofu CLI configuration search paths and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->