### PR TITLE
chore: Addressing flake in `TestCatalogJSONLFormatCleansUpOnEarlyExit`

### DIFF
--- a/internal/cli/commands/catalog/catalog.go
+++ b/internal/cli/commands/catalog/catalog.go
@@ -47,10 +47,17 @@ func Run(
 	}
 
 	tempDirs := tui.NewTempDirTracker(v.FS)
+
+	streamCtx, stopStream := context.WithCancel(ctx)
+	defer stopStream()
+
+	stopNotify := notifyBrokenPipe(ctx, stopStream)
+	defer stopNotify()
+
 	defer tempDirs.Cleanup(l)
 
 	return Stream(
-		ctx, l, v.Writers.Writer, renderer,
+		streamCtx, l, v.Writers.Writer, renderer,
 		newLoadFunc(l, v, opts.TerragruntOptions, tempDirs, repoURL),
 	)
 }

--- a/internal/cli/commands/catalog/sigpipe_unix.go
+++ b/internal/cli/commands/catalog/sigpipe_unix.go
@@ -11,18 +11,24 @@ import (
 )
 
 // notifyBrokenPipe makes a write to a closed standard output fail with EPIPE
-// instead of killing the process.
+// instead of killing the process, and returns the function that restores the
+// default disposition.
 //
 // Go raises SIGPIPE for writes to file descriptors 1 and 2, and kills the
 // program with it, but only while the program is not receiving the signal.
-// Receiving it for the life of the stream is what lets the renderer stop on
-// its own and lets the command remove the repositories it cloned on the way
-// out, which a signal death skips.
+// Receiving it is what lets the renderer stop on its own and lets the command
+// remove the repositories it cloned on the way out, which a signal death
+// skips.
 //
 // Cancelling from the callback ends discovery as soon as the reader goes
-// away, rather than at whichever write fails next. Registration is scoped to
-// ctx, so the rest of the process, the TUI included, keeps the default
-// disposition.
-func notifyBrokenPipe(ctx context.Context, cancel context.CancelFunc) {
-	signal.NotifierWithContext(ctx, func(_ os.Signal) { cancel() }, syscall.SIGPIPE)
+// away, rather than at whichever write fails next. The registration outlives
+// that cancellation and ends only when the caller stops it: cleanup writes
+// too, and by then the reader is already gone. Everything outside that
+// window, the TUI included, keeps the default disposition.
+func notifyBrokenPipe(ctx context.Context, cancel context.CancelFunc) context.CancelFunc {
+	notifyCtx, stop := context.WithCancel(ctx)
+
+	signal.NotifierWithContext(notifyCtx, func(_ os.Signal) { cancel() }, syscall.SIGPIPE)
+
+	return stop
 }

--- a/internal/cli/commands/catalog/sigpipe_windows.go
+++ b/internal/cli/commands/catalog/sigpipe_windows.go
@@ -7,4 +7,6 @@ import "context"
 // notifyBrokenPipe does nothing on Windows, which has no SIGPIPE. A write to
 // a pipe whose reader has gone fails with an error there, so the renderer
 // already learns about it the same way it does for any other write failure.
-func notifyBrokenPipe(_ context.Context, _ context.CancelFunc) {}
+func notifyBrokenPipe(_ context.Context, _ context.CancelFunc) context.CancelFunc {
+	return func() {}
+}

--- a/internal/cli/commands/catalog/stream.go
+++ b/internal/cli/commands/catalog/stream.go
@@ -38,8 +38,6 @@ func Stream(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	notifyBrokenPipe(ctx, cancel)
-
 	componentCh := make(chan *tui.ComponentEntry, componentChannelBufferSize)
 
 	g, gctx := errgroup.WithContext(ctx)

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -47,6 +47,10 @@ const (
 	// outgrows a pipe buffer, so the child is still writing when the reader
 	// stops.
 	catalogEarlyExitModules = 400
+
+	// catalogPipeDoneMarker separates a child process that reached the end of
+	// the command from one that died before it could clean up.
+	catalogPipeDoneMarker = "catalog pipe child finished"
 )
 
 func TestCatalogGitRepoUpdate(t *testing.T) {
@@ -534,6 +538,14 @@ func TestCatalogJSONLFormatCleansUpOnEarlyExit(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(line), &entry))
 	assert.Equal(t, "module", entry.Kind)
 
+	require.Contains(
+		t,
+		childStderr.String(),
+		catalogPipeDoneMarker,
+		"the child never reached the end of the command, so it never got to clean up (child exit: %v)",
+		waitErr,
+	)
+
 	leftovers, err := filepath.Glob(filepath.Join(childTempDir, "catalog-*"))
 	require.NoError(t, err)
 	assert.Empty(
@@ -556,9 +568,17 @@ func TestCatalogPipeHelper(t *testing.T) {
 		t.Skip("not the catalog pipe child process")
 	}
 
-	require.NoError(t, helpers.RunTerragruntCommand(t,
+	err := helpers.RunTerragruntCommand(t,
 		"terragrunt catalog --experiment catalog-format --format jsonl --working-dir "+workDir,
-		os.Stdout, os.Stderr))
+		os.Stdout, os.Stderr)
+
+	// Standard output is the broken pipe under test, so the marker goes to
+	// standard error, and it is written before the assertion below: a failed
+	// assertion writes to standard output, which kills this process with
+	// SIGPIPE.
+	fmt.Fprintln(os.Stderr, catalogPipeDoneMarker)
+
+	require.NoError(t, err)
 }
 
 // catalogManyModulesFixture builds a repository of count modules, each with a


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6612.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog command cancellation and broken-pipe handling.
  * Ensured cleanup continues reliably when output streams close early.
  * Improved behavior across supported operating systems.

* **Tests**
  * Added coverage verifying command completion and temporary resource cleanup after early pipe termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->