### PR TITLE
test: prove oci module portability between tofu and terragrunt

### DIFF
--- a/docs/src/data/experiments/oci.mdx
+++ b/docs/src/data/experiments/oci.mdx
@@ -93,7 +93,7 @@ To transition the `oci` feature to a stable release, the following must be addre
 - [x] OpenTofu CLI-config and ambient Docker-config credential discovery matching OpenTofu's search order.
 - [x] Credential-helper support (`docker-credential-*`, `ecr-login`) so ECR and other helper-backed registries work through the configured helper.
 - [x] Content-addressable caching keyed on the resolved manifest digest, with correct re-resolution of mutable tags.
-- [ ] A portability guarantee that one source string produces an identical module via `tofu` and Terragrunt.
+- [x] A portability guarantee that one source string produces an identical module via `tofu` and Terragrunt.
 - [ ] Documentation covering the source syntax, authentication tiers, and publishing contract.
 - [x] Integration test coverage driving the full download chain against a local OCI Distribution registry.
 - [ ] Gated CI coverage against hosted registries (GHCR, ECR) with real credentials.

--- a/test/helpers/ociregistry/ociregistry.go
+++ b/test/helpers/ociregistry/ociregistry.go
@@ -5,6 +5,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/json"
+	"encoding/pem"
 	"io"
 	"maps"
 	"net/http"
@@ -88,6 +89,11 @@ func (r *Registry) Address() string {
 // Client returns an HTTP client that trusts the registry's certificate.
 func (r *Registry) Client() *http.Client {
 	return r.server.Client()
+}
+
+// CertPEM returns the registry's certificate, so a child process can trust it through SSL_CERT_FILE.
+func (r *Registry) CertPEM() []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: r.server.Certificate().Raw})
 }
 
 // PushModule packs files into a module zip, publishes it under repo and tag, and returns the manifest descriptor.

--- a/test/integration_tofu_oci_portability_test.go
+++ b/test/integration_tofu_oci_portability_test.go
@@ -4,6 +4,7 @@ package test_test
 
 import (
 	"encoding/json"
+	"io"
 	"io/fs"
 	"net/url"
 	"os"
@@ -22,7 +23,9 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/ociregistry"
 )
@@ -81,7 +84,7 @@ func TestTofuOCIModulePortability(t *testing.T) {
 	}
 }
 
-// TestTofuOCIMovedTagReResolution pins that both tools serve the new content after a tag moves, never a stale cache.
+// TestTofuOCIMovedTagReResolution pins that clean installs after a tag moves serve the new content in both tools.
 func TestTofuOCIMovedTagReResolution(t *testing.T) {
 	t.Parallel()
 
@@ -90,7 +93,7 @@ func TestTofuOCIMovedTagReResolution(t *testing.T) {
 
 	source := "oci://" + registry.Address() + "/" + tofuOCIPortabilityRepository + "?tag=1.0.0"
 
-	// One venv for both rounds, so the second pull must re-resolve through the same CAS store.
+	// Each round installs clean; the CAS store under the process cache dir carries over, so a stale entry would surface.
 	v := portabilityVenv(t, registry)
 
 	require.Equal(t, tofuOCIPortabilityFiles, tofuOCIModuleTree(t, registry, source))
@@ -131,13 +134,15 @@ func tofuOCIModuleTree(t *testing.T, registry *ociregistry.Registry, source stri
 	cliConfig := filepath.Join(home, "cli.tfrc")
 	require.NoError(t, os.WriteFile(cliConfig, nil, 0o600))
 
-	cmd := exec.CommandContext(t.Context(), "tofu", "get")
+	cmd := exec.CommandContext(t.Context(), helpers.TofuBinary, "get")
 	cmd.Dir = workDir
 
+	// os/exec deduplicates keeping later values, so these override any ambient copies.
 	cmd.Env = append(os.Environ(),
 		"HOME="+home,
 		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
 		"TF_CLI_CONFIG_FILE="+cliConfig,
+		"TF_DATA_DIR="+filepath.Join(workDir, ".terraform"),
 		"SSL_CERT_FILE="+certFile,
 	)
 
@@ -175,9 +180,12 @@ func terragruntOCIModuleTree(t *testing.T, v *venv.Venv, source string) map[stri
 		},
 	}
 
+	l := logger.CreateLogger()
+	l.SetOptions(log.WithOutput(io.Discard))
+
 	_, err = run.DownloadTerraformSourceIfNecessary(
 		t.Context(),
-		logger.CreateLogger(),
+		l,
 		v,
 		src,
 		configbridge.NewRunOptions(opts),
@@ -221,6 +229,11 @@ func tofuInstalledModuleDir(t *testing.T, workDir string) string {
 	for _, module := range manifest.Modules {
 		if module.Key != "vpc" {
 			continue
+		}
+
+		// A pinned absolute TF_DATA_DIR makes tofu record absolute module dirs.
+		if filepath.IsAbs(module.Dir) {
+			return module.Dir
 		}
 
 		return filepath.Join(workDir, module.Dir)

--- a/test/integration_tofu_oci_portability_test.go
+++ b/test/integration_tofu_oci_portability_test.go
@@ -1,0 +1,275 @@
+//go:build tofu && (linux || darwin)
+
+package test_test
+
+import (
+	"encoding/json"
+	"io/fs"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/configbridge"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/internal/runner/run"
+	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
+	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/ociregistry"
+)
+
+// tofuOCIPortabilityRepository is the repository the portability tests publish under.
+const tofuOCIPortabilityRepository = "terraform-modules/vpc"
+
+// tofuOCIPortabilityFiles is the module tree published once and consumed by both tools.
+var tofuOCIPortabilityFiles = map[string]string{
+	"main.tf": `output "root" {
+  value = "root"
+}
+`,
+	"modules/sub/main.tf": `output "sub" {
+  value = "sub"
+}
+`,
+}
+
+// TestTofuOCIModulePortability pins that one oci source string yields byte-identical modules via tofu and Terragrunt.
+func TestTofuOCIModulePortability(t *testing.T) {
+	t.Parallel()
+
+	// The manifest contract is the portability guarantee, so drift must fail here first.
+	require.Equal(t, getter.ArtifactTypeModulePkg, ociregistry.ArtifactTypeModulePkg)
+	require.Equal(t, getter.MediaTypeModuleZip, ociregistry.MediaTypeModuleZip)
+
+	registry := ociregistry.Start(t)
+	manifest := registry.PushModule(t, tofuOCIPortabilityRepository, "1.0.0", tofuOCIPortabilityFiles)
+	registry.PushModule(t, tofuOCIPortabilityRepository, "latest", tofuOCIPortabilityFiles)
+
+	base := "oci://" + registry.Address() + "/" + tofuOCIPortabilityRepository
+	subTree := map[string]string{"main.tf": tofuOCIPortabilityFiles["modules/sub/main.tf"]}
+
+	testCases := []struct {
+		want map[string]string
+		name string
+		src  string
+	}{
+		{name: "tag pin", src: base + "?tag=1.0.0", want: tofuOCIPortabilityFiles},
+		{name: "digest pin", src: base + "?digest=" + manifest.Digest.String(), want: tofuOCIPortabilityFiles},
+		{name: "no query defaults to latest", src: base, want: tofuOCIPortabilityFiles},
+		{name: "subdir selection", src: base + "//modules/sub?tag=1.0.0", want: subTree},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tofuTree := tofuOCIModuleTree(t, registry, tc.src)
+			terragruntTree := terragruntOCIModuleTree(t, portabilityVenv(t, registry), tc.src)
+
+			require.Equal(t, tc.want, tofuTree, "tofu must materialize exactly the published module view")
+			require.Equal(t, tofuTree, terragruntTree, "one source string must yield byte-identical modules in both tools")
+		})
+	}
+}
+
+// TestTofuOCIMovedTagReResolution pins that both tools serve the new content after a tag moves, never a stale cache.
+func TestTofuOCIMovedTagReResolution(t *testing.T) {
+	t.Parallel()
+
+	registry := ociregistry.Start(t)
+	registry.PushModule(t, tofuOCIPortabilityRepository, "1.0.0", tofuOCIPortabilityFiles)
+
+	source := "oci://" + registry.Address() + "/" + tofuOCIPortabilityRepository + "?tag=1.0.0"
+
+	// One venv for both rounds, so the second pull must re-resolve through the same CAS store.
+	v := portabilityVenv(t, registry)
+
+	require.Equal(t, tofuOCIPortabilityFiles, tofuOCIModuleTree(t, registry, source))
+	require.Equal(t, tofuOCIPortabilityFiles, terragruntOCIModuleTree(t, v, source))
+
+	// The moved tag drops the subdir, so stale cache content cannot hide as a subset match.
+	movedFiles := map[string]string{
+		"main.tf": `output "root" {
+  value = "root-moved"
+}
+`,
+	}
+	registry.PushModule(t, tofuOCIPortabilityRepository, "1.0.0", movedFiles)
+
+	tofuTree := tofuOCIModuleTree(t, registry, source)
+	terragruntTree := terragruntOCIModuleTree(t, v, source)
+
+	require.Equal(t, movedFiles, tofuTree, "tofu must serve the moved tag's content")
+	require.Equal(t, tofuTree, terragruntTree, "a moved tag must stay portable, never a stale cache on either side")
+}
+
+// tofuOCIModuleTree installs source through the real tofu binary and returns the effective module tree.
+func tofuOCIModuleTree(t *testing.T, registry *ociregistry.Registry, source string) map[string]string {
+	t.Helper()
+
+	workDir := t.TempDir()
+	rootConfig := `module "vpc" {
+  source = "` + source + `"
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.tf"), []byte(rootConfig), 0o600))
+
+	// An empty home and CLI config keep the pull anonymous; SSL_CERT_FILE trusts the test registry.
+	home := t.TempDir()
+	certFile := filepath.Join(home, "registry-cert.pem")
+	require.NoError(t, os.WriteFile(certFile, registry.CertPEM(), 0o600))
+
+	cliConfig := filepath.Join(home, "cli.tfrc")
+	require.NoError(t, os.WriteFile(cliConfig, nil, 0o600))
+
+	cmd := exec.CommandContext(t.Context(), "tofu", "get")
+	cmd.Dir = workDir
+
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+		"TF_CLI_CONFIG_FILE="+cliConfig,
+		"SSL_CERT_FILE="+certFile,
+	)
+
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "tofu get must install the oci module: %s", output)
+
+	return visibleModuleTree(t, tofuInstalledModuleDir(t, workDir))
+}
+
+// terragruntOCIModuleTree downloads source through Terragrunt's production path and returns the module tree.
+func terragruntOCIModuleTree(t *testing.T, v *venv.Venv, source string) map[string]string {
+	t.Helper()
+
+	downloadDir := t.TempDir()
+	sourceURL, err := url.Parse(source)
+	require.NoError(t, err)
+
+	src := &tf.Source{
+		CanonicalSourceURL: sourceURL,
+		DownloadDir:        downloadDir,
+		WorkingDir:         downloadDir,
+		// The version file lives outside the compared tree, since it is Terragrunt bookkeeping.
+		VersionFile: filepath.Join(t.TempDir(), "version-file.txt"),
+	}
+
+	opts, err := options.NewTerragruntOptionsForTest("./should-not-be-used")
+	require.NoError(t, err)
+
+	opts.Experiments = experiment.NewExperiments()
+	require.NoError(t, opts.Experiments.EnableExperiment(experiment.OCI))
+
+	cfg := &runcfg.RunConfig{
+		Terraform: runcfg.TerraformConfig{
+			ExtraArgs: []runcfg.TerraformExtraArguments{},
+		},
+	}
+
+	_, err = run.DownloadTerraformSourceIfNecessary(
+		t.Context(),
+		logger.CreateLogger(),
+		v,
+		src,
+		configbridge.NewRunOptions(opts),
+		cfg,
+		report.NewReport(),
+	)
+	require.NoError(t, err)
+
+	return visibleModuleTree(t, downloadDir)
+}
+
+// portabilityVenv builds a hermetic venv so a developer's own credentials cannot authenticate the pull.
+func portabilityVenv(t *testing.T, registry *ociregistry.Registry) *venv.Venv {
+	t.Helper()
+
+	home := t.TempDir()
+	v := venv.OSVenv().
+		WithEnv(map[string]string{"HOME": home}).
+		WithUserHomeDir(func() (string, error) { return home, nil })
+	v.HTTP = registry.Client()
+
+	return v
+}
+
+// tofuInstalledModuleDir reads the module manifest for the directory tofu actually resolved, which
+// differs from the install root when the source selects a //subdir.
+func tofuInstalledModuleDir(t *testing.T, workDir string) string {
+	t.Helper()
+
+	manifestBytes, err := os.ReadFile(filepath.Join(workDir, ".terraform", "modules", "modules.json"))
+	require.NoError(t, err)
+
+	var manifest struct {
+		Modules []struct {
+			Key string `json:"Key"`
+			Dir string `json:"Dir"`
+		} `json:"Modules"`
+	}
+	require.NoError(t, json.Unmarshal(manifestBytes, &manifest))
+
+	for _, module := range manifest.Modules {
+		if module.Key != "vpc" {
+			continue
+		}
+
+		return filepath.Join(workDir, module.Dir)
+	}
+
+	require.FailNow(t, "module vpc not present in tofu's module manifest")
+
+	return ""
+}
+
+// visibleModuleTree returns the module's user-visible files keyed by slash-separated relative path.
+func visibleModuleTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+
+	tree := map[string]string{}
+
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+
+		// Dot-prefixed entries are tool bookkeeping, not module content.
+		if strings.HasPrefix(entry.Name(), ".") && rel != "." {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if entry.IsDir() {
+			return nil
+		}
+
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+
+		tree[filepath.ToSlash(rel)] = string(data)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	return tree
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

- Prove one oci:// source is portable between tofu and Terragrunt
- Experiment status update

RFC: https://github.com/gruntwork-io/terragrunt/issues/4555

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Confirmed OCI module portability as complete in the stabilization criteria.

- **Tests**
  - Added integration coverage for OCI module portability between OpenTofu and Terragrunt on Linux and macOS.
  - Verified tagged and digest-pinned modules, subdirectory resolution, content consistency, and refreshed tag resolution.
  - Added support for securely sharing local registry certificates with test processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->