### PR TITLE
chore: Gate real `hg` usage test behind the `exec` build flag

### DIFF
--- a/internal/getter/resolver_hg_exec_test.go
+++ b/internal/getter/resolver_hg_exec_test.go
@@ -1,0 +1,63 @@
+//go:build exec
+
+// Real-hg parity test for HgResolver. It spawns the actual hg binary and
+// builds a repository on disk, which costs orders of magnitude more than the
+// in-memory exec tests in resolver_hg_test.go, so it is gated behind the exec
+// tag alongside the other real-binary parity suites. The default build pins
+// the same contracts through the in-memory exec.
+
+package getter_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecHgResolver_AgainstRealHg verifies the resolver against the
+// actual hg binary when it is installed. It uses a freshly-initialized
+// repository on disk so the test does not reach the network. The
+// assertion pins the resolver's key against a ContentKey derived
+// from the full 40-char node hash reported by the stable
+// `hg log -T {node}` template API; this regresses if the resolver
+// reverts to `--id`'s 12-char short form.
+func TestExecHgResolver_AgainstRealHg(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("hg"); err != nil {
+		t.Skip("hg binary not installed on this host")
+	}
+
+	repoDir := t.TempDir()
+
+	hg := func(args ...string) string {
+		cmd := exec.CommandContext(t.Context(), "hg", args...)
+		cmd.Dir = repoDir
+
+		out, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "hg %v failed: %s", args, string(out))
+
+		return string(out)
+	}
+
+	hg("init", ".")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("hello\n"), 0o644))
+	hg("--config", "ui.username=test <test@test>", "commit", "-A", "-m", "initial")
+
+	// The template API is a stable hg contract, unlike debug output text.
+	fullNode := strings.TrimSpace(hg("log", "-r", "tip", "-T", "{node}"))
+	require.Len(t, fullNode, 40, "hg log -T {node} must report a full 40-char node hash")
+
+	r := getter.NewHgResolver()
+
+	got, err := r.Probe(t.Context(), repoDir+"?rev=tip")
+	require.NoError(t, err)
+	assert.Equal(t, cas.ContentKey("hg-node", fullNode), got)
+}

--- a/internal/getter/resolver_hg_test.go
+++ b/internal/getter/resolver_hg_test.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/url"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
@@ -197,47 +193,6 @@ func TestHgResolver_AcceptsRevWithShellMetacharacters(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, gotArgs, "--rev=tip ; echo pwned",
 		"shell metacharacters must reach hg as part of a single argv element")
-}
-
-// TestHgResolver_AgainstRealHg verifies the resolver against the
-// actual hg binary when it is installed. It uses a freshly-initialized
-// repository on disk so the test does not reach the network. The
-// assertion pins the resolver's key against a ContentKey derived
-// from the full 40-char node hash reported by the stable
-// `hg log -T {node}` template API; this regresses if the resolver
-// reverts to `--id`'s 12-char short form.
-func TestHgResolver_AgainstRealHg(t *testing.T) {
-	t.Parallel()
-
-	if _, err := exec.LookPath("hg"); err != nil {
-		t.Skip("hg binary not installed on this host")
-	}
-
-	repoDir := t.TempDir()
-
-	hg := func(args ...string) string {
-		cmd := exec.CommandContext(t.Context(), "hg", args...)
-		cmd.Dir = repoDir
-
-		out, err := cmd.CombinedOutput()
-		require.NoErrorf(t, err, "hg %v failed: %s", args, string(out))
-
-		return string(out)
-	}
-
-	hg("init", ".")
-	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("hello\n"), 0o644))
-	hg("--config", "ui.username=test <test@test>", "commit", "-A", "-m", "initial")
-
-	// The template API is a stable hg contract, unlike debug output text.
-	fullNode := strings.TrimSpace(hg("log", "-r", "tip", "-T", "{node}"))
-	require.Len(t, fullNode, 40, "hg log -T {node} must report a full 40-char node hash")
-
-	r := getter.NewHgResolver()
-
-	got, err := r.Probe(t.Context(), repoDir+"?rev=tip")
-	require.NoError(t, err)
-	assert.Equal(t, cas.ContentKey("hg-node", fullNode), got)
 }
 
 // hgHandler returns a vexec.Handler that always produces the given


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6619.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage using a real Mercurial installation.
  * Verified revision resolution and content key generation in a temporary repository.
  * Tests automatically skip when Mercurial is unavailable.
  * Retained existing stub-based test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->