### PR TITLE
fix: Addressing feedback from #6565 and #6605

### DIFF
--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -88,9 +88,14 @@ type Dependency struct {
 //   - For MockOutputs, the two maps will be deeply merged together. This means that maps are recursively merged, while
 //     lists are concatenated together.
 //   - For MockOutputsAllowedTerraformCommands, the source will be concatenated to the target.
+//   - For Expansion, the source block replaces the target block outright.
 //
 // Note that RenderedOutputs is ignored in the deep merge operation.
 func (dep *Dependency) DeepMerge(sourceDepConfig *Dependency) error {
+	if sourceDepConfig.Expansion != nil {
+		dep.Expansion = sourceDepConfig.Expansion
+	}
+
 	if sourceDepConfig.ConfigPath.AsString() != "" {
 		dep.ConfigPath = sourceDepConfig.ConfigPath
 	}

--- a/pkg/config/dependency_test.go
+++ b/pkg/config/dependency_test.go
@@ -295,3 +295,67 @@ dependency "enabled" {
 	// Only enabled dependency should be in the paths
 	assert.Len(t, terragruntConfig.Dependencies.Paths, 1)
 }
+
+// TestDependencyDeepMergeExpansion pins that an expansion block survives the deep
+// merge an include performs. DeepMerge copies field by field, so a field it does not
+// name is dropped silently rather than caught by the compiler.
+func TestDependencyDeepMergeExpansion(t *testing.T) {
+	t.Parallel()
+
+	forEach := hclparse.ExpansionBlock{
+		ForEach: new(cty.SetVal([]cty.Value{cty.StringVal("web")})),
+	}
+	count := hclparse.ExpansionBlock{Count: new(cty.NumberIntVal(2))}
+
+	testCases := []struct {
+		target   *hclparse.ExpansionBlock
+		source   *hclparse.ExpansionBlock
+		expected *hclparse.ExpansionBlock
+		name     string
+	}{
+		{
+			name:     "source expansion is adopted when the target has none",
+			target:   nil,
+			source:   &forEach,
+			expected: &forEach,
+		},
+		{
+			name:     "target expansion is retained when the source has none",
+			target:   &forEach,
+			source:   nil,
+			expected: &forEach,
+		},
+		{
+			name:     "source expansion replaces the target expansion",
+			target:   &count,
+			source:   &forEach,
+			expected: &forEach,
+		},
+		{
+			name:     "neither side expands",
+			target:   nil,
+			source:   nil,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dep := config.Dependency{
+				Name:       "vpc",
+				ConfigPath: cty.StringVal("../vpc"),
+				Expansion:  tc.target,
+			}
+			source := config.Dependency{
+				Name:       "vpc",
+				ConfigPath: cty.StringVal("../vpc"),
+				Expansion:  tc.source,
+			}
+
+			require.NoError(t, dep.DeepMerge(&source))
+			assert.Equal(t, tc.expected, dep.Expansion)
+		})
+	}
+}

--- a/pkg/config/hclparse/expansion.go
+++ b/pkg/config/hclparse/expansion.go
@@ -24,6 +24,8 @@ const (
 	eachKeyAttrName    = "key"
 	eachValueAttrName  = "value"
 	countIndexAttrName = "index"
+
+	forEachElementLabel = forEachAttrName + " element"
 )
 
 // DefaultMaxInstances bounds how many instances a single block may expand into,
@@ -319,7 +321,8 @@ func expandForEach(
 	return instances, nil
 }
 
-// requireConcrete rejects meta-arg values that cannot be iterated or converted.
+// requireConcrete rejects expansion values that cannot be iterated, converted, or
+// stringified.
 func requireConcrete(value cty.Value, attr string, subject *hcl.Range) error {
 	if !value.IsKnown() {
 		return UnknownExpansionValueError{Attr: attr, Subject: subject}
@@ -334,6 +337,13 @@ func requireConcrete(value cty.Value, attr string, subject *hcl.Range) error {
 
 // expansionKey renders a for_each element key as the string used in addresses.
 func expansionKey(key cty.Value, subject *hcl.Range) (string, error) {
+	// A set's elements are its own keys, so an unknown or null element reaches here
+	// having satisfied the collection-level check in expandForEach. AsString and
+	// AsBigFloat panic on both.
+	if err := requireConcrete(key, forEachElementLabel, subject); err != nil {
+		return "", err
+	}
+
 	switch key.Type() {
 	case cty.String:
 		return key.AsString(), nil

--- a/pkg/config/hclparse/expansion_test.go
+++ b/pkg/config/hclparse/expansion_test.go
@@ -88,6 +88,28 @@ dependency "a" {
 	assert.ElementsMatch(t, []string{"../web/frontend", "../api/backend"}, paths)
 }
 
+// TestExpandBlockForEachMapNullValue pins that the concreteness check on element keys
+// leaves values alone: a map key is concrete no matter what it maps to, so a null
+// value only fails the body that dereferences it.
+func TestExpandBlockForEachMapNullValue(t *testing.T) {
+	t.Parallel()
+
+	instances, err := expand(t, `
+dependency "a" {
+  expansion {
+    for_each = local.service_map_with_null_value
+  }
+
+  path = "../${each.key}"
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+
+	assert.Equal(t, []string{"web"}, keysOf(instances))
+	assert.Equal(t, "../web", instances[0].Value.(*testBlock).Path)
+}
+
 func TestExpandBlockCount(t *testing.T) {
 	t.Parallel()
 
@@ -287,9 +309,10 @@ dependency "a" {
 	}
 }
 
-// TestExpandBlockRejectsNonConcreteValues pins that unknown and null meta-args are
-// reported rather than crashing. cty's LengthInt and ElementIterator panic on both,
-// and a for_each fed from a dependency output can be either.
+// TestExpandBlockRejectsNonConcreteValues pins that unknown and null values are
+// reported rather than crashing, both when the meta-arg itself is non-concrete and
+// when a concrete set carries a non-concrete element. cty panics on both in either
+// position, and a for_each fed from a dependency output can be either.
 func TestExpandBlockRejectsNonConcreteValues(t *testing.T) {
 	t.Parallel()
 
@@ -316,6 +339,21 @@ func TestExpandBlockRejectsNonConcreteValues(t *testing.T) {
 		{
 			name:   "null count",
 			attr:   "count = local.null_count",
+			target: new(hclparse.NullExpansionValueError),
+		},
+		{
+			name:   "unknown for_each element",
+			attr:   "for_each = local.services_with_unknown_element",
+			target: new(hclparse.UnknownExpansionValueError),
+		},
+		{
+			name:   "null for_each element",
+			attr:   "for_each = local.services_with_null_element",
+			target: new(hclparse.NullExpansionValueError),
+		},
+		{
+			name:   "null numeric for_each element",
+			attr:   "for_each = local.numeric_keys_with_null_element",
 			target: new(hclparse.NullExpansionValueError),
 		},
 	}
@@ -555,6 +593,21 @@ func expand(
 				"null_services":    cty.NullVal(cty.Set(cty.String)),
 				"unknown_count":    cty.UnknownVal(cty.Number),
 				"null_count":       cty.NullVal(cty.Number),
+				"services_with_unknown_element": cty.SetVal([]cty.Value{
+					cty.StringVal("web"),
+					cty.UnknownVal(cty.String),
+				}),
+				"services_with_null_element": cty.SetVal([]cty.Value{
+					cty.StringVal("web"),
+					cty.NullVal(cty.String),
+				}),
+				"numeric_keys_with_null_element": cty.SetVal([]cty.Value{
+					cty.NumberIntVal(1),
+					cty.NullVal(cty.Number),
+				}),
+				"service_map_with_null_value": cty.MapVal(map[string]cty.Value{
+					"web": cty.NullVal(cty.String),
+				}),
 			}),
 		},
 	}

--- a/pkg/config/include_test.go
+++ b/pkg/config/include_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -518,6 +519,40 @@ func TestDeepMergeConfigIntoIncludedConfig(t *testing.T) {
 					config.Dependency{
 						Name:       "vpc",
 						ConfigPath: cty.StringVal("../vpc"),
+					},
+				},
+			},
+		},
+		// Deep merge a dependency that expands, where only the source declares expansion
+		{
+			name: "dependency expansion",
+			source: &config.TerragruntConfig{
+				TerragruntDependencies: config.Dependencies{
+					config.Dependency{
+						Name:       "vpc",
+						ConfigPath: cty.StringVal("../vpc"),
+						Expansion: &hclparse.ExpansionBlock{
+							ForEach: new(cty.SetVal([]cty.Value{cty.StringVal("web")})),
+						},
+					},
+				},
+			},
+			target: &config.TerragruntConfig{
+				TerragruntDependencies: config.Dependencies{
+					config.Dependency{
+						Name:       "vpc",
+						ConfigPath: cty.StringVal("../vpc"),
+					},
+				},
+			},
+			expected: &config.TerragruntConfig{
+				TerragruntDependencies: config.Dependencies{
+					config.Dependency{
+						Name:       "vpc",
+						ConfigPath: cty.StringVal("../vpc"),
+						Expansion: &hclparse.ExpansionBlock{
+							ForEach: new(cty.SetVal([]cty.Value{cty.StringVal("web")})),
+						},
 					},
 				},
 			},


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses review feedback from #6565 and #6605

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency expansion settings are now correctly preserved or replaced during merges.
  * Improved handling of `for_each` expansions with null values.
  * Invalid, unknown, or null element keys now produce clear validation errors instead of causing failures.
* **Tests**
  * Added coverage for dependency expansion merging and `for_each` expansion scenarios, including null values and invalid keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->