### PR TITLE
fix: Fixing provider cache server archive dir race

### DIFF
--- a/docs/src/data/changelog/v1.1.3/provider-cache-archive-dir-race.mdx
+++ b/docs/src/data/changelog/v1.1.3/provider-cache-archive-dir-race.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.3"
+category: "bug-fixes"
+---
+
+#### Keep cached provider archives out of the working directory
+
+With the [provider cache server](/features/caching/provider-cache-server) enabled via `--provider-cache`, the server could start answering requests before it had finished preparing the directories it caches into. A provider requested in that window had its archive and lock file written relative to the working directory instead of into the cache, leaving zip files behind in your project.
+
+This race condition has been resolved, meaning that providers will always be properly downloaded into the cache directory.

--- a/internal/tf/cache/server.go
+++ b/internal/tf/cache/server.go
@@ -115,6 +115,16 @@ func (server *Server) Listen(ctx context.Context) (net.Listener, error) {
 func (server *Server) Run(ctx context.Context, ln net.Listener) error {
 	server.logger.Infof("Start Terragrunt Cache server")
 
+	// Initialize before serving, not alongside it: the listener is already
+	// accepting connections by the time Run is called, so a service still
+	// building its state in a goroutine can be handed a request that reads
+	// that state half-built.
+	for _, service := range server.services {
+		if err := service.Init(); err != nil {
+			return err
+		}
+	}
+
 	errGroup, ctx := errgroup.WithContext(ctx)
 
 	for _, service := range server.services {

--- a/internal/tf/cache/server_init_test.go
+++ b/internal/tf/cache/server_init_test.go
@@ -1,0 +1,62 @@
+package cache_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+// serveTimeout bounds how long the test waits for a server that should never
+// have started serving in the first place.
+const serveTimeout = 10 * time.Second
+
+// TestServerRunInitializesServicesBeforeServing pins the order the server
+// starts in. A service builds the directories it writes to when it
+// initializes, and the listener is already accepting connections by the time
+// Run is called, so requests waiting in the backlog are answered the moment
+// Serve begins. A service initialized alongside serving can therefore hand a
+// request paths it has not built yet, which is how provider archives ended up
+// written relative to the working directory.
+//
+// A service that cannot initialize makes that order observable: the failure
+// has to stop the server before it serves, rather than surface once it stops.
+func TestServerRunInitializesServicesBeforeServing(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+
+	// No cache directory, so the provider service cannot initialize.
+	server := cache.NewServer(
+		cache.WithHostname("127.0.0.1"),
+		cache.WithLogger(l),
+		cache.WithProviderService(services.NewProviderService("", t.TempDir(), nil, l)),
+	)
+
+	ln, err := server.Listen(t.Context())
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+
+	go func() { done <- server.Run(t.Context(), ln) }()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, services.ErrCacheDirNotSpecified)
+
+		// Closing the listener the test opened is what proves the server never
+		// took it over: a run that reached Serve closes it while shutting
+		// down, leaving nothing here to close.
+		require.NoError(
+			t,
+			ln.Close(),
+			"the server served on the listener before reporting the failure",
+		)
+	case <-time.After(serveTimeout):
+		t.Fatal("the server neither served nor reported the initialization failure")
+	}
+}

--- a/internal/tf/cache/services/errors.go
+++ b/internal/tf/cache/services/errors.go
@@ -1,9 +1,15 @@
 package services
 
 import (
+	"errors"
 	"fmt"
 	"os"
 )
+
+// ErrCacheDirNotSpecified is returned by [ProviderService.Init] when the
+// service was built without a cache directory, leaving it nowhere to write
+// the providers it caches. Match with errors.Is.
+var ErrCacheDirNotSpecified = errors.New("provider cache directory not specified")
 
 // UnexpectedProviderCachePathError is returned when something other than a
 // Terragrunt-managed symlink occupies a provider's package path inside the

--- a/internal/tf/cache/services/provider_cache.go
+++ b/internal/tf/cache/services/provider_cache.go
@@ -540,28 +540,34 @@ func WithHTTPClient(c vhttp.Client) ProviderServiceOption {
 }
 
 type ProviderService struct {
-	logger                log.Logger
-	providerCacheWarmUpCh chan *ProviderCache
-	credsSource           *cliconfig.CredentialsSource
+	logger log.Logger
 
 	// fs is the filesystem for file operations.
 	fs vfs.FS
 
-	httpClient vhttp.Client
+	initErr               error
+	providerCacheWarmUpCh chan *ProviderCache
+	credsSource           *cliconfig.CredentialsSource
+	httpClient            vhttp.Client
 
-	// The path to store unpacked providers. The file structure is the same as terraform plugin cache dir.
-	cacheDir string
-
-	// The path to a predictable temporary directory for provider lock files.
+	// tempDir is a predictable temporary directory for provider lock files.
 	tempDir string
 
 	archiveDir string
 
-	// the user plugins directory, by default: %APPDATA%\terraform.d\plugins on Windows, ~/.terraform.d/plugins on other systems.
-	userCacheDir   string
+	// userCacheDir is the user plugins directory, by default:
+	// %APPDATA%\terraform.d\plugins on Windows, ~/.terraform.d/plugins on
+	// other systems.
+	userCacheDir string
+
+	// cacheDir is the path to store unpacked providers. The file structure is
+	// the same as the terraform plugin cache dir.
+	cacheDir string
+
 	providerCaches ProviderCaches
 	cacheMu        sync.RWMutex
 	cacheReadyMu   sync.RWMutex
+	initOnce       sync.Once
 }
 
 // FS returns the configured filesystem.
@@ -740,10 +746,25 @@ func (service *ProviderService) GetProviderCache(provider *models.Provider) *Pro
 	return nil
 }
 
-// Run is responsible to handle a new caching requestID and removing temporary files upon completion.
-func (service *ProviderService) Run(ctx context.Context) error {
+// Init creates the directories the service caches into. It runs at most once,
+// whichever caller reaches it first, and returns the same result to the rest.
+//
+// The server calls it before it serves a single request, because
+// [ProviderService.CacheProvider] builds every path it hands a provider out of
+// these directories: a request answered before they exist would write the
+// provider's archive and lock file to whatever the working directory happens
+// to be.
+func (service *ProviderService) Init() error {
+	service.initOnce.Do(func() {
+		service.initErr = service.init()
+	})
+
+	return service.initErr
+}
+
+func (service *ProviderService) init() error {
 	if service.cacheDir == "" {
-		return errors.New("provider cache directory not specified")
+		return ErrCacheDirNotSpecified
 	}
 
 	service.logger.Debugf("Starting provider cache service with cache dir: %q", service.cacheDir)
@@ -770,6 +791,15 @@ func (service *ProviderService) Run(ctx context.Context) error {
 	}
 
 	service.logger.Debugf("Provider cache service archive dir: %s", service.archiveDir)
+
+	return nil
+}
+
+// Run is responsible to handle a new caching requestID and removing temporary files upon completion.
+func (service *ProviderService) Run(ctx context.Context) error {
+	if err := service.Init(); err != nil {
+		return err
+	}
 
 	var (
 		errs   []error

--- a/internal/tf/cache/services/provider_cache_test.go
+++ b/internal/tf/cache/services/provider_cache_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
 
 func TestRemoveStaleSymlink(t *testing.T) {
@@ -145,4 +146,27 @@ type lstatErrorFS struct {
 
 func (fs *lstatErrorFS) LstatIfPossible(string) (os.FileInfo, bool, error) {
 	return nil, false, fs.err
+}
+
+// TestProviderServiceInitIsIdempotent covers the server initializing a
+// service that a caller may also drive through Run: the directories are
+// created once, and both callers see the same outcome.
+func TestProviderServiceInitIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	service := services.NewProviderService(
+		t.TempDir(), t.TempDir(), nil, logger.CreateLogger(),
+	)
+
+	require.NoError(t, service.Init())
+	require.NoError(t, service.Init())
+}
+
+func TestProviderServiceInitWithoutCacheDir(t *testing.T) {
+	t.Parallel()
+
+	service := services.NewProviderService("", t.TempDir(), nil, logger.CreateLogger())
+
+	require.ErrorIs(t, service.Init(), services.ErrCacheDirNotSpecified)
+	require.ErrorIs(t, service.Run(t.Context()), services.ErrCacheDirNotSpecified)
 }

--- a/internal/tf/cache/services/service.go
+++ b/internal/tf/cache/services/service.go
@@ -7,5 +7,10 @@ import (
 )
 
 type Service interface {
+	// Init prepares the service to answer requests. The server calls it
+	// before it starts serving, so no request observes a half-built service.
+	// It is safe to call more than once; only the first call does the work.
+	Init() error
+
 	Run(ctx context.Context) error
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Saw that running some racy tests locally resulted in untracked zip files. This resolves that.

Should be theoretically encounterable in production, but I don't know how likely it is.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a startup race that could place provider archive and lock files in the working directory instead of the cache directory.
  - Provider services now initialize before requests are served or background processing begins.
  - Missing provider cache directories now produce a clear, consistent initialization error.
  - Repeated initialization attempts are handled safely and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->