### PR TITLE
fix: Plumbing through `evalCtx` for discovery boundary

### DIFF
--- a/docs/src/data/changelog/v1.1.3/discovery-boundary.mdx
+++ b/docs/src/data/changelog/v1.1.3/discovery-boundary.mdx
@@ -14,4 +14,9 @@ cd environments/staging
 terragrunt run --all plan --experiment bounded-discovery --filter '...{vpc}' --discovery-boundary .
 ```
 
-Any configuration that resolves outside the boundary, whether a dependent or a dependency, is neither read nor parsed nor returned; configurations inside it are discovered as usual. The boundary must be an existing directory that contains the working directory; relative paths are resolved against the working directory.
+Any configuration that resolves outside the boundary, whether a dependent or a dependency, is neither read nor parsed nor returned; configurations inside it are discovered as usual. The boundary must be an existing directory, and relative paths are resolved against the working directory. Dependent traversal searches upward from the working directory, so filters that use it also need the boundary to be the working directory or one of its parents. Dependency traversal follows declared paths from the units a filter matched, so dependency-only filters accept any directory, including one below the working directory:
+
+```bash
+# From the repository root, follow app's dependencies but keep them within prod
+terragrunt find --experiment bounded-discovery --filter '{./prod/app}...' --discovery-boundary ./prod
+```

--- a/docs/src/data/changelog/v1.1.3/discovery-boundary.mdx
+++ b/docs/src/data/changelog/v1.1.3/discovery-boundary.mdx
@@ -5,7 +5,7 @@ category: "experiments-added"
 
 #### `bounded-discovery` experiment encloses graph discovery within a directory
 
-Filter expressions that traverse the dependency graph reach beyond the working directory: dependents (`--filter '...{unit}'`) by walking up to the git repository root, dependencies (`--filter '{unit}...'`) by following declared paths. Either way, Terragrunt reads and parses every configuration it touches. In monorepos with isolated environments, that traversal can fail or do wasted work reading sibling environments.
+Filter expressions that traverse the dependency graph reach beyond the working directory: dependents (`--filter '...{unit}'`) by walking up to the git repository root, dependencies (`--filter '{unit}...'`) by following declared paths. In monorepos with isolated environments, that traversal can fail or do wasted work reaching into sibling environments.
 
 Enable the new [`bounded-discovery`](/reference/experiments/active#bounded-discovery) experiment to unlock the `--discovery-boundary` flag (env: `TG_DISCOVERY_BOUNDARY`), which replaces the git repository root as a single enclosure for that traversal:
 
@@ -14,7 +14,9 @@ cd environments/staging
 terragrunt run --all plan --experiment bounded-discovery --filter '...{vpc}' --discovery-boundary .
 ```
 
-Any configuration that resolves outside the boundary, whether a dependent or a dependency, is neither read nor parsed nor returned; configurations inside it are discovered as usual. The boundary must be an existing directory, and relative paths are resolved against the working directory. Dependent traversal searches upward from the working directory, so filters that use it also need the boundary to be the working directory or one of its parents. Dependency traversal follows declared paths from the units a filter matched, so dependency-only filters accept any directory, including one below the working directory:
+A configuration that traversal reaches outside the boundary, whether a dependent or a dependency, is not returned: `find` does not list it and `run --all` does not run it. It is still read, because a unit inside the boundary that depends on it needs its outputs, and the dependency edge between them still orders the units that do run.
+
+The boundary must be an existing directory, and relative paths are resolved against the working directory. Dependent traversal searches upward from the working directory, so filters that use it also need the boundary to be the working directory or one of its parents. Dependency traversal follows declared paths from the units a filter matched, so dependency-only filters accept any directory, including one below the working directory:
 
 ```bash
 # From the repository root, follow app's dependencies but keep them within prod

--- a/docs/src/data/flags/discovery-boundary.mdx
+++ b/docs/src/data/flags/discovery-boundary.mdx
@@ -13,9 +13,11 @@ import { Aside } from '@astrojs/starlight/components';
 This flag is gated behind the [`bounded-discovery`](/reference/experiments/active#bounded-discovery) experiment. Enable it with `--experiment=bounded-discovery` (or `TG_EXPERIMENT=bounded-discovery`); otherwise setting `--discovery-boundary` returns an error. The flag's behavior may change while the experiment is in progress.
 </Aside>
 
-Filter expressions that traverse the dependency graph reach beyond the working directory. Dependents (`...{unit}`) can live anywhere, so Terragrunt searches from the working directory up to the git repository root; dependencies (`{unit}...`) are declared by path and can point anywhere. Either way, Terragrunt reads and parses every configuration it touches along the way.
+Filter expressions that traverse the dependency graph reach beyond the working directory. Dependents (`...{unit}`) can live anywhere, so Terragrunt searches from the working directory up to the git repository root; dependencies (`{unit}...`) are declared by path and can point anywhere.
 
-The `--discovery-boundary` flag is a single enclosure for that traversal: it replaces the git repository root as the outer limit, and any configuration that resolves outside it, whether a dependent or a dependency, is neither read nor parsed nor returned. Configurations inside the boundary are discovered as usual.
+The `--discovery-boundary` flag is a single enclosure for that traversal: it replaces the git repository root as the outer limit, and a configuration that traversal reaches outside it is not returned, so `find` does not list it and `run --all` does not run it. Configurations inside the boundary are discovered as usual.
+
+The boundary decides which configurations a command acts on, not which ones Terragrunt may read. A unit inside the boundary can declare a dependency outside it, and that dependency is still read and parsed: Terragrunt needs its configuration to fetch the outputs the dependent unit consumes, and it needs the dependency edge to order the units that do run. What the boundary withholds is the unit itself, which is left for a separate run to apply, the same way a dependency outside the working directory is treated today.
 
 This matters in monorepos where environments are isolated from each other. When sibling environments cannot be parsed independently, the default search fails or wastes work reaching into them:
 
@@ -51,5 +53,7 @@ terragrunt find --filter '{./prod/app}...' --discovery-boundary ./prod
 ```
 
 The boundary must be an existing directory. Relative paths are resolved against the working directory.
+
+The boundary applies to what traversal reaches, so a command that names no filter keeps every configuration under the working directory even when the boundary sits below it. Narrow the working directory itself, with `--working-dir`, to change where discovery starts.
 
 Where the boundary may sit depends on the directions the filters traverse. Dependent traversal searches upward from the working directory, so a boundary that excludes the working directory could never take effect; filters that traverse dependents require the boundary to be the working directory or one of its parents. Dependency traversal follows declared paths outward from the units a filter matched and never consults the working directory, so filters that traverse only dependencies accept any directory, including one below the working directory. That is the same rule the inline `(dir)` operand follows.

--- a/docs/src/data/flags/discovery-boundary.mdx
+++ b/docs/src/data/flags/discovery-boundary.mdx
@@ -45,6 +45,11 @@ terragrunt run --all plan --filter '...{vpc}' --discovery-boundary ..
 
 # Equivalent, via environment variable
 TG_DISCOVERY_BOUNDARY=. terragrunt find --filter '...{vpc}'
+
+# From the repository root, keep app's dependencies within prod
+terragrunt find --filter '{./prod/app}...' --discovery-boundary ./prod
 ```
 
-The boundary must be an existing directory that is the working directory or one of its parents. Relative paths are resolved against the working directory.
+The boundary must be an existing directory. Relative paths are resolved against the working directory.
+
+Where the boundary may sit depends on the directions the filters traverse. Dependent traversal searches upward from the working directory, so a boundary that excludes the working directory could never take effect; filters that traverse dependents require the boundary to be the working directory or one of its parents. Dependency traversal follows declared paths outward from the units a filter matched and never consults the working directory, so filters that traverse only dependencies accept any directory, including one below the working directory. That is the same rule the inline `(dir)` operand follows.

--- a/internal/discovery/constructor.go
+++ b/internal/discovery/constructor.go
@@ -40,7 +40,7 @@ type StackGenerateOptions struct {
 }
 
 // NewForDiscoveryCommand creates a Discovery configured for discovery commands (find/list).
-func NewForDiscoveryCommand(l log.Logger, fs vfs.FS, opts *DiscoveryCommandOptions) (*Discovery, error) {
+func NewForDiscoveryCommand(l log.Logger, fsys vfs.FS, opts *DiscoveryCommandOptions) (*Discovery, error) {
 	d := NewDiscovery(opts.WorkingDir).
 		WithSuppressParseErrors().
 		WithBreakCycles()
@@ -104,7 +104,7 @@ func NewForDiscoveryCommand(l log.Logger, fs vfs.FS, opts *DiscoveryCommandOptio
 
 	if opts.DiscoveryBoundary != "" {
 		boundary, err := resolveDiscoveryBoundary(
-			fs,
+			fsys,
 			opts.WorkingDir,
 			opts.DiscoveryBoundary,
 			boundaryEnclosureFor(opts.Filters),
@@ -120,7 +120,7 @@ func NewForDiscoveryCommand(l log.Logger, fs vfs.FS, opts *DiscoveryCommandOptio
 }
 
 // NewForHCLCommand creates a Discovery configured for HCL commands (hcl validate/format).
-func NewForHCLCommand(l log.Logger, fs vfs.FS, opts HCLCommandOptions) (*Discovery, error) {
+func NewForHCLCommand(l log.Logger, fsys vfs.FS, opts HCLCommandOptions) (*Discovery, error) {
 	d := NewDiscovery(opts.WorkingDir)
 
 	if len(opts.Filters) > 0 {
@@ -129,7 +129,7 @@ func NewForHCLCommand(l log.Logger, fs vfs.FS, opts HCLCommandOptions) (*Discove
 
 	if opts.DiscoveryBoundary != "" {
 		boundary, err := resolveDiscoveryBoundary(
-			fs,
+			fsys,
 			opts.WorkingDir,
 			opts.DiscoveryBoundary,
 			boundaryEnclosureFor(opts.Filters),

--- a/internal/discovery/constructor.go
+++ b/internal/discovery/constructor.go
@@ -103,7 +103,12 @@ func NewForDiscoveryCommand(l log.Logger, fs vfs.FS, opts *DiscoveryCommandOptio
 	}
 
 	if opts.DiscoveryBoundary != "" {
-		boundary, err := resolveDiscoveryBoundary(fs, opts.WorkingDir, opts.DiscoveryBoundary)
+		boundary, err := resolveDiscoveryBoundary(
+			fs,
+			opts.WorkingDir,
+			opts.DiscoveryBoundary,
+			boundaryEnclosureFor(opts.Filters),
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -123,7 +128,12 @@ func NewForHCLCommand(l log.Logger, fs vfs.FS, opts HCLCommandOptions) (*Discove
 	}
 
 	if opts.DiscoveryBoundary != "" {
-		boundary, err := resolveDiscoveryBoundary(fs, opts.WorkingDir, opts.DiscoveryBoundary)
+		boundary, err := resolveDiscoveryBoundary(
+			fs,
+			opts.WorkingDir,
+			opts.DiscoveryBoundary,
+			boundaryEnclosureFor(opts.Filters),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -34,7 +34,12 @@ func (d *Discovery) Discover(
 	l.Debugf("Discovery: %d filter(s) configured: %s", len(d.filters), d.filters)
 
 	if d.discoveryBoundary != "" {
-		boundary, boundaryErr := resolveDiscoveryBoundary(v.FS, d.workingDir, d.discoveryBoundary)
+		boundary, boundaryErr := resolveDiscoveryBoundary(
+			v.FS,
+			d.workingDir,
+			d.discoveryBoundary,
+			boundaryEnclosureFor(d.filters),
+		)
 		if boundaryErr != nil {
 			return nil, boundaryErr
 		}
@@ -198,7 +203,7 @@ func (d *Discovery) Discover(
 			len(components),
 		)
 
-		filtered, err := d.filters.Evaluate(l, components)
+		filtered, err := d.filters.Evaluate(l, d.evaluationContext(), components)
 		if err != nil {
 			return components, err
 		}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -31,6 +31,16 @@ func (d *Discovery) Discover(
 ) (component.Components, error) {
 	d.classifier = filter.NewClassifier(d.filters)
 
+	// A working directory that cannot be walked to discovers nothing, which is
+	// reported as an empty result rather than an error, so it keeps the
+	// spelling it was given and comparisons against it stay consistent.
+	resolvedWorkingDir, resolveErr := resolveDir(v.FS, d.workingDir)
+	if resolveErr != nil {
+		resolvedWorkingDir = filepath.Clean(d.workingDir)
+	}
+
+	d.resolvedWorkingDir = resolvedWorkingDir
+
 	l.Debugf("Discovery: %d filter(s) configured: %s", len(d.filters), d.filters)
 
 	if d.discoveryBoundary != "" {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -227,6 +227,8 @@ func (d *Discovery) Discover(
 		components = filtered
 	}
 
+	components = d.dropOutsideBoundary(l, components)
+
 	cycleCheckErr := telemetry.TelemeterFromContext(ctx).
 		Collect(ctx, l, "discovery_cycle_check", map[string]any{},
 			func(childCtx context.Context, l log.Logger) error {
@@ -815,6 +817,56 @@ func (d *Discovery) applyQueueFilters(
 	components = d.applyExcludeModules(opts, components)
 
 	return components
+}
+
+// dropOutsideBoundary removes the components graph traversal reached across the
+// discovery boundary from what discovery returns. Their configurations were
+// still read and the edges pointing at them still stand, so the components that
+// do run can be ordered against them and can fetch their outputs. Components the
+// filesystem walk found are left alone, boundary or not: the boundary says how
+// far a run may follow the graph, not where discovery starts.
+func (d *Discovery) dropOutsideBoundary(l log.Logger, components component.Components) component.Components {
+	if d.discoveryBoundary == "" {
+		return components
+	}
+
+	// An inline "(dir)" operand overrides the flag for the expression carrying
+	// it, and evaluation has already honored that. Applying the flag again here
+	// would undo an operand that reaches wider than it.
+	if d.filters.HasGraphBoundary() {
+		return components
+	}
+
+	kept := make(component.Components, 0, len(components))
+
+	for _, c := range components {
+		if reachedByTraversal(c) && isExternal(d.discoveryBoundary, c.Path()) {
+			l.Debugf(
+				"Discovery: %s was reached across discovery boundary %s; not returning it",
+				c.Path(),
+				d.discoveryBoundary,
+			)
+
+			continue
+		}
+
+		kept = append(kept, c)
+	}
+
+	return kept
+}
+
+// reachedByTraversal reports whether a component entered discovery by following
+// the dependency graph rather than by being walked to.
+func reachedByTraversal(c component.Component) bool {
+	dctx := c.DiscoveryContext()
+	if dctx == nil {
+		return false
+	}
+
+	origin := dctx.Origin()
+
+	return origin == component.OriginGraphDiscovery || origin == component.OriginRelationshipDiscovery
 }
 
 // applyExcludeModules marks units (and optionally their dependencies) excluded via terragrunt exclude blocks.

--- a/internal/discovery/discovery_boundary_test.go
+++ b/internal/discovery/discovery_boundary_test.go
@@ -1,6 +1,7 @@
 package discovery_test
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -370,6 +371,85 @@ func TestDiscoveryBoundary_DependencyDirectionOutsideWorkingDir(t *testing.T) {
 			configs, err := f.discover(t, v, "{"+f.edgeDir+"}...", tc.boundary)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, paths, configs.Filter(component.UnitKind).Paths())
+		})
+	}
+}
+
+// Test that relationship discovery stops at the boundary rather than leaving the
+// pruning to filter evaluation. Evaluation drops out-of-boundary components from
+// the result either way, so the observable difference is on the kept components:
+// their dependency edges no longer point across the boundary, which is what shows
+// the out-of-boundary configuration was never read.
+func TestDiscoveryBoundary_RelationshipDiscoveryStopsAtBoundary(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		query        string
+		boundary     string
+		expectedDeps []string
+	}{
+		{
+			name:         "flag boundary prunes the crossing edge",
+			query:        "{%[1]s}...",
+			boundary:     ".",
+			expectedDeps: nil,
+		},
+		{
+			// The inline operand overrides the flag and reaches wider, so
+			// relationship discovery must not have pruned to the flag.
+			name:         "wider inline operand keeps the crossing edge",
+			query:        "{%[1]s}...(..)",
+			boundary:     ".",
+			expectedDeps: []string{"external"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f, v := newBoundaryFixture(t)
+
+			byName := map[string]string{"external": f.externalDir}
+			expected := make([]string, len(tc.expectedDeps))
+
+			for i, n := range tc.expectedDeps {
+				expected[i] = byName[n]
+			}
+
+			opts := options.NewTerragruntOptions()
+			opts.WorkingDir = f.stagingDir
+			opts.RootWorkingDir = f.stagingDir
+
+			query := fmt.Sprintf(tc.query, f.edgeDir)
+
+			filters, err := filter.ParseFilterQueries(logger.CreateLogger(), []string{query})
+			require.NoError(t, err)
+
+			configs, err := discovery.NewDiscovery(f.stagingDir).
+				WithFilters(filters).
+				WithRelationships().
+				WithDiscoveryBoundary(tc.boundary).
+				Discover(t.Context(), logger.CreateLogger(), v, opts)
+			require.NoError(t, err)
+
+			var edge component.Component
+
+			for _, c := range configs {
+				if c.Path() == f.edgeDir {
+					edge = c
+				}
+			}
+
+			require.NotNil(t, edge, "edge should always be discovered; it is the filter target")
+
+			depPaths := make([]string, 0, len(edge.Dependencies()))
+			for _, dep := range edge.Dependencies() {
+				depPaths = append(depPaths, dep.Path())
+			}
+
+			assert.ElementsMatch(t, expected, depPaths)
 		})
 	}
 }

--- a/internal/discovery/discovery_boundary_test.go
+++ b/internal/discovery/discovery_boundary_test.go
@@ -211,18 +211,34 @@ func TestNewForDiscoveryCommand_DiscoveryBoundaryValidation(t *testing.T) {
 
 	f, v := newBoundaryFixture(t)
 
+	newForDiscoveryCommand := func(t *testing.T, query, boundary string) (*discovery.Discovery, error) {
+		t.Helper()
+
+		filters, err := filter.ParseFilterQueries(logger.CreateLogger(), []string{query})
+		require.NoError(t, err)
+
+		return discovery.NewForDiscoveryCommand(logger.CreateLogger(), v.FS, &discovery.DiscoveryCommandOptions{
+			WorkingDir:        f.stagingDir,
+			DiscoveryBoundary: boundary,
+			Filters:           filters,
+		})
+	}
+
 	testCases := []struct {
 		errAs    any
 		name     string
+		query    string
 		boundary string
 	}{
 		{
 			name:     "nonexistent boundary",
+			query:    "...{" + f.vpcDir + "}",
 			boundary: filepath.Join(f.repoRoot, "does-not-exist"),
 			errAs:    &discovery.DiscoveryBoundaryDirError{},
 		},
 		{
-			name:     "boundary does not contain working directory",
+			name:     "dependent direction cannot start outside the boundary",
+			query:    "...{" + f.vpcDir + "}",
 			boundary: f.consumerDir,
 			errAs:    &discovery.DiscoveryBoundaryScopeError{},
 		},
@@ -232,10 +248,7 @@ func TestNewForDiscoveryCommand_DiscoveryBoundaryValidation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := discovery.NewForDiscoveryCommand(logger.CreateLogger(), v.FS, &discovery.DiscoveryCommandOptions{
-				WorkingDir:        f.stagingDir,
-				DiscoveryBoundary: tc.boundary,
-			})
+			_, err := newForDiscoveryCommand(t, tc.query, tc.boundary)
 			require.ErrorAs(t, err, tc.errAs)
 		})
 	}
@@ -243,11 +256,120 @@ func TestNewForDiscoveryCommand_DiscoveryBoundaryValidation(t *testing.T) {
 	t.Run("valid boundary", func(t *testing.T) {
 		t.Parallel()
 
-		d, err := discovery.NewForDiscoveryCommand(logger.CreateLogger(), v.FS, &discovery.DiscoveryCommandOptions{
-			WorkingDir:        f.stagingDir,
-			DiscoveryBoundary: "..",
-		})
+		d, err := newForDiscoveryCommand(t, "...{"+f.vpcDir+"}", "..")
 		require.NoError(t, err)
 		require.NotNil(t, d)
 	})
+
+	t.Run("dependency direction accepts a boundary outside the working directory", func(t *testing.T) {
+		t.Parallel()
+
+		d, err := newForDiscoveryCommand(t, "{"+f.edgeDir+"}...", f.consumerDir)
+		require.NoError(t, err)
+		require.NotNil(t, d)
+	})
+}
+
+// Test that the boundary survives filter evaluation when relationships are
+// discovered, as the runner pool does for `run --all`. Components kept by the
+// graph phase still carry edges pointing across the boundary, so evaluation
+// has to refuse to follow them rather than growing the set back.
+func TestDiscoveryBoundary_SurvivesFilterEvaluationWithRelationships(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		boundary string
+		expected []string
+	}{
+		{
+			name:     "unbounded traversal reaches the sibling environment",
+			boundary: "",
+			expected: []string{"edge", "external"},
+		},
+		{
+			name:     "bounded traversal stops at the boundary",
+			boundary: ".",
+			expected: []string{"edge"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f, v := newBoundaryFixture(t)
+
+			byName := map[string]string{"edge": f.edgeDir, "external": f.externalDir}
+			paths := make([]string, len(tc.expected))
+
+			for i, n := range tc.expected {
+				paths[i] = byName[n]
+			}
+
+			opts := options.NewTerragruntOptions()
+			opts.WorkingDir = f.stagingDir
+			opts.RootWorkingDir = f.stagingDir
+
+			filters, err := filter.ParseFilterQueries(logger.CreateLogger(), []string{"{" + f.edgeDir + "}..."})
+			require.NoError(t, err)
+
+			d := discovery.NewDiscovery(f.stagingDir).WithFilters(filters).WithRelationships()
+
+			if tc.boundary != "" {
+				d = d.WithDiscoveryBoundary(tc.boundary)
+			}
+
+			configs, err := d.Discover(t.Context(), logger.CreateLogger(), v, opts)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, paths, configs.Filter(component.UnitKind).Paths())
+		})
+	}
+}
+
+// Test that a boundary the working directory sits outside of is accepted and
+// honored for dependency-direction filters, matching what the equivalent
+// inline "(dir)" operand already does.
+func TestDiscoveryBoundary_DependencyDirectionOutsideWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	f, v := newBoundaryFixture(t)
+
+	// environments/production holds edge's dependency but not the working
+	// directory (environments/staging).
+	productionDir := filepath.Dir(f.externalDir)
+
+	testCases := []struct {
+		name     string
+		boundary string
+		expected []string
+	}{
+		{
+			name:     "dependency inside the boundary is traversed",
+			boundary: productionDir,
+			expected: []string{"edge", "external"},
+		},
+		{
+			name:     "dependency outside the boundary is pruned",
+			boundary: f.consumerDir,
+			expected: []string{"edge"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			byName := map[string]string{"edge": f.edgeDir, "external": f.externalDir}
+			paths := make([]string, len(tc.expected))
+
+			for i, n := range tc.expected {
+				paths[i] = byName[n]
+			}
+
+			configs, err := f.discover(t, v, "{"+f.edgeDir+"}...", tc.boundary)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, paths, configs.Filter(component.UnitKind).Paths())
+		})
+	}
 }

--- a/internal/discovery/discovery_boundary_test.go
+++ b/internal/discovery/discovery_boundary_test.go
@@ -375,33 +375,76 @@ func TestDiscoveryBoundary_DependencyDirectionOutsideWorkingDir(t *testing.T) {
 	}
 }
 
-// Test that relationship discovery stops at the boundary rather than leaving the
-// pruning to filter evaluation. Evaluation drops out-of-boundary components from
-// the result either way, so the observable difference is on the kept components:
-// their dependency edges no longer point across the boundary, which is what shows
-// the out-of-boundary configuration was never read.
-func TestDiscoveryBoundary_RelationshipDiscoveryStopsAtBoundary(t *testing.T) {
+// Test that a run carrying no filter keeps every component the filesystem walk
+// found, boundary or not, and only withholds what traversal reached across the
+// boundary. A component that stays in the run has to keep the edges that order
+// it, so an edge may only be withheld along with the component it points at.
+func TestDiscoveryBoundary_UnfilteredRunWithholdsOnlyWhatTraversalReached(t *testing.T) {
+	t.Parallel()
+
+	f, v := newBoundaryFixture(t)
+
+	opts := options.NewTerragruntOptions()
+	opts.WorkingDir = f.stagingDir
+	opts.RootWorkingDir = f.stagingDir
+
+	configs, err := discovery.NewDiscovery(f.stagingDir).
+		WithRelationships().
+		WithDiscoveryBoundary(".").
+		Discover(t.Context(), logger.CreateLogger(), v, opts)
+	require.NoError(t, err)
+
+	// production/external is edge's dependency, reached across the boundary.
+	assert.ElementsMatch(
+		t,
+		[]string{f.vpcDir, f.appDir, f.edgeDir},
+		configs.Filter(component.UnitKind).Paths(),
+	)
+
+	var edge component.Component
+
+	for _, c := range configs {
+		if c.Path() == f.edgeDir {
+			edge = c
+		}
+	}
+
+	require.NotNil(t, edge)
+
+	depPaths := make([]string, 0, len(edge.Dependencies()))
+	for _, dep := range edge.Dependencies() {
+		depPaths = append(depPaths, dep.Path())
+	}
+
+	assert.Equal(t, []string{f.externalDir}, depPaths, "the edge that orders edge against its dependency stands")
+}
+
+// Test that a dependency the boundary excludes is still read and still linked.
+// Dropping the edge would leave a run unable to order itself against that
+// dependency or fetch its outputs, so the boundary has to keep the edge while
+// keeping the component itself out of what discovery returns.
+func TestDiscoveryBoundary_ExcludedDependencyStaysLinked(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name         string
-		query        string
-		boundary     string
-		expectedDeps []string
+		name     string
+		query    string
+		boundary string
+		returned []string
 	}{
 		{
-			name:         "flag boundary prunes the crossing edge",
-			query:        "{%[1]s}...",
-			boundary:     ".",
-			expectedDeps: nil,
+			name:     "flag boundary keeps the crossing edge out of the result",
+			query:    "{%[1]s}...",
+			boundary: ".",
+			returned: []string{"edge"},
 		},
 		{
-			// The inline operand overrides the flag and reaches wider, so
-			// relationship discovery must not have pruned to the flag.
-			name:         "wider inline operand keeps the crossing edge",
-			query:        "{%[1]s}...(..)",
-			boundary:     ".",
-			expectedDeps: []string{"external"},
+			// The inline operand overrides the flag and reaches wider, so the
+			// dependency it reaches is returned as well as linked.
+			name:     "wider inline operand returns what it reaches",
+			query:    "{%[1]s}...(..)",
+			boundary: ".",
+			returned: []string{"edge", "external"},
 		},
 	}
 
@@ -411,10 +454,10 @@ func TestDiscoveryBoundary_RelationshipDiscoveryStopsAtBoundary(t *testing.T) {
 
 			f, v := newBoundaryFixture(t)
 
-			byName := map[string]string{"external": f.externalDir}
-			expected := make([]string, len(tc.expectedDeps))
+			byName := map[string]string{"edge": f.edgeDir, "external": f.externalDir}
+			expected := make([]string, len(tc.returned))
 
-			for i, n := range tc.expectedDeps {
+			for i, n := range tc.returned {
 				expected[i] = byName[n]
 			}
 
@@ -434,6 +477,8 @@ func TestDiscoveryBoundary_RelationshipDiscoveryStopsAtBoundary(t *testing.T) {
 				Discover(t.Context(), logger.CreateLogger(), v, opts)
 			require.NoError(t, err)
 
+			assert.ElementsMatch(t, expected, configs.Filter(component.UnitKind).Paths())
+
 			var edge component.Component
 
 			for _, c := range configs {
@@ -449,7 +494,12 @@ func TestDiscoveryBoundary_RelationshipDiscoveryStopsAtBoundary(t *testing.T) {
 				depPaths = append(depPaths, dep.Path())
 			}
 
-			assert.ElementsMatch(t, expected, depPaths)
+			assert.Equal(
+				t,
+				[]string{f.externalDir},
+				depPaths,
+				"the dependency stays linked whether or not the boundary returns it",
+			)
 		})
 	}
 }

--- a/internal/discovery/errors.go
+++ b/internal/discovery/errors.go
@@ -191,7 +191,8 @@ type DiscoveryBoundaryScopeError struct {
 func (e DiscoveryBoundaryScopeError) Error() string {
 	return fmt.Sprintf(
 		"discovery boundary %q does not contain the working directory %q. "+
-			"The boundary must be the working directory or one of its parent directories.",
+			"Filters that traverse dependents search upward from the working directory, "+
+			"so their boundary must be the working directory or one of its parent directories.",
 		e.Boundary, e.WorkingDir,
 	)
 }

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -521,44 +521,6 @@ func resolveGraphBoundary(fsys vfs.FS, workingDir, boundary string) (string, err
 	return resolved, nil
 }
 
-// relationshipBoundaries returns every directory a filter on this run could
-// confine graph traversal to. Relationship discovery holds no filter expression,
-// so it may only skip a dependency falling outside all of them; evaluation
-// applies the exact per-expression boundary afterwards.
-func (d *Discovery) relationshipBoundaries() []string {
-	// Without the flag, an expression carrying no inline operand is unbounded,
-	// and pruning it to another expression's operand would rob it of
-	// dependencies it may reach.
-	if d.discoveryBoundary == "" {
-		return nil
-	}
-
-	inline := d.filters.GraphBoundaries()
-	boundaries := make([]string, 0, len(inline)+1)
-	boundaries = append(boundaries, d.discoveryBoundary)
-
-	// An inline operand overrides the flag, so it can reach wider than it.
-	for _, raw := range inline {
-		boundaries = append(boundaries, absBoundary(d.workingDir, raw))
-	}
-
-	slices.Sort(boundaries)
-
-	return slices.Compact(boundaries)
-}
-
-// outsideBoundaries reports whether path falls outside every one of boundaries.
-// No boundaries means nothing is out of bounds.
-func outsideBoundaries(boundaries []string, path string) bool {
-	if len(boundaries) == 0 {
-		return false
-	}
-
-	return !slices.ContainsFunc(boundaries, func(boundary string) bool {
-		return !isExternal(boundary, path)
-	})
-}
-
 // boundaryEnclosure states whether a discovery boundary has to enclose the
 // working directory to be usable.
 type boundaryEnclosure int

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -461,18 +461,33 @@ func (d *Discovery) dependentWalkBoundary() string {
 }
 
 // evaluationContext hands filter evaluation the settings its graph traversal
-// has to honor. Discover resolves the boundary before any phase runs, so this
-// carries the absolute path rather than the raw user input.
+// has to honor. Discover resolves the boundary and the working directory before
+// any phase runs, so this carries absolute paths rather than raw user input.
 func (d *Discovery) evaluationContext() filter.EvaluationContext {
 	return filter.EvaluationContext{
-		WorkingDir:        d.workingDir,
-		DiscoveryBoundary: d.discoveryBoundary,
+		WorkingDir:         d.workingDir,
+		ResolvedWorkingDir: d.resolvedWorkingDir,
+		DiscoveryBoundary:  d.discoveryBoundary,
 	}
 }
 
+// resolveDir canonicalizes dir through the discovery filesystem, so that the
+// paths a boundary is compared against are resolved by the same filesystem that
+// produced them rather than by the OS underneath it. Resolution fails on a
+// directory that cannot be walked to, so callers that do not require dir to
+// exist have to say what an unwalkable path means to them.
+func resolveDir(fsys vfs.FS, dir string) (string, error) {
+	resolved, err := vfs.EvalSymlinks(fsys, dir)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Clean(resolved), nil
+}
+
 // validateBoundaryDir reports whether resolved names an existing directory.
-func validateBoundaryDir(fs vfs.FS, resolved string) error {
-	info, err := fs.Stat(resolved)
+func validateBoundaryDir(fsys vfs.FS, resolved string) error {
+	info, err := fsys.Stat(resolved)
 	if err != nil {
 		return NewDiscoveryBoundaryDirError(resolved, err)
 	}
@@ -496,10 +511,10 @@ func absBoundary(workingDir, boundary string) string {
 // resolveGraphBoundary canonicalizes a raw "(dir)" boundary value against
 // the working directory and validates that it points at an existing directory.
 // Returns the resolved absolute path.
-func resolveGraphBoundary(fs vfs.FS, workingDir, boundary string) (string, error) {
+func resolveGraphBoundary(fsys vfs.FS, workingDir, boundary string) (string, error) {
 	resolved := absBoundary(workingDir, boundary)
 
-	if err := validateBoundaryDir(fs, resolved); err != nil {
+	if err := validateBoundaryDir(fsys, resolved); err != nil {
 		return "", err
 	}
 
@@ -572,16 +587,21 @@ func boundaryEnclosureFor(filters filter.Filters) boundaryEnclosure {
 // it to contain the working directory only when enclosure demands it. Returns the
 // resolved absolute path.
 func resolveDiscoveryBoundary(
-	fs vfs.FS,
+	fsys vfs.FS,
 	workingDir, boundary string,
 	enclosure boundaryEnclosure,
 ) (string, error) {
-	resolved, err := util.CanonicalResolvedPath(boundary, workingDir)
+	canonical, err := util.CanonicalPath(boundary, workingDir)
 	if err != nil {
 		return "", NewDiscoveryBoundaryDirError(boundary, err)
 	}
 
-	if err := validateBoundaryDir(fs, resolved); err != nil {
+	resolved, err := resolveDir(fsys, canonical)
+	if err != nil {
+		return "", NewDiscoveryBoundaryDirError(canonical, err)
+	}
+
+	if err := validateBoundaryDir(fsys, resolved); err != nil {
 		return "", err
 	}
 
@@ -589,7 +609,14 @@ func resolveDiscoveryBoundary(
 		return resolved, nil
 	}
 
-	resolvedWorkingDir := util.ResolvePath(workingDir)
+	// Enclosure asks where the working directory sits, not whether it exists,
+	// and discovery answers a working directory that holds nothing with an
+	// empty result rather than an error. A path that cannot be walked to keeps
+	// the spelling it was given.
+	resolvedWorkingDir, err := resolveDir(fsys, workingDir)
+	if err != nil {
+		resolvedWorkingDir = filepath.Clean(workingDir)
+	}
 
 	rel, err := filepath.Rel(resolved, resolvedWorkingDir)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
 	inthclparse "github.com/gruntwork-io/terragrunt/internal/hclparse"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
@@ -459,6 +460,16 @@ func (d *Discovery) dependentWalkBoundary() string {
 	return d.gitRoot
 }
 
+// evaluationContext hands filter evaluation the settings its graph traversal
+// has to honor. Discover resolves the boundary before any phase runs, so this
+// carries the absolute path rather than the raw user input.
+func (d *Discovery) evaluationContext() filter.EvaluationContext {
+	return filter.EvaluationContext{
+		WorkingDir:        d.workingDir,
+		DiscoveryBoundary: d.discoveryBoundary,
+	}
+}
+
 // validateBoundaryDir reports whether resolved names an existing directory.
 func validateBoundaryDir(fs vfs.FS, resolved string) error {
 	info, err := fs.Stat(resolved)
@@ -491,10 +502,38 @@ func resolveGraphBoundary(fs vfs.FS, workingDir, boundary string) (string, error
 	return resolved, nil
 }
 
+// boundaryEnclosure states whether a discovery boundary has to enclose the
+// working directory to be usable.
+type boundaryEnclosure int
+
+const (
+	boundaryEnclosureOptional boundaryEnclosure = iota
+	boundaryEnclosureRequired
+)
+
+// boundaryEnclosureFor reports what the given filters demand of a discovery
+// boundary. Only the dependent walk starts at the working directory, so only
+// it is defeated by a boundary that excludes the working directory. Dependency
+// traversal starts at the matched components and follows their declared
+// dependencies, so a boundary narrower than the working directory prunes that
+// walk exactly as the inline "(dir)" operand does.
+func boundaryEnclosureFor(filters filter.Filters) boundaryEnclosure {
+	if filters.HasDependents() {
+		return boundaryEnclosureRequired
+	}
+
+	return boundaryEnclosureOptional
+}
+
 // resolveDiscoveryBoundary canonicalizes a user-supplied discovery boundary against
-// the working directory and validates that it is an existing directory that
-// contains the working directory. Returns the resolved absolute path.
-func resolveDiscoveryBoundary(fs vfs.FS, workingDir, boundary string) (string, error) {
+// the working directory and validates that it is an existing directory, requiring
+// it to contain the working directory only when enclosure demands it. Returns the
+// resolved absolute path.
+func resolveDiscoveryBoundary(
+	fs vfs.FS,
+	workingDir, boundary string,
+	enclosure boundaryEnclosure,
+) (string, error) {
 	resolved, err := util.CanonicalResolvedPath(boundary, workingDir)
 	if err != nil {
 		return "", NewDiscoveryBoundaryDirError(boundary, err)
@@ -502,6 +541,10 @@ func resolveDiscoveryBoundary(fs vfs.FS, workingDir, boundary string) (string, e
 
 	if err := validateBoundaryDir(fs, resolved); err != nil {
 		return "", err
+	}
+
+	if enclosure == boundaryEnclosureOptional {
+		return resolved, nil
 	}
 
 	resolvedWorkingDir := util.ResolvePath(workingDir)

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -484,22 +484,64 @@ func validateBoundaryDir(fs vfs.FS, resolved string) error {
 	return nil
 }
 
+// absBoundary canonicalizes a raw boundary value against the working directory.
+func absBoundary(workingDir, boundary string) string {
+	if filepath.IsAbs(boundary) {
+		return filepath.Clean(boundary)
+	}
+
+	return filepath.Clean(filepath.Join(workingDir, boundary))
+}
+
 // resolveGraphBoundary canonicalizes a raw "(dir)" boundary value against
 // the working directory and validates that it points at an existing directory.
 // Returns the resolved absolute path.
 func resolveGraphBoundary(fs vfs.FS, workingDir, boundary string) (string, error) {
-	resolved := boundary
-	if !filepath.IsAbs(resolved) {
-		resolved = filepath.Join(workingDir, resolved)
-	}
-
-	resolved = filepath.Clean(resolved)
+	resolved := absBoundary(workingDir, boundary)
 
 	if err := validateBoundaryDir(fs, resolved); err != nil {
 		return "", err
 	}
 
 	return resolved, nil
+}
+
+// relationshipBoundaries returns every directory a filter on this run could
+// confine graph traversal to. Relationship discovery holds no filter expression,
+// so it may only skip a dependency falling outside all of them; evaluation
+// applies the exact per-expression boundary afterwards.
+func (d *Discovery) relationshipBoundaries() []string {
+	// Without the flag, an expression carrying no inline operand is unbounded,
+	// and pruning it to another expression's operand would rob it of
+	// dependencies it may reach.
+	if d.discoveryBoundary == "" {
+		return nil
+	}
+
+	inline := d.filters.GraphBoundaries()
+	boundaries := make([]string, 0, len(inline)+1)
+	boundaries = append(boundaries, d.discoveryBoundary)
+
+	// An inline operand overrides the flag, so it can reach wider than it.
+	for _, raw := range inline {
+		boundaries = append(boundaries, absBoundary(d.workingDir, raw))
+	}
+
+	slices.Sort(boundaries)
+
+	return slices.Compact(boundaries)
+}
+
+// outsideBoundaries reports whether path falls outside every one of boundaries.
+// No boundaries means nothing is out of bounds.
+func outsideBoundaries(boundaries []string, path string) bool {
+	if len(boundaries) == 0 {
+		return false
+	}
+
+	return !slices.ContainsFunc(boundaries, func(boundary string) bool {
+		return !isExternal(boundary, path)
+	})
 }
 
 // boundaryEnclosure states whether a discovery boundary has to enclose the

--- a/internal/discovery/phase_parse.go
+++ b/internal/discovery/phase_parse.go
@@ -272,7 +272,7 @@ func (p *ParsePhase) parseAndReclassify(
 
 	if discovery.classifier != nil {
 		for _, expr := range discovery.classifier.ParseExpressions() {
-			matched, err := filter.Evaluate(l, expr, component.Components{c})
+			matched, err := filter.Evaluate(l, discovery.evaluationContext(), expr, component.Components{c})
 			if err != nil {
 				l.Debugf("Error evaluating parse expression for %s: %v", c.Path(), err)
 				continue

--- a/internal/discovery/phase_relationship.go
+++ b/internal/discovery/phase_relationship.go
@@ -30,7 +30,6 @@ type relationshipTraversalState struct {
 	discovery                *Discovery
 	allComponents            *component.Components
 	interTransientComponents *component.ThreadSafeComponents
-	boundaries               []string
 }
 
 // NewRelationshipPhase creates a new RelationshipPhase.
@@ -91,7 +90,6 @@ func (p *RelationshipPhase) runRelationshipDiscovery(
 		discovery:                discovery,
 		allComponents:            &input.Components,
 		interTransientComponents: interTransientComponents,
-		boundaries:               discovery.relationshipBoundaries(),
 	}
 
 	var (
@@ -190,14 +188,10 @@ func (p *RelationshipPhase) discoverRelationships(
 	depsToDiscover := make(component.Components, 0, len(paths))
 
 	for _, path := range paths {
-		// Skipping before the component is materialized is what keeps an
-		// out-of-boundary dependency from being read and parsed at all.
-		if outsideBoundaries(state.boundaries, path) {
-			l.Debugf("Dependency %s is outside every discovery boundary; skipping", path)
-
-			continue
-		}
-
+		// The boundary is deliberately not applied here: a dependency outside it
+		// is still read and linked, so the units that do run can order against
+		// it and fetch its outputs. [Discovery.dropOutsideBoundary] decides what
+		// is returned.
 		dep, created := p.dependencyToDiscover(
 			c,
 			path,

--- a/internal/discovery/phase_relationship.go
+++ b/internal/discovery/phase_relationship.go
@@ -30,6 +30,7 @@ type relationshipTraversalState struct {
 	discovery                *Discovery
 	allComponents            *component.Components
 	interTransientComponents *component.ThreadSafeComponents
+	boundaries               []string
 }
 
 // NewRelationshipPhase creates a new RelationshipPhase.
@@ -90,6 +91,7 @@ func (p *RelationshipPhase) runRelationshipDiscovery(
 		discovery:                discovery,
 		allComponents:            &input.Components,
 		interTransientComponents: interTransientComponents,
+		boundaries:               discovery.relationshipBoundaries(),
 	}
 
 	var (
@@ -188,6 +190,14 @@ func (p *RelationshipPhase) discoverRelationships(
 	depsToDiscover := make(component.Components, 0, len(paths))
 
 	for _, path := range paths {
+		// Skipping before the component is materialized is what keeps an
+		// out-of-boundary dependency from being read and parsed at all.
+		if outsideBoundaries(state.boundaries, path) {
+			l.Debugf("Dependency %s is outside every discovery boundary; skipping", path)
+
+			continue
+		}
+
 		dep, created := p.dependencyToDiscover(
 			c,
 			path,

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -126,6 +126,11 @@ type Discovery struct {
 	// workingDir is the directory to search for Terragrunt configurations.
 	workingDir string
 
+	// resolvedWorkingDir is workingDir with symlinks resolved, which is how
+	// boundaries and dependency paths name it. Discover fills it in before any
+	// phase runs.
+	resolvedWorkingDir string
+
 	// gitRoot is the detected git repository root: the default ceiling for the
 	// upstream dependent walk. It is detected lazily and only when needed, so
 	// it stays empty when a discoveryBoundary is set (see

--- a/internal/filter/classifier_test.go
+++ b/internal/filter/classifier_test.go
@@ -640,7 +640,7 @@ func TestClassifier_AgreesWithEvaluateOnSingleFilters(t *testing.T) {
 				newTestStack("./stacks/stack2"),
 			}
 
-			kept, err := filters.Evaluate(l, components)
+			kept, err := filters.Evaluate(l, filter.EvaluationContext{}, components)
 			require.NoError(t, err)
 
 			classifier := filter.NewClassifier(filters)

--- a/internal/filter/evaluator.go
+++ b/internal/filter/evaluator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -30,23 +31,54 @@ const (
 type graphTraversalParams struct {
 	resultSet   map[string]component.Component
 	visited     map[string]int
+	boundary    string
 	direction   GraphDirection
 	warnOnLimit bool
 }
 
-// EvaluationContext provides additional context for filter evaluation, such as Git worktree directories.
+// EvaluationContext carries the discovery settings that graph traversal has to
+// honor. The zero value traverses the whole component graph.
 type EvaluationContext struct {
-	// GitWorktrees maps Git references to temporary worktree directory paths.
-	// This is used by GitFilter expressions to access different Git references.
-	GitWorktrees map[string]string
-	// WorkingDir is the base working directory for resolving relative paths.
-	WorkingDir string
+	WorkingDir        string
+	DiscoveryBoundary string
+}
+
+// graphBoundary returns the directory confining traversal for one direction of
+// a graph expression, empty when that direction is unbounded. An inline "(dir)"
+// operand overrides the discovery boundary, and is resolved against the working
+// directory the same way discovery resolves it.
+func (c EvaluationContext) graphBoundary(bound GraphBound) string {
+	if bound.Boundary == "" {
+		return c.DiscoveryBoundary
+	}
+
+	if filepath.IsAbs(bound.Boundary) {
+		return filepath.Clean(bound.Boundary)
+	}
+
+	return filepath.Clean(filepath.Join(c.WorkingDir, bound.Boundary))
+}
+
+// outsideBoundary reports whether path falls outside boundary. An empty
+// boundary bounds nothing.
+func outsideBoundary(boundary, path string) bool {
+	if boundary == "" {
+		return false
+	}
+
+	rel, err := filepath.Rel(boundary, filepath.Clean(path))
+	if err != nil {
+		return true
+	}
+
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // Evaluate evaluates an expression against a list of components and returns the filtered components.
 // If logger is provided, it will be used for logging warnings during evaluation.
 func Evaluate(
 	l log.Logger,
+	evalCtx EvaluationContext,
 	expr Expression,
 	components component.Components,
 ) (component.Components, error) {
@@ -60,11 +92,11 @@ func Evaluate(
 	case *AttributeExpression:
 		return evaluateAttributeFilter(l, node, components)
 	case *PrefixExpression:
-		return evaluatePrefixExpression(l, node, components)
+		return evaluatePrefixExpression(l, evalCtx, node, components)
 	case *InfixExpression:
-		return evaluateInfixExpression(l, node, components)
+		return evaluateInfixExpression(l, evalCtx, node, components)
 	case *GraphExpression:
-		return evaluateGraphExpression(l, node, components)
+		return evaluateGraphExpression(l, evalCtx, node, components)
 	case *GitExpression:
 		return evaluateGitFilter(node, components)
 	default:
@@ -245,6 +277,7 @@ func traceFilterMiss(l log.Logger, expr Expression, c component.Component) {
 // evaluatePrefixExpression evaluates a prefix expression (negation).
 func evaluatePrefixExpression(
 	l log.Logger,
+	evalCtx EvaluationContext,
 	expr *PrefixExpression,
 	components component.Components,
 ) (component.Components, error) {
@@ -252,7 +285,7 @@ func evaluatePrefixExpression(
 		return nil, NewEvaluationError("unknown prefix operator: " + expr.Operator)
 	}
 
-	toExclude, err := Evaluate(l, expr.Right, components)
+	toExclude, err := Evaluate(l, evalCtx, expr.Right, components)
 	if err != nil {
 		return nil, err
 	}
@@ -288,6 +321,7 @@ func evaluatePrefixExpression(
 // evaluateInfixExpression evaluates an infix expression (intersection).
 func evaluateInfixExpression(
 	l log.Logger,
+	evalCtx EvaluationContext,
 	expr *InfixExpression,
 	components component.Components,
 ) (component.Components, error) {
@@ -295,12 +329,12 @@ func evaluateInfixExpression(
 		return nil, NewEvaluationError("unknown infix operator: " + expr.Operator)
 	}
 
-	leftResult, err := Evaluate(l, expr.Left, components)
+	leftResult, err := Evaluate(l, evalCtx, expr.Left, components)
 	if err != nil {
 		return nil, err
 	}
 
-	rightResult, err := Evaluate(l, expr.Right, leftResult)
+	rightResult, err := Evaluate(l, evalCtx, expr.Right, leftResult)
 	if err != nil {
 		return nil, err
 	}
@@ -311,10 +345,11 @@ func evaluateInfixExpression(
 // evaluateGraphExpression evaluates a graph expression by traversing dependency/dependent graphs.
 func evaluateGraphExpression(
 	l log.Logger,
+	evalCtx EvaluationContext,
 	expr *GraphExpression,
 	components component.Components,
 ) (component.Components, error) {
-	targetMatches, err := Evaluate(l, expr.Target, components)
+	targetMatches, err := Evaluate(l, evalCtx, expr.Target, components)
 	if err != nil {
 		return nil, err
 	}
@@ -350,6 +385,7 @@ func evaluateGraphExpression(
 		params := &graphTraversalParams{
 			resultSet:   resultSet,
 			visited:     make(map[string]int),
+			boundary:    evalCtx.graphBoundary(expr.Dependencies),
 			direction:   GraphDirectionDependencies,
 			warnOnLimit: warnOnLimit,
 		}
@@ -371,6 +407,7 @@ func evaluateGraphExpression(
 		params := &graphTraversalParams{
 			resultSet:   resultSet,
 			visited:     make(map[string]int),
+			boundary:    evalCtx.graphBoundary(expr.Dependents),
 			direction:   GraphDirectionDependents,
 			warnOnLimit: warnOnLimit,
 		}
@@ -454,6 +491,20 @@ func traverseGraph(
 
 	for _, related := range relatedComponents {
 		relatedPath := related.Path()
+
+		// A component reachable only by passing through the boundary is
+		// excluded along with the hop that leaves it, so traversal stops here
+		// rather than skipping the hop and continuing past it.
+		if outsideBoundary(params.boundary, relatedPath) {
+			l.Debugf(
+				"%s %s is outside discovery boundary %s; skipping",
+				params.direction,
+				relatedPath,
+				params.boundary,
+			)
+
+			continue
+		}
 
 		// It's not clear why this isn't necessary. It might be in the future.
 		// Tests pass without it, however, so we'll leave it out for now.

--- a/internal/filter/evaluator.go
+++ b/internal/filter/evaluator.go
@@ -31,6 +31,7 @@ const (
 type graphTraversalParams struct {
 	resultSet   map[string]component.Component
 	visited     map[string]int
+	evalCtx     EvaluationContext
 	boundary    string
 	direction   GraphDirection
 	warnOnLimit bool
@@ -39,8 +40,32 @@ type graphTraversalParams struct {
 // EvaluationContext carries the discovery settings that graph traversal has to
 // honor. The zero value traverses the whole component graph.
 type EvaluationContext struct {
-	WorkingDir        string
-	DiscoveryBoundary string
+	WorkingDir         string
+	ResolvedWorkingDir string
+	DiscoveryBoundary  string
+}
+
+// canonical restates a path under the working directory in the spelling symlink
+// resolution gave that directory. A directory reaches evaluation under two
+// names whenever the working directory is itself reached through a symlink: the
+// filesystem walk keeps the name Terragrunt was invoked with, while dependency
+// paths come back from config parsing resolved. Those two names never compare
+// equal, which leaves every component looking out of bounds, and substituting
+// the prefix settles it without evaluation having to reach for a filesystem it
+// cannot see.
+func (c EvaluationContext) canonical(path string) string {
+	clean := filepath.Clean(path)
+
+	if c.WorkingDir == "" || c.ResolvedWorkingDir == "" || c.ResolvedWorkingDir == c.WorkingDir {
+		return clean
+	}
+
+	rel, err := filepath.Rel(c.WorkingDir, clean)
+	if err != nil || climbsOut(rel) {
+		return clean
+	}
+
+	return filepath.Join(c.ResolvedWorkingDir, rel)
 }
 
 // graphBoundary returns the directory confining traversal for one direction of
@@ -49,28 +74,39 @@ type EvaluationContext struct {
 // directory the same way discovery resolves it.
 func (c EvaluationContext) graphBoundary(bound GraphBound) string {
 	if bound.Boundary == "" {
-		return c.DiscoveryBoundary
+		if c.DiscoveryBoundary == "" {
+			return ""
+		}
+
+		return c.canonical(c.DiscoveryBoundary)
 	}
 
 	if filepath.IsAbs(bound.Boundary) {
-		return filepath.Clean(bound.Boundary)
+		return c.canonical(bound.Boundary)
 	}
 
-	return filepath.Clean(filepath.Join(c.WorkingDir, bound.Boundary))
+	return c.canonical(filepath.Join(c.WorkingDir, bound.Boundary))
 }
 
-// outsideBoundary reports whether path falls outside boundary. An empty
+// outsideBoundary reports whether path falls outside boundary. Both are
+// expected to have been through [EvaluationContext.canonical]. An empty
 // boundary bounds nothing.
 func outsideBoundary(boundary, path string) bool {
 	if boundary == "" {
 		return false
 	}
 
-	rel, err := filepath.Rel(boundary, filepath.Clean(path))
+	rel, err := filepath.Rel(boundary, path)
 	if err != nil {
 		return true
 	}
 
+	return climbsOut(rel)
+}
+
+// climbsOut reports whether a relative path leaves the directory it was
+// computed against.
+func climbsOut(rel string) bool {
 	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
@@ -385,6 +421,7 @@ func evaluateGraphExpression(
 		params := &graphTraversalParams{
 			resultSet:   resultSet,
 			visited:     make(map[string]int),
+			evalCtx:     evalCtx,
 			boundary:    evalCtx.graphBoundary(expr.Dependencies),
 			direction:   GraphDirectionDependencies,
 			warnOnLimit: warnOnLimit,
@@ -407,6 +444,7 @@ func evaluateGraphExpression(
 		params := &graphTraversalParams{
 			resultSet:   resultSet,
 			visited:     make(map[string]int),
+			evalCtx:     evalCtx,
 			boundary:    evalCtx.graphBoundary(expr.Dependents),
 			direction:   GraphDirectionDependents,
 			warnOnLimit: warnOnLimit,
@@ -495,7 +533,7 @@ func traverseGraph(
 		// A component reachable only by passing through the boundary is
 		// excluded along with the hop that leaves it, so traversal stops here
 		// rather than skipping the hop and continuing past it.
-		if outsideBoundary(params.boundary, relatedPath) {
+		if outsideBoundary(params.boundary, params.evalCtx.canonical(relatedPath)) {
 			l.Debugf(
 				"%s %s is outside discovery boundary %s; skipping",
 				params.direction,

--- a/internal/filter/evaluator_test.go
+++ b/internal/filter/evaluator_test.go
@@ -101,7 +101,7 @@ func TestEvaluate_PathFilter(t *testing.T) {
 			t.Parallel()
 
 			l := log.New()
-			result, err := filter.Evaluate(l, tt.filter, components)
+			result, err := filter.Evaluate(l, filter.EvaluationContext{}, tt.filter, components)
 			require.NoError(t, err)
 
 			assert.ElementsMatch(t, tt.expected, result)
@@ -169,7 +169,7 @@ func TestEvaluate_AttributeFilter(t *testing.T) {
 			t.Parallel()
 
 			l := log.New()
-			result, err := filter.Evaluate(l, tt.filter, components)
+			result, err := filter.Evaluate(l, filter.EvaluationContext{}, tt.filter, components)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tt.expected, result)
 		})
@@ -185,7 +185,7 @@ func TestEvaluate_AttributeFilter_InvalidKey(t *testing.T) {
 
 	attrFilter := mustAttr(t, "invalid", "foo")
 	l := log.New()
-	result, err := filter.Evaluate(l, attrFilter, components)
+	result, err := filter.Evaluate(l, filter.EvaluationContext{}, attrFilter, components)
 
 	require.Error(t, err)
 	assert.Nil(t, result)
@@ -287,7 +287,7 @@ func TestEvaluate_AttributeFilter_Reading(t *testing.T) {
 			}
 
 			l := log.New()
-			result, err := filter.Evaluate(l, tt.filter, testComponents)
+			result, err := filter.Evaluate(l, filter.EvaluationContext{}, tt.filter, testComponents)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tt.expected, result)
 		})
@@ -348,7 +348,7 @@ func TestEvaluate_AttributeFilter_Source(t *testing.T) {
 			t.Parallel()
 
 			l := log.New()
-			result, err := filter.Evaluate(l, tt.filter, components)
+			result, err := filter.Evaluate(l, filter.EvaluationContext{}, tt.filter, components)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tt.expected, result)
 		})
@@ -365,7 +365,7 @@ func TestEvaluate_AttributeFilter_Reading_ComponentAddedOnlyOnce(t *testing.T) {
 	// This glob should match multiple files in the Reading slice, but component should only be added once
 	attrFilter := mustAttr(t, "reading", "shared*")
 	l := log.New()
-	result, err := filter.Evaluate(l, attrFilter, components)
+	result, err := filter.Evaluate(l, filter.EvaluationContext{}, attrFilter, components)
 	require.NoError(t, err)
 
 	// Should only have one component even though three files matched
@@ -465,7 +465,7 @@ func TestEvaluate_PrefixExpression(t *testing.T) {
 			t.Parallel()
 
 			l := log.New()
-			result, err := filter.Evaluate(l, tt.expr, components)
+			result, err := filter.Evaluate(l, filter.EvaluationContext{}, tt.expr, components)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tt.expected, result)
 		})
@@ -545,7 +545,7 @@ func TestEvaluate_InfixExpression(t *testing.T) {
 			t.Parallel()
 
 			l := log.New()
-			result, err := filter.Evaluate(l, tt.expr, components)
+			result, err := filter.Evaluate(l, filter.EvaluationContext{}, tt.expr, components)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tt.expected, result)
 		})
@@ -650,7 +650,7 @@ func TestEvaluate_ComplexExpressions(t *testing.T) {
 			t.Parallel()
 
 			l := log.New()
-			result, err := filter.Evaluate(l, tt.expr, components)
+			result, err := filter.Evaluate(l, filter.EvaluationContext{}, tt.expr, components)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tt.expected, result)
 		})
@@ -665,7 +665,7 @@ func TestEvaluate_EdgeCases(t *testing.T) {
 
 		components := []component.Component{component.NewUnit("./app")}
 		l := log.New()
-		result, err := filter.Evaluate(l, nil, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, nil, components)
 
 		require.Error(t, err)
 		assert.Nil(t, result)
@@ -677,7 +677,7 @@ func TestEvaluate_EdgeCases(t *testing.T) {
 
 		expr := mustAttr(t, "name", "foo")
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, []component.Component{})
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, []component.Component{})
 
 		require.NoError(t, err)
 		assert.Empty(t, result)
@@ -848,7 +848,7 @@ func TestEvaluate_GraphExpression(t *testing.T) {
 			}
 
 			l := log.New()
-			result, err := filter.Evaluate(l, tt.expr, components)
+			result, err := filter.Evaluate(l, filter.EvaluationContext{}, tt.expr, components)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, expected, result)
 		})
@@ -891,7 +891,7 @@ func TestEvaluate_GraphExpression_ComplexGraph(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []component.Component{app, db, cache, vpc}, result)
 	})
@@ -926,7 +926,7 @@ func TestEvaluate_GraphExpression_ComplexGraph(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []component.Component{vpc, db, cache, app}, result)
 	})
@@ -950,7 +950,7 @@ func TestEvaluate_GraphExpression_EmptyResults(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -974,7 +974,7 @@ func TestEvaluate_GraphExpression_NoDependencies(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []component.Component{isolated}, result)
 	})
@@ -988,7 +988,7 @@ func TestEvaluate_GraphExpression_NoDependencies(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []component.Component{isolated}, result)
 	})
@@ -1019,7 +1019,7 @@ func TestEvaluate_GraphExpression_CircularDependencies(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 		// Should include both a and b, but not loop infinitely
 		assert.ElementsMatch(t, []component.Component{a, b}, result)
@@ -1035,7 +1035,7 @@ func TestEvaluate_GraphExpression_CircularDependencies(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 		// Should include both a and b, but not loop infinitely
 		assert.ElementsMatch(t, []component.Component{a, b}, result)
@@ -1076,7 +1076,7 @@ func TestEvaluate_GraphExpression_WithPathFilter(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []component.Component{app, db, vpc}, result)
 	})
@@ -1107,7 +1107,7 @@ func TestEvaluate_GraphExpression_DepthLimited(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []component.Component{d, c}, result)
 	})
@@ -1121,7 +1121,7 @@ func TestEvaluate_GraphExpression_DepthLimited(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []component.Component{d, c, b}, result)
 	})
@@ -1135,7 +1135,7 @@ func TestEvaluate_GraphExpression_DepthLimited(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []component.Component{a, b}, result)
 	})
@@ -1149,7 +1149,7 @@ func TestEvaluate_GraphExpression_DepthLimited(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []component.Component{a, b, c}, result)
 	})
@@ -1163,7 +1163,7 @@ func TestEvaluate_GraphExpression_DepthLimited(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []component.Component{d, c, b, a}, result)
 	})
@@ -1209,7 +1209,7 @@ func TestEvaluate_GraphExpression_DepthLimited_MultipleTargets(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 
 		// Should include: targetA, targetB, intermediate (1 hop from A),
@@ -1381,7 +1381,7 @@ func TestEvaluate_GitFilter(t *testing.T) {
 			components := tt.setup()
 
 			l := log.New()
-			result, err := filter.Evaluate(l, gitFilter, components)
+			result, err := filter.Evaluate(l, filter.EvaluationContext{}, gitFilter, components)
 
 			if tt.wantError {
 				require.Error(t, err)
@@ -1491,7 +1491,7 @@ func TestEvaluate_GraphExpressionWithGitExpressionTarget(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 
 		resultPaths := make([]string, len(result))
@@ -1536,7 +1536,7 @@ func TestEvaluate_GraphExpressionWithGitExpressionTarget(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 
 		resultPaths := make([]string, len(result))
@@ -1582,7 +1582,7 @@ func TestEvaluate_GraphExpressionWithGitExpressionTarget(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 
 		resultPaths := make([]string, len(result))
@@ -1623,7 +1623,7 @@ func TestEvaluate_GraphExpressionWithGitExpressionTarget(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 
 		assert.Empty(t, result, "Should return empty when no components match git filter")
@@ -1667,7 +1667,7 @@ func TestEvaluate_GraphExpressionWithGitExpressionTarget(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 
 		resultPaths := make([]string, len(result))
@@ -1713,7 +1713,7 @@ func TestEvaluate_GraphExpressionWithGitExpressionTarget(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 
 		resultPaths := make([]string, len(result))
@@ -1759,7 +1759,7 @@ func TestEvaluate_GraphExpressionWithGitExpressionTarget(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 
 		resultPaths := make([]string, len(result))
@@ -1824,7 +1824,7 @@ func TestEvaluate_GraphExpressionWithGitTarget_DependencyChain(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 
 		resultPaths := make([]string, len(result))
@@ -1844,7 +1844,7 @@ func TestEvaluate_GraphExpressionWithGitTarget_DependencyChain(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 
 		resultPaths := make([]string, len(result))
@@ -1867,7 +1867,7 @@ func TestEvaluate_GraphExpressionWithGitTarget_DependencyChain(t *testing.T) {
 		}
 
 		l := log.New()
-		result, err := filter.Evaluate(l, expr, components)
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, components)
 		require.NoError(t, err)
 
 		resultPaths := make([]string, len(result))
@@ -1883,4 +1883,97 @@ func TestEvaluate_GraphExpressionWithGitTarget_DependencyChain(t *testing.T) {
 			resultPaths,
 		)
 	})
+}
+
+// Test that graph traversal stops at the discovery boundary. Discovery prunes
+// out-of-boundary components while walking, but the components it keeps still
+// carry relationship edges pointing across the boundary, so evaluation has to
+// refuse to follow them or it grows the result set back.
+func TestEvaluate_GraphExpression_DiscoveryBoundary(t *testing.T) {
+	t.Parallel()
+
+	// prod/vpc <- prod/db <- prod/app -> shared/dns -> shared/iam
+	newGraph := func() (component.Components, map[string]component.Component) {
+		byName := map[string]component.Component{
+			"vpc": component.NewUnit("/repo/prod/vpc"),
+			"db":  component.NewUnit("/repo/prod/db"),
+			"app": component.NewUnit("/repo/prod/app"),
+			"dns": component.NewUnit("/repo/shared/dns"),
+			"iam": component.NewUnit("/repo/shared/iam"),
+		}
+
+		byName["app"].AddDependency(byName["db"])
+		byName["db"].AddDependency(byName["vpc"])
+		byName["app"].AddDependency(byName["dns"])
+		byName["dns"].AddDependency(byName["iam"])
+
+		comps := component.Components{
+			byName["vpc"], byName["db"], byName["app"], byName["dns"], byName["iam"],
+		}
+
+		return comps, byName
+	}
+
+	testCases := []struct {
+		name              string
+		workingDir        string
+		discoveryBoundary string
+		inlineBoundary    string
+		expected          []string
+	}{
+		{
+			name:     "unbounded traversal crosses into shared",
+			expected: []string{"app", "db", "vpc", "dns", "iam"},
+		},
+		{
+			name:              "discovery boundary stops traversal",
+			discoveryBoundary: "/repo/prod",
+			expected:          []string{"app", "db", "vpc"},
+		},
+		{
+			name:              "inline operand overrides the discovery boundary",
+			discoveryBoundary: "/repo/prod",
+			inlineBoundary:    "/repo",
+			expected:          []string{"app", "db", "vpc", "dns", "iam"},
+		},
+		{
+			name:           "relative inline operand resolves against the working directory",
+			workingDir:     "/repo",
+			inlineBoundary: "./prod",
+			expected:       []string{"app", "db", "vpc"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			comps, byName := newGraph()
+
+			expected := make([]string, len(tc.expected))
+			for i, n := range tc.expected {
+				expected[i] = byName[n].Path()
+			}
+
+			expr := &filter.GraphExpression{
+				Target:       mustAttr(t, "name", "app"),
+				Dependencies: filter.GraphBound{Include: true, Boundary: tc.inlineBoundary},
+			}
+
+			evalCtx := filter.EvaluationContext{
+				WorkingDir:        tc.workingDir,
+				DiscoveryBoundary: tc.discoveryBoundary,
+			}
+
+			result, err := filter.Evaluate(log.New(), evalCtx, expr, comps)
+			require.NoError(t, err)
+
+			paths := make([]string, len(result))
+			for i, c := range result {
+				paths[i] = c.Path()
+			}
+
+			assert.ElementsMatch(t, expected, paths)
+		})
+	}
 }

--- a/internal/filter/evaluator_test.go
+++ b/internal/filter/evaluator_test.go
@@ -1977,3 +1977,80 @@ func TestEvaluate_GraphExpression_DiscoveryBoundary(t *testing.T) {
 		})
 	}
 }
+
+// Test that a boundary still contains components the filesystem walk recorded
+// under a symlinked working directory. Discovery hands the boundary over
+// resolved, so an unresolved component path only compares as inside if
+// evaluation reconciles the two spellings.
+func TestEvaluate_GraphExpression_BoundaryUnderSymlinkedWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	// The walk spells paths the way Terragrunt was invoked, /link/repo, while
+	// dependency paths come back from config parsing as /real/repo.
+	const (
+		workingDir         = "/link/repo"
+		resolvedWorkingDir = "/real/repo"
+	)
+
+	app := component.NewUnit(workingDir + "/prod/app")
+	db := component.NewUnit(workingDir + "/prod/db")
+	dns := component.NewUnit(resolvedWorkingDir + "/shared/dns")
+
+	app.AddDependency(db)
+	app.AddDependency(dns)
+
+	comps := component.Components{app, db, dns}
+
+	testCases := []struct {
+		name     string
+		expr     *filter.GraphExpression
+		expected []string
+	}{
+		{
+			name: "dependency inside the boundary survives",
+			expr: &filter.GraphExpression{
+				Target:       mustAttr(t, "name", "app"),
+				Dependencies: filter.GraphBound{Include: true},
+			},
+			expected: []string{app.Path(), db.Path()},
+		},
+		{
+			name: "dependent inside the boundary survives",
+			expr: &filter.GraphExpression{
+				Target:     mustAttr(t, "name", "db"),
+				Dependents: filter.GraphBound{Include: true},
+			},
+			expected: []string{db.Path(), app.Path()},
+		},
+		{
+			name: "inline operand under the symlinked working directory holds",
+			expr: &filter.GraphExpression{
+				Target:       mustAttr(t, "name", "app"),
+				Dependencies: filter.GraphBound{Include: true, Boundary: "./prod"},
+			},
+			expected: []string{app.Path(), db.Path()},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			evalCtx := filter.EvaluationContext{
+				WorkingDir:         workingDir,
+				ResolvedWorkingDir: resolvedWorkingDir,
+				DiscoveryBoundary:  resolvedWorkingDir + "/prod",
+			}
+
+			result, err := filter.Evaluate(log.New(), evalCtx, tc.expr, comps)
+			require.NoError(t, err)
+
+			paths := make([]string, len(result))
+			for i, c := range result {
+				paths[i] = c.Path()
+			}
+
+			assert.ElementsMatch(t, tc.expected, paths)
+		})
+	}
+}

--- a/internal/filter/evaluator_windows_test.go
+++ b/internal/filter/evaluator_windows_test.go
@@ -31,7 +31,7 @@ func TestWindowsFilterNativeSeparators(t *testing.T) {
 			c := component.NewUnit("apps/app1")
 
 			l := logger.CreateLogger()
-			result, err := filter.Evaluate(l, expr, []component.Component{c})
+			result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, []component.Component{c})
 			require.NoError(t, err)
 			assert.Len(t, result, 1)
 		},
@@ -44,7 +44,7 @@ func TestWindowsFilterNativeSeparators(t *testing.T) {
 		expr := mustAttr(t, "reading", "shared/config.hcl")
 
 		l := logger.CreateLogger()
-		result, err := filter.Evaluate(l, expr, []component.Component{c})
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, []component.Component{c})
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
 	})
@@ -62,7 +62,7 @@ func TestWindowsFilterNativeSeparators(t *testing.T) {
 		expr := mustAttr(t, "source", "**/IaC/modules/sns")
 
 		l := logger.CreateLogger()
-		result, err := filter.Evaluate(l, expr, []component.Component{c})
+		result, err := filter.Evaluate(l, filter.EvaluationContext{}, expr, []component.Component{c})
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
 	})

--- a/internal/filter/examples_test.go
+++ b/internal/filter/examples_test.go
@@ -34,7 +34,7 @@ func Example_basicPathFilter() {
 	}
 
 	l := log.New()
-	result, _ := filter.Apply(l, "./apps/*", components)
+	result, _ := filter.Apply(l, filter.EvaluationContext{}, "./apps/*", components)
 
 	for _, c := range result {
 		fmt.Println(filepath.Base(c.Path()))
@@ -59,7 +59,7 @@ func Example_attributeFilter() {
 	}
 
 	l := log.New()
-	result, _ := filter.Apply(l, "name=api", components)
+	result, _ := filter.Apply(l, filter.EvaluationContext{}, "name=api", components)
 
 	for _, c := range result {
 		fmt.Println(c.Path())
@@ -83,7 +83,7 @@ func Example_exclusionFilter() {
 	}
 
 	l := log.New()
-	result, _ := filter.Apply(l, "!legacy", components)
+	result, _ := filter.Apply(l, filter.EvaluationContext{}, "!legacy", components)
 
 	for _, c := range result {
 		fmt.Println(filepath.Base(c.Path()))
@@ -112,7 +112,7 @@ func Example_intersectionFilter() {
 
 	// Select components in ./apps/ that are named "frontend"
 	l := log.New()
-	result, _ := filter.Apply(l, "./apps/* | frontend", components)
+	result, _ := filter.Apply(l, filter.EvaluationContext{}, "./apps/* | frontend", components)
 
 	for _, c := range result {
 		fmt.Println(filepath.Base(c.Path()))
@@ -143,7 +143,7 @@ func Example_complexQuery() {
 
 	// Select all services except worker
 	l := log.New()
-	result, _ := filter.Apply(l, "./services/* | !worker", components)
+	result, _ := filter.Apply(l, filter.EvaluationContext{}, "./services/* | !worker", components)
 
 	for _, c := range result {
 		fmt.Println(filepath.Base(c.Path()))
@@ -172,7 +172,7 @@ func Example_parseAndEvaluate() {
 
 	// Evaluate multiple times with different config sets
 	l := log.New()
-	result1, _ := f.Evaluate(l, components)
+	result1, _ := f.Evaluate(l, filter.EvaluationContext{}, components)
 	fmt.Printf("Found %d components\n", len(result1))
 
 	// You can also inspect the original query
@@ -202,7 +202,7 @@ func Example_recursiveWildcard() {
 
 	// Match all infrastructure components at any depth
 	l := log.New()
-	result, _ := filter.Apply(l, "./infrastructure/**", components)
+	result, _ := filter.Apply(l, filter.EvaluationContext{}, "./infrastructure/**", components)
 
 	for _, c := range result {
 		fmt.Println(filepath.Base(c.Path()))
@@ -256,7 +256,7 @@ func Example_multipleFilters() {
 		"./apps/*",
 		"name=db",
 	})
-	result, _ := filters.Evaluate(l, components)
+	result, _ := filters.Evaluate(l, filter.EvaluationContext{}, components)
 
 	// Sort for consistent output
 	names := make([]string, len(result))

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -77,31 +77,6 @@ func (f *Filter) HasGraphBoundary() bool {
 	return found
 }
 
-// GraphBoundaries returns every inline "(dir)" boundary operand in the filter,
-// unresolved and in no particular order.
-func (f *Filter) GraphBoundaries() []string {
-	var boundaries []string
-
-	WalkExpressions(f.expr, func(e Expression) bool {
-		g, ok := e.(*GraphExpression)
-		if !ok {
-			return true
-		}
-
-		if g.Dependents.Boundary != "" {
-			boundaries = append(boundaries, g.Dependents.Boundary)
-		}
-
-		if g.Dependencies.Boundary != "" {
-			boundaries = append(boundaries, g.Dependencies.Boundary)
-		}
-
-		return true
-	})
-
-	return boundaries
-}
-
 // HasDependents reports whether any graph expression in the filter traverses
 // the dependent direction.
 func (f *Filter) HasDependents() bool {

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -77,6 +77,31 @@ func (f *Filter) HasGraphBoundary() bool {
 	return found
 }
 
+// GraphBoundaries returns every inline "(dir)" boundary operand in the filter,
+// unresolved and in no particular order.
+func (f *Filter) GraphBoundaries() []string {
+	var boundaries []string
+
+	WalkExpressions(f.expr, func(e Expression) bool {
+		g, ok := e.(*GraphExpression)
+		if !ok {
+			return true
+		}
+
+		if g.Dependents.Boundary != "" {
+			boundaries = append(boundaries, g.Dependents.Boundary)
+		}
+
+		if g.Dependencies.Boundary != "" {
+			boundaries = append(boundaries, g.Dependencies.Boundary)
+		}
+
+		return true
+	})
+
+	return boundaries
+}
+
 // HasDependents reports whether any graph expression in the filter traverses
 // the dependent direction.
 func (f *Filter) HasDependents() bool {

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -42,9 +42,10 @@ func (f *Filter) String() string {
 // If logger is provided, it will be used for logging warnings during evaluation.
 func (f *Filter) Evaluate(
 	l log.Logger,
+	evalCtx EvaluationContext,
 	components component.Components,
 ) (component.Components, error) {
-	return Evaluate(l, f.expr, components)
+	return Evaluate(l, evalCtx, f.expr, components)
 }
 
 // Expression returns the parsed AST expression.
@@ -76,10 +77,29 @@ func (f *Filter) HasGraphBoundary() bool {
 	return found
 }
 
+// HasDependents reports whether any graph expression in the filter traverses
+// the dependent direction.
+func (f *Filter) HasDependents() bool {
+	found := false
+
+	WalkExpressions(f.expr, func(e Expression) bool {
+		if g, ok := e.(*GraphExpression); ok && g.Dependents.Include {
+			found = true
+
+			return false
+		}
+
+		return true
+	})
+
+	return found
+}
+
 // Apply is a convenience function that parses and evaluates a filter in one step.
 // It's equivalent to calling Parse followed by Evaluate.
 func Apply(
 	l log.Logger,
+	evalCtx EvaluationContext,
 	filterString string,
 	components component.Components,
 ) (component.Components, error) {
@@ -88,5 +108,5 @@ func Apply(
 		return nil, err
 	}
 
-	return filter.Evaluate(l, components)
+	return filter.Evaluate(l, evalCtx, components)
 }

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -171,27 +171,27 @@ func TestFilter_ParseAndEvaluate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			filter, err := filter.Parse(tt.filterString)
+			f, err := filter.Parse(tt.filterString)
 
 			if tt.expectError {
 				require.Error(t, err)
-				assert.Nil(t, filter)
+				assert.Nil(t, f)
 
 				return
 			}
 
 			require.NoError(t, err)
 
-			require.NotNil(t, filter)
+			require.NotNil(t, f)
 
-			logger := log.New()
-			result, err := filter.Evaluate(logger, testComponents)
+			l := log.New()
+			result, err := f.Evaluate(l, filter.EvaluationContext{}, testComponents)
 			require.NoError(t, err)
 
 			assert.ElementsMatch(t, tt.expected, result)
 
 			// Verify String() returns original query
-			assert.Equal(t, tt.filterString, filter.String())
+			assert.Equal(t, tt.filterString, f.String())
 		})
 	}
 }
@@ -249,7 +249,7 @@ func TestFilter_Apply(t *testing.T) {
 			t.Parallel()
 
 			l := log.New()
-			result, err := filter.Apply(l, tt.filterString, tt.components)
+			result, err := filter.Apply(l, filter.EvaluationContext{}, tt.filterString, tt.components)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -355,7 +355,7 @@ func TestFilter_RealWorldScenarios(t *testing.T) {
 			t.Parallel()
 
 			l := log.New()
-			result, err := filter.Apply(l, tt.filterString, repoComponents)
+			result, err := filter.Apply(l, filter.EvaluationContext{}, tt.filterString, repoComponents)
 			require.NoError(t, err)
 
 			resultNames := make([]string, 0, len(result))
@@ -375,7 +375,7 @@ func TestFilter_EdgeCasesAndErrorHandling(t *testing.T) {
 		t.Parallel()
 
 		l := log.New()
-		result, err := filter.Apply(l, "nonexistent", testComponents)
+		result, err := filter.Apply(l, filter.EvaluationContext{}, "nonexistent", testComponents)
 		require.NoError(t, err)
 
 		assert.Empty(t, result)
@@ -384,15 +384,15 @@ func TestFilter_EdgeCasesAndErrorHandling(t *testing.T) {
 	t.Run("multiple parse and evaluate calls", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := filter.Parse("app1")
+		f, err := filter.Parse("app1")
 		require.NoError(t, err)
 
 		l := log.New()
 
-		result1, err := filter.Evaluate(l, testComponents)
+		result1, err := f.Evaluate(l, filter.EvaluationContext{}, testComponents)
 		require.NoError(t, err)
 
-		result2, err := filter.Evaluate(l, testComponents)
+		result2, err := f.Evaluate(l, filter.EvaluationContext{}, testComponents)
 		require.NoError(t, err)
 
 		assert.Equal(t, result1, result2)
@@ -420,7 +420,7 @@ func TestFilter_EdgeCasesAndErrorHandling(t *testing.T) {
 
 		for _, tt := range tests {
 			l := log.New()
-			result, err := filter.Apply(l, tt.filterString, testComponents)
+			result, err := filter.Apply(l, filter.EvaluationContext{}, tt.filterString, testComponents)
 			require.NoError(t, err)
 
 			assert.ElementsMatch(t, expected, result)

--- a/internal/filter/filters.go
+++ b/internal/filter/filters.go
@@ -92,6 +92,18 @@ func (f Filters) HasGraphBoundary() bool {
 	return false
 }
 
+// GraphBoundaries returns every inline "(dir)" boundary operand across all
+// filters, unresolved and in no particular order.
+func (f Filters) GraphBoundaries() []string {
+	var boundaries []string
+
+	for _, filter := range f {
+		boundaries = append(boundaries, filter.GraphBoundaries()...)
+	}
+
+	return boundaries
+}
+
 // HasDependents reports whether any filter traverses the dependent direction.
 func (f Filters) HasDependents() bool {
 	for _, filter := range f {

--- a/internal/filter/filters.go
+++ b/internal/filter/filters.go
@@ -92,6 +92,17 @@ func (f Filters) HasGraphBoundary() bool {
 	return false
 }
 
+// HasDependents reports whether any filter traverses the dependent direction.
+func (f Filters) HasDependents() bool {
+	for _, filter := range f {
+		if filter.HasDependents() {
+			return true
+		}
+	}
+
+	return false
+}
+
 // RequiresDiscovery returns the first expression that requires discovery of Terragrunt components if any do.
 func (f Filters) RequiresDiscovery() (Expression, bool) {
 	for _, filter := range f {
@@ -217,6 +228,7 @@ func (f Filters) RestrictToStacks() Filters {
 // If logger is provided, it will be used for logging warnings during evaluation.
 func (f Filters) Evaluate(
 	l log.Logger,
+	evalCtx EvaluationContext,
 	components component.Components,
 ) (component.Components, error) {
 	if len(f) == 0 {
@@ -239,7 +251,7 @@ func (f Filters) Evaluate(
 	}
 
 	// Phase 1: Get initial set of components, which might need to be filtered further by negative filters
-	combined, err := initialComponents(l, positiveFilters, components)
+	combined, err := initialComponents(l, evalCtx, positiveFilters, components)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +268,7 @@ func (f Filters) Evaluate(
 	rejected := make(map[string]struct{}, len(combined))
 
 	for _, filter := range negativeFilters {
-		kept, err := filter.Evaluate(l, combined)
+		kept, err := filter.Evaluate(l, evalCtx, combined)
 		if err != nil {
 			return nil, err
 		}
@@ -320,7 +332,7 @@ func (f Filters) EvaluateOnFiles(
 		return comps, nil
 	}
 
-	return f.Evaluate(l, comps)
+	return f.Evaluate(l, EvaluationContext{WorkingDir: workingDir}, comps)
 }
 
 // String returns a JSON array representation of all filter strings.
@@ -356,6 +368,7 @@ func containsGitExpression(expr Expression) bool {
 
 func initialComponents(
 	l log.Logger,
+	evalCtx EvaluationContext,
 	positiveFilters []*Filter,
 	components component.Components,
 ) (component.Components, error) {
@@ -366,7 +379,7 @@ func initialComponents(
 	seen := make(map[string]component.Component, len(components))
 
 	for _, filter := range positiveFilters {
-		result, err := filter.Evaluate(l, components)
+		result, err := filter.Evaluate(l, evalCtx, components)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/filter/filters.go
+++ b/internal/filter/filters.go
@@ -92,18 +92,6 @@ func (f Filters) HasGraphBoundary() bool {
 	return false
 }
 
-// GraphBoundaries returns every inline "(dir)" boundary operand across all
-// filters, unresolved and in no particular order.
-func (f Filters) GraphBoundaries() []string {
-	var boundaries []string
-
-	for _, filter := range f {
-		boundaries = append(boundaries, filter.GraphBoundaries()...)
-	}
-
-	return boundaries
-}
-
 // HasDependents reports whether any filter traverses the dependent direction.
 func (f Filters) HasDependents() bool {
 	for _, filter := range f {

--- a/internal/filter/filters_test.go
+++ b/internal/filter/filters_test.go
@@ -137,7 +137,7 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		l := log.New()
-		result, err := filters.Evaluate(l, components)
+		result, err := filters.Evaluate(l, filter.EvaluationContext{}, components)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, components, result)
 	})
@@ -149,7 +149,7 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		l := log.New()
-		result, err := filters.Evaluate(l, components)
+		result, err := filters.Evaluate(l, filter.EvaluationContext{}, components)
 		require.NoError(t, err)
 
 		expected := component.Components{
@@ -174,7 +174,7 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		l := log.New()
-		result, err := filters.Evaluate(l, components)
+		result, err := filters.Evaluate(l, filter.EvaluationContext{}, components)
 		require.NoError(t, err)
 
 		expected := component.Components{
@@ -198,7 +198,7 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		l := log.New()
-		result, err := filters.Evaluate(l, components)
+		result, err := filters.Evaluate(l, filter.EvaluationContext{}, components)
 		require.NoError(t, err)
 
 		expected := component.Components{
@@ -225,7 +225,7 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		l := log.New()
-		result, err := filters.Evaluate(l, components)
+		result, err := filters.Evaluate(l, filter.EvaluationContext{}, components)
 		require.NoError(t, err)
 
 		expected := component.Components{
@@ -252,7 +252,7 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		l := log.New()
-		result, err := filters.Evaluate(l, components)
+		result, err := filters.Evaluate(l, filter.EvaluationContext{}, components)
 		require.NoError(t, err)
 
 		expected := component.Components{
@@ -275,7 +275,7 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		l := log.New()
-		result, err := filters.Evaluate(l, components)
+		result, err := filters.Evaluate(l, filter.EvaluationContext{}, components)
 		require.NoError(t, err)
 
 		expected := component.Components{
@@ -305,7 +305,7 @@ func TestFilters_Evaluate(t *testing.T) {
 		require.NoError(t, err)
 
 		l := log.New()
-		result, err := filters.Evaluate(l, components)
+		result, err := filters.Evaluate(l, filter.EvaluationContext{}, components)
 		require.NoError(t, err)
 
 		expected := component.Components{
@@ -407,7 +407,7 @@ func TestFilters_EvaluateCompoundNegation(t *testing.T) {
 			filters, err := filter.ParseFilterQueries(l, tt.filters)
 			require.NoError(t, err)
 
-			result, err := filters.Evaluate(l, newComponents())
+			result, err := filters.Evaluate(l, filter.EvaluationContext{}, newComponents())
 			require.NoError(t, err)
 
 			assert.ElementsMatch(t, tt.expected, paths(result))
@@ -418,7 +418,7 @@ func TestFilters_EvaluateCompoundNegation(t *testing.T) {
 
 			// A single filter has no union or subtraction to arrange, so Filters.Evaluate owes
 			// the same answer as walking the filter's own AST.
-			direct, err := filters[0].Evaluate(l, newComponents())
+			direct, err := filters[0].Evaluate(l, filter.EvaluationContext{}, newComponents())
 			require.NoError(t, err)
 
 			assert.ElementsMatch(t, paths(direct), paths(result))
@@ -456,7 +456,7 @@ func TestFilters_EvaluateNegationsAreOrderIndependent(t *testing.T) {
 			filters, err := filter.ParseFilterQueries(l, order)
 			require.NoError(t, err)
 
-			result, err := filters.Evaluate(l, components)
+			result, err := filters.Evaluate(l, filter.EvaluationContext{}, components)
 			require.NoError(t, err)
 
 			assert.Empty(t, paths(result), "excluding db and its dependents leaves nothing")

--- a/internal/filter/parser_boundary_test.go
+++ b/internal/filter/parser_boundary_test.go
@@ -293,3 +293,28 @@ func TestParser_GraphBoundaryErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestFilters_GraphBoundaries(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		query    string
+		expected []string
+	}{
+		{query: "{./apps/foo}", expected: nil},
+		{query: "...{./apps/foo}...", expected: nil},
+		{query: "{./apps/foo}...(./a)", expected: []string{"./a"}},
+		{query: "(./a)...{./apps/foo}", expected: []string{"./a"}},
+		{query: "(./a)...{./apps/foo}...(./b)", expected: []string{"./a", "./b"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.query, func(t *testing.T) {
+			t.Parallel()
+
+			f, err := filter.Parse(tc.query)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.expected, filter.Filters{f}.GraphBoundaries())
+		})
+	}
+}

--- a/internal/filter/parser_boundary_test.go
+++ b/internal/filter/parser_boundary_test.go
@@ -293,28 +293,3 @@ func TestParser_GraphBoundaryErrors(t *testing.T) {
 		})
 	}
 }
-
-func TestFilters_GraphBoundaries(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		query    string
-		expected []string
-	}{
-		{query: "{./apps/foo}", expected: nil},
-		{query: "...{./apps/foo}...", expected: nil},
-		{query: "{./apps/foo}...(./a)", expected: []string{"./a"}},
-		{query: "(./a)...{./apps/foo}", expected: []string{"./a"}},
-		{query: "(./a)...{./apps/foo}...(./b)", expected: []string{"./a", "./b"}},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.query, func(t *testing.T) {
-			t.Parallel()
-
-			f, err := filter.Parse(tc.query)
-			require.NoError(t, err)
-			assert.ElementsMatch(t, tc.expected, filter.Filters{f}.GraphBoundaries())
-		})
-	}
-}

--- a/internal/filter/parser_boundary_test.go
+++ b/internal/filter/parser_boundary_test.go
@@ -171,6 +171,32 @@ func TestFilters_HasGraphBoundary(t *testing.T) {
 	assert.False(t, filter.Filters{without}.HasGraphBoundary())
 }
 
+func TestFilters_HasDependents(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		query    string
+		expected bool
+	}{
+		{query: "...{./apps/foo}", expected: true},
+		{query: "...{./apps/foo}...", expected: true},
+		{query: "(./a)...{./apps/foo}", expected: true},
+		{query: "{./apps/foo}...", expected: false},
+		{query: "{./apps/foo}...(./a)", expected: false},
+		{query: "{./apps/foo}", expected: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.query, func(t *testing.T) {
+			t.Parallel()
+
+			f, err := filter.Parse(tc.query)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, filter.Filters{f}.HasDependents())
+		})
+	}
+}
+
 // TestParser_BracedPathWithParens verifies that a path whose name contains
 // literal parentheses is disambiguated by wrapping it in braces, so the
 // parens are kept as part of the path rather than parsed as a boundary.

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -866,7 +866,7 @@ func stacksReadingFiles(
 	matched := make([]*component.Stack, 0, len(readingFilters))
 
 	for _, f := range readingFilters {
-		evaluated, err := filter.Evaluate(l, f.Expression(), components)
+		evaluated, err := filter.Evaluate(l, filter.EvaluationContext{}, f.Expression(), components)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/stacks/generate/generate_test.go
+++ b/internal/stacks/generate/generate_test.go
@@ -147,7 +147,7 @@ func TestStackDiscoveryFilters(t *testing.T) {
 			parsed, err := filter.ParseFilterQueries(l, tt.filters)
 			require.NoError(t, err)
 
-			selected, err := generate.StackDiscoveryFilters(parsed).Evaluate(l, stacks)
+			selected, err := generate.StackDiscoveryFilters(parsed).Evaluate(l, filter.EvaluationContext{}, stacks)
 			require.NoError(t, err)
 
 			selectedPaths := make([]string, 0, len(selected))


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

`--discovery-boundary` and the inline `(dir)` operand disagreed about which
boundaries were legal, and neither one survived filter evaluation. This fixes
both halves.

The boundary was used for determining whether any components would be evaluated earlier in discovery, but not in the final filter evaluation phase. This resulted in components showing up in discovery, even though they fell outside the discovery boundary. This was fixed. 

Containment checks also now leverage the graph traversal direction in determining the validity of a boundary. A boundary that isn't in the current working directory can't properly start dependent discovery, whereas this is a valid boundary for dependencies.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that discovery boundaries must be existing directories.
  * Documented boundary rules for dependent and dependency-only traversal.
  * Added an example for limiting dependency discovery to a repository subdirectory.

* **Bug Fixes**
  * Discovery boundaries are now consistently enforced during relationship-aware filtering.
  * Dependency-only traversal can use boundaries outside or below the working directory.
  * Dependent traversal continues to require the boundary to be the working directory or an ancestor.
  * Components outside the boundary remain available for dependency ordering but are excluded from results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->