### PR TITLE
docs: document oci module sources, authentication, and caching

### DIFF
--- a/docs/src/content/docs/03-features/01-units/13-oci.mdx
+++ b/docs/src/content/docs/03-features/01-units/13-oci.mdx
@@ -1,0 +1,131 @@
+---
+title: OCI Registries
+description: Learn how to source OpenTofu/Terraform modules from OCI registries.
+slug: features/units/oci
+sidebar:
+  order: 13
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Terragrunt can download modules from OCI Distribution registries such as Amazon ECR, GitHub Container Registry, Azure Container Registry, Google Artifact Registry, and self-hosted registries. A module published once is consumable by both `tofu` and Terragrunt with the same source string.
+
+<Aside type="tip" title="Experimental">
+  OCI sources are part of the [`oci` experiment](/reference/experiments/active#oci). Enable it with `--experiment oci` (or `TG_EXPERIMENT=oci`) until it graduates to general availability.
+</Aside>
+
+## Using OCI sources
+
+OCI sources take the form `oci://REGISTRY_HOST/REPOSITORY[//SUBDIR][?tag=TAG|?digest=DIGEST]`. The registry host may carry a port, and the repository may have multiple path segments.
+
+```hcl
+# terragrunt.hcl
+terraform {
+  source = "oci://ghcr.io/acme/terraform-modules/vpc?tag=1.0.0"
+}
+```
+
+The same syntax works in the `unit` and `stack` blocks of a `terragrunt.stack.hcl`:
+
+```hcl
+# terragrunt.stack.hcl
+unit "vpc" {
+  source = "oci://ghcr.io/acme/terraform-modules/vpc?tag=1.0.0"
+  path   = "vpc"
+}
+```
+
+- `?tag=` selects a tag; `?digest=sha256:...` pins an immutable manifest digest. Setting both is an error, and no other query parameters are accepted.
+- When neither is set, Terragrunt uses the `latest` tag.
+- `//SUBDIR` selects one directory from the module package, as with other source types: `oci://ghcr.io/acme/terraform-modules/vpc//modules/subnets?tag=1.0.0`.
+
+Prefer `?digest=` for production pins: a digest can never move, while a tag can be re-pushed.
+
+## Publishing modules
+
+Terragrunt downloads the same artifact shape OpenTofu defines for modules: an OCI image manifest whose artifact type is `application/vnd.opentofu.modulepkg`, carrying exactly one layer of media type `archive/zip` that holds the module files zipped at the archive root.
+
+[`oras`](https://oras.land) publishes that shape directly:
+
+```bash
+cd vpc-module
+zip -r module.zip .
+oras push ghcr.io/acme/terraform-modules/vpc:1.0.0 \
+  --artifact-type application/vnd.opentofu.modulepkg \
+  module.zip:archive/zip
+```
+
+`oras push` prints the manifest digest, which is the value to use in `?digest=` pins.
+
+## Authentication
+
+Terragrunt resolves registry credentials the way OpenTofu does, so one configuration serves both tools. When nothing matches a registry, Terragrunt pulls anonymously.
+
+### OpenTofu CLI configuration
+
+Credentials come from `oci_credentials` and `oci_default_credentials` blocks in OpenTofu's CLI configuration. Terragrunt reads the file named by `TF_CLI_CONFIG_FILE` or `TERRAFORM_CONFIG`; otherwise the first of `~/.tofurc`, `~/.terraformrc`, and (when `XDG_CONFIG_HOME` is set) `$XDG_CONFIG_HOME/opentofu/tofurc` that exists (on Windows, `%APPDATA%\tofu.rc` and `%APPDATA%\terraform.rc`). Unless one of those environment variables is set, Terragrunt also merges the `*.tfrc` and `*.tfrc.json` files in OpenTofu's configuration directory.
+
+```hcl
+# ~/.tofurc
+oci_credentials "ghcr.io" {
+  username = "octocat"
+  password = "ghp_example"
+}
+
+oci_credentials "registry.example.com/platform" {
+  access_token  = "example-access"
+  refresh_token = "example-refresh"
+}
+
+oci_default_credentials {
+  docker_credentials_helper = "osxkeychain"
+}
+```
+
+- A block label is a registry domain, optionally followed by a repository prefix that narrows which repositories it covers.
+- Each `oci_credentials` block configures exactly one credential style: `username` and `password`, `access_token` and `refresh_token`, or `docker_credentials_helper`.
+- A `docker_credentials_helper` can only be set for a whole registry, not a repository prefix.
+- A CLI configuration file that exists but is invalid is an error rather than being skipped, so a typo cannot silently change which credentials are sent. A missing file is simply not used.
+
+### Ambient Docker and containers files
+
+Terragrunt also reads the credential files container tools leave behind, in the same order OpenTofu uses:
+
+1. `$XDG_RUNTIME_DIR/containers/auth.json` (Linux, when `XDG_RUNTIME_DIR` is set)
+2. `$HOME/.config/containers/auth.json` (Windows and macOS)
+3. `$XDG_CONFIG_HOME/containers/auth.json`, or `$HOME/.config/containers/auth.json` when `XDG_CONFIG_HOME` is unset
+4. `$HOME/.docker/config.json`
+
+The `DOCKER_CONFIG` environment variable is not consulted, matching OpenTofu. Set `docker_style_config_files` in `oci_default_credentials` to replace the search list with explicit paths, or to an empty list to disable ambient discovery; `discover_ambient_credentials = false` disables it as well.
+
+### Credential helpers
+
+Both surfaces can name [Docker credential helpers](https://docs.docker.com/reference/cli/docker/login/#credential-helpers): `docker_credentials_helper` in the CLI configuration, and `credHelpers` or `credsStore` in a Docker config file. A helper named `NAME` runs as `docker-credential-NAME` found on `PATH`.
+
+For Amazon ECR, install [`docker-credential-ecr-login`](https://github.com/awslabs/amazon-ecr-credential-helper) and map your registry to it:
+
+```json
+# ~/.docker/config.json
+
+{
+  "credHelpers": {
+    "123456789012.dkr.ecr.us-east-1.amazonaws.com": "ecr-login"
+  }
+}
+```
+
+The helper mints a fresh token on every run from ambient AWS credentials, so ECR's short-lived passwords never need to be stored. The equivalent CLI-configuration form is an `oci_credentials` block for the registry with `docker_credentials_helper = "ecr-login"`.
+
+### Credential selection
+
+Terragrunt ranks every matching credential, from CLI configuration and ambient files together, by how specifically it names the repository being pulled: an entry naming the repository beats one naming only the registry, which beats a global fallback such as `credsStore` or the `oci_default_credentials` helper. When two candidates match equally, a CLI-configuration entry wins over an ambient one, and a helper wins over a stored password. Only the selected credential is used, and only its helper is executed.
+
+## Caching
+
+With [Content Addressable Storage](/features/caching/cas) enabled, `terraform.source` downloads are [cached by the resolved manifest digest](/features/caching/cas/oci). Tags are re-resolved each time Terragrunt downloads the source, so a re-pushed tag misses the cache and fetches the new content while unchanged tags keep hitting the same entry. On later runs of an already-downloaded unit, Terragrunt reuses `.terragrunt-cache` without contacting the registry; pass `--source-update` to pick up a re-pushed tag. `unit` and `stack` components fetch directly from the registry without the cache.
+
+## Limits
+
+- Manifests above 4 MiB and layers above 512 MiB are rejected; layers above 50 MiB log a warning before downloading.
+- Module archives are limited to 512 MiB and 10000 files when extracted.
+- Every downloaded blob is verified against the digest its manifest declares before use.

--- a/docs/src/content/docs/03-features/07-caching/04-cas/10-oci.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/10-oci.mdx
@@ -1,0 +1,37 @@
+---
+title: OCI
+description: How the CAS probes and deduplicates oci registry sources.
+slug: features/caching/cas/oci
+sidebar:
+  order: 10
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Experimental">
+OCI sources are part of the [`oci` experiment](/reference/experiments/active#oci). Enable it with `--experiment oci`.
+</Aside>
+
+## Overview
+
+An OCI reference resolves to an immutable manifest digest, which makes it an ideal cache key: a `?digest=` pin already is one, and a `?tag=` resolves to one with a single registry request. The CAS keys the module package by that manifest digest, so caching tracks content rather than the mutable tag.
+
+## The cheap probe
+
+A source pinned with `?digest=` needs no registry request at all: the digest itself is the cache key. A source using `?tag=` (or the implicit `latest`) resolves the tag to its current manifest digest with one metadata request, capped at ten seconds. A `//subdir` selector is stripped before the probe, so two requests that differ only by subdirectory share one key; the cached tree is the full module package, and the requested subdirectory is extracted when linking.
+
+## Cache key & deduplication
+
+The key is the manifest digest, so a tag and a digest pin that name the same manifest share one CAS entry, as do the same module pulled from the same registry by different configurations. Because tags are re-resolved on every probe, a re-pushed tag resolves to a new digest and misses the cache instead of serving stale content. File blobs are content-addressed.
+
+## Cache miss
+
+When the digest is not yet in the store, Terragrunt rewrites the fetch itself to `?digest=`, downloads the module package, ingests it, and links it into the target. Fetching by the resolved digest rather than the tag means a tag moving mid-fetch can never store the wrong content under the key.
+
+## Cache hit
+
+When the digest is already present, Terragrunt links the cached tree without contacting the registry beyond the tag resolution.
+
+## Fallback behavior
+
+A probe failure, such as an unreachable registry or an unresolvable tag, yields no key, and Terragrunt falls back to downloading and content-hashing the result; the underlying error surfaces on the real fetch attempt. `unit` and `stack` components with `oci://` sources do not use the CAS and always fetch directly.

--- a/docs/src/content/docs/03-features/07-caching/04-cas/index.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/index.mdx
@@ -46,6 +46,7 @@ Each getter has a dedicated page describing its exact mechanics:
 | [Google Cloud Storage](/features/caching/cas/gcs) | Object metadata read exposes the MD5 or CRC32C checksum | Content-addressed |
 | [Mercurial](/features/caching/cas/mercurial) | `hg identify` resolves a revision to a node hash | Content-addressed |
 | [OpenTofu/Terraform Registry](/features/caching/cas/registry) | Registry protocol resolves the underlying archive URL | Content-addressed on the immutable archive |
+| [OCI](/features/caching/cas/oci) | A `?digest=` pin is the key itself; a tag resolves to its manifest digest | Content-addressed on the manifest digest |
 | [SMB](/features/caching/cas/smb) | None; always downloads | Content-addressed on the downloaded tree |
 | [Local paths](/features/caching/cas/local) | None; always copies | Content-addressed on the copied tree |
 

--- a/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/02-blocks.mdx
@@ -49,6 +49,11 @@ The `terraform` block supports the following arguments:
     registry module
     [terraform-aws-modules/iam](https://registry.terraform.io/modules/terraform-aws-modules/iam/aws/latest), you can
     use the following: `tfr:///terraform-aws-modules/iam/aws//modules/iam-policy?version=4.3.0`.
+  - The `source` parameter can pull modules from OCI registries using the `oci` protocol, in the format
+    `oci://REGISTRY_HOST/REPOSITORY[//SUBDIR][?tag=TAG|?digest=DIGEST]`. For example:
+    `oci://ghcr.io/acme/terraform-modules/vpc?tag=1.0.0`. When neither `tag` nor `digest` is set, the
+    `latest` tag is used. This requires the [`oci` experiment](/reference/experiments/active#oci); see
+    [OCI registries](/features/units/oci) for the publishing contract and authentication.
 
 <Since version="1.1.1">
 

--- a/docs/src/data/experiments/oci.mdx
+++ b/docs/src/data/experiments/oci.mdx
@@ -94,7 +94,7 @@ To transition the `oci` feature to a stable release, the following must be addre
 - [x] Credential-helper support (`docker-credential-*`, `ecr-login`) so ECR and other helper-backed registries work through the configured helper.
 - [x] Content-addressable caching keyed on the resolved manifest digest, with correct re-resolution of mutable tags.
 - [x] A portability guarantee that one source string produces an identical module via `tofu` and Terragrunt.
-- [ ] Documentation covering the source syntax, authentication tiers, and publishing contract.
+- [x] Documentation covering the source syntax, authentication tiers, and publishing contract.
 - [x] Integration test coverage driving the full download chain against a local OCI Distribution registry.
 - [ ] Gated CI coverage against hosted registries (GHCR, ECR) with real credentials.
 - [ ] Community feedback on real-world usage.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

- Add oci:// usage, publishing, and authentication docs
- Add the OCI page to the CAS section
- Reference oci:// in the terraform.source block docs

<img width="250" height="409" alt="image" src="https://github.com/user-attachments/assets/f643bc61-8882-47c7-b45f-d97d30f2a6a7" />

RFC: https://github.com/gruntwork-io/terragrunt/issues/4555

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for sourcing and publishing modules through OCI registries.
  * Documented OCI authentication, credential precedence, caching, size limits, and blob verification.
  * Added instructions for OCI-based content-addressable storage, including digest resolution, deduplication, and fallback behavior.
  * Clarified OCI source syntax, tags, digests, subdirectories, and required configuration.
  * Updated OCI experiment documentation to reflect complete documentation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->