### PR TITLE
chore: Cleaning up `NewParsingContext` constructor by passing in `venv` as a param

### DIFF
--- a/internal/cli/commands/backend/bootstrap/bootstrap.go
+++ b/internal/cli/commands/backend/bootstrap/bootstrap.go
@@ -36,8 +36,7 @@ func runBootstrap(
 		"working_dir":            opts.WorkingDir,
 		"terragrunt_config_path": opts.TerragruntConfigPath,
 	}, func(ctx context.Context, l log.Logger) error {
-		_, pctx := configbridge.NewParsingContext(ctx, l, opts)
-		pctx = pctx.WithVenv(v)
+		_, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 		remoteState, err := config.ParseRemoteState(ctx, l, pctx)
 		if err != nil || remoteState == nil {

--- a/internal/cli/commands/backend/delete/delete.go
+++ b/internal/cli/commands/backend/delete/delete.go
@@ -32,8 +32,7 @@ func runDelete(
 	v *venv.Venv,
 	opts *options.TerragruntOptions,
 ) error {
-	_, pctx := configbridge.NewParsingContext(ctx, l, opts)
-	pctx = pctx.WithVenv(v)
+	_, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
 	if err != nil || remoteState == nil {

--- a/internal/cli/commands/backend/migrate/migrate.go
+++ b/internal/cli/commands/backend/migrate/migrate.go
@@ -78,8 +78,7 @@ func Run(
 	srcV := v.WithEnvCloned()
 	dstV := v.WithEnvCloned()
 
-	_, srcPctx := configbridge.NewParsingContext(ctx, l, srcOpts)
-	srcPctx = srcPctx.WithVenv(srcV)
+	_, srcPctx := configbridge.NewParsingContext(ctx, l, srcV, srcOpts)
 
 	srcRemoteState, err := config.ParseRemoteState(ctx, l, srcPctx)
 	if err != nil {
@@ -95,8 +94,7 @@ func Run(
 	// configured. Propagate that back so pullState runs in the correct directory.
 	srcOpts.WorkingDir = srcPctx.WorkingDir
 
-	_, dstPctx := configbridge.NewParsingContext(ctx, l, dstOpts)
-	dstPctx = dstPctx.WithVenv(dstV)
+	_, dstPctx := configbridge.NewParsingContext(ctx, l, dstV, dstOpts)
 
 	dstRemoteState, err := config.ParseRemoteState(ctx, l, dstPctx)
 	if err != nil {

--- a/internal/cli/commands/catalog/catalog.go
+++ b/internal/cli/commands/catalog/catalog.go
@@ -130,11 +130,11 @@ func discoverAndLoad(
 	g, gctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		return discoverCatalogConfigURLs(gctx, l, opts, urlCh)
+		return discoverCatalogConfigURLs(gctx, l, v, opts, urlCh)
 	})
 
 	g.Go(func() error {
-		return discoverSourceFileURLs(gctx, l, opts, urlCh)
+		return discoverSourceFileURLs(gctx, l, v, opts, urlCh)
 	})
 
 	go func() {
@@ -214,10 +214,11 @@ func discoverAndLoad(
 func discoverCatalogConfigURLs(
 	ctx context.Context,
 	l log.Logger,
+	v *venv.Venv,
 	opts *options.TerragruntOptions,
 	urlCh chan<- string,
 ) error {
-	_, pctx := configbridge.NewParsingContext(ctx, l, opts)
+	_, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 	catalogCfg, err := config.ReadCatalogConfig(ctx, l, pctx)
 	if err != nil {
@@ -241,10 +242,11 @@ func discoverCatalogConfigURLs(
 func discoverSourceFileURLs(
 	ctx context.Context,
 	l log.Logger,
+	v *venv.Venv,
 	opts *options.TerragruntOptions,
 	urlCh chan<- string,
 ) error {
-	ctx, pctx := configbridge.NewParsingContext(ctx, l, opts)
+	ctx, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 	urls, err := tui.DiscoverSourceURLs(ctx, l, pctx)
 	if err != nil {

--- a/internal/cli/commands/catalog/tui/source_discovery_test.go
+++ b/internal/cli/commands/catalog/tui/source_discovery_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -126,7 +127,7 @@ inputs = {
 `), 0o644))
 
 	l := logger.CreateLogger()
-	ctx, pctx := config.NewParsingContext(t.Context(), l, config.WithStrictControls(controls.New()))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, venvtest.NewWithOSFS(), config.WithStrictControls(controls.New()))
 	pctx.RootWorkingDir = tmpDir
 
 	urls, err := tui.DiscoverSourceURLs(ctx, l, pctx)
@@ -144,7 +145,7 @@ func TestDiscoverSourceURLs_EmptyDir(t *testing.T) {
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	l := logger.CreateLogger()
-	ctx, pctx := config.NewParsingContext(t.Context(), l, config.WithStrictControls(controls.New()))
+	ctx, pctx := config.NewParsingContext(t.Context(), l, venvtest.NewWithOSFS(), config.WithStrictControls(controls.New()))
 	pctx.RootWorkingDir = tmpDir
 
 	urls, err := tui.DiscoverSourceURLs(ctx, l, pctx)

--- a/internal/cli/commands/hcl/validate/validate.go
+++ b/internal/cli/commands/hcl/validate/validate.go
@@ -161,8 +161,7 @@ func RunValidate(
 			stackFilePath := filepath.Join(c.Path(), config.DefaultStackFile)
 			parseOpts.TerragruntConfigPath = stackFilePath
 
-			ctx, parser := configbridge.NewParsingContext(ctx, l, parseOpts)
-			parser = parser.WithVenv(componentV)
+			ctx, parser := configbridge.NewParsingContext(ctx, l, componentV, parseOpts)
 
 			values, err := config.ReadValues(ctx, parser, l, c.Path())
 			if err != nil {
@@ -213,8 +212,7 @@ func RunValidate(
 		parseOpts.TerragruntConfigPath = filepath.Join(c.Path(), configFilename)
 		parseOpts.OriginalTerragruntConfigPath = parseOpts.TerragruntConfigPath
 
-		_, pctx := configbridge.NewParsingContext(ctx, l, parseOpts)
-		pctx = pctx.WithVenv(componentV)
+		_, pctx := configbridge.NewParsingContext(ctx, l, componentV, parseOpts)
 
 		if _, err := config.ReadTerragruntConfig(ctx, l, pctx, parseOptions); err != nil {
 			parseErrs = append(parseErrs, err)

--- a/internal/cli/commands/run/run.go
+++ b/internal/cli/commands/run/run.go
@@ -96,8 +96,7 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, v *
 		return err
 	}
 
-	parseCtx, pctx := configbridge.NewParsingContext(ctx, l, opts)
-	pctx = pctx.WithVenv(v)
+	parseCtx, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 	cfg, err := config.ReadTerragruntConfig(parseCtx, l, pctx, pctx.ParserOptions)
 	if err != nil {
@@ -263,8 +262,8 @@ func getTerragruntConfig(
 	v *venv.Venv,
 	opts *options.TerragruntOptions,
 ) (*config.TerragruntConfig, error) {
-	ctx, configCtx := configbridge.NewParsingContext(ctx, l, opts)
-	configCtx = configCtx.WithVenv(v).WithDecodeList(
+	ctx, configCtx := configbridge.NewParsingContext(ctx, l, v, opts)
+	configCtx = configCtx.WithDecodeList(
 		config.TerragruntVersionConstraints,
 		config.FeatureFlagsBlock,
 	)

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -569,8 +569,7 @@ func applyCatalogConfigToScaffold(
 	v *venv.Venv,
 	opts *options.TerragruntOptions,
 ) {
-	_, pctx := configbridge.NewParsingContext(ctx, l, opts)
-	pctx = pctx.WithVenv(v)
+	_, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 	catalogCfg, err := config.ReadCatalogConfig(ctx, l, pctx)
 	if err != nil {
@@ -723,8 +722,7 @@ func prepareBoilerplateFiles(
 
 	// if boilerplate dir is not found, create one with default template
 	if !util.IsDir(boilerplateDir) {
-		_, pctx := configbridge.NewParsingContext(ctx, l, opts)
-		pctx = pctx.WithVenv(v)
+		_, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 		config, err := config.ReadCatalogConfig(ctx, l, pctx)
 		if err != nil {

--- a/internal/cli/commands/scaffold/scaffold_test.go
+++ b/internal/cli/commands/scaffold/scaffold_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -112,7 +113,7 @@ func TestDefaultTemplateVariables(t *testing.T) {
 	opts, err := options.NewTerragruntOptionsForTest(filepath.Join(outputDir, "terragrunt.hcl"))
 	require.NoError(t, err)
 
-	_, pctx := configbridge.NewParsingContext(t.Context(), l, opts)
+	_, pctx := configbridge.NewParsingContext(t.Context(), l, venvtest.NewWithOSFS(), opts)
 	cfg, err := config.ReadTerragruntConfig(
 		t.Context(),
 		l,
@@ -219,7 +220,7 @@ func TestDefaultTemplateUserValueOverridesTODO(t *testing.T) {
 	opts, err := options.NewTerragruntOptionsForTest(filepath.Join(outputDir, "terragrunt.hcl"))
 	require.NoError(t, err)
 
-	_, pctx := configbridge.NewParsingContext(t.Context(), l, opts)
+	_, pctx := configbridge.NewParsingContext(t.Context(), l, venvtest.NewWithOSFS(), opts)
 	cfg, err := config.ReadTerragruntConfig(
 		t.Context(),
 		l,
@@ -454,7 +455,7 @@ catalog {
 			l := logger.CreateLogger()
 
 			// First, verify catalog config parsing
-			_, catalogPctx := configbridge.NewParsingContext(context.Background(), l, opts)
+			_, catalogPctx := configbridge.NewParsingContext(context.Background(), l, venvtest.NewWithOSFS(), opts)
 			catalogCfg, err := config.ReadCatalogConfig(context.Background(), l, catalogPctx)
 			require.NoError(t, err)
 			require.NotNil(t, catalogCfg, tc.description)
@@ -548,7 +549,7 @@ catalog {
 	l := logger.CreateLogger()
 
 	// Parse the configuration
-	_, catalogPctx := configbridge.NewParsingContext(context.Background(), l, opts)
+	_, catalogPctx := configbridge.NewParsingContext(context.Background(), l, venvtest.NewWithOSFS(), opts)
 	catalogCfg, err := config.ReadCatalogConfig(context.Background(), l, catalogPctx)
 	require.NoError(t, err)
 	require.NotNil(t, catalogCfg)
@@ -587,7 +588,7 @@ catalog {
 	l := logger.CreateLogger()
 
 	// Parse the configuration
-	_, catalogPctx := configbridge.NewParsingContext(context.Background(), l, opts)
+	_, catalogPctx := configbridge.NewParsingContext(context.Background(), l, venvtest.NewWithOSFS(), opts)
 	catalogCfg, err := config.ReadCatalogConfig(context.Background(), l, catalogPctx)
 	require.NoError(t, err)
 	require.NotNil(t, catalogCfg)

--- a/internal/cli/commands/stack/stack.go
+++ b/internal/cli/commands/stack/stack.go
@@ -100,10 +100,10 @@ func RunGenerate(
 	}
 
 	// After generation, hint when a literal stack filter left nested stacks ungenerated.
-	funcsFor := configbridge.StackFuncFactory(ctx, l, opts)
+	funcsFor := configbridge.StackFuncFactory(ctx, l, v, opts)
 	tips.GiveStackNestedGenerateTip(
 		l,
-		vfs.NewOSFS(),
+		v.FS,
 		funcsFor,
 		opts.WorkingDir,
 		opts.Filters,

--- a/internal/configbridge/bridge.go
+++ b/internal/configbridge/bridge.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -22,9 +23,10 @@ import (
 func NewParsingContext(
 	ctx context.Context,
 	l log.Logger,
+	v *venv.Venv,
 	opts *options.TerragruntOptions,
 ) (context.Context, *config.ParsingContext) {
-	ctx, pctx := config.NewParsingContext(ctx, l, config.WithStrictControls(opts.StrictControls))
+	ctx, pctx := config.NewParsingContext(ctx, l, v, config.WithStrictControls(opts.StrictControls))
 	populateFromOpts(pctx, opts)
 
 	return ctx, pctx
@@ -36,9 +38,10 @@ func NewParsingContext(
 func StackFuncFactory(
 	ctx context.Context,
 	l log.Logger,
+	v *venv.Venv,
 	opts *options.TerragruntOptions,
 ) inthclparse.StackFuncFactory {
-	_, pctx := NewParsingContext(ctx, l, opts)
+	_, pctx := NewParsingContext(ctx, l, v, opts)
 
 	return func(stackDir string) (map[string]function.Function, error) {
 		return config.EarlyStackParseFunctions(ctx, l, stackDir, pctx)

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -247,7 +247,7 @@ func (d *Discovery) Discover(
 		if err := telemetry.TelemeterFromContext(ctx).Collect(ctx, l, "discovery_phase_stack_configs", map[string]any{
 			"components_in": len(components),
 		}, func(childCtx context.Context, childL log.Logger) error {
-			storeStackConfigs(childCtx, childL, opts, components)
+			storeStackConfigs(childCtx, childL, v, opts, components)
 
 			return nil
 		}); err != nil {

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -340,6 +340,7 @@ func extractDependencyPaths(cfg *config.TerragruntConfig, c component.Component)
 func storeStackConfigs(
 	ctx context.Context,
 	l log.Logger,
+	v *venv.Venv,
 	opts *options.TerragruntOptions,
 	components component.Components,
 ) {
@@ -359,7 +360,7 @@ func storeStackConfigs(
 		// A fresh context per stack scopes it to that stack's file and values, so
 		// a config referencing values.* parses instead of failing on missing
 		// values (and shows its definitions in consumers like browse).
-		ctx, pctx := configbridge.NewParsingContext(ctx, l, opts)
+		ctx, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 		values, err := config.ReadValues(ctx, pctx, l, stackDir)
 		if err != nil {
@@ -389,8 +390,7 @@ func stackDependencyPaths(
 	opts *options.TerragruntOptions,
 	depPaths []string,
 ) ([]string, error) {
-	_, pctx := configbridge.NewParsingContext(ctx, l, opts)
-	pctx = pctx.WithVenv(v)
+	_, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 	// Factory builds the dir-scoped function map for each stack dir visited during expansion.
 	funcsFor := inthclparse.StackFuncFactory(

--- a/internal/discovery/phase_parse.go
+++ b/internal/discovery/phase_parse.go
@@ -378,8 +378,8 @@ func parseComponent(
 				}
 			}
 
-			ctx, parsingCtx := configbridge.NewParsingContext(ctx, l, parseOpts)
-			parsingCtx = parsingCtx.WithVenv(parseV).WithDecodeList(
+			ctx, parsingCtx := configbridge.NewParsingContext(ctx, l, parseV, parseOpts)
+			parsingCtx = parsingCtx.WithDecodeList(
 				config.TerraformSource,
 				config.DependenciesBlock,
 				config.DependencyBlock,

--- a/internal/prepare/prepare.go
+++ b/internal/prepare/prepare.go
@@ -57,8 +57,7 @@ func PrepareConfig(
 		return nil, err
 	}
 
-	ctx, pctx := configbridge.NewParsingContext(ctx, l, opts)
-	pctx = pctx.WithVenv(v)
+	ctx, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 	terragruntConfig, err := config.ReadTerragruntConfig(ctx, l, pctx, pctx.ParserOptions)
 	if err != nil {

--- a/internal/runner/graph/graph.go
+++ b/internal/runner/graph/graph.go
@@ -27,7 +27,7 @@ import (
 // Run executes the configured terraform command against the dependency
 // graph of the unit in the working directory.
 func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *options.TerragruntOptions) error {
-	// Get credentials BEFORE config parsing — sops_decrypt_file() and
+	// Get credentials BEFORE config parsing: sops_decrypt_file() and
 	// get_aws_account_id() in locals need auth-provider credentials
 	// available in v.Env during HCL evaluation.
 	// *Getter discarded: graph.Run only needs creds in v.Env for initial config parse.
@@ -44,8 +44,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *options.Terragru
 		return err
 	}
 
-	ctx, pctx := configbridge.NewParsingContext(ctx, l, opts)
-	pctx = pctx.WithVenv(v)
+	ctx, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 	cfg, err := config.ReadTerragruntConfig(ctx, l, pctx, pctx.ParserOptions)
 	if err != nil {

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -172,6 +172,11 @@ func DownloadTerraformSource(
 // (git, hg, smb) or writes through os, so on a virtual filesystem it would
 // silently touch the real disk.
 //
+// A cas:: source belongs with the rejected ones rather than alongside tfr and
+// oci: the store it reads and writes is a real git repository on disk, which
+// is why [github.com/gruntwork-io/terragrunt/internal/cas] refuses a non-OS
+// filesystem itself.
+//
 // It panics with [ErrNilSource] on a nil source, so the contract fails where
 // it is broken rather than at whichever field is read first.
 func requireOSFilesystemForSource(fsys vfs.FS, src *tf.Source) error {

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -1512,6 +1512,11 @@ func TestDownloadTerraformSourceRejectsNonOSFilesystemPerSource(t *testing.T) {
 			rejected: false,
 		},
 		{
+			name:     "cas source needs the real disk",
+			source:   "cas::sha256:0000000000000000000000000000000000000000000000000000000000000000//foo",
+			rejected: true,
+		},
+		{
 			name:            "tfr source stays on the venv filesystem",
 			source:          "tfr://registry.invalid/foo/bar/baz?version=1.0.0",
 			rejected:        false,

--- a/internal/runner/runall/runall.go
+++ b/internal/runner/runall/runall.go
@@ -186,7 +186,7 @@ func Run(
 		}
 
 		// After generation, hint when a literal stack filter left nested stacks ungenerated.
-		funcsFor := configbridge.StackFuncFactory(ctx, l, opts)
+		funcsFor := configbridge.StackFuncFactory(ctx, l, v, opts)
 		tips.GiveStackNestedGenerateTip(l, v.FS, funcsFor, opts.WorkingDir, opts.Filters, opts.Tips)
 	} else {
 		l.Debugf("Skipping stack generation in %s", opts.WorkingDir)

--- a/internal/runner/runnerpool/builder_helpers.go
+++ b/internal/runner/runnerpool/builder_helpers.go
@@ -236,8 +236,8 @@ func checkUnitVersionConstraints(
 
 	// This is almost definitely already parsed, but we'll check just in case.
 	if unitConfig == nil {
-		configCtx, pctx := configbridge.NewParsingContext(ctx, l, unitOpts)
-		pctx = pctx.WithVenv(v).WithDecodeList(
+		configCtx, pctx := configbridge.NewParsingContext(ctx, l, v, unitOpts)
+		pctx = pctx.WithDecodeList(
 			config.TerragruntVersionConstraints,
 			config.FeatureFlagsBlock,
 		)

--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -518,7 +518,7 @@ func (rnr *Runner) Run(
 
 				unitRunner := common.NewUnitRunner(u)
 
-				// Get credentials BEFORE config parsing — sops_decrypt_file() and
+				// Get credentials BEFORE config parsing: sops_decrypt_file() and
 				// get_aws_account_id() in locals need auth-provider credentials
 				// available in v.Env during HCL evaluation.
 				// See https://github.com/gruntwork-io/terragrunt/issues/5515
@@ -549,9 +549,9 @@ func (rnr *Runner) Run(
 						parseCtx, pctx := configbridge.NewParsingContext(
 							readCtx,
 							unitLogger,
+							unitV,
 							unitOpts,
 						)
-						pctx = pctx.WithVenv(unitV)
 
 						var readErr error
 

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -197,7 +197,7 @@ func (g *Generator) generateStacks(
 
 // warnOnRepeatedClaims logs a warning when a stack file is claimed by more than
 // one parent in the same invocation. All nodes here are stack files by
-// construction — ListStackFiles filters to *component.Stack only.
+// construction, since ListStackFiles filters to *component.Stack only.
 func warnOnRepeatedClaims(l log.Logger, levelNodes []*StackNode, claimedBy map[string]string) {
 	for _, node := range levelNodes {
 		parent := "root"
@@ -247,8 +247,7 @@ func generateLevel(
 		}
 
 		wp.Submit(func() error {
-			_, pctx := configbridge.NewParsingContext(ctx, l, opts)
-			pctx = pctx.WithVenv(v)
+			_, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 			scopedLogger, scopedPctx, err := pctx.WithConfigPath(l, node.FilePath)
 			if err != nil {

--- a/internal/stacks/output/output.go
+++ b/internal/stacks/output/output.go
@@ -133,8 +133,7 @@ func StackOutput(
 	for _, path := range foundFiles {
 		dir := filepath.Dir(path)
 
-		ctx, pctx := configbridge.NewParsingContext(ctx, l, opts)
-		pctx = pctx.WithVenv(v)
+		ctx, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 		values, valuesErr := config.ReadValues(ctx, pctx, l, dir)
 		if valuesErr != nil {

--- a/internal/venv/venv.go
+++ b/internal/venv/venv.go
@@ -96,7 +96,10 @@ type Venv struct {
 	Writers  *writer.Writers
 }
 
-// WithReader returns a copy of v that reads console input from r.
+// WithReader returns a copy of v that reads console input from r, buffered so
+// that every consumer shares one position in the stream. A consumer that wraps
+// its own buffer around [Venv.Reader] strands whatever that buffer read past
+// the bytes it needed.
 func (v *Venv) WithReader(r io.Reader) *Venv {
 	c := *v
 	c.Reader = bufio.NewReader(r)
@@ -278,7 +281,7 @@ func (v *Venv) RequireUserHomeDir() {
 // OS streams.
 //
 // It returns a *[Venv] so the bundle is threaded by pointer through every
-// downstream call — small parameter, no copying. Shallow-copying a
+// downstream call: small parameter, no copying. Shallow-copying a
 // pointed-to [Venv] (via `local := *v`) still shares the Env map with the
 // original, so callers must go through [Venv.WithEnvCloned] before mutating
 // environment variables; writer swaps stay independent because

--- a/pkg/config/autoinclude_test.go
+++ b/pkg/config/autoinclude_test.go
@@ -12,6 +12,7 @@ import (
 	inthclparse "github.com/gruntwork-io/terragrunt/internal/hclparse"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +56,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -119,7 +120,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -199,7 +200,7 @@ include "base" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -250,7 +251,7 @@ include "common" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -331,7 +332,7 @@ dependency "leak" {
 `), 0644),
 	)
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -384,7 +385,7 @@ exclude {
 
 	l := logger.CreateLogger()
 
-	ctxFull, pctxFull := newTestParsingContext(t, cfgPath)
+	ctxFull, pctxFull := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctxFull.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	parsedFull, err := config.ParseConfigFile(ctxFull, pctxFull, l, cfgPath, nil)
@@ -398,7 +399,7 @@ exclude {
 		"autoinclude exclude must win in full parse",
 	)
 
-	ctxPartial, pctxPartial := newTestParsingContext(t, cfgPath)
+	ctxPartial, pctxPartial := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctxPartial.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctxPartial = pctxPartial.WithDecodeList(config.ExcludeBlock).WithSkipOutputsResolution()
 
@@ -431,7 +432,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 
 	l := logger.CreateLogger()
 
@@ -461,7 +462,7 @@ inputs = {
 }
 `), 0644))
 
-	// Autoinclude with overlapping inputs — should win on conflicts
+	// Autoinclude with overlapping inputs, which should win on conflicts
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
 	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
 inputs = {
@@ -470,7 +471,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 
 	l := logger.CreateLogger()
 
@@ -511,7 +512,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 
 	l := logger.CreateLogger()
 
@@ -559,7 +560,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx = pctx.WithDecodeList(config.DependencyBlock, config.RemoteStateBlock).
 		WithSkipOutputsResolution()
@@ -617,7 +618,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -661,7 +662,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, autoIncludePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), autoIncludePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -697,7 +698,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -757,7 +758,7 @@ inputs = {
 
 	l := logger.CreateLogger()
 
-	ctxFull, pctxFull := newTestParsingContext(t, cfgPath)
+	ctxFull, pctxFull := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctxFull.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	parsedFull, err := config.ParseConfigFile(ctxFull, pctxFull, l, cfgPath, nil)
@@ -778,7 +779,7 @@ inputs = {
 		"autoinclude terraform source must win in full parse",
 	)
 
-	ctxPartial, pctxPartial := newTestParsingContext(t, cfgPath)
+	ctxPartial, pctxPartial := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctxPartial.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctxPartial = pctxPartial.WithDecodeList(config.TerraformSource).WithSkipOutputsResolution()
 
@@ -835,7 +836,7 @@ errors {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx = pctx.WithDecodeList(
 		config.DependencyBlock,
@@ -902,7 +903,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx = pctx.WithDecodeList(config.DependencyBlock).WithSkipOutputsResolution()
 
@@ -967,7 +968,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, autoIncludePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), autoIncludePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 	pctx = pctx.WithDecodeList(config.DependencyBlock, config.RemoteStateBlock).
@@ -1006,7 +1007,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	// A shared config cache so the second parse can see (and would otherwise reuse) the first entry.
 	ctx = context.WithValue(
 		ctx,
@@ -1097,7 +1098,7 @@ remote_state {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	// A shared config cache so the second parse can see (and would otherwise reuse) the first entry.
 	ctx = context.WithValue(
 		ctx,
@@ -1181,7 +1182,7 @@ dependency "bar" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock, config.DependencyBlock).
 		WithSkipOutputsResolution()
@@ -1226,7 +1227,7 @@ stack "networking" {
 `), 0644))
 
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -1294,7 +1295,7 @@ inputs = {
 `), 0644))
 
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -1340,7 +1341,7 @@ unit "app" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, stackPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()

--- a/pkg/config/catalog.go
+++ b/pkg/config/catalog.go
@@ -134,7 +134,7 @@ func findCatalogConfig(
 		default: // continue
 		}
 
-		parseCtx, pctx := NewParsingContext(ctx, l, WithStrictControls(outerPctx.StrictControls))
+		parseCtx, pctx := NewParsingContext(ctx, l, outerPctx.Venv, WithStrictControls(outerPctx.StrictControls))
 		pctx.TerragruntConfigPath = filepath.Join(
 			filepath.Dir(configPath),
 			util.UniqueID(),

--- a/pkg/config/catalog_test.go
+++ b/pkg/config/catalog_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -133,7 +134,7 @@ func TestCatalogParseConfigFile(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			_, catalogPctx := newTestParsingContext(t, tt.configPath)
+			_, catalogPctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tt.configPath)
 			catalogPctx.ScaffoldRootFileName = filepath.Base(tt.configPath)
 			config, err := config.ReadCatalogConfig(t.Context(), l, catalogPctx)
 

--- a/pkg/config/config_as_cty_test.go
+++ b/pkg/config/config_as_cty_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // This test makes sure that all the fields from the TerragruntConfig struct are accounted for in the conversion to
@@ -305,7 +306,7 @@ func TestStackUnitCtyReading(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,
@@ -330,7 +331,7 @@ func TestStackLocalsCtyReading(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,

--- a/pkg/config/config_helpers_hcl_mem_test.go
+++ b/pkg/config/config_helpers_hcl_mem_test.go
@@ -27,9 +27,8 @@ func TestHCLGetRepoRoot(t *testing.T) {
 	})
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, "/synthetic/repo/root/unit/terragrunt.hcl")
+	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), "/synthetic/repo/root/unit/terragrunt.hcl")
 	ctx = config.WithConfigValues(ctx)
-	pctx.Venv = venvtest.New().WithExec(exec)
 
 	const hcl = `locals {
   repo = get_repo_root()
@@ -57,9 +56,8 @@ func TestHCLGetPathFromRepoRoot(t *testing.T) {
 	})
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, "/repo/services/api/terragrunt.hcl")
+	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), "/repo/services/api/terragrunt.hcl")
 	ctx = config.WithConfigValues(ctx)
-	pctx.Venv = venvtest.New().WithExec(exec)
 	pctx.WorkingDir = "/repo/services/api"
 
 	const hcl = `locals {
@@ -82,9 +80,8 @@ func TestHCLGetPathToRepoRoot(t *testing.T) {
 	})
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, "/repo/services/api/terragrunt.hcl")
+	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), "/repo/services/api/terragrunt.hcl")
 	ctx = config.WithConfigValues(ctx)
-	pctx.Venv = venvtest.New().WithExec(exec)
 	pctx.WorkingDir = "/repo/services/api"
 
 	const hcl = `locals {
@@ -107,9 +104,8 @@ func TestHCLGetRepoRootPropagatesGitError(t *testing.T) {
 	})
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, "/not/a/repo/terragrunt.hcl")
+	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), "/not/a/repo/terragrunt.hcl")
 	ctx = config.WithConfigValues(ctx)
-	pctx.Venv = venvtest.New().WithExec(exec)
 
 	const hcl = `locals {
   repo = get_repo_root()
@@ -133,9 +129,8 @@ func TestHCLRunCmd(t *testing.T) {
 	})
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, t.TempDir()+"/terragrunt.hcl")
+	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir()+"/terragrunt.hcl")
 	ctx = config.WithConfigValues(ctx)
-	pctx.Venv = venvtest.New().WithExec(exec)
 
 	const hcl = `locals {
   account = run_cmd("--terragrunt-quiet", "describe", "--account", "prod")

--- a/pkg/config/config_helpers_mem_test.go
+++ b/pkg/config/config_helpers_mem_test.go
@@ -30,9 +30,8 @@ func TestRunCommandMemExec(t *testing.T) {
 	})
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, t.TempDir())
+	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
 	ctx = config.WithConfigValues(ctx)
-	pctx.Venv = venvtest.New().WithExec(exec)
 
 	out, err := config.RunCommand(ctx, pctx, l, []string{"echoer", "hello"})
 	require.NoError(t, err)
@@ -55,9 +54,8 @@ func TestRunCommandCacheHitsCollapseSubprocessForks(t *testing.T) {
 	})
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, t.TempDir())
+	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
 	ctx = config.WithConfigValues(ctx)
-	pctx.Venv = venvtest.New().WithExec(exec)
 
 	args := []string{"expensive-cmd", "--flag"}
 
@@ -88,9 +86,8 @@ func TestRunCommandNoCacheRefuses(t *testing.T) {
 	})
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, t.TempDir())
+	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
 	ctx = config.WithConfigValues(ctx)
-	pctx.Venv = venvtest.New().WithExec(exec)
 
 	for range 3 {
 		_, err := config.RunCommand(ctx, pctx, l, []string{"--terragrunt-no-cache", "cmd"})
@@ -115,9 +112,8 @@ func TestRunCommandSurfacesSubprocessFailure(t *testing.T) {
 	})
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, t.TempDir())
+	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
 	ctx = config.WithConfigValues(ctx)
-	pctx.Venv = venvtest.New().WithExec(exec)
 
 	_, err := config.RunCommand(ctx, pctx, l, []string{"failing-cmd"})
 	require.Error(t, err)
@@ -138,12 +134,10 @@ func TestRunCommandGlobalCacheSharesAcrossWorkingDirs(t *testing.T) {
 	})
 
 	l := logger.CreateLogger()
-	ctx, pctxA := newTestParsingContext(t, t.TempDir())
+	ctx, pctxA := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
 	ctx = config.WithConfigValues(ctx)
-	pctxA.Venv = venvtest.New().WithExec(exec)
 
-	_, pctxB := newTestParsingContext(t, t.TempDir())
-	pctxB.Venv = venvtest.New().WithExec(exec)
+	_, pctxB := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
 
 	args := []string{"--terragrunt-global-cache", "cmd"}
 
@@ -192,9 +186,8 @@ func TestRunCommandConflictingCacheFlags(t *testing.T) {
 			})
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, t.TempDir())
+			ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
 			ctx = config.WithConfigValues(ctx)
-			pctx.Venv = venvtest.New().WithExec(exec)
 
 			_, err := config.RunCommand(ctx, pctx, l, tc.args)
 			require.Error(t, err)
@@ -216,9 +209,8 @@ func TestRunCommandDoesNotMutateCallerArgs(t *testing.T) {
 	})
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, t.TempDir())
+	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
 	ctx = config.WithConfigValues(ctx)
-	pctx.Venv = venvtest.New().WithExec(exec)
 
 	args := []string{"--terragrunt-quiet", "--terragrunt-global-cache", "cmd", "subarg"}
 	want := slices.Clone(args)
@@ -241,9 +233,8 @@ func TestRunCommandEmptyParamsErrors(t *testing.T) {
 	})
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, t.TempDir())
+	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
 	ctx = config.WithConfigValues(ctx)
-	pctx.Venv = venvtest.New().WithExec(exec)
 
 	_, err := config.RunCommand(ctx, pctx, l, nil)
 	require.Error(t, err)
@@ -265,9 +256,8 @@ func TestRunCommandReceivesPctxEnv(t *testing.T) {
 	})
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, t.TempDir())
+	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
 	ctx = config.WithConfigValues(ctx)
-	pctx.Venv = venvtest.New().WithExec(exec)
 	pctx.Venv.Env = map[string]string{"TG_TEST_TOKEN": "abc123"}
 
 	_, err := config.RunCommand(ctx, pctx, l, []string{"reader"})

--- a/pkg/config/config_helpers_test.go
+++ b/pkg/config/config_helpers_test.go
@@ -18,10 +18,11 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/util"
-	"github.com/gruntwork-io/terragrunt/internal/writer"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -141,7 +142,7 @@ func TestPathRelativeToInclude(t *testing.T) {
 	for _, tc := range testCases {
 		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params, tc.configPath)
 		l := logger.CreateLogger()
-		ctx, pctx := newTestParsingContext(t, tc.configPath)
+		ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
 		pctx = pctx.WithTrackInclude(trackInclude)
 		actualPath, actualErr := config.PathRelativeToInclude(ctx, pctx, l, tc.params)
 		require.NoError(
@@ -275,7 +276,7 @@ func TestPathRelativeFromInclude(t *testing.T) {
 	for _, tc := range testCases {
 		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params, tc.configPath)
 		l := logger.CreateLogger()
-		ctx, pctx := newTestParsingContext(t, tc.configPath)
+		ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
 		pctx = pctx.WithTrackInclude(trackInclude)
 		actualPath, actualErr := config.PathRelativeFromInclude(ctx, pctx, l, tc.params)
 		require.NoError(
@@ -528,7 +529,7 @@ func TestFindInParentFolders(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, tc.configPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
 
 			if tc.maxFoldersToCheck != 0 {
 				pctx.MaxFoldersToCheck = tc.maxFoldersToCheck
@@ -578,7 +579,7 @@ unit "test" {
 	require.NoError(t, err)
 
 	l := logger.CreateLogger()
-	_, pctx := newTestParsingContext(t, stackHclPath)
+	_, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackHclPath)
 	pctx.WorkingDir = tempDir
 
 	stackConfig, err := config.ReadStackConfigFile(t.Context(), l, pctx, stackHclPath, nil)
@@ -605,7 +606,7 @@ func TestFindInParentFoldersSharedRunContext(t *testing.T) {
 	}
 
 	l := logger.CreateLogger()
-	baseCtx, pctx := newTestParsingContext(t, first)
+	baseCtx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), first)
 	ctx := config.WithConfigValues(baseCtx)
 
 	firstPath, err := config.FindInParentFolders(ctx, pctx, l, []string{"root.hcl"})
@@ -654,7 +655,7 @@ func TestFindInParentFoldersSharedRunContextWithRacing(t *testing.T) {
 	}
 
 	l := logger.CreateLogger()
-	baseCtx, basePctx := newTestParsingContext(t, configPaths[0])
+	baseCtx, basePctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPaths[0])
 	ctx := config.WithConfigValues(baseCtx)
 
 	group, groupCtx := errgroup.WithContext(ctx)
@@ -769,7 +770,7 @@ func TestResolveTerragruntInterpolation(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, tc.configPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
 
 			if tc.maxFoldersToCheck != 0 {
 				pctx.MaxFoldersToCheck = tc.maxFoldersToCheck
@@ -866,7 +867,7 @@ func TestResolveEnvInterpolationConfigString(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, tc.configPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
 
 			if tc.env != nil {
 				pctx.Venv.Env = tc.env
@@ -924,7 +925,7 @@ func TestResolveCommandsInterpolationConfigString(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, tc.configPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
 			actualOut, actualErr := config.ParseConfigString(
 				ctx,
 				pctx,
@@ -982,7 +983,7 @@ func TestResolveCliArgsInterpolationConfigString(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 			pctx.TerraformCliArgs = iacargs.New(cliArgs...)
 
 			actualOut, actualErr := config.ParseConfigString(
@@ -1053,17 +1054,18 @@ func testGetTerragruntDir(t *testing.T, configPath string, expectedPath string) 
 	t.Helper()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 	actualPath, err := config.GetTerragruntDir(ctx, pctx, l)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
 	assert.Equal(t, expectedPath, actualPath)
 }
 
-// newTestParsingContext creates a ParsingContext with sensible test defaults.
-// Replicates NewTerragruntOptionsForTest + configbridge.populateFromOpts.
+// newTestParsingContext creates a ParsingContext around v with sensible test
+// defaults. Replicates NewTerragruntOptionsForTest + configbridge.populateFromOpts.
 func newTestParsingContext(
 	tb testing.TB,
+	v *venv.Venv,
 	configPath string,
 ) (context.Context, *config.ParsingContext) {
 	tb.Helper()
@@ -1072,6 +1074,7 @@ func newTestParsingContext(
 	ctx, pctx := config.NewParsingContext(
 		tb.Context(),
 		l,
+		v,
 		config.WithStrictControls(controls.New()),
 	)
 
@@ -1083,10 +1086,8 @@ func newTestParsingContext(
 	pctx.DownloadDir = downloadDir
 	pctx.TFPath = "tofu"
 	pctx.AutoInit = true
-	pctx.Venv.Env = map[string]string{}
 	pctx.SourceMap = map[string]string{}
 	pctx.TerraformCliArgs = iacargs.New()
-	pctx.Venv.Writers = &writer.Writers{Writer: os.Stdout, ErrWriter: os.Stderr}
 	pctx.MaxFoldersToCheck = 100
 	pctx.TofuImplementation = tfimpl.Unknown
 	pctx.Experiments = experiment.NewExperiments()
@@ -1214,7 +1215,7 @@ func TestGetParentTerragruntDir(t *testing.T) {
 	for _, tc := range testCases {
 		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params, tc.configPath)
 		l := logger.CreateLogger()
-		ctx, pctx := newTestParsingContext(t, tc.configPath)
+		ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
 		pctx = pctx.WithTrackInclude(trackInclude)
 		actualPath, actualErr := config.GetParentTerragruntDir(ctx, pctx, l, tc.params)
 		require.NoError(
@@ -1294,7 +1295,7 @@ func TestTerraformBuiltInFunctions(t *testing.T) {
 			)
 			configString := fmt.Sprintf("inputs = { test = %s }", tc.input)
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, cfgPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 			actual, err := config.ParseConfigString(ctx, pctx, l, cfgPath, configString, nil)
 			require.NoError(t, err, "For hcl '%s', unexpected error: %v", tc.input, err)
 
@@ -1427,7 +1428,7 @@ func TestTerragruntDeepMergeFunction(t *testing.T) {
 			cfgPath := "../../test/fixtures/config-terraform-functions/" + config.DefaultTerragruntConfigPath
 			configString := fmt.Sprintf("inputs = { test = %s }", tc.input)
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, cfgPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 			require.NoError(t, pctx.Experiments.EnableExperiment(experiment.DeepMerge))
 			actual, err := config.ParseConfigString(ctx, pctx, l, cfgPath, configString, nil)
 			require.NoError(t, err)
@@ -1447,7 +1448,7 @@ func TestTerragruntDeepMergeFunctionRequiresExperiment(t *testing.T) {
 	cfgPath := "../../test/fixtures/config-terraform-functions/" + config.DefaultTerragruntConfigPath
 	configString := `inputs = { test = deep_merge({ a = 1 }, { b = 2 }) }`
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	_, err := config.ParseConfigString(ctx, pctx, l, cfgPath, configString, nil)
 
 	require.Error(t, err)
@@ -1460,7 +1461,7 @@ func TestTerragruntDeepMergeFunctionInvalidType(t *testing.T) {
 	cfgPath := "../../test/fixtures/config-terraform-functions/" + config.DefaultTerragruntConfigPath
 	configString := `inputs = { test = deep_merge({ a = 1 }, "invalid") }`
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.DeepMerge))
 	_, err := config.ParseConfigString(ctx, pctx, l, cfgPath, configString, nil)
 
@@ -1481,7 +1482,7 @@ func TestTerragruntDeepMergeFunctionFilesetJSONEndToEnd(t *testing.T) {
 	require.NoError(t, err)
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.DeepMerge))
 
 	cfg, err := config.ParseConfigFile(ctx, pctx, l, cfgPath, nil)
@@ -1590,7 +1591,7 @@ func TestReadTerragruntConfigInputs(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,
@@ -1645,7 +1646,7 @@ func TestReadTerragruntConfigRemoteState(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,
@@ -1687,7 +1688,7 @@ func TestReadTerragruntConfigHooks(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,
@@ -1737,7 +1738,7 @@ func TestReadTerragruntConfigLocals(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,
@@ -1774,7 +1775,7 @@ func TestReadTerragruntConfigResolvesRelativeToOriginalTerragruntDir(t *testing.
 	require.NoError(t, err)
 
 	// correct original path: get_original_terragrunt_dir() resolves to the unit dir
-	ctx, pctx := newTestParsingContext(t, unitFilename)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), unitFilename)
 	pctx.OriginalTerragruntConfigPath = unitFilename
 	pctx.SkipOutput = true
 
@@ -1789,7 +1790,7 @@ func TestReadTerragruntConfigResolvesRelativeToOriginalTerragruntDir(t *testing.
 		config.DefaultTerragruntConfigPath,
 	)
 
-	ctxWrong, pctxWrong := newTestParsingContext(t, unitFilename)
+	ctxWrong, pctxWrong := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), unitFilename)
 	pctxWrong.OriginalTerragruntConfigPath = parentFilename
 	pctxWrong.SkipOutput = true
 
@@ -1890,7 +1891,7 @@ func TestStartsWith(t *testing.T) {
 		t.Run(fmt.Sprintf("%v %v", id, tc.args), func(t *testing.T) {
 			t.Parallel()
 
-			ctx, pctx := newTestParsingContext(t, "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
 			actual, err := config.StartsWith(ctx, pctx, tc.args)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, actual)
@@ -1920,7 +1921,7 @@ func TestEndsWith(t *testing.T) {
 		t.Run(fmt.Sprintf("%v %v", id, tc.args), func(t *testing.T) {
 			t.Parallel()
 
-			ctx, pctx := newTestParsingContext(t, "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
 			actual, err := config.EndsWith(ctx, pctx, tc.args)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, actual)
@@ -1973,7 +1974,7 @@ func TestTimeCmp(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
 
 			actual, err := config.TimeCmp(ctx, pctx, l, tc.args)
 			if tc.err != "" {
@@ -2016,7 +2017,7 @@ func TestStrContains(t *testing.T) {
 		t.Run(fmt.Sprintf("StrContains %v", tc.args), func(t *testing.T) {
 			t.Parallel()
 
-			ctx, pctx := newTestParsingContext(t, "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
 
 			actual, err := config.StrContains(ctx, pctx, tc.args)
 			if tc.err != "" {
@@ -2034,7 +2035,7 @@ func TestReadTFVarsFiles(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,
@@ -2149,7 +2150,7 @@ func TestConstraintCheck(t *testing.T) {
 			func(t *testing.T) {
 				t.Parallel()
 
-				ctx, pctx := newTestParsingContext(t, "")
+				ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
 
 				actual, err := config.ConstraintCheck(ctx, pctx, tc.args)
 				if tc.err != "" {
@@ -2181,7 +2182,7 @@ func TestStartsWithArityRegression(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx, pctx := newTestParsingContext(t, "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
 
 			require.NotPanics(t, func() {
 				_, err := config.StartsWith(ctx, pctx, tc.args)
@@ -2209,7 +2210,7 @@ func TestEndsWithArityRegression(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx, pctx := newTestParsingContext(t, "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
 
 			require.NotPanics(t, func() {
 				_, err := config.EndsWith(ctx, pctx, tc.args)
@@ -2237,7 +2238,7 @@ func TestStrContainsArityRegression(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx, pctx := newTestParsingContext(t, "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
 
 			require.NotPanics(t, func() {
 				_, err := config.StrContains(ctx, pctx, tc.args)
@@ -2275,7 +2276,7 @@ func TestRunCommandOptionsOnlyArityRegression(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
 
 			require.NotPanics(t, func() {
 				_, err := config.RunCommand(ctx, pctx, l, tc.params)

--- a/pkg/config/config_partial_test.go
+++ b/pkg/config/config_partial_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -36,7 +37,7 @@ dependencies {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -74,7 +75,7 @@ prevent_destroy = false
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	_, err := config.PartialParseConfigString(
 		ctx,
 		pctx,
@@ -111,7 +112,7 @@ skip = true
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock, config.TerragruntFlags)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -141,7 +142,7 @@ func TestPartialParseOmittedItems(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock, config.TerragruntFlags)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -180,7 +181,7 @@ func TestPartialParseDoesNotResolveIgnoredBlockEvenInParent(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 	pctx = pctx.WithDecodeList(config.TerragruntFlags)
 	_, err = config.PartialParseConfigFile(ctx, pctx, l, configPath, nil)
 	require.NoError(t, err)
@@ -340,7 +341,7 @@ include "grandparent" {
 
 			l := logger.CreateLogger()
 
-			ctx, pctx := newTestParsingContext(t, childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
 			pctx = pctx.WithDecodeList(config.TerragruntFlags)
 
 			_, err := config.PartialParseConfigFile(ctx, pctx, l, childPath, nil)
@@ -371,7 +372,7 @@ func TestPartialParseOnlyInheritsSelectedBlocksFlags(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 	pctx = pctx.WithDecodeList(config.TerragruntFlags)
 	terragruntConfig, err := config.PartialParseConfigFile(ctx, pctx, l, configPath, nil)
 	require.NoError(t, err)
@@ -403,7 +404,7 @@ func TestPartialParseOnlyInheritsSelectedBlocksDependencies(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 	terragruntConfig, err := config.PartialParseConfigFile(ctx, pctx, l, configPath, nil)
 	require.NoError(t, err)
@@ -432,7 +433,7 @@ dependency "vpc" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -466,7 +467,7 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -502,7 +503,7 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -539,7 +540,7 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock, config.DependencyBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -576,7 +577,7 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock, config.DependenciesBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -613,7 +614,7 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock, config.DependenciesBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -650,7 +651,7 @@ terraform {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.TerraformSource)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -683,7 +684,7 @@ dependency "ec2" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -719,7 +720,7 @@ func TestPartialParseSavesToHclCache(t *testing.T) {
 	// Setup cache and context
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	ctx = context.WithValue(ctx, config.HclCacheContextKey, hclCache)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
@@ -756,7 +757,7 @@ func TestPartialParseCacheHitOnSecondParse(t *testing.T) {
 
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	ctx = context.WithValue(ctx, config.HclCacheContextKey, hclCache)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
@@ -795,7 +796,7 @@ func TestPartialParseCacheInvalidationOnFileModification(t *testing.T) {
 
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	ctx = context.WithValue(ctx, config.HclCacheContextKey, hclCache)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
@@ -846,7 +847,7 @@ func TestPartialParseCacheWithInvalidFile(t *testing.T) {
 
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	ctx = context.WithValue(ctx, config.HclCacheContextKey, hclCache)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
@@ -883,7 +884,7 @@ func TestPartialParseCacheKeyFormat(t *testing.T) {
 
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	ctx = context.WithValue(ctx, config.HclCacheContextKey, hclCache)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
@@ -962,7 +963,7 @@ func TestPartialParseConfigCacheDifferentCallers(t *testing.T) {
 	l := logger.CreateLogger()
 
 	// Parse shared config from module A's context.
-	ctxA, pctxA := newTestParsingContext(t, moduleAConfigPath)
+	ctxA, pctxA := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), moduleAConfigPath)
 	ctxA = context.WithValue(ctxA, config.HclCacheContextKey, hclCache)
 	ctxA = context.WithValue(ctxA, config.TerragruntConfigCacheContextKey, configCache)
 	pctxA.UsePartialParseConfigCache = true
@@ -973,7 +974,7 @@ func TestPartialParseConfigCacheDifferentCallers(t *testing.T) {
 	require.NotNil(t, configA)
 
 	// Parse shared config from module B's context (different TerragruntConfigPath).
-	ctxB, pctxB := newTestParsingContext(t, moduleBConfigPath)
+	ctxB, pctxB := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), moduleBConfigPath)
 	ctxB = context.WithValue(ctxB, config.HclCacheContextKey, hclCache)
 	ctxB = context.WithValue(ctxB, config.TerragruntConfigCacheContextKey, configCache)
 	pctxB.UsePartialParseConfigCache = true
@@ -1020,7 +1021,7 @@ exclude {
 `
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.FeatureFlagsBlock, config.ExcludeBlock)
 
 	terragruntConfig, err := config.PartialParseConfigString(
@@ -1064,7 +1065,7 @@ exclude {
 `
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.TerragruntFlags)
 
 	_, err := config.PartialParseConfigString(
@@ -1100,7 +1101,7 @@ exclude {
 `
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.FeatureFlagsBlock, config.ExcludeBlock)
 
 	terragruntConfig, err := config.PartialParseConfigString(
@@ -1142,7 +1143,7 @@ terraform {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.TerraformExtraArgs)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -1203,7 +1204,7 @@ dependency "upstream" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock, config.TerraformExtraArgs).
 		WithDiagnosticsSuppressed(l)
 	terragruntConfig, err := config.PartialParseConfigString(
@@ -1256,7 +1257,7 @@ dependency "upstream" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 
 	pctx = pctx.WithDecodeList(config.TerraformSource)
 
@@ -1296,7 +1297,7 @@ dependency "upstream" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.TerraformSource)
 
 	_, err := config.PartialParseConfigString(
@@ -1332,7 +1333,7 @@ terraform {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.TerraformSource)
 	_, err := config.PartialParseConfigString(
 		ctx,
@@ -1468,7 +1469,7 @@ exclude {
 			require.NoError(t, os.WriteFile(childPath, []byte(tc.childHCL), 0644))
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
 			pctx = pctx.WithDecodeList(config.FeatureFlagsBlock, config.ExcludeBlock)
 
 			for name, value := range tc.cliFlags {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -36,7 +37,7 @@ remote_state {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -70,7 +71,7 @@ remote_state = {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -113,7 +114,7 @@ remote_state = {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -163,7 +164,7 @@ remote_state {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -198,7 +199,7 @@ remote_state = {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 }
@@ -224,7 +225,7 @@ generate = {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -257,7 +258,7 @@ generate = {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 }
@@ -276,7 +277,7 @@ func TestParseTerragruntJsonConfigRemoteStateMinimalConfig(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -305,7 +306,7 @@ remote_state {}
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 	assert.Contains(
@@ -336,7 +337,7 @@ remote_state {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -391,7 +392,7 @@ func TestParseTerragruntJsonConfigRemoteStateFullConfig(t *testing.T) {
 `
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -433,7 +434,7 @@ retryable_errors = [".*Error.*"]
 `
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "retryable_errors")
@@ -451,7 +452,7 @@ func TestParseTerragruntJsonConfigRetryConfiguration(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	_, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -477,7 +478,7 @@ func TestParseIamRole(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -505,7 +506,7 @@ func TestParseIamAssumeRoleDuration(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -533,7 +534,7 @@ func TestParseIamAssumeRoleSessionName(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -567,7 +568,7 @@ func TestParseIamWebIdentity(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -599,7 +600,7 @@ dependencies {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -638,7 +639,7 @@ dependencies {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -696,7 +697,7 @@ dependencies {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -764,7 +765,7 @@ func TestParseTerragruntJsonConfigRemoteStateDynamoDbTerraformConfigAndDependenc
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -832,7 +833,7 @@ include {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 
 	terragruntConfig, parseErr := config.ParseConfigString(ctx, pctx, l, cfgPath, cfg, nil)
 	if assert.NoError(t, parseErr, "Unexpected error: %v", parseErr) {
@@ -879,7 +880,7 @@ include {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 
 	terragruntConfig, parseErr := config.ParseConfigString(ctx, pctx, l, cfgPath, cfg, nil)
 	if assert.NoError(t, parseErr, "Unexpected error: %v", parseErr) {
@@ -938,7 +939,7 @@ remote_state {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 
 	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, cfgPath, cfg, nil)
 	if assert.NoError(t, err, "Unexpected error: %v", err) {
@@ -988,7 +989,7 @@ dependencies {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, configPath, cfg, nil)
 	require.NoError(t, err, "Unexpected error: %v", err)
 
@@ -1039,7 +1040,7 @@ func TestParseTerragruntJsonConfigIncludeOverrideAll(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
 	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, cfgPath, cfg, nil)
 	require.NoError(t, err, "Unexpected error: %v", err)
 
@@ -1072,7 +1073,7 @@ func TestParseTerragruntConfigTwoLevels(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 
 	_, actualErr := config.ParseConfigString(ctx, pctx, l, configPath, cfg, nil)
 
@@ -1105,7 +1106,7 @@ func TestParseTerragruntConfigThreeLevels(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 
 	_, actualErr := config.ParseConfigString(ctx, pctx, l, configPath, cfg, nil)
 
@@ -1137,7 +1138,7 @@ func TestParseTerragruntConfigEmptyConfig(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -1163,7 +1164,7 @@ func TestParseTerragruntConfigEmptyConfigOldConfig(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	cfg, err := config.ParseConfigString(
 		ctx,
@@ -1189,7 +1190,7 @@ terraform {}
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -1221,7 +1222,7 @@ terraform {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -1263,7 +1264,7 @@ terraform {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -1333,7 +1334,7 @@ terraform {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -1415,7 +1416,7 @@ func TestParseTerragruntJsonConfigTerraformWithMultipleExtraArguments(t *testing
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -1739,7 +1740,7 @@ prevent_destroy = true
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -1768,7 +1769,7 @@ prevent_destroy = false
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -1797,7 +1798,7 @@ skip = true
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
@@ -1814,7 +1815,7 @@ skip = false
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
@@ -1848,7 +1849,7 @@ terraform {
 	)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, absConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), absConfigPath)
 	pctx.MaxFoldersToCheck = 5
 
 	terragruntConfig, err := config.ParseConfigString(
@@ -1980,7 +1981,7 @@ func BenchmarkReadTerragruntConfig(b *testing.B) {
 			require.NoError(b, err)
 
 			l := createLogger()
-			_, pctx := newTestParsingContext(b, workingDir)
+			_, pctx := newTestParsingContext(b, venvtest.NewOSWithEmptyEnv(), workingDir)
 			pctx.UsePartialParseConfigCache = fixture.usePartialParseCache
 
 			b.ResetTimer()
@@ -2062,7 +2063,7 @@ func TestBestEffortParseConfigString(t *testing.T) {
 
 			l := createLogger()
 
-			ctx, pctx := newTestParsingContext(t, "test-time-mock")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 			terragruntConfig, err := config.ParseConfigString(
 				ctx,
@@ -2095,7 +2096,7 @@ func TestParseConfigGenerateBlockWithHclFmt(t *testing.T) {
 }`
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -2128,7 +2129,7 @@ func TestParseConfigGenerateAttrWithHclFmt(t *testing.T) {
 }`
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -2160,7 +2161,7 @@ func TestParseConfigGenerateBlockWithMutable(t *testing.T) {
 }`
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MutableGenerate))
 
 	terragruntConfig, err := config.ParseConfigString(
@@ -2194,7 +2195,7 @@ func TestParseConfigGenerateAttrWithMutable(t *testing.T) {
 }`
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MutableGenerate))
 
 	terragruntConfig, err := config.ParseConfigString(
@@ -2227,7 +2228,7 @@ func TestParseConfigGenerateBlockMutableRequiresExperiment(t *testing.T) {
 }`
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	_, err := config.ParseConfigString(
 		ctx,
@@ -2253,7 +2254,7 @@ func TestParseConfigWithMissingIfExists(t *testing.T) {
 }`
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -2311,7 +2312,7 @@ dependency "dep" {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 
 	pctx.WorkingDir = unitPath
 
@@ -2513,7 +2514,7 @@ inputs = {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -2678,7 +2679,7 @@ exclude {
 }
 `
 
-	ctx, pctx := newTestParsingContext(t, "test-exclude-no-run")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-exclude-no-run")
 	cfg, err := config.ParseConfigString(
 		ctx,
 		pctx,

--- a/pkg/config/cty_helpers_internal_test.go
+++ b/pkg/config/cty_helpers_internal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -15,7 +16,7 @@ import (
 
 // TestIncludeConfigAsCtyValWrapsErrorWithIncludeNameAndPath is a regression test for
 // https://github.com/gruntwork-io/terragrunt/issues/6282. When resolving an exposed include fails, the error must
-// identify WHICH include block and WHICH included (parent) file caused it — otherwise low-level, location-less
+// identify WHICH include block and WHICH included (parent) file caused it. Otherwise low-level, location-less
 // errors (e.g. the gocty "unsuitable value: a bool is required") are impossible to debug.
 func TestIncludeConfigAsCtyValWrapsErrorWithIncludeNameAndPath(t *testing.T) {
 	t.Parallel()
@@ -30,7 +31,7 @@ func TestIncludeConfigAsCtyValWrapsErrorWithIncludeNameAndPath(t *testing.T) {
 	require.NoError(t, os.WriteFile(childPath, []byte("terraform {\n  source = \".\"\n}\n"), 0644))
 
 	l := logger.CreateLogger()
-	ctx, pctx := NewParsingContext(t.Context(), l, WithStrictControls(controls.New()))
+	ctx, pctx := NewParsingContext(t.Context(), l, venvtest.NewWithOSFS(), WithStrictControls(controls.New()))
 	pctx.TerragruntConfigPath = childPath
 	pctx.WorkingDir = tmpDir
 

--- a/pkg/config/dependency_test.go
+++ b/pkg/config/dependency_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -128,7 +129,7 @@ func TestParseDependencyBlockMultiple(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, filename)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), filename)
 	err = pctx.Experiments.EnableExperiment(experiment.DependencyFetchOutputFromState)
 	require.NoError(t, err)
 
@@ -183,7 +184,7 @@ dependency "enabled" {
 }
 `
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock)
 
 	// Should not panic - disabled deps bypass config_path validation
@@ -224,7 +225,7 @@ func TestDependencyOriginalTerragruntDir(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, filename)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), filename)
 	pctx.OriginalTerragruntConfigPath = filename
 	pctx.SkipOutput = true
 
@@ -247,7 +248,7 @@ func TestDependencyOriginalTerragruntDir(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	ctxB, pctxB := newTestParsingContext(t, unitBFilename)
+	ctxB, pctxB := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), unitBFilename)
 	pctxB.OriginalTerragruntConfigPath = unitBFilename
 
 	unitBConfig, err := config.ParseConfigFile(
@@ -278,7 +279,7 @@ dependency "enabled" {
 }
 `
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock)
 
 	// Should not error - disabled deps bypass config_path validation

--- a/pkg/config/dependency_tf_test.go
+++ b/pkg/config/dependency_tf_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,7 +35,7 @@ func TestTFExposedIncludeFullParseSurfacesNoOutputsError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, childPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
 	pctx.Venv.Env = venv.OSVenv().Env
 	pctx.Venv.FS = vfs.NewOSFS()
 	pctx.TFPath = helpers.WrappedBinary(ctx)

--- a/pkg/config/early_stack_eval_test.go
+++ b/pkg/config/early_stack_eval_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,7 +68,7 @@ var terragruntFuncNames = []string{
 func newStackParsePctx(t *testing.T, baseDir string) *config.ParsingContext {
 	t.Helper()
 
-	_, pctx := config.NewParsingContext(t.Context(), logger.CreateLogger())
+	_, pctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), venvtest.NewOSWithEmptyEnv())
 	pctx.TerragruntConfigPath = filepath.Join(baseDir, "terragrunt.hcl")
 	pctx.WorkingDir = baseDir
 	pctx.MaxFoldersToCheck = 100

--- a/pkg/config/exclude_include_test.go
+++ b/pkg/config/exclude_include_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -61,7 +62,7 @@ include "root" {
 }
 `), 0644))
 
-			ctx, pctx := newTestParsingContext(t, childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
 
 			l := logger.CreateLogger()
 
@@ -137,7 +138,7 @@ exclude {
 }
 `), 0644))
 
-			ctx, pctx := newTestParsingContext(t, childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
 
 			l := logger.CreateLogger()
 
@@ -201,7 +202,7 @@ include "root" {
 }
 `), 0644))
 
-			ctx, pctx := newTestParsingContext(t, childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
 
 			l := logger.CreateLogger()
 
@@ -260,7 +261,7 @@ include "root" {
 }
 `), 0644))
 
-			ctx, pctx := newTestParsingContext(t, childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
 
 			l := logger.CreateLogger()
 
@@ -318,7 +319,7 @@ include "root" {
 }
 `), 0644))
 
-			ctx, pctx := newTestParsingContext(t, childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
 
 			l := logger.CreateLogger()
 

--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -198,7 +199,7 @@ func TestParseConfigStringExpansionRequiresExperiment(t *testing.T) {
 	skipInExperimentMode(t)
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 
 	_, err := config.ParseConfigString(
 		ctx,
@@ -244,7 +245,7 @@ func TestReadStackConfigStringExpansionRequiresExperiment(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, config.DefaultStackFile)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultStackFile)
 
 			_, err := config.ReadStackConfigString(
 				ctx,
@@ -288,7 +289,7 @@ include "extra" {
 `), 0o644))
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, stackPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackPath)
 	pctx.Venv.FS = fsys
 
 	_, err := config.ReadStackConfigFile(ctx, l, pctx, stackPath, nil)
@@ -563,7 +564,7 @@ func newExpansionParsingContext(
 ) (context.Context, *config.ParsingContext) {
 	tb.Helper()
 
-	ctx, pctx := newTestParsingContext(tb, configPath)
+	ctx, pctx := newTestParsingContext(tb, venvtest.NewOSWithEmptyEnv(), configPath)
 	require.NoError(tb, pctx.Experiments.EnableExperiment(experiment.BlockIteration))
 
 	return ctx, pctx

--- a/pkg/config/external_test.go
+++ b/pkg/config/external_test.go
@@ -1,6 +1,6 @@
 // This file validates that the pkg/config package is usable by external consumers
 // as a public API. All tests here use only the external (black-box) package name
-// `config_test` and import only public packages — no `internal/` imports are allowed.
+// `config_test` and import only public packages: no `internal/` imports are allowed.
 
 package config_test
 
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -433,7 +434,7 @@ inputs = {
 `
 
 	ctx := t.Context()
-	ctx, pctx := config.NewParsingContext(ctx, l)
+	ctx, pctx := config.NewParsingContext(ctx, l, venvtest.NewWithOSFS())
 	cfg, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -468,7 +469,7 @@ unit "db" {
 `
 
 	ctx := t.Context()
-	ctx, pctx := config.NewParsingContext(ctx, l)
+	ctx, pctx := config.NewParsingContext(ctx, l, venvtest.NewWithOSFS())
 
 	v := cty.ObjectVal(map[string]cty.Value{})
 
@@ -510,7 +511,7 @@ unit "db" {
 `
 
 	ctx := t.Context()
-	ctx, pctx := config.NewParsingContext(ctx, l)
+	ctx, pctx := config.NewParsingContext(ctx, l, venvtest.NewWithOSFS())
 
 	sc, err := config.ReadStackConfigString(
 		ctx,
@@ -550,7 +551,7 @@ unit "db" {
 `
 
 	ctx := t.Context()
-	ctx, pctx := config.NewParsingContext(ctx, l)
+	ctx, pctx := config.NewParsingContext(ctx, l, venvtest.NewWithOSFS())
 
 	v := cty.ObjectVal(map[string]cty.Value{
 		"app_path": cty.StringVal("foo"),
@@ -576,7 +577,7 @@ unit "db" {
 
 // TestExternalReadValuesAndParseStackConfig validates that an external consumer
 // can read a terragrunt.values.hcl file from disk using ReadValues and feed the
-// result into ReadStackConfigString — no internal/ imports required.
+// result into ReadStackConfigString, with no internal/ imports required.
 func TestExternalReadValuesAndParseStackConfig(t *testing.T) {
 	t.Parallel()
 
@@ -594,7 +595,7 @@ region   = "us-west-2"
 	)
 
 	ctx := t.Context()
-	ctx, pctx := config.NewParsingContext(ctx, l)
+	ctx, pctx := config.NewParsingContext(ctx, l, venvtest.NewWithOSFS())
 
 	// Read values from the file on disk.
 	values, err := config.ReadValues(ctx, pctx, l, dir)
@@ -618,7 +619,7 @@ unit "app" {
 
 // TestExternalReadValuesAndParseConfig validates that an external consumer can
 // parse a regular terragrunt.hcl that references values.* when a
-// terragrunt.values.hcl file sits next to it — no internal/ imports required.
+// terragrunt.values.hcl file sits next to it, with no internal/ imports required.
 //
 // ParseConfig automatically calls ReadValues from the config file's directory,
 // so the configPath argument must point into the directory containing the
@@ -640,7 +641,7 @@ region = "eu-west-1"
 	)
 
 	ctx := t.Context()
-	ctx, pctx := config.NewParsingContext(ctx, l)
+	ctx, pctx := config.NewParsingContext(ctx, l, venvtest.NewWithOSFS())
 
 	// Use a configPath inside the temp dir so ParseConfig discovers the
 	// adjacent terragrunt.values.hcl automatically.

--- a/pkg/config/find_in_parent_folders_bench_test.go
+++ b/pkg/config/find_in_parent_folders_bench_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +23,7 @@ func BenchmarkFindInParentFolders(b *testing.B) {
 
 			b.Run("depth="+strconv.Itoa(depth)+"/units="+strconv.Itoa(units), func(b *testing.B) {
 				l := logger.CreateLogger()
-				baseCtx, pctx := newTestParsingContext(b, configPaths[0])
+				baseCtx, pctx := newTestParsingContext(b, venvtest.NewOSWithEmptyEnv(), configPaths[0])
 				params := []string{benchRootFileName}
 
 				for b.Loop() {

--- a/pkg/config/fuzz_test.go
+++ b/pkg/config/fuzz_test.go
@@ -34,7 +34,7 @@ func FuzzHCLStringHelpers(f *testing.F) {
 	f.Fuzz(func(t *testing.T, raw string) {
 		args := strings.Split(raw, "\x00")
 
-		ctx, pctx := newTestParsingContext(t, "")
+		ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
 
 		swOut, swErr := config.StartsWith(ctx, pctx, args)
 		ewOut, ewErr := config.EndsWith(ctx, pctx, args)
@@ -67,7 +67,7 @@ func FuzzHCLStringHelpers(f *testing.F) {
 
 // FuzzHCLRunCommand fuzzes config.RunCommand with arbitrary argv. Subprocess execution
 // is intercepted by an in-memory vexec backend installed via pctx.Exec, so no real host
-// commands ever run — even mutator-supplied paths like "/bin/sh\x00-c\x00rm -rf /" are
+// commands ever run, even mutator-supplied paths like "/bin/sh\x00-c\x00rm -rf /" are
 // captured by the mock instead of reaching the operating system.
 //
 // Asserts:
@@ -98,7 +98,7 @@ func FuzzHCLRunCommand(f *testing.F) {
 		"\x00",
 		"\x00\x00",
 		"--terragrunt-quiet\x00\x00/bin/echo\x00hi", // empty arg between flags and command
-		"/bin/echo\x00--terragrunt-quiet",           // trailing flag (not stripped — only leading flags are)
+		"/bin/echo\x00--terragrunt-quiet",           // trailing flag (not stripped, since only leading flags are)
 		" \x00--terragrunt-quiet\x00cmd",            // whitespace as command
 	}
 	for _, s := range seeds {
@@ -123,8 +123,7 @@ func FuzzHCLRunCommand(f *testing.F) {
 			return vexec.Result{Stdout: []byte(mockOutput)}
 		})
 
-		ctx, pctx := newTestParsingContext(t, "")
-		pctx.Venv = venvtest.New().WithExec(memExec)
+		ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(memExec), "")
 
 		l := logger.CreateLogger()
 		out, err := config.RunCommand(ctx, pctx, l, argsForCall)

--- a/pkg/config/locals_test.go
+++ b/pkg/config/locals_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestEvaluateLocalsBlock(t *testing.T) {
@@ -22,7 +23,7 @@ func TestEvaluateLocalsBlock(t *testing.T) {
 		ParseFromString(LocalsTestConfig, config.DefaultTerragruntConfigPath)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	evaluatedLocals, err := config.EvaluateLocalsBlock(ctx, pctx, logger.CreateLogger(), file)
 	require.NoError(t, err)
 
@@ -65,7 +66,7 @@ func TestEvaluateLocalsBlockMultiDeepReference(t *testing.T) {
 		ParseFromString(LocalsTestMultiDeepReferenceConfig, config.DefaultTerragruntConfigPath)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	evaluatedLocals, err := config.EvaluateLocalsBlock(ctx, pctx, logger.CreateLogger(), file)
 	require.NoError(t, err)
 
@@ -102,7 +103,7 @@ func TestEvaluateLocalsBlockImpossibleWillFail(t *testing.T) {
 		ParseFromString(LocalsTestImpossibleConfig, config.DefaultTerragruntConfigPath)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	_, err = config.EvaluateLocalsBlock(ctx, pctx, logger.CreateLogger(), file)
 	require.Error(t, err)
 
@@ -119,7 +120,7 @@ func TestEvaluateLocalsBlockMultipleLocalsBlocksWillFail(t *testing.T) {
 		ParseFromString(MultipleLocalsBlockConfig, config.DefaultTerragruntConfigPath)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	_, err = config.EvaluateLocalsBlock(ctx, pctx, logger.CreateLogger(), file)
 	require.Error(t, err)
 }

--- a/pkg/config/mark_as_read_test.go
+++ b/pkg/config/mark_as_read_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,7 +27,7 @@ func TestMarkGlobAsRead(t *testing.T) {
 
 	l := logger.CreateLogger()
 	configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
-	ctx, pctx := newTestParsingContext(t, configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 	pctx.WorkingDir = dir
 
 	// Drive the HCL function via a locals block so we exercise the registered cty wrapper.
@@ -63,7 +64,7 @@ func TestMarkGlobAsReadEscapesMetacharacter(t *testing.T) {
 
 	l := logger.CreateLogger()
 	configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
-	ctx, pctx := newTestParsingContext(t, configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 	pctx.WorkingDir = dir
 
 	// The HCL string literal '"a\\*b.tf"' decodes to 'a\*b.tf', which the glob
@@ -95,7 +96,7 @@ func TestMarkGlobAsReadBoundaryFlag(t *testing.T) {
 
 	l := logger.CreateLogger()
 	configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
-	ctx, pctx := newTestParsingContext(t, configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 	pctx.WorkingDir = dir
 
 	hcl := `locals { matched = mark_glob_as_read("--terragrunt-boundary=.", "{*.yaml}") }`
@@ -133,7 +134,7 @@ func TestMarkGlobAsReadGitRootBoundary(t *testing.T) {
 	t.Run("pattern above the repository root errors", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, pctx := newTestParsingContext(t, configPath)
+		ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 		pctx.WorkingDir = unitDir
 
 		hcl := `locals { matched = mark_glob_as_read("/{*.yaml}") }`
@@ -145,7 +146,7 @@ func TestMarkGlobAsReadGitRootBoundary(t *testing.T) {
 	t.Run("try wrapper recovers to empty", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, pctx := newTestParsingContext(t, configPath)
+		ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 		pctx.WorkingDir = unitDir
 
 		hcl := `locals {
@@ -183,7 +184,7 @@ func TestMarkManyAsReadMarksModuleSourceFilesByDefault(t *testing.T) {
 	hcl := `terraform { source = "../../modules/foo" }`
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 	pctx.WorkingDir = unitDir
 
 	out, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
@@ -219,7 +220,7 @@ func TestMarkManyAsReadRelativeConfigPathAnchorsToWorkingDir(t *testing.T) {
 	hcl := `terraform { source = "../../modules/foo" }`
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 	pctx.WorkingDir = unitDir
 
 	out, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, hcl, nil)
@@ -250,7 +251,7 @@ func TestMarkManyAsReadPartialParseSource(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, configPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 			pctx.WorkingDir = unitDir
 			pctx = pctx.WithDecodeList(decode)
 
@@ -295,7 +296,7 @@ func TestMarkManyAsReadPartialParseIncludedSource(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
 			pctx.WorkingDir = unitDir
 			pctx = pctx.WithDecodeList(decode)
 

--- a/pkg/config/parsing_context.go
+++ b/pkg/config/parsing_context.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"io"
 	"maps"
 	"os"
@@ -33,6 +34,11 @@ const (
 	MaxParseDepth = 1000
 )
 
+// ErrParsingContextVenvNil is the panic value [NewParsingContext] raises when
+// its venv argument is nil. Every caller is handed the bundle main.go built,
+// so a nil points at a caller bug rather than a runtime condition.
+var ErrParsingContextVenvNil = errors.New("config.NewParsingContext: venv must not be nil")
+
 // ParsingContext provides various variables that are used throughout all funcs and passed from function to function.
 // Using `ParsingContext` makes the code more readable.
 // Note: context.Context should be passed explicitly as the first parameter to functions, not embedded in this struct.
@@ -40,8 +46,6 @@ type ParsingContext struct {
 	// Venv is the virtualized environment used by HCL helper functions
 	// that shell out (e.g. get_repo_root) or evaluate dependency outputs.
 	// It also carries the shell environment and stdout/stderr writers.
-	// Defaults to the OS-backed environment when [NewParsingContext] is
-	// called; callers with a threaded root Venv override via [WithVenv].
 	Venv *venv.Venv
 
 	TerraformCliArgs *iacargs.IacArgs
@@ -117,15 +121,22 @@ type ParsingContext struct {
 	skipAutoIncludeMerge bool
 }
 
+// NewParsingContext builds a parsing context whose file reads, subprocesses,
+// and decryption all travel on v.
 func NewParsingContext(
 	ctx context.Context,
 	l log.Logger,
+	v *venv.Venv,
 	opts ...Option,
 ) (context.Context, *ParsingContext) {
+	if v == nil {
+		panic(ErrParsingContextVenvNil)
+	}
+
 	pctx := &ParsingContext{
 		TerraformCliArgs: iacargs.New(),
 		FilesRead:        NewFilesRead(),
-		Venv:             venv.OSVenv(),
+		Venv:             v,
 	}
 
 	for _, opt := range opts {
@@ -139,8 +150,8 @@ func NewParsingContext(
 
 // Clone returns a copy of the ParsingContext.
 // Maps and the embedded Venv (including its Writers pointer and Env map)
-// are deep-copied so that mutations on a clone — credential injection,
-// writer redirection, etc. — do not affect the original or other clones.
+// are deep-copied so that mutations on a clone (credential injection,
+// writer redirection, and so on) do not affect the original or other clones.
 func (ctx *ParsingContext) Clone() *ParsingContext {
 	clone := *ctx
 
@@ -211,16 +222,6 @@ func (ctx *ParsingContext) WithTrackInclude(trackInclude *TrackInclude) *Parsing
 func (ctx *ParsingContext) WithParseOption(parserOptions []hclparse.Option) *ParsingContext {
 	c := ctx.Clone()
 	c.ParserOptions = parserOptions
-
-	return c
-}
-
-// WithVenv returns a new ParsingContext that uses the supplied virtualized
-// environment for HCL helpers that shell out (e.g. get_repo_root) and for
-// dependency-output evaluation.
-func (ctx *ParsingContext) WithVenv(v *venv.Venv) *ParsingContext {
-	c := ctx.Clone()
-	c.Venv = v
 
 	return c
 }

--- a/pkg/config/parsing_context_test.go
+++ b/pkg/config/parsing_context_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +30,7 @@ func TestWithDependencyConfigPath_CustomDownloadDir_Preserved(t *testing.T) {
 	customDownloadDir := filepath.Join(tmpDir, "custom-cache")
 
 	l := logger.CreateLogger()
-	_, pctx := config.NewParsingContext(t.Context(), l, config.WithStrictControls(controls.New()))
+	_, pctx := config.NewParsingContext(t.Context(), l, venvtest.NewOSWithEmptyEnv(), config.WithStrictControls(controls.New()))
 
 	_, callerDefaultDir := util.DefaultWorkingAndDownloadDirs(callerConfigPath)
 	pctx.TerragruntConfigPath = callerConfigPath
@@ -58,7 +59,7 @@ func TestWithDependencyConfigPath_DefaultDownloadDir_Updated(t *testing.T) {
 	depConfigPath := filepath.Join(tmpDir, "modules", "vpc", "terragrunt.hcl")
 
 	l := logger.CreateLogger()
-	_, pctx := config.NewParsingContext(t.Context(), l, config.WithStrictControls(controls.New()))
+	_, pctx := config.NewParsingContext(t.Context(), l, venvtest.NewOSWithEmptyEnv(), config.WithStrictControls(controls.New()))
 
 	// Set DownloadDir to the caller's default (no TG_DOWNLOAD_DIR override).
 	_, callerDefaultDir := util.DefaultWorkingAndDownloadDirs(callerConfigPath)
@@ -92,7 +93,7 @@ func TestWithDependencyConfigPath_CustomDownloadDir_NotDefaultForAnyModule(t *te
 	customDownloadDir := filepath.Join(tmpDir, ".terragrunt-cache")
 
 	l := logger.CreateLogger()
-	_, pctx := config.NewParsingContext(t.Context(), l, config.WithStrictControls(controls.New()))
+	_, pctx := config.NewParsingContext(t.Context(), l, venvtest.NewOSWithEmptyEnv(), config.WithStrictControls(controls.New()))
 
 	_, callerDefaultDir := util.DefaultWorkingAndDownloadDirs(callerConfigPath)
 	pctx.TerragruntConfigPath = callerConfigPath
@@ -106,4 +107,17 @@ func TestWithDependencyConfigPath_CustomDownloadDir_NotDefaultForAnyModule(t *te
 
 	assert.Equal(t, customDownloadDir, depCtx.DownloadDir,
 		"custom TG_DOWNLOAD_DIR must be preserved even when it shares the root tmpDir")
+}
+
+// TestNewParsingContextPanicsOnNilVenv pins the constructor's contract, so a
+// caller that passes no venv fails there rather than on a nil dereference deep
+// inside an HCL helper.
+func TestNewParsingContextPanicsOnNilVenv(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+
+	require.PanicsWithValue(t, config.ErrParsingContextVenvNil, func() {
+		config.NewParsingContext(t.Context(), l, nil)
+	})
 }

--- a/pkg/config/sops_race_test.go
+++ b/pkg/config/sops_race_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/internal/vsops"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -70,9 +71,10 @@ func TestSOPSDecryptConcurrencyWithRacing(t *testing.T) {
 			<-barrier
 
 			l := logger.CreateLogger()
-			_, pctx := NewParsingContext(ctx, l, WithStrictControls(controls.New()))
+			v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: fmt.Sprintf("token-%d", idx)})
+
+			_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
 			pctx.WorkingDir = filepath.Dir(filePath)
-			pctx.Venv.Env = map[string]string{authKey: fmt.Sprintf("token-%d", idx)}
 
 			result, err := sopsDecryptFileImpl(ctx, pctx, l, filePath, "json", mockDecrypter)
 			assert.NoError(t, err)

--- a/pkg/config/sops_test.go
+++ b/pkg/config/sops_test.go
@@ -14,12 +14,13 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/internal/vsops"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // generateTestSecretFiles creates plain JSON files in a temp directory.
-// No SOPS encryption needed — the test injects a mock decrypter to read raw files.
+// No SOPS encryption needed: the test injects a mock decrypter to read raw files.
 func generateTestSecretFiles(t *testing.T, count int) []string {
 	t.Helper()
 
@@ -63,7 +64,7 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 	secretFiles := generateTestSecretFiles(t, 1)
 	secretFile := secretFiles[0]
 
-	// Mock decrypter that requires authKey to be set — simulates KMS auth.
+	// Mock decrypter that requires authKey to be set, simulating KMS auth.
 	authRequiringDecrypter := vsops.NewMemDecrypter(func(path string, _ string) ([]byte, error) {
 		token := os.Getenv(authKey)
 		if token == "" {
@@ -75,7 +76,7 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 
 	// Subtest 1: Existing process env vars are preserved (not overridden).
 	// Models: CI runner has real AWS_SESSION_TOKEN, auth-provider returns empty token.
-	// sopsDecryptFileImpl must NOT override the real token with empty — SOPS uses process env.
+	// sopsDecryptFileImpl must NOT override the real token with empty, since SOPS uses process env.
 	t.Run(
 		"existing_process_env_preserved",
 		func(t *testing.T) { //nolint:paralleltest // mutates process env
@@ -83,10 +84,10 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 
 			l := logger.CreateLogger()
 			ctx := WithConfigValues(t.Context())
-			_, pctx := NewParsingContext(ctx, l, WithStrictControls(controls.New()))
+			v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: ""})
+
+			_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
 			pctx.WorkingDir = filepath.Dir(secretFile)
-			// pctx.Venv.Env has empty value for authKey (like auth-provider returning empty session token)
-			pctx.Venv.Env = map[string]string{authKey: ""}
 
 			result, err := sopsDecryptFileImpl(
 				ctx,
@@ -99,7 +100,7 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 			require.NoError(t, err, "decrypt must succeed using existing process env credentials")
 			assert.Contains(t, result, `"value":"secret-from-unit-01"`)
 
-			// Process env must still have the real token — not overridden
+			// Process env must still have the real token, not overridden
 			assert.Equal(t, "real-ci-token", os.Getenv(authKey),
 				"existing process env var must not be overridden")
 		},
@@ -114,9 +115,10 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 
 			l := logger.CreateLogger()
 			ctx := WithConfigValues(t.Context())
-			_, pctx := NewParsingContext(ctx, l, WithStrictControls(controls.New()))
+			v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: "fresh-token"})
+
+			_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
 			pctx.WorkingDir = filepath.Dir(secretFile)
-			pctx.Venv.Env = map[string]string{authKey: "fresh-token"}
 
 			result, err := sopsDecryptFileImpl(
 				ctx,
@@ -146,14 +148,14 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 
 			l := logger.CreateLogger()
 			ctx := WithConfigValues(t.Context())
-			_, pctx := NewParsingContext(ctx, l, WithStrictControls(controls.New()))
+			v := venvtest.NewWithOSFS().WithEnv(map[string]string{})
+
+			_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
 			pctx.WorkingDir = filepath.Dir(secretFile)
-			// Empty env — simulates auth-provider NOT having run (the original bug)
-			pctx.Venv.Env = map[string]string{}
 
 			_, err := sopsDecryptFileImpl(ctx, pctx, l, secretFile, "json", authRequiringDecrypter)
 			require.Error(t, err,
-				"decrypt must fail without auth credentials — reproduces original issue #5515")
+				"decrypt must fail without auth credentials, reproducing original issue #5515")
 		},
 	)
 
@@ -205,9 +207,11 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 					)
 
 					l := logger.CreateLogger()
-					_, pctx := NewParsingContext(ctx, l, WithStrictControls(controls.New()))
+					v := venvtest.NewWithOSFS().
+						WithEnv(map[string]string{authKey: expectedToken})
+
+					_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
 					pctx.WorkingDir = filepath.Dir(filePath)
-					pctx.Venv.Env = map[string]string{authKey: expectedToken}
 
 					result, decryptErr := sopsDecryptFileImpl(
 						ctx,
@@ -239,7 +243,7 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // muta
 			require.Zero(
 				t,
 				failures.Load(),
-				"all goroutines must see their own auth token during decrypt — env isolation failed",
+				"all goroutines must see their own auth token during decrypt; env isolation failed",
 			)
 
 			assert.Empty(t, os.Getenv(authKey),

--- a/pkg/config/stack_fs_error_test.go
+++ b/pkg/config/stack_fs_error_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,11 +32,10 @@ unit "app" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, stackPath)
-	pctx.Venv = pctx.Venv.WithFS(statErrorFS{
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv().WithFS(statErrorFS{
 		FS:       vfs.NewOSFS(),
 		failPath: filepath.Join(tmpDir, inthclparse.AutoIncludeStackFile),
-	})
+	}), stackPath)
 
 	_, err := config.ReadStackConfigFile(ctx, logger.CreateLogger(), pctx, stackPath, nil)
 	require.ErrorIs(t, err, errStatFailed)
@@ -52,12 +52,12 @@ func TestReadValuesPropagatesStatError(t *testing.T) {
 
 	ctx, pctx := newTestParsingContext(
 		t,
+		venvtest.NewOSWithEmptyEnv().WithFS(statErrorFS{
+			FS:       vfs.NewOSFS(),
+			failPath: filepath.Join(tmpDir, "terragrunt.values.hcl"),
+		}),
 		filepath.Join(tmpDir, config.DefaultTerragruntConfigPath),
 	)
-	pctx.Venv = pctx.Venv.WithFS(statErrorFS{
-		FS:       vfs.NewOSFS(),
-		failPath: filepath.Join(tmpDir, "terragrunt.values.hcl"),
-	})
 
 	values, err := config.ReadValues(ctx, pctx, logger.CreateLogger(), tmpDir)
 	require.ErrorIs(t, err, errStatFailed)

--- a/pkg/config/stack_oci_test.go
+++ b/pkg/config/stack_oci_test.go
@@ -59,8 +59,7 @@ func generateOCIStack(t *testing.T, kind, sourceScheme string, ociEnabled bool) 
 	l := logger.CreateLogger()
 	l.SetOptions(log.WithOutput(&logBuf), log.WithLevel(log.DebugLevel))
 
-	_, pctx := config.NewParsingContext(t.Context(), l, config.WithStrictControls(controls.New()))
-	pctx.Venv = v
+	_, pctx := config.NewParsingContext(t.Context(), l, v, config.WithStrictControls(controls.New()))
 	pctx.TerragruntStackConfigPath = stackPath
 	pctx.RootWorkingDir = filepath.Dir(stackPath)
 	pctx.WorkingDir = filepath.Dir(stackPath)

--- a/pkg/config/stack_test.go
+++ b/pkg/config/stack_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +33,7 @@ stack "projects" {
 }
 
 `
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	terragruntStackConfig, err := config.ReadStackConfigString(
 		ctx,
 		logger.CreateLogger(),
@@ -111,7 +112,7 @@ stack "network" {
     no_dot_terragrunt_stack = true
 }
 `
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	terragruntStackConfig, err := config.ReadStackConfigString(
 		ctx,
 		logger.CreateLogger(),
@@ -175,7 +176,7 @@ locals {
 	project = "my-project
 }
 `
-	ctx, pctx := newTestParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
 	_, err := config.ReadStackConfigString(
 		ctx,
 		logger.CreateLogger(),

--- a/pkg/config/stack_validation_test.go
+++ b/pkg/config/stack_validation_test.go
@@ -9,6 +9,7 @@ import (
 	inthclparse "github.com/gruntwork-io/terragrunt/internal/hclparse"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -419,7 +420,7 @@ unit "extra" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	_, err := config.ReadStackConfigFile(ctx, logger.CreateLogger(), pctx, stackFilePath, nil)
@@ -493,7 +494,7 @@ unit "extra" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	stackConfig, err := config.ReadStackConfigFile(
@@ -549,7 +550,7 @@ unit "added" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	stackConfig, err := config.ReadStackConfigFile(
@@ -642,7 +643,7 @@ stack "added" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	stackConfig, err := config.ReadStackConfigFile(
@@ -724,7 +725,7 @@ unit "extra" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	_, err := config.ReadStackConfigFile(ctx, logger.CreateLogger(), pctx, stackFilePath, nil)
@@ -765,7 +766,7 @@ unit "vpc" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	_, err := config.ReadStackConfigFile(ctx, logger.CreateLogger(), pctx, stackFilePath, nil)
@@ -813,7 +814,7 @@ unit "vpc" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	stackConfig, err := config.ReadStackConfigFile(
@@ -878,7 +879,7 @@ unit "vpc" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	stackConfig, err := config.ReadStackConfigFile(

--- a/pkg/config/terraform_version_test.go
+++ b/pkg/config/terraform_version_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +26,7 @@ terraform {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
 	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.VersionAttribute))
 
 	terragruntConfig, err := config.ParseConfigString(
@@ -143,7 +144,7 @@ include "root" {
 
 			l := logger.CreateLogger()
 
-			ctx, pctx := newTestParsingContext(t, childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
 			require.NoError(t, pctx.Experiments.EnableExperiment(experiment.VersionAttribute))
 
 			terragruntConfig, err := config.ParseConfigFile(ctx, pctx, l, childPath, nil)

--- a/test/helpers/venvtest/venvtest.go
+++ b/test/helpers/venvtest/venvtest.go
@@ -43,3 +43,17 @@ func New() *venv.Venv {
 		Writers: &writer.Writers{Writer: io.Discard, ErrWriter: io.Discard},
 	}
 }
+
+// NewWithOSFS returns [New] with the real filesystem swapped in, for tests
+// whose fixtures live on disk but which need nothing else live.
+func NewWithOSFS() *venv.Venv {
+	return New().WithFS(vfs.NewOSFS())
+}
+
+// NewOSWithEmptyEnv returns the OS-backed bundle with an empty environment, so
+// a variable set on the machine running the suite cannot reach the code under
+// test. Tests that drive the real filesystem and real subprocesses need it;
+// prefer [NewWithOSFS] when only the filesystem has to be real.
+func NewOSWithEmptyEnv() *venv.Venv {
+	return venv.OSVenv().WithEnv(map[string]string{})
+}

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -201,7 +201,7 @@ func readConfig(t *testing.T, opts *options.TerragruntOptions) *config.Terragrun
 	require.NoError(t, err)
 
 	l := logger.CreateLogger()
-	_, pctx := configbridge.NewParsingContext(t.Context(), l, opts)
+	_, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), opts)
 	cfg, err := config.ReadTerragruntConfig(
 		t.Context(),
 		l,

--- a/test/integration_parse_test.go
+++ b/test/integration_parse_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -85,6 +86,7 @@ func TestParseAllFixtureFiles(t *testing.T) {
 			ctx, pctx := configbridge.NewParsingContext(
 				context.TODO(), // Using context.TODO() instead of t.Context() here because we end up storing way too much in context otherwise.
 				l,
+				venv.OSVenv(),
 				opts,
 			)
 

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	inthclparse "github.com/gruntwork-io/terragrunt/internal/hclparse"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
@@ -360,7 +361,7 @@ func TestStackDepsDAGExpandsStackToUnits(t *testing.T) {
 	)
 
 	l := logger.CreateLogger()
-	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, options.NewTerragruntOptions())
+	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), options.NewTerragruntOptions())
 
 	unitPaths, err := inthclparse.UnitPathsFromStackDir(
 		vfs.NewOSFS(),
@@ -403,7 +404,7 @@ func TestStackDepsUnitPathsFromNestedOnlyStack(t *testing.T) {
 	)
 
 	l := logger.CreateLogger()
-	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, options.NewTerragruntOptions())
+	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), options.NewTerragruntOptions())
 
 	unitPaths, err := inthclparse.UnitPathsFromStackDir(
 		vfs.NewOSFS(),
@@ -429,7 +430,7 @@ func TestStackDepsUnitPathsFromMissingStackFile(t *testing.T) {
 	root := helpers.TmpDirWOSymlinks(t)
 
 	l := logger.CreateLogger()
-	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, options.NewTerragruntOptions())
+	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), options.NewTerragruntOptions())
 
 	unitPaths, err := inthclparse.UnitPathsFromStackDir(
 		vfs.NewOSFS(),
@@ -1919,7 +1920,7 @@ func newStackDepsParsingContext(
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.StackDependencies))
 	opts.TerragruntConfigPath = configPath
 
-	return configbridge.NewParsingContext(t.Context(), l, opts)
+	return configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), opts)
 }
 
 // partialParseDiscovery partial parses a unit config the way discovery does, with the


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Ensures that we don't accidentally construct `NewParsingContext` without explicit venv.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
