### PR TITLE
chore: Updating mem exec so that it fails closed

### DIFF
--- a/internal/vexec/fault.go
+++ b/internal/vexec/fault.go
@@ -2,8 +2,34 @@ package vexec
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os/exec"
 )
+
+// ErrNoSpawn is returned by execs built from [NewNoSpawnExec], wrapped in an
+// error naming the command that was attempted. Match it with [errors.Is].
+var ErrNoSpawn = errors.New("vexec: process execution not permitted")
+
+// NewNoSpawnExec returns an [Exec] whose every command fails with an error
+// wrapping [ErrNoSpawn]. It lets tests assert that a code path spawns no
+// subprocess, the same way
+// [github.com/gruntwork-io/terragrunt/internal/vhttp.NewNoNetworkClient] and
+// [github.com/gruntwork-io/terragrunt/internal/vfs.NoSymlinkFS] do for their
+// respective subsystems.
+//
+// A test whose subject is meant to run a command supplies its own handler via
+// [NewMemExec] instead. Prefer this to a handler that returns an empty
+// [Result]: an empty result reports success with no output, which callers that
+// read a command's stdout take as an authoritative answer.
+//
+// LookPath still resolves, so a path lookup alone does not fail. Wrap in
+// [NoLookPathExec] to close that off too.
+func NewNoSpawnExec() Exec {
+	return NewMemExec(func(_ context.Context, inv Invocation) Result {
+		return Result{Err: fmt.Errorf("%w: %s", ErrNoSpawn, inv.Name)}
+	})
+}
 
 // NoLookPathExec wraps an Exec and always fails LookPath with exec.ErrNotFound,
 // simulating a system where the requested binary is not on PATH. Command

--- a/internal/vexec/vexec_test.go
+++ b/internal/vexec/vexec_test.go
@@ -347,3 +347,28 @@ func TestOSCmder(t *testing.T) {
 	_, ok = memCmd.(vexec.OSCmder)
 	assert.False(t, ok, "in-memory Cmd must NOT implement OSCmder")
 }
+
+func TestNewNoSpawnExec(t *testing.T) {
+	t.Parallel()
+
+	e := vexec.NewNoSpawnExec()
+
+	err := e.Command(t.Context(), "git", "rev-parse", "--show-toplevel").Run()
+	require.ErrorIs(t, err, vexec.ErrNoSpawn)
+	assert.Contains(t, err.Error(), "git", "the error must name the command that was refused")
+
+	out, err := e.Command(t.Context(), "tofu", "output").Output()
+	require.ErrorIs(t, err, vexec.ErrNoSpawn)
+	assert.Empty(t, out)
+}
+
+// TestNewNoSpawnExecResolvesLookPath pins that a path lookup still succeeds, so
+// a caller that only probes for a binary is unaffected. NoLookPathExec closes
+// that off for tests that need it.
+func TestNewNoSpawnExecResolvesLookPath(t *testing.T) {
+	t.Parallel()
+
+	path, err := vexec.NewNoSpawnExec().LookPath("tofu")
+	require.NoError(t, err)
+	assert.Equal(t, "tofu", path)
+}

--- a/test/helpers/venvtest/venvtest.go
+++ b/test/helpers/venvtest/venvtest.go
@@ -6,7 +6,6 @@ package venvtest
 
 import (
 	"bufio"
-	"context"
 	"io"
 	"runtime"
 	"strings"
@@ -19,16 +18,19 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/writer"
 )
 
-// New returns an in-memory venv: a no-op mem exec, an in-memory filesystem,
+// New returns an in-memory venv: a fail-closed exec, an in-memory filesystem,
 // a fail-closed no-network HTTP client, a mem SOPS decrypter yielding empty
 // cleartext, an empty (non-nil) environment, deterministic platform handles,
 // an empty console reader, and both writers wired to [io.Discard]. Refine it
 // with venv.Venv's fluent With methods.
+//
+// A test whose subject runs a command supplies a handler through WithHandler.
+// Until it does, the command fails with [vexec.ErrNoSpawn] rather than
+// reporting success with empty output, which a caller reading the command's
+// stdout would take as a real answer.
 func New() *venv.Venv {
 	return &venv.Venv{
-		Exec: vexec.NewMemExec(
-			func(context.Context, vexec.Invocation) vexec.Result { return vexec.Result{} },
-		),
+		Exec:   vexec.NewNoSpawnExec(),
 		FS:     vfs.NewMemMapFS(),
 		HTTP:   vhttp.NewNoNetworkClient(),
 		Sops:   vsops.NewMemDecrypter(func(string, string) ([]byte, error) { return nil, nil }),

--- a/test/helpers/venvtest/venvtest_test.go
+++ b/test/helpers/venvtest/venvtest_test.go
@@ -1,0 +1,37 @@
+package venvtest_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewFailsClosedOnSpawn pins the default executor. A handler returning an
+// empty result would report success with no output, and code that reads a
+// command's stdout takes that empty string for the command's answer: an empty
+// git top-level directory, an empty version, an empty list of workspaces.
+func TestNewFailsClosedOnSpawn(t *testing.T) {
+	t.Parallel()
+
+	err := venvtest.New().Exec.Command(t.Context(), "git", "rev-parse", "--show-toplevel").Run()
+	require.ErrorIs(t, err, vexec.ErrNoSpawn)
+}
+
+// TestWithHandlerOverridesFailClosed pins the escape hatch a test uses when
+// its subject is meant to run a command.
+func TestWithHandlerOverridesFailClosed(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New().WithHandler(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		return vexec.Result{Stdout: []byte(inv.Name + " ran\n")}
+	})
+
+	out, err := v.Exec.Command(t.Context(), "tofu", "version").Output()
+	require.NoError(t, err)
+	assert.Equal(t, "tofu ran\n", string(out))
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Updates `venvtest.New()` so that it uses a `NewNoSpawnExec`, which fails closed. The idea here is that if we accidentally set up a test that uses `venvtest.New()` not expecting a process to be spawned, but one is, we should get an error instead of a pass.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended command execution when no execution handler is configured.
  * Command attempts now fail clearly while preserving command lookup behavior.
  * Added error details identifying the refused command.

* **Tests**
  * Added coverage for blocked command execution, empty output, command resolution, and custom handler overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->