### PR TITLE
chore: Addressing feedback from #6621

### DIFF
--- a/docs/src/data/changelog/v1.1.3/sequential-prompts-piped-input.mdx
+++ b/docs/src/data/changelog/v1.1.3/sequential-prompts-piped-input.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.3"
+category: "bug-fixes"
+---
+
+#### Answer every prompt when input is piped in
+
+A run that asks for confirmation more than once, such as `terragrunt backend delete` prompting for both the lock table entry and the state object, used to read only the first answer when the answers were piped in rather than typed. The remaining answers were discarded while reading ahead, and the next prompt failed with an end-of-input error. Every prompt in a run now reads from the same input, so piping `yes` for each one works.

--- a/internal/cli/commands/hcl/format/format.go
+++ b/internal/cli/commands/hcl/format/format.go
@@ -273,7 +273,7 @@ func formatTgHCL(
 	}
 
 	if fileUpdated {
-		l.Infof("%s was updated", tgHclFile)
+		l.Debugf("Updating %s", tgHclFile)
 		return vfs.WriteFile(fsys, tgHclFile, newContents, info.Mode())
 	}
 

--- a/internal/shell/prompt.go
+++ b/internal/shell/prompt.go
@@ -1,7 +1,6 @@
 package shell
 
 import (
-	"bufio"
 	"context"
 	"strings"
 
@@ -18,6 +17,8 @@ func PromptUserForInput(
 	prompt string,
 	nonInteractive bool,
 ) (string, error) {
+	v.RequireReader()
+
 	errWriter := v.Writers.ErrWriter
 
 	// We are writing directly to ErrWriter so the prompt is always visible
@@ -45,13 +46,11 @@ func PromptUserForInput(
 
 	exec.PrepareStdinForPrompt(l)
 
-	reader := bufio.NewReader(v.Reader)
-
 	inputCh := make(chan string)
 	errCh := make(chan error)
 
 	go func() {
-		input, err := reader.ReadString('\n')
+		input, err := v.Reader.ReadString('\n')
 		if err != nil {
 			errCh <- err
 			return

--- a/internal/shell/prompt_test.go
+++ b/internal/shell/prompt_test.go
@@ -1,0 +1,85 @@
+package shell_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/shell"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPromptUserForInputSequential pins that a run prompting more than once
+// reads every answer. The venv buffers stdin once, so the read-ahead from the
+// first prompt stays available to the second.
+func TestPromptUserForInputSequential(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	v := venvtest.New().WithReader(strings.NewReader("first\nsecond\n"))
+
+	first, err := shell.PromptUserForInput(t.Context(), l, v, "one: ", false)
+	require.NoError(t, err)
+	assert.Equal(t, "first", first)
+
+	second, err := shell.PromptUserForInput(t.Context(), l, v, "two: ", false)
+	require.NoError(t, err)
+	assert.Equal(t, "second", second)
+}
+
+func TestPromptUserForYesNo(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{name: "y", input: "y\n", expected: true},
+		{name: "yes", input: "yes\n", expected: true},
+		{name: "uppercase yes", input: "YES\n", expected: true},
+		{name: "n", input: "n\n", expected: false},
+		{name: "anything else", input: "maybe\n", expected: false},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := logger.CreateLogger()
+			v := venvtest.New().WithReader(strings.NewReader(tt.input))
+
+			got, err := shell.PromptUserForYesNo(t.Context(), l, v, "proceed?", false)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestPromptUserForYesNoNonInteractive pins that stdin is never consulted when
+// the non-interactive flag is set: the answer is "yes" despite the "no" input.
+func TestPromptUserForYesNoNonInteractive(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	v := venvtest.New().WithReader(strings.NewReader("no\n"))
+
+	got, err := shell.PromptUserForYesNo(t.Context(), l, v, "proceed?", true)
+	require.NoError(t, err)
+	assert.True(t, got)
+}
+
+func TestPromptUserForInputPanicsOnUnsetReader(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+	v.Reader = nil
+
+	assert.PanicsWithError(t, venv.ErrVenvReaderUnset.Error(), func() {
+		_, _ = shell.PromptUserForInput(t.Context(), logger.CreateLogger(), v, "one: ", false)
+	})
+}

--- a/internal/venv/venv.go
+++ b/internal/venv/venv.go
@@ -16,6 +16,7 @@
 package venv
 
 import (
+	"bufio"
 	"errors"
 	"io"
 	"maps"
@@ -80,13 +81,16 @@ type Platform struct {
 // inputs contributions resolve. Writers is held as a pointer so per-call
 // overrides via [writer.Writers.WithWriter] and [writer.Writers.WithErrWriter]
 // produce fresh pointers without mutating the caller's value; never mutate its
-// fields in place, since shallow-copied Venvs share the pointer.
+// fields in place, since shallow-copied Venvs share the pointer. Reader is
+// buffered once and held as a pointer for the same reason: a run that prompts
+// more than once must keep reading from a single buffer, or the first prompt's
+// read-ahead swallows the input the next prompt is waiting for.
 type Venv struct {
 	FS       vfs.FS
 	Exec     vexec.Exec
 	HTTP     vhttp.Client
 	Sops     vsops.Decrypter
-	Reader   io.Reader
+	Reader   *bufio.Reader
 	Env      map[string]string
 	Platform *Platform
 	Writers  *writer.Writers
@@ -95,7 +99,7 @@ type Venv struct {
 // WithReader returns a copy of v that reads console input from r.
 func (v *Venv) WithReader(r io.Reader) *Venv {
 	c := *v
-	c.Reader = r
+	c.Reader = bufio.NewReader(r)
 
 	return &c
 }
@@ -285,7 +289,7 @@ func OSVenv() *Venv {
 		Exec:   vexec.NewOSExec(),
 		HTTP:   vhttp.NewOSClient(),
 		Sops:   vsops.NewOSDecrypter(),
-		Reader: os.Stdin,
+		Reader: bufio.NewReader(os.Stdin),
 		Env:    ParseEnviron(os.Environ()),
 		Platform: &Platform{
 			UserHomeDir: os.UserHomeDir,

--- a/test/helpers/venvtest/venvtest.go
+++ b/test/helpers/venvtest/venvtest.go
@@ -5,6 +5,7 @@
 package venvtest
 
 import (
+	"bufio"
 	"context"
 	"io"
 	"runtime"
@@ -31,7 +32,7 @@ func New() *venv.Venv {
 		FS:     vfs.NewMemMapFS(),
 		HTTP:   vhttp.NewNoNetworkClient(),
 		Sops:   vsops.NewMemDecrypter(func(string, string) ([]byte, error) { return nil, nil }),
-		Reader: strings.NewReader(""),
+		Reader: bufio.NewReader(strings.NewReader("")),
 		Env:    map[string]string{},
 		Platform: &venv.Platform{
 			UserHomeDir: func() (string, error) {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses feedback from #6621.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sequential prompts now correctly consume answers from the same piped input, allowing multiple confirmations without unexpected end-of-input errors.
  - Repeated prompt input is handled more reliably across command execution.
  - Routine formatting updates no longer appear as prominent informational messages.

- **Documentation**
  - Added a changelog entry describing the sequential prompt fix in version 1.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->