### PR TITLE
chore: Enforce venv capture

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - errorlint
     - exhaustive
     - fatcontext
+    - forbidigo
     - gocheckcompilerdirectives
     - gochecksumtype
     - goconst
@@ -99,6 +100,36 @@ linters:
               desc: use github.com/gruntwork-io/terragrunt/internal/md instead
     dupl:
       threshold: 120
+    # Terragrunt routes every side effect through the virtualized environment
+    # (internal/venv) so a run can be driven entirely in memory. These patterns
+    # catch the ways code reaches past that seam to the real OS. The exclusion
+    # list at the bottom of this file allows for exclusions (typically in tests).
+    forbidigo:
+      analyze-types: true
+      forbid:
+        - pattern: ^os\.(ReadFile|WriteFile|Open|OpenFile|Create|CreateTemp|MkdirTemp|Stat|Lstat|Mkdir|MkdirAll|Remove|RemoveAll|ReadDir|Rename|Symlink|Readlink|Chmod|Chdir|Getwd|Link|Truncate)$
+          pkg: ^os$
+          msg: read and write through the venv's vfs.FS instead of the real filesystem
+        - pattern: ^os\.(Getenv|Setenv|Unsetenv|LookupEnv|Environ|ExpandEnv)$
+          pkg: ^os$
+          msg: read and write the venv's Env map instead of the process environment
+        - pattern: ^os\.(UserHomeDir|UserCacheDir|UserConfigDir)$
+          pkg: ^os$
+          msg: use the venv's Platform handles instead of reading the invoking user's directories
+        - pattern: ^exec\.(Command|CommandContext|LookPath)$
+          pkg: ^os/exec$
+          msg: spawn through the venv's vexec.Exec instead of os/exec
+        - pattern: ^http\.(Get|Post|Head|PostForm)$
+          pkg: ^net/http$
+          msg: send through the venv's vhttp.Client instead of net/http package functions
+        - pattern: ^http\.Default(Client|Transport)$
+          pkg: ^net/http$
+          msg: send through the venv's vhttp.Client instead of the shared default client
+        - pattern: ^filepath\.(Walk|WalkDir|Glob)$
+          pkg: ^path/filepath$
+          msg: walk the venv's vfs.FS via vfs.WalkDir or vfs.WalkDirParallel instead of the real filesystem
+        - pattern: ^(vfs\.NewOSFS|vexec\.NewOSExec|vhttp\.NewOSClient|vsops\.NewOSDecrypter)$
+          msg: take the handle from the venv already in scope rather than building a fresh OS-backed one
     errcheck:
       check-type-assertions: false
       check-blank: false
@@ -145,6 +176,51 @@ linters:
           - unparam
           - wsl
         path: _test\.go
+      # Tests frequently drive real fixtures on disk, so tests
+      # are allowed to bypass venv.
+      - linters:
+          - forbidigo
+        path: (_test\.go|^test/|^internal/git/server\.go)
+      # The packages that implement venv, plus the console and pty
+      # layer they sit on, are where the real OS calls are supposed to live.
+      - linters:
+          - forbidigo
+        path: ^internal/(vfs|vexec|vhttp|vsops|venv|os)/
+
+      # Everything below are the call sites that predate the forbidigo
+      # rules above. They reach the real OS directly and still need porting to
+      # venv. Delete entries as they are ported.
+
+      - linters:
+          - forbidigo
+        path: ^(internal/cli/commands/browse/tui/model\.go|internal/cli/commands/catalog/cli\.go|internal/cli/commands/catalog/tui/form\.go|internal/cli/commands/catalog/tui/tags_layout\.go|internal/cli/commands/commands\.go|internal/cli/commands/hcl/validate/validate\.go|internal/cli/commands/help/cli\.go|internal/cli/commands/render/render\.go|internal/cli/commands/scaffold/cli\.go|internal/cli/commands/scaffold/scaffold\.go)$
+      # Env-var-backed flags resolve against the process environment rather
+      # than the venv's Env map, so every flag parsed from an env var bypasses
+      # the seam.
+      #
+      # TODO: Update LookupEnvFunc to close this.
+      - linters:
+          - forbidigo
+        path: ^(internal/clihelper/app\.go|internal/clihelper/flag\.go|internal/clihelper/map_flag\.go|internal/clihelper/slice_flag\.go)$
+      - linters:
+          - forbidigo
+        path: ^(internal/tf/cache/handlers/filesystem_mirror_provider\.go|internal/tf/cache/helpers/http\.go|internal/tf/cliconfig/credentials\.go|internal/tf/getproviders/constraints\.go|internal/tf/getproviders/hash\.go|internal/tf/getproviders/lock\.go|internal/tf/getproviders/package_authentication\.go|internal/tf/source\.go|internal/tf/tf\.go)$
+      - linters:
+          - forbidigo
+        path: ^(internal/runner/common/unit_runner\.go|internal/runner/run/debug\.go|internal/runner/run/run\.go|internal/runner/runnerpool/runner\.go)$
+      - linters:
+          - forbidigo
+        path: ^(pkg/config/catalog\.go|pkg/config/config_helpers\.go|pkg/config/config_partial\.go|pkg/config/config\.go|pkg/config/dependency\.go|pkg/config/stack\.go)$
+      # DefaultWrappedPath is a package-level var, so it probes for `tofu` at
+      # init time, before any venv exists.
+      #
+      # TODO: Make the lookup lazy with a once so we can inject venv into this.
+      - linters:
+          - forbidigo
+        path: ^pkg/options/options\.go$
+      - linters:
+          - forbidigo
+        path: ^(internal/awshelper/config\.go|internal/discovery/helpers\.go|internal/discovery/phase_worktree\.go|internal/engine/engine\.go|internal/engine/verification\.go|internal/gcphelper/config\.go|internal/getter/tfrhelpers\.go|internal/git/git\.go|internal/panicreport/panicreport\.go|internal/remotestate/remote_state\.go|internal/remotestate/terraform_state_file\.go|internal/report/writer\.go|internal/services/catalog/module/doc\.go|internal/services/catalog/module/module\.go|internal/shell/git\.go|internal/shell/run_cmd\.go|internal/stacks/clean/clean\.go|internal/tfimpl/tfimpl\.go|internal/util/file\.go|internal/util/lockfile\.go|internal/worktrees/worktrees\.go)$
       # We end up with duplicated content in this package to save us from duplicating code in other packages.
       - linters:
           - dupl
@@ -161,7 +237,7 @@ linters:
       # trying to get this merged in.
       - linters:
           - lll
-        path-except: '^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|browse|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/codegen/|internal/configbridge/|internal/discovery/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/filter/|internal/gcphelper/|internal/getter/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/report/|internal/retry/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)'
+        path-except: "^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|browse|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/codegen/|internal/configbridge/|internal/discovery/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/filter/|internal/gcphelper/|internal/getter/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/report/|internal/retry/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)"
     paths:
       - docs
       - _ci

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1041,7 +1042,7 @@ func runAppTest(
 	app.Writer = &bytes.Buffer{}
 	app.ErrWriter = &bytes.Buffer{}
 
-	app.Flags = append(global.NewFlags(l, opts, nil), run.NewFlags(l, opts, nil)...)
+	app.Flags = append(global.NewFlags(l, opts, nil), run.NewFlags(l, opts, venvtest.New(), nil)...)
 	app.Commands = terragruntCommands.WrapAction(commands.WrapWithTelemetry(l, opts, venv.OSVenv()))
 	app.OsExiter = cli.OSExiter
 	app.Action = func(ctx context.Context, cliCtx *clihelper.Context) error {

--- a/internal/cli/commands/aws-provider-patch/cli.go
+++ b/internal/cli/commands/aws-provider-patch/cli.go
@@ -73,7 +73,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 	opts.StrictControls.FilterByNames(controls.DeprecatedCommands, controls.CLIRedesign, CommandName).
 		AddSubcontrols(control)
 
-	cmdFlags := append(runcmd.NewFlags(l, opts, nil), NewFlags(l, opts, nil)...)
+	cmdFlags := append(runcmd.NewFlags(l, opts, v, nil), NewFlags(l, opts, nil)...)
 	cmdFlags = append(cmdFlags, shared.NewAllFlag(opts, nil))
 
 	cmd := &clihelper.Command{

--- a/internal/cli/commands/browse/browse.go
+++ b/internal/cli/commands/browse/browse.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/os/stdout"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	viewtui "github.com/gruntwork-io/terragrunt/internal/view/tui"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
@@ -74,7 +73,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *Options) error {
 		color = tui.ColorEnabled
 	}
 
-	err = tui.Run(ctx, l, vfs.NewOSFS(), root, color, resultCh, warnCh)
+	err = tui.Run(ctx, l, v.FS, root, color, resultCh, warnCh)
 
 	cancel()
 	<-done

--- a/internal/cli/commands/catalog/tui/update.go
+++ b/internal/cli/commands/catalog/tui/update.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/md"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/component"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	viewtui "github.com/gruntwork-io/terragrunt/internal/view/tui"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -679,7 +678,7 @@ func discoverFormCmd(
 ) tea.Cmd {
 	return func() tea.Msg {
 		if c.Kind.IsCopyable() {
-			return discoverValuesFields(c)
+			return discoverValuesFields(v, c)
 		}
 
 		return discoverModuleFields(ctx, l, v, opts, c)
@@ -721,7 +720,7 @@ func discoverModuleFields(
 // discoverValuesFields walks the unit/stack's HCL for `values.*` refs and
 // returns a formReadyMsg. CollectValuesReferences operates on the already
 // cloned local copy, so there's no download.
-func discoverValuesFields(c *Component) tea.Msg {
+func discoverValuesFields(v *venv.Venv, c *Component) tea.Msg {
 	configName := c.Kind.ConfigFile()
 	if configName == "" {
 		return formDiscoveryErrMsg{
@@ -730,7 +729,7 @@ func discoverValuesFields(c *Component) tea.Msg {
 	}
 
 	refs, err := component.CollectValuesReferences(
-		vfs.NewOSFS(),
+		v.FS,
 		filepath.Join(c.Repo.Path(), c.Dir, configName),
 	)
 	if err != nil {

--- a/internal/cli/commands/dag/graph/cli.go
+++ b/internal/cli/commands/dag/graph/cli.go
@@ -23,7 +23,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 	sharedFlags := shared.NewQueueFlags(opts, nil)
 	sharedFlags = append(sharedFlags, shared.NewBackendFlags(opts, nil)...)
 	sharedFlags = append(sharedFlags, shared.NewFeatureFlags(opts, nil)...)
-	sharedFlags = append(sharedFlags, shared.NewFilterFlags(l, opts)...)
+	sharedFlags = append(sharedFlags, shared.NewFilterFlags(l, opts, v)...)
 
 	return &clihelper.Command{
 		Name: CommandName,

--- a/internal/cli/commands/discoverysetup/discoverysetup.go
+++ b/internal/cli/commands/discoverysetup/discoverysetup.go
@@ -27,7 +27,7 @@ func Worktrees(
 	opts *options.TerragruntOptions,
 	d *discovery.Discovery,
 ) (*discovery.Discovery, func(context.Context), error) {
-	wts, err := worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{
+	wts, err := worktrees.NewWorktrees(ctx, l, v, worktrees.WorktreeOpts{
 		WorkingDir:     opts.WorkingDir,
 		GitExpressions: opts.Filters.UniqueGitFilters(),
 		Experiments:    opts.Experiments,

--- a/internal/cli/commands/find/cli.go
+++ b/internal/cli/commands/find/cli.go
@@ -38,9 +38,9 @@ const (
 	QueueConstructAsFlagAlias = "as"
 )
 
-func NewFlags(l log.Logger, opts *Options, prefix flags.Prefix) clihelper.Flags {
+func NewFlags(l log.Logger, opts *Options, v *venv.Venv, prefix flags.Prefix) clihelper.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
-	filterFlags := shared.NewFilterFlags(l, opts.TerragruntOptions)
+	filterFlags := shared.NewFilterFlags(l, opts.TerragruntOptions, v)
 
 	const numLocalFlags = 11
 
@@ -150,7 +150,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 	cmdOpts := NewOptions(opts)
 
 	// Base flags for find plus backend/feature flags
-	flags := NewFlags(l, cmdOpts, nil)
+	flags := NewFlags(l, cmdOpts, v, nil)
 	flags = append(flags, shared.NewBackendFlags(opts, nil)...)
 	flags = append(flags, shared.NewFeatureFlags(opts, nil)...)
 	flags = append(flags, shared.NewNoDiscoveryAuthProviderCmdFlag(opts, nil))

--- a/internal/cli/commands/hcl/format/cli.go
+++ b/internal/cli/commands/hcl/format/cli.go
@@ -22,7 +22,7 @@ const (
 	StdinFlagName      = "stdin"
 )
 
-func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix) clihelper.Flags {
+func NewFlags(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv, prefix flags.Prefix) clihelper.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 	terragruntPrefix := flags.Prefix{flags.TerragruntPrefix}
 
@@ -114,7 +114,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 	}
 
 	flagSet = flagSet.Add(shared.NewQueueFlags(opts, nil)...)
-	flagSet = flagSet.Add(shared.NewFilterFlags(l, opts)...)
+	flagSet = flagSet.Add(shared.NewFilterFlags(l, opts, v)...)
 	flagSet = flagSet.Add(shared.NewParallelismFlag(opts))
 
 	return flagSet
@@ -125,7 +125,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 		Name:    CommandName,
 		Aliases: []string{CommandNameAlias},
 		Usage:   "Recursively find HashiCorp Configuration Language (HCL) files and rewrite them into a canonical format.",
-		Flags:   NewFlags(l, opts, nil),
+		Flags:   NewFlags(l, opts, v, nil),
 		Action: func(ctx context.Context, _ *clihelper.Context) error {
 			return Run(ctx, l, v, opts.OptionsFromContext(ctx))
 		},

--- a/internal/cli/commands/hcl/validate/cli.go
+++ b/internal/cli/commands/hcl/validate/cli.go
@@ -20,7 +20,7 @@ const (
 	JSONFlagName           = "json"
 )
 
-func NewFlags(l log.Logger, opts *options.TerragruntOptions) clihelper.Flags {
+func NewFlags(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) clihelper.Flags {
 	tgPrefix := flags.Prefix{flags.TgPrefix}
 	terragruntPrefix := flags.Prefix{flags.TerragruntPrefix}
 
@@ -89,7 +89,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions) clihelper.Flags {
 	}
 
 	flagSet = flagSet.Add(shared.NewQueueFlags(opts, nil)...)
-	flagSet = flagSet.Add(shared.NewFilterFlags(l, opts)...)
+	flagSet = flagSet.Add(shared.NewFilterFlags(l, opts, v)...)
 
 	return flagSet
 }
@@ -98,7 +98,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 	cmd := &clihelper.Command{
 		Name:                         CommandName,
 		Usage:                        "Recursively find HashiCorp Configuration Language (HCL) files and validate them.",
-		Flags:                        NewFlags(l, opts),
+		Flags:                        NewFlags(l, opts, v),
 		DisabledErrorOnUndefinedFlag: true,
 		Action: func(ctx context.Context, _ *clihelper.Context) error {
 			return Run(ctx, l, v, opts.OptionsFromContext(ctx))

--- a/internal/cli/commands/hcl/validate/validate.go
+++ b/internal/cli/commands/hcl/validate/validate.go
@@ -121,6 +121,7 @@ func RunValidate(
 	worktrees, parseErr := worktrees.NewWorktrees(
 		ctx,
 		l,
+		v,
 		worktrees.WorktreeOpts{
 			WorkingDir:     opts.WorkingDir,
 			GitExpressions: gitFilters,
@@ -315,6 +316,7 @@ func RunValidateInputs(
 	worktrees, worktreeErr := worktrees.NewWorktrees(
 		ctx,
 		l,
+		v,
 		worktrees.WorktreeOpts{
 			WorkingDir:     opts.WorkingDir,
 			GitExpressions: gitFilters,

--- a/internal/cli/commands/info/print/cli.go
+++ b/internal/cli/commands/info/print/cli.go
@@ -16,7 +16,7 @@ const (
 )
 
 func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *clihelper.Command {
-	cmdFlags := runcmd.NewFlags(l, opts, nil)
+	cmdFlags := runcmd.NewFlags(l, opts, v, nil)
 	cmdFlags = append(cmdFlags, shared.NewAllFlag(opts, nil))
 
 	cmd := &clihelper.Command{

--- a/internal/cli/commands/list/cli.go
+++ b/internal/cli/commands/list/cli.go
@@ -38,9 +38,9 @@ const (
 	QueueConstructAsFlagAlias = "as"
 )
 
-func NewFlags(l log.Logger, opts *Options, prefix flags.Prefix) clihelper.Flags {
+func NewFlags(l log.Logger, opts *Options, v *venv.Venv, prefix flags.Prefix) clihelper.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
-	filterFlags := shared.NewFilterFlags(l, opts.TerragruntOptions)
+	filterFlags := shared.NewFilterFlags(l, opts.TerragruntOptions, v)
 
 	const numLocalFlags = 9
 
@@ -140,7 +140,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 	prefix := flags.Prefix{CommandName}
 
 	// Base flags for list plus backend/feature flags
-	flags := NewFlags(l, cmdOpts, prefix)
+	flags := NewFlags(l, cmdOpts, v, prefix)
 	flags = append(flags, shared.NewBackendFlags(opts, prefix)...)
 	flags = append(flags, shared.NewFeatureFlags(opts, prefix)...)
 	flags = append(flags, shared.NewNoDiscoveryAuthProviderCmdFlag(opts, prefix))

--- a/internal/cli/commands/render/cli.go
+++ b/internal/cli/commands/render/cli.go
@@ -151,7 +151,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 	prefix := flags.Prefix{CommandName}
 	renderOpts := NewOptions(opts)
 
-	cmdFlags := append(runcmd.NewFlags(l, opts, nil), NewFlags(renderOpts, prefix)...)
+	cmdFlags := append(runcmd.NewFlags(l, opts, v, nil), NewFlags(renderOpts, prefix)...)
 	cmdFlags = append(cmdFlags, shared.NewAllFlag(opts, prefix))
 
 	cmd := &clihelper.Command{

--- a/internal/cli/commands/run/cli.go
+++ b/internal/cli/commands/run/cli.go
@@ -19,7 +19,7 @@ const (
 )
 
 func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *clihelper.Command {
-	cmdFlags := NewFlags(l, opts, nil)
+	cmdFlags := NewFlags(l, opts, v, nil)
 	cmdFlags = append(cmdFlags, shared.NewAllFlag(opts, nil), shared.NewGraphFlag(opts, nil))
 
 	cmd := &clihelper.Command{

--- a/internal/cli/commands/run/flags.go
+++ b/internal/cli/commands/run/flags.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/report"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
@@ -96,7 +97,7 @@ var ErrNoDependencyOutputsRequiresExperiment = errors.New(
 )
 
 // NewFlags creates and returns global flags.
-func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix) clihelper.Flags {
+func NewFlags(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv, prefix flags.Prefix) clihelper.Flags {
 	tgPrefix := flags.Prefix{flags.TgPrefix}
 	terragruntPrefix := flags.Prefix{flags.TerragruntPrefix}
 	cmdFlags := clihelper.Flags{
@@ -655,7 +656,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, prefix flags.Prefix
 	cmdFlags = cmdFlags.Add(shared.NewFailFastFlag(opts))
 	cmdFlags = cmdFlags.Add(shared.NewIAMAssumeRoleFlags(opts, prefix)...)
 	cmdFlags = cmdFlags.Add(shared.NewQueueFlags(opts, prefix)...)
-	cmdFlags = cmdFlags.Add(shared.NewFilterFlags(l, opts)...)
+	cmdFlags = cmdFlags.Add(shared.NewFilterFlags(l, opts, v)...)
 	cmdFlags = cmdFlags.Add(shared.NewParallelismFlag(opts))
 	cmdFlags = cmdFlags.Add(shared.NewCASFlags(opts, prefix)...)
 

--- a/internal/cli/commands/run/flags_test.go
+++ b/internal/cli/commands/run/flags_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +18,7 @@ func TestNoHooksFlagRequiresExperiment(t *testing.T) {
 	t.Parallel()
 
 	opts := options.NewTerragruntOptions()
-	flags := runcommand.NewFlags(logger.CreateLogger(), opts, nil)
+	flags := runcommand.NewFlags(logger.CreateLogger(), opts, venvtest.New(), nil)
 
 	require.NoError(t, flags.Parse(clihelper.Args{"--no-hooks"}))
 
@@ -32,7 +33,7 @@ func TestNoHooksFlagAllowedWithExperiment(t *testing.T) {
 
 	opts := options.NewTerragruntOptions()
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.OptionalHooks))
-	flags := runcommand.NewFlags(logger.CreateLogger(), opts, nil)
+	flags := runcommand.NewFlags(logger.CreateLogger(), opts, venvtest.New(), nil)
 
 	require.NoError(t, flags.Parse(clihelper.Args{"--no-hooks"}))
 	require.NoError(t, flags.RunActions(context.Background(), &clihelper.Context{}))
@@ -43,7 +44,7 @@ func TestNoDependencyOutputsFlagRequiresExperiment(t *testing.T) {
 	t.Parallel()
 
 	opts := options.NewTerragruntOptions()
-	flags := runcommand.NewFlags(logger.CreateLogger(), opts, nil)
+	flags := runcommand.NewFlags(logger.CreateLogger(), opts, venvtest.New(), nil)
 
 	require.NoError(t, flags.Parse(clihelper.Args{"--no-dependency-outputs"}))
 
@@ -58,7 +59,7 @@ func TestNoDependencyOutputsFlagAllowedWithExperiment(t *testing.T) {
 
 	opts := options.NewTerragruntOptions()
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.OptionalDependencyOutputs))
-	flags := runcommand.NewFlags(logger.CreateLogger(), opts, nil)
+	flags := runcommand.NewFlags(logger.CreateLogger(), opts, venvtest.New(), nil)
 
 	require.NoError(t, flags.Parse(clihelper.Args{"--no-dependency-outputs"}))
 	require.NoError(t, flags.RunActions(context.Background(), &clihelper.Context{}))

--- a/internal/cli/commands/stack/cli.go
+++ b/internal/cli/commands/stack/cli.go
@@ -41,7 +41,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 				Action: func(ctx context.Context, _ *clihelper.Context) error {
 					return RunGenerate(ctx, l, v, opts.OptionsFromContext(ctx))
 				},
-				Flags: defaultFlags(l, opts, nil),
+				Flags: defaultFlags(l, opts, v, nil),
 			},
 			&clihelper.Command{
 				Name:  runCommandName,
@@ -49,7 +49,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 				Action: func(ctx context.Context, _ *clihelper.Context) error {
 					return Run(ctx, l, v, opts.OptionsFromContext(ctx))
 				},
-				Flags: defaultFlags(l, opts, nil),
+				Flags: defaultFlags(l, opts, v, nil),
 			},
 			&clihelper.Command{
 				Name:  outputCommandName,
@@ -62,7 +62,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 
 					return RunOutput(ctx, l, v, opts.OptionsFromContext(ctx), index)
 				},
-				Flags: outputFlags(l, opts, nil),
+				Flags: outputFlags(l, opts, v, nil),
 			},
 			&clihelper.Command{
 				Name:  cleanCommandName,
@@ -79,6 +79,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 func defaultFlags(
 	l log.Logger,
 	opts *options.TerragruntOptions,
+	v *venv.Venv,
 	prefix flags.Prefix,
 ) clihelper.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
@@ -93,12 +94,13 @@ func defaultFlags(
 		}),
 	}
 
-	return append(runcmd.NewFlags(l, opts, nil), flags...)
+	return append(runcmd.NewFlags(l, opts, v, nil), flags...)
 }
 
 func outputFlags(
 	l log.Logger,
 	opts *options.TerragruntOptions,
+	v *venv.Venv,
 	prefix flags.Prefix,
 ) clihelper.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
@@ -128,5 +130,5 @@ func outputFlags(
 		}),
 	}
 
-	return append(defaultFlags(l, opts, prefix), flags...)
+	return append(defaultFlags(l, opts, v, prefix), flags...)
 }

--- a/internal/cli/commands/stack/stack.go
+++ b/internal/cli/commands/stack/stack.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/stacks/output"
 	"github.com/gruntwork-io/terragrunt/internal/tips"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
@@ -38,7 +37,7 @@ func RunGenerate(
 		return nil
 	}
 
-	tips.GiveStackTargetTip(l, vfs.NewOSFS(), opts.WorkingDir, opts.Filters, opts.Tips)
+	tips.GiveStackTargetTip(l, v.FS, opts.WorkingDir, opts.Filters, opts.Tips)
 
 	opts.StackAction = "generate"
 
@@ -70,7 +69,7 @@ func RunGenerate(
 	if len(gitFilters) > 0 {
 		var err error
 
-		wts, err = worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{
+		wts, err = worktrees.NewWorktrees(ctx, l, v, worktrees.WorktreeOpts{
 			WorkingDir:     opts.WorkingDir,
 			GitExpressions: gitFilters,
 			Experiments:    opts.Experiments,

--- a/internal/cli/flags/shared/filter.go
+++ b/internal/cli/flags/shared/filter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
@@ -30,7 +30,7 @@ var ErrDiscoveryBoundaryRequiresExperiment = errors.New(
 )
 
 // NewFilterFlags creates flags for specifying filter queries.
-func NewFilterFlags(l log.Logger, opts *options.TerragruntOptions) clihelper.Flags {
+func NewFilterFlags(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) clihelper.Flags {
 	tgPrefix := flags.Prefix{flags.TgPrefix}
 
 	return clihelper.Flags{
@@ -78,7 +78,7 @@ func NewFilterFlags(l log.Logger, opts *options.TerragruntOptions) clihelper.Fla
 					}
 
 					// Check for uncommitted changes
-					gitRunner, err := git.NewGitRunner(vexec.NewOSExec())
+					gitRunner, err := git.NewGitRunner(v.Exec)
 					if err != nil {
 						return clihelper.NewExitError(err, clihelper.ExitCodeGeneralError)
 					}

--- a/internal/cli/flags/shared/filter_test.go
+++ b/internal/cli/flags/shared/filter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,7 +17,7 @@ func TestDiscoveryBoundaryFlagRequiresExperiment(t *testing.T) {
 	t.Parallel()
 
 	opts := options.NewTerragruntOptions()
-	flags := shared.NewFilterFlags(logger.CreateLogger(), opts)
+	flags := shared.NewFilterFlags(logger.CreateLogger(), opts, venvtest.New())
 
 	require.NoError(t, flags.Parse(clihelper.Args{"--discovery-boundary", "."}))
 
@@ -30,7 +31,7 @@ func TestDiscoveryBoundaryFlagAllowedWithExperiment(t *testing.T) {
 
 	opts := options.NewTerragruntOptions()
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.BoundedDiscovery))
-	flags := shared.NewFilterFlags(logger.CreateLogger(), opts)
+	flags := shared.NewFilterFlags(logger.CreateLogger(), opts, venvtest.New())
 
 	require.NoError(t, flags.Parse(clihelper.Args{"--discovery-boundary", "."}))
 	require.NoError(t, flags.RunActions(t.Context(), &clihelper.Context{}))

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -475,7 +475,7 @@ func TestWorktreePhase_Integration_CommandArgs(t *testing.T) {
 				WorkingDir:     tmpDir,
 				GitExpressions: gitExpressions,
 			}
-			w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
+			w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -761,7 +761,7 @@ unit "unit_to_be_untouched" {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -916,7 +916,7 @@ func TestWorktreePhase_Integration_StackSourceOnlyInOneRef(t *testing.T) {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1219,7 +1219,7 @@ locals {
 				WorkingDir:     tmpDir,
 				GitExpressions: filters.UniqueGitFilters(),
 			}
-			w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
+			w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -1317,7 +1317,7 @@ locals {
 		WorkingDir:     basicDir,
 		GitExpressions: filters.UniqueGitFilters(),
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1594,7 +1594,7 @@ locals {
 				WorkingDir:     tmpDir,
 				GitExpressions: filters.UniqueGitFilters(),
 			}
-			w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
+			w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -1702,7 +1702,7 @@ func TestWorktreePhase_Integration_FromSubdirectory_MultipleCommits(t *testing.T
 				WorkingDir:     basicDir,
 				GitExpressions: filters.UniqueGitFilters(),
 			}
-			w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
+			w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -1891,7 +1891,7 @@ unit "app" {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -2085,7 +2085,7 @@ unit "app" {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -2269,7 +2269,7 @@ unit "app" {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -2434,7 +2434,7 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -2575,7 +2575,7 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -2701,7 +2701,7 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -2758,7 +2758,7 @@ func runWorktreeDiscovery(
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -2871,7 +2871,7 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -3025,7 +3025,7 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -3150,7 +3150,7 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -3250,7 +3250,7 @@ locals {
 	filters, parseErr := filter.ParseFilterQueries(l, filterQueries)
 	require.NoError(t, parseErr)
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: filters.UniqueGitFilters(),
 	})
@@ -3333,7 +3333,7 @@ locals {
 	filters, parseErr := filter.ParseFilterQueries(l, []string{"[HEAD~1...HEAD]", "!./land-mine"})
 	require.NoError(t, parseErr)
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: filters.UniqueGitFilters(),
 	})
@@ -3439,7 +3439,7 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -3544,7 +3544,7 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -103,9 +103,11 @@ func WithDefaultGenericDispatch(opts ...GenericFetcherOption) CASGetterOption {
 			c = g.Venv.HTTP
 		}
 
+		g.Venv.RequireExec()
+
 		g.fetchers = DefaultGenericFetchers(
 			slices.Concat(opts, []GenericFetcherOption{WithHTTPClient(c)})...)
-		g.resolvers = DefaultSourceResolvers(c, opts...)
+		g.resolvers = DefaultSourceResolvers(c, g.Venv.Exec, opts...)
 	}
 }
 

--- a/internal/getter/casgetter_tfr_test.go
+++ b/internal/getter/casgetter_tfr_test.go
@@ -38,8 +38,7 @@ func TestCASGetter_TFRRoutesThroughCAS(t *testing.T) {
 	l := logger.CreateLogger()
 	httpClient := server.Client()
 
-	tfr := getter.NewRegistryGetter(l, vfs.NewOSFS()).
-		WithHTTPClient(httpClient).
+	tfr := getter.NewRegistryGetter(l, vfs.NewOSFS(), httpClient).
 		WithTofuImplementation(tfimpl.Terraform)
 
 	resolver := getter.NewTFRResolver().

--- a/internal/getter/defaults.go
+++ b/internal/getter/defaults.go
@@ -166,8 +166,7 @@ func DefaultGenericFetchers(opts ...GenericFetcherOption) map[string]getter.Gett
 			)
 		}
 
-		m[SchemeTFR] = NewRegistryGetter(cfg.logger, cfg.fs).
-			WithHTTPClient(cfg.httpClient).
+		m[SchemeTFR] = NewRegistryGetter(cfg.logger, cfg.fs, cfg.httpClient).
 			WithEnv(cfg.env).
 			WithTofuImplementation(cfg.tfrImpl)
 	}
@@ -270,7 +269,7 @@ func buildGetters(b *builder) []Getter {
 			NewCASProtocolGetter(b.logger, b.casStore, b.casVenv),
 			NewCASGetter(b.logger, b.casStore, b.casVenv, b.casCloneOpts,
 				WithGenericFetchers(fetchers),
-				WithGenericResolvers(DefaultSourceResolvers(b.httpClient, resolverOpts...)),
+				WithGenericResolvers(DefaultSourceResolvers(b.httpClient, b.casVenv.Exec, resolverOpts...)),
 			),
 		)
 	}

--- a/internal/getter/resolver.go
+++ b/internal/getter/resolver.go
@@ -2,6 +2,7 @@ package getter
 
 import (
 	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 )
@@ -23,11 +24,12 @@ type SourceResolver = cas.SourceResolver
 // so the probe and the fetch resolve against the same registry host, and
 // [WithDispatchEnv] so the probe carries the same registry credentials.
 //
-// The http, https, and tfr resolvers all probe over c. [CASGetter]
-// callers normally go through [WithDefaultGenericDispatch], which
-// supplies the venv's client.
+// The http, https, and tfr resolvers all probe over c, and the hg resolver
+// spawns `hg` through e. [CASGetter] callers normally go through
+// [WithDefaultGenericDispatch], which supplies the venv's client and executor.
 func DefaultSourceResolvers(
 	c vhttp.Client,
+	e vexec.Exec,
 	opts ...GenericFetcherOption,
 ) map[string]SourceResolver {
 	var cfg genericFetcherConfig
@@ -61,7 +63,7 @@ func DefaultSourceResolvers(
 		SchemeHTTPS: httpsRes,
 		SchemeS3:    NewS3Resolver(),
 		SchemeGCS:   NewGCSResolver(),
-		SchemeHg:    NewHgResolver(),
+		SchemeHg:    NewHgResolver(e),
 		SchemeTFR:   tfr,
 	}
 

--- a/internal/getter/resolver_hg.go
+++ b/internal/getter/resolver_hg.go
@@ -25,17 +25,17 @@ const hgResolverTimeout = 10 * time.Second
 
 // HgResolver is a [cas.SourceResolver] for Mercurial sources.
 type HgResolver struct {
-	// Exec runs the hg binary. Required; [NewHgResolver] wires
-	// [vexec.NewOSExec]. Tests substitute an in-memory backend.
+	// Exec runs the hg binary. Required; [NewHgResolver] takes it from the
+	// caller. Tests substitute an in-memory backend.
 	Exec vexec.Exec
 	// HgBinary overrides the binary name resolved via [vexec.Exec.LookPath].
 	// Empty means "hg".
 	HgBinary string
 }
 
-// NewHgResolver returns a resolver bound to the real OS-backed exec
-// and the ambient `hg` binary on PATH.
-func NewHgResolver() *HgResolver { return &HgResolver{Exec: vexec.NewOSExec()} }
+// NewHgResolver returns a resolver that spawns `hg` through e, resolving the
+// binary name against e's PATH.
+func NewHgResolver(e vexec.Exec) *HgResolver { return &HgResolver{Exec: e} }
 
 // Scheme returns "hg".
 func (r *HgResolver) Scheme() string { return "hg" }

--- a/internal/getter/resolver_hg_exec_test.go
+++ b/internal/getter/resolver_hg_exec_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +56,7 @@ func TestExecHgResolver_AgainstRealHg(t *testing.T) {
 	fullNode := strings.TrimSpace(hg("log", "-r", "tip", "-T", "{node}"))
 	require.Len(t, fullNode, 40, "hg log -T {node} must report a full 40-char node hash")
 
-	r := getter.NewHgResolver()
+	r := getter.NewHgResolver(vexec.NewOSExec())
 
 	got, err := r.Probe(t.Context(), repoDir+"?rev=tip")
 	require.NoError(t, err)

--- a/internal/getter/resolver_oci_test.go
+++ b/internal/getter/resolver_oci_test.go
@@ -243,11 +243,12 @@ func TestDefaultSourceResolversOCIConfig(t *testing.T) {
 
 	v := venvtest.New()
 
-	_, found := getter.DefaultSourceResolvers(v.HTTP)[getter.SchemeOCI]
+	_, found := getter.DefaultSourceResolvers(v.HTTP, v.Exec)[getter.SchemeOCI]
 	assert.False(t, found, "oci resolver must be absent without WithOCIConfig")
 
 	resolvers := getter.DefaultSourceResolvers(
 		v.HTTP,
+		v.Exec,
 		getter.WithDispatchLogger(logger.CreateLogger()),
 		getter.WithDispatchFS(v.FS),
 		getter.WithOCIConfig(v),

--- a/internal/getter/tfr.go
+++ b/internal/getter/tfr.go
@@ -55,29 +55,19 @@ func (r *RegistryGetter) auth() RegistryAuth {
 	return RegistryAuth{Env: r.Env, ReadUserConfig: vfs.IsOSFS(r.FS)}
 }
 
-// NewRegistryGetter returns a [RegistryGetter] configured with sensible
-// defaults: a [vhttp.NewOSClient] for registry-protocol requests, the
-// supplied logger for diagnostic output, the supplied filesystem for
-// archive expansion, and [tfimpl.OpenTofu] as the default implementation.
-// A logger is required because this package does not consistently guard
-// against a nil logger, so requiring one at construction time prevents
-// nil-pointer panics at call time. Use the With* methods to customize
-// other behavior.
-func NewRegistryGetter(l log.Logger, fs vfs.FS) *RegistryGetter {
+// NewRegistryGetter returns a [RegistryGetter] that issues registry-protocol
+// requests through c, logs diagnostics to l, expands archives onto fs, and
+// defaults to [tfimpl.OpenTofu]. A logger is required because this package
+// does not consistently guard against a nil logger, so requiring one at
+// construction time prevents nil-pointer panics at call time. Use the With*
+// methods to customize other behavior.
+func NewRegistryGetter(l log.Logger, fs vfs.FS, c vhttp.Client) *RegistryGetter {
 	return &RegistryGetter{
-		HTTPClient:         vhttp.NewOSClient(),
+		HTTPClient:         c,
 		Logger:             l,
 		FS:                 fs,
 		TofuImplementation: tfimpl.OpenTofu,
 	}
-}
-
-// WithHTTPClient overrides the HTTP client used for registry-protocol
-// requests. Intended for tests that swap in a [vhttp.NewMemClient] handler
-// or for callers that need custom transport configuration.
-func (r *RegistryGetter) WithHTTPClient(c vhttp.Client) *RegistryGetter {
-	r.HTTPClient = c
-	return r
 }
 
 // WithTofuImplementation selects which default registry domain is used when

--- a/internal/getter/tfr_test.go
+++ b/internal/getter/tfr_test.go
@@ -227,8 +227,7 @@ func newRegistryTestClient(t *testing.T, httpClient *http.Client, impl tfimpl.Ty
 
 	l := logger.CreateLogger()
 
-	tfr := getter.NewRegistryGetter(l, vfs.NewOSFS()).
-		WithHTTPClient(httpClient).
+	tfr := getter.NewRegistryGetter(l, vfs.NewOSFS(), httpClient).
 		WithTofuImplementation(impl)
 
 	return getter.NewClient(

--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	goversion "github.com/hashicorp/go-version"
@@ -397,21 +398,13 @@ type VersionResolver struct {
 	mu         sync.Mutex
 }
 
-// NewVersionResolver returns a VersionResolver with an empty cache and a
-// [vhttp.NewOSClient] for registry-protocol requests.
-func NewVersionResolver() *VersionResolver {
+// NewVersionResolver returns a VersionResolver with an empty cache that
+// issues registry-protocol requests through c.
+func NewVersionResolver(c vhttp.Client) *VersionResolver {
 	return &VersionResolver{
-		httpClient: vhttp.NewOSClient(),
+		httpClient: c,
 		cache:      make(map[string]string),
 	}
-}
-
-// WithHTTPClient overrides the HTTP client used for registry-protocol
-// requests. Intended for tests routing through a
-// [net/http/httptest.Server].
-func (r *VersionResolver) WithHTTPClient(c vhttp.Client) *VersionResolver {
-	r.httpClient = c
-	return r
 }
 
 // WithAuth sets the credentials the registry protocol authenticates with.
@@ -575,7 +568,7 @@ func applyHostToken(req *http.Request, auth RegistryAuth) (*http.Request, error)
 	// virtual filesystem, so a run that is not on the real disk skips it and
 	// authenticates from the env alone.
 	if auth.ReadUserConfig {
-		cliCfg, err := cliconfig.LoadUserConfig()
+		cliCfg, err := cliconfig.LoadUserConfig(vfs.NewOSFS())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/getter/tfrhelpers_test.go
+++ b/internal/getter/tfrhelpers_test.go
@@ -43,7 +43,7 @@ func TestVersionResolverMemoizesWithRacing(t *testing.T) {
 	server := httptest.NewTLSServer(mux)
 	t.Cleanup(server.Close)
 
-	resolver := getter.NewVersionResolver().WithHTTPClient(server.Client())
+	resolver := getter.NewVersionResolver(server.Client())
 	source := "tfr://" + server.Listener.Addr().String() + "/foo/bar/baz"
 
 	var wg sync.WaitGroup

--- a/internal/getter/types_test.go
+++ b/internal/getter/types_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
@@ -20,7 +21,7 @@ import (
 func TestRegistryGetterMode(t *testing.T) {
 	t.Parallel()
 
-	r := getter.NewRegistryGetter(logger.CreateLogger(), vfs.NewOSFS())
+	r := getter.NewRegistryGetter(logger.CreateLogger(), vfs.NewOSFS(), vhttp.NewOSClient())
 
 	mode, err := r.Mode(t.Context(), &url.URL{Scheme: "tfr"})
 	require.NoError(t, err)
@@ -32,7 +33,7 @@ func TestRegistryGetterMode(t *testing.T) {
 func TestRegistryGetterGetFile(t *testing.T) {
 	t.Parallel()
 
-	r := getter.NewRegistryGetter(logger.CreateLogger(), vfs.NewOSFS())
+	r := getter.NewRegistryGetter(logger.CreateLogger(), vfs.NewOSFS(), vhttp.NewOSClient())
 
 	err := r.GetFile(t.Context(), &getter.Request{})
 	require.Error(t, err)
@@ -43,7 +44,7 @@ func TestRegistryGetterGetFile(t *testing.T) {
 func TestRegistryGetterDetect(t *testing.T) {
 	t.Parallel()
 
-	r := getter.NewRegistryGetter(logger.CreateLogger(), vfs.NewOSFS())
+	r := getter.NewRegistryGetter(logger.CreateLogger(), vfs.NewOSFS(), vhttp.NewOSClient())
 
 	tests := []struct {
 		req  *getter.Request

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -66,10 +66,6 @@ func ExtractRepoName(repo string) string {
 
 // WithWorkDir returns a new GitRunner with the specified working directory
 func (g *GitRunner) WithWorkDir(workDir string) *GitRunner {
-	if g == nil {
-		return &GitRunner{WorkDir: workDir, exec: vexec.NewOSExec(), repoRootMu: &sync.Mutex{}}
-	}
-
 	// GetRepoRoot writes the memo fields under repoRootMu, so the copy must
 	// hold the same lock to avoid racing with a concurrent memoization.
 	g.repoRootMu.Lock()

--- a/internal/git/git_commands_test.go
+++ b/internal/git/git_commands_test.go
@@ -50,15 +50,6 @@ func TestNewGitRunner(t *testing.T) {
 func TestGitRunner_WithWorkDir(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nil receiver", func(t *testing.T) {
-		t.Parallel()
-
-		var runner *git.GitRunner
-
-		got := runner.WithWorkDir("/repo")
-		assert.Equal(t, "/repo", got.WorkDir)
-	})
-
 	t.Run("resets memoized repo root", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/panicreport/panicreport.go
+++ b/internal/panicreport/panicreport.go
@@ -119,10 +119,11 @@ type RecoveredError struct {
 	stack []byte
 }
 
-// New returns a Reporter wired with production defaults.
-func New() *Reporter {
+// New returns a Reporter that writes its crash report through fs and reads
+// the remaining process details from the OS.
+func New(fs vfs.FS) *Reporter {
 	return &Reporter{
-		FS:        vfs.NewOSFS(),
+		FS:        fs,
 		Now:       time.Now,
 		Getwd:     os.Getwd,
 		GetPID:    os.Getpid,
@@ -389,14 +390,9 @@ func (r *Reporter) getPID() int {
 	return os.Getpid()
 }
 
-// writeFile writes through r.FS, falling back to a fresh OS FS when unset.
+// writeFile writes through r.FS.
 func (r *Reporter) writeFile(name string, data []byte, perm os.FileMode) error {
-	fs := r.FS
-	if fs == nil {
-		fs = vfs.NewOSFS()
-	}
-
-	return vfs.WriteFile(fs, name, data, perm)
+	return vfs.WriteFile(r.FS, name, data, perm)
 }
 
 // workingDir returns cwd, or TempDir if cwd is empty or errors.

--- a/internal/providercache/archive_staging_test.go
+++ b/internal/providercache/archive_staging_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -134,6 +135,8 @@ func startProviderCacheRun(t *testing.T, registryName, upstreamURL string) *prov
 		helpers.TmpDirWOSymlinks(t),
 		nil,
 		l,
+		vfs.NewOSFS(),
+		vhttp.NewOSClient(),
 	)
 
 	// The pre-populated discovery cache points version and platform lookups at

--- a/internal/providercache/concurrent_warmup_test.go
+++ b/internal/providercache/concurrent_warmup_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -120,7 +121,7 @@ func TestProviderCacheConcurrentWarmupWithRacing(t *testing.T) {
 	providerCacheDir := helpers.TmpDirWOSymlinks(t)
 	pluginCacheDir := helpers.TmpDirWOSymlinks(t)
 
-	providerService := services.NewProviderService(providerCacheDir, pluginCacheDir, nil, l)
+	providerService := services.NewProviderService(providerCacheDir, pluginCacheDir, nil, l, vfs.NewOSFS(), vhttp.NewOSClient())
 
 	// The pre-populated discovery cache points version and platform lookups at
 	// the fake upstream over plain HTTP, without DNS lookups.

--- a/internal/providercache/nested_modules_credentials_test.go
+++ b/internal/providercache/nested_modules_credentials_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -102,7 +103,7 @@ func TestNestedModuleCredentials(t *testing.T) {
 	pluginCacheDir := helpers.TmpDirWOSymlinks(t)
 
 	l := logger.CreateLogger()
-	providerService := services.NewProviderService(providerCacheDir, pluginCacheDir, nil, l)
+	providerService := services.NewProviderService(providerCacheDir, pluginCacheDir, nil, l, vfs.NewOSFS(), vhttp.NewOSClient())
 	proxyProviderHandler := handlers.NewProxyProviderHandler(
 		l,
 		vhttp.NewNoNetworkClient(),

--- a/internal/providercache/providercache.go
+++ b/internal/providercache/providercache.go
@@ -139,7 +139,7 @@ func (pc *ProviderCache) Init(
 	}
 
 	// Pass filesystem to LoadUserConfig
-	cliCfg, err := cliconfig.LoadUserConfig(cliconfig.WithFS(v.FS))
+	cliCfg, err := cliconfig.LoadUserConfig(v.FS)
 	if err != nil {
 		return err
 	}
@@ -156,8 +156,8 @@ func (pc *ProviderCache) Init(
 		userProviderDir,
 		cliCfg.CredentialsSource(),
 		l,
-		services.WithFS(v.FS),
-		services.WithHTTPClient(v.HTTP),
+		v.FS,
+		v.HTTP,
 	)
 	proxyProviderHandler := handlers.NewProxyProviderHandler(l, v.HTTP, cliCfg.CredentialsSource())
 

--- a/internal/providercache/providercache_test.go
+++ b/internal/providercache/providercache_test.go
@@ -157,7 +157,8 @@ func testProviderCache(t *testing.T, c vhttp.Client) {
 				pluginCacheDir,
 				nil,
 				l,
-				services.WithHTTPClient(c),
+				vfs.NewOSFS(),
+				c,
 			)
 			providerHandler := handlers.NewDirectProviderHandler(
 				l,

--- a/internal/runner/run/context.go
+++ b/internal/runner/run/context.go
@@ -32,20 +32,21 @@ func GetRunVersionCache(ctx context.Context) *cache.Cache[string] {
 // resolver so that units sharing a module source and constraint query the
 // registry once per run instead of once each.
 func WithModuleVersionResolver(ctx context.Context, v *venv.Venv) context.Context {
-	resolver := getter.NewVersionResolver().
-		WithHTTPClient(v.HTTP).
-		WithAuth(getter.RegistryAuth{Env: v.Env, ReadUserConfig: vfs.IsOSFS(v.FS)})
-
-	return context.WithValue(ctx, moduleVersionResolverContextKey, resolver)
+	return context.WithValue(ctx, moduleVersionResolverContextKey, newModuleVersionResolver(v))
 }
 
 // ModuleVersionResolverFromContext returns the resolver installed by
 // [WithModuleVersionResolver]. If none was installed, it returns a fresh
-// resolver whose memoization is scoped to the caller alone.
-func ModuleVersionResolverFromContext(ctx context.Context) *getter.VersionResolver {
+// resolver, on v's client, whose memoization is scoped to the caller alone.
+func ModuleVersionResolverFromContext(ctx context.Context, v *venv.Venv) *getter.VersionResolver {
 	if resolver, ok := ctx.Value(moduleVersionResolverContextKey).(*getter.VersionResolver); ok {
 		return resolver
 	}
 
-	return getter.NewVersionResolver()
+	return newModuleVersionResolver(v)
+}
+
+func newModuleVersionResolver(v *venv.Venv) *getter.VersionResolver {
+	return getter.NewVersionResolver(v.HTTP).
+		WithAuth(getter.RegistryAuth{Env: v.Env, ReadUserConfig: vfs.IsOSFS(v.FS)})
 }

--- a/internal/runner/run/context_test.go
+++ b/internal/runner/run/context_test.go
@@ -29,8 +29,8 @@ func TestModuleVersionResolverSharedPerRunWithRacing(t *testing.T) {
 	source := "tfr://" + server.Listener.Addr().String() + "/foo/bar/baz"
 	l := logger.CreateLogger()
 
-	ctx := run.WithModuleVersionResolver(t.Context(), venv.OSVenv())
-	run.ModuleVersionResolverFromContext(ctx).WithHTTPClient(server.Client())
+	v := venv.OSVenv().WithHTTP(server.Client())
+	ctx := run.WithModuleVersionResolver(t.Context(), v)
 
 	var wg sync.WaitGroup
 
@@ -44,7 +44,7 @@ func TestModuleVersionResolverSharedPerRunWithRacing(t *testing.T) {
 			// download path does. If lookups stopped returning the one shared
 			// resolver, the fresh fallback would not trust the test server's
 			// certificate and Pin would fail.
-			pinned, err := run.ModuleVersionResolverFromContext(ctx).Pin(
+			pinned, err := run.ModuleVersionResolverFromContext(ctx, v).Pin(
 				ctx, l, tfimpl.OpenTofu, source, "~> 3.0",
 			)
 			assert.NoError(t, err)
@@ -59,10 +59,9 @@ func TestModuleVersionResolverSharedPerRunWithRacing(t *testing.T) {
 	// A second installed resolver stands in for a second run: its cache must
 	// start cold, proving memoization lives on the run's context rather than
 	// in package-level state.
-	otherCtx := run.WithModuleVersionResolver(t.Context(), venv.OSVenv())
-	run.ModuleVersionResolverFromContext(otherCtx).WithHTTPClient(server.Client())
+	otherCtx := run.WithModuleVersionResolver(t.Context(), v)
 
-	pinned, err := run.ModuleVersionResolverFromContext(otherCtx).Pin(
+	pinned, err := run.ModuleVersionResolverFromContext(otherCtx, v).Pin(
 		otherCtx, l, tfimpl.OpenTofu, source, "~> 3.0",
 	)
 	require.NoError(t, err)
@@ -83,7 +82,9 @@ func TestModuleVersionResolverFromContextFallback(t *testing.T) {
 	source := "tfr://" + server.Listener.Addr().String() + "/foo/bar/baz"
 	l := logger.CreateLogger()
 
-	first := run.ModuleVersionResolverFromContext(t.Context()).WithHTTPClient(server.Client())
+	v := venv.OSVenv().WithHTTP(server.Client())
+
+	first := run.ModuleVersionResolverFromContext(t.Context(), v)
 
 	for range 2 {
 		pinned, err := first.Pin(t.Context(), l, tfimpl.OpenTofu, source, "~> 3.0")
@@ -93,7 +94,7 @@ func TestModuleVersionResolverFromContextFallback(t *testing.T) {
 
 	assert.Equal(t, int64(1), versionsHits.Load())
 
-	second := run.ModuleVersionResolverFromContext(t.Context()).WithHTTPClient(server.Client())
+	second := run.ModuleVersionResolverFromContext(t.Context(), v)
 
 	pinned, err := second.Pin(t.Context(), l, tfimpl.OpenTofu, source, "~> 3.0")
 	require.NoError(t, err)

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -70,7 +70,7 @@ func DownloadTerraformSource(
 
 	source = tf.RewriteLegacyGCSPublicSource(ctx, l, source, opts.StrictControls)
 
-	source, err := resolveTerraformModuleVersion(ctx, l, source, opts, cfg)
+	source, err := resolveTerraformModuleVersion(ctx, l, v, source, opts, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -227,6 +227,7 @@ func moduleCopyOptions(opts *Options, cfg *runcfg.RunConfig) []util.CopyOption {
 func resolveTerraformModuleVersion(
 	ctx context.Context,
 	l log.Logger,
+	v *venv.Venv,
 	source string,
 	opts *Options,
 	cfg *runcfg.RunConfig,
@@ -259,7 +260,7 @@ func resolveTerraformModuleVersion(
 		return source, nil
 	}
 
-	pinned, err := ModuleVersionResolverFromContext(ctx).Pin(
+	pinned, err := ModuleVersionResolverFromContext(ctx, v).Pin(
 		ctx,
 		l,
 		opts.TofuImplementation,
@@ -721,8 +722,7 @@ func BuildDownloadClient(
 			WithIncludeInCopy(cfg.Terraform.IncludeInCopy...).
 			WithExcludeFromCopy(cfg.Terraform.ExcludeFromCopy...).
 			WithFastCopy(controls.IsFastCopyEnabled(opts.StrictControls))),
-		getter.WithTFRegistry(getter.NewRegistryGetter(l, v.FS).
-			WithHTTPClient(v.HTTP).
+		getter.WithTFRegistry(getter.NewRegistryGetter(l, v.FS, v.HTTP).
 			WithEnv(v.Env).
 			WithTofuImplementation(opts.TofuImplementation)),
 	}

--- a/internal/runner/runall/runall.go
+++ b/internal/runner/runall/runall.go
@@ -127,7 +127,7 @@ func Run(
 	// ErrUserCancelled.
 	var wts *worktrees.Worktrees
 	if len(gitFilters) > 0 {
-		wts, err = worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{
+		wts, err = worktrees.NewWorktrees(ctx, l, v, worktrees.WorktreeOpts{
 			WorkingDir:     opts.WorkingDir,
 			GitExpressions: gitFilters,
 			Experiments:    opts.Experiments,

--- a/internal/stacks/output/output.go
+++ b/internal/stacks/output/output.go
@@ -82,7 +82,7 @@ func StackOutput(
 	l.Debugf("Generating output from %s", opts.WorkingDir)
 
 	// Create worktrees internally if filter-flag experiment is enabled and git filters are present
-	wts, err := buildWorktreesIfNeeded(ctx, l, opts)
+	wts, err := buildWorktreesIfNeeded(ctx, l, v, opts)
 	if err != nil {
 		return cty.NilVal, fmt.Errorf("failed to create worktrees: %w", err)
 	}
@@ -346,6 +346,7 @@ func readUnitOutput(
 func buildWorktreesIfNeeded(
 	ctx context.Context,
 	l log.Logger,
+	v *venv.Venv,
 	opts *options.TerragruntOptions,
 ) (*worktrees.Worktrees, error) {
 	gitFilters := opts.Filters.UniqueGitFilters()
@@ -353,7 +354,7 @@ func buildWorktreesIfNeeded(
 		return nil, nil
 	}
 
-	return worktrees.NewWorktrees(ctx, l, worktrees.WorktreeOpts{
+	return worktrees.NewWorktrees(ctx, l, v, worktrees.WorktreeOpts{
 		WorkingDir:     opts.WorkingDir,
 		GitExpressions: gitFilters,
 		Experiments:    opts.Experiments,

--- a/internal/tf/cache/download_auth_test.go
+++ b/internal/tf/cache/download_auth_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
@@ -38,7 +39,7 @@ func TestDownloadRouteRequiresSecretSegment(t *testing.T) {
 		cache.WithHostname("127.0.0.1"),
 		cache.WithToken(token),
 		cache.WithLogger(l),
-		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l)),
+		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, vfs.NewOSFS(), vhttp.NewOSClient())),
 		cache.WithProxyProviderHandler(
 			handlers.NewProxyProviderHandler(l, vhttp.NewNoNetworkClient(), nil),
 		),
@@ -108,7 +109,7 @@ func TestDownloadSegmentIsRedactedFromLogs(t *testing.T) {
 	server := cache.NewServer(
 		cache.WithHostname("127.0.0.1"),
 		cache.WithLogger(l),
-		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l)),
+		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, vfs.NewOSFS(), vhttp.NewOSClient())),
 		cache.WithProxyProviderHandler(
 			handlers.NewProxyProviderHandler(l, vhttp.NewNoNetworkClient(), nil),
 		),

--- a/internal/tf/cache/server_init_test.go
+++ b/internal/tf/cache/server_init_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
 
@@ -34,7 +36,7 @@ func TestServerRunInitializesServicesBeforeServing(t *testing.T) {
 	server := cache.NewServer(
 		cache.WithHostname("127.0.0.1"),
 		cache.WithLogger(l),
-		cache.WithProviderService(services.NewProviderService("", t.TempDir(), nil, l)),
+		cache.WithProviderService(services.NewProviderService("", t.TempDir(), nil, l, vfs.NewOSFS(), vhttp.NewOSClient())),
 	)
 
 	ln, err := server.Listen(t.Context())

--- a/internal/tf/cache/server_test.go
+++ b/internal/tf/cache/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/models"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
@@ -220,7 +221,7 @@ func TestServerRunReportsServeFailure(t *testing.T) {
 	server := cache.NewServer(
 		cache.WithHostname("127.0.0.1"),
 		cache.WithLogger(l),
-		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l)),
+		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, vfs.NewOSFS(), vhttp.NewNoNetworkClient())),
 	)
 
 	ln, err := server.Listen(t.Context())

--- a/internal/tf/cache/services/provider_cache.go
+++ b/internal/tf/cache/services/provider_cache.go
@@ -523,22 +523,6 @@ func (cache *ProviderCache) acquireLockFile(ctx context.Context) (*util.Lockfile
 // ProviderServiceOption configures a ProviderService.
 type ProviderServiceOption func(*ProviderService)
 
-// WithFS sets the filesystem for file operations.
-// If not set, defaults to the real OS filesystem.
-func WithFS(fs vfs.FS) ProviderServiceOption {
-	return func(ps *ProviderService) {
-		ps.fs = fs
-	}
-}
-
-// WithHTTPClient sets the HTTP client used for upstream provider fetches.
-// If not set, defaults to [vhttp.NewOSClient].
-func WithHTTPClient(c vhttp.Client) ProviderServiceOption {
-	return func(ps *ProviderService) {
-		ps.httpClient = c
-	}
-}
-
 type ProviderService struct {
 	logger log.Logger
 
@@ -585,6 +569,8 @@ func NewProviderService(
 	userCacheDir string,
 	credsSource *cliconfig.CredentialsSource,
 	l log.Logger,
+	fs vfs.FS,
+	c vhttp.Client,
 	opts ...ProviderServiceOption,
 ) *ProviderService {
 	service := &ProviderService{
@@ -593,8 +579,8 @@ func NewProviderService(
 		providerCacheWarmUpCh: make(chan *ProviderCache, providerCacheWarmUpChBufferSize),
 		credsSource:           credsSource,
 		logger:                l,
-		fs:                    vfs.NewOSFS(),
-		httpClient:            vhttp.NewOSClient(),
+		fs:                    fs,
+		httpClient:            c,
 	}
 
 	for _, opt := range opts {

--- a/internal/tf/cache/services/provider_cache_test.go
+++ b/internal/tf/cache/services/provider_cache_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
 
@@ -155,7 +156,7 @@ func TestProviderServiceInitIsIdempotent(t *testing.T) {
 	t.Parallel()
 
 	service := services.NewProviderService(
-		t.TempDir(), t.TempDir(), nil, logger.CreateLogger(),
+		t.TempDir(), t.TempDir(), nil, logger.CreateLogger(), vfs.NewOSFS(), vhttp.NewOSClient(),
 	)
 
 	require.NoError(t, service.Init())
@@ -165,7 +166,9 @@ func TestProviderServiceInitIsIdempotent(t *testing.T) {
 func TestProviderServiceInitWithoutCacheDir(t *testing.T) {
 	t.Parallel()
 
-	service := services.NewProviderService("", t.TempDir(), nil, logger.CreateLogger())
+	service := services.NewProviderService(
+		"", t.TempDir(), nil, logger.CreateLogger(), vfs.NewOSFS(), vhttp.NewOSClient(),
+	)
 
 	require.ErrorIs(t, service.Init(), services.ErrCacheDirNotSpecified)
 	require.ErrorIs(t, service.Run(t.Context()), services.ErrCacheDirNotSpecified)

--- a/internal/tf/cliconfig/config.go
+++ b/internal/tf/cliconfig/config.go
@@ -40,10 +40,10 @@ func WithFS(fs vfs.FS) ConfigOption {
 	}
 }
 
-// NewConfig creates a new Config with default values.
-func NewConfig() *Config {
+// NewConfig creates a new Config that saves through fs.
+func NewConfig(fs vfs.FS) *Config {
 	return &Config{
-		fs: vfs.NewOSFS(),
+		fs: fs,
 	}
 }
 

--- a/internal/tf/cliconfig/config_test.go
+++ b/internal/tf/cliconfig/config_test.go
@@ -16,7 +16,7 @@ func TestAddHost(t *testing.T) {
 	t.Run("new host is appended", func(t *testing.T) {
 		t.Parallel()
 
-		cfg := cliconfig.NewConfig()
+		cfg := cliconfig.NewConfig(vfs.NewMemMapFS())
 		cfg.AddHost("registry.example.com", map[string]string{
 			"providers.v1": "https://registry.example.com/v1/providers/",
 		})
@@ -33,7 +33,7 @@ func TestAddHost(t *testing.T) {
 	t.Run("existing host services are merged", func(t *testing.T) {
 		t.Parallel()
 
-		cfg := cliconfig.NewConfig()
+		cfg := cliconfig.NewConfig(vfs.NewMemMapFS())
 		cfg.AddHost("registry.example.com", map[string]string{
 			"modules.v1": "https://registry.example.com/v1/modules/",
 		})
@@ -59,7 +59,7 @@ func TestAddHost(t *testing.T) {
 	t.Run("overlapping service key is overwritten by new value", func(t *testing.T) {
 		t.Parallel()
 
-		cfg := cliconfig.NewConfig()
+		cfg := cliconfig.NewConfig(vfs.NewMemMapFS())
 		cfg.AddHost("registry.example.com", map[string]string{
 			"providers.v1": "https://old-url.example.com/v1/providers/",
 			"modules.v1":   "https://registry.example.com/v1/modules/",
@@ -86,7 +86,7 @@ func TestAddHost(t *testing.T) {
 	t.Run("multiple different hosts are all appended", func(t *testing.T) {
 		t.Parallel()
 
-		cfg := cliconfig.NewConfig()
+		cfg := cliconfig.NewConfig(vfs.NewMemMapFS())
 		cfg.AddHost(
 			"registry.terraform.io",
 			map[string]string{"providers.v1": "http://localhost/tf/"},
@@ -134,7 +134,7 @@ func TestConfig(t *testing.T) {
 					},
 				},
 			},
-			config: cliconfig.NewConfig().
+			config: cliconfig.NewConfig(vfs.NewMemMapFS()).
 				WithDisableCheckpoint().
 				WithPluginCacheDir("path/to/plugin/cache/dir1"),
 			expectedHCL: `
@@ -169,7 +169,7 @@ disable_checkpoint_signature = false
 `,
 		},
 		{
-			config: cliconfig.NewConfig().
+			config: cliconfig.NewConfig(vfs.NewMemMapFS()).
 				WithPluginCacheDir(tempCacheDir),
 			expectedHCL: `
 provider_installation {

--- a/internal/tf/cliconfig/user_config.go
+++ b/internal/tf/cliconfig/user_config.go
@@ -3,18 +3,20 @@ package cliconfig
 import (
 	"path/filepath"
 
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/hashicorp/terraform/command/cliconfig"
 	"github.com/hashicorp/terraform/tfdiags"
 )
 
 // LoadUserConfig loads the user configuration is read as raw data and stored at the top of the saved configuration file.
 // The location of the default config is different for each OS https://developer.hashicorp.com/terraform/cli/config/config-file#locations
-func LoadUserConfig(opts ...ConfigOption) (*Config, error) {
-	return loadUserConfig(cliconfig.LoadConfig, opts...)
+func LoadUserConfig(fs vfs.FS, opts ...ConfigOption) (*Config, error) {
+	return loadUserConfig(cliconfig.LoadConfig, fs, opts...)
 }
 
 func loadUserConfig(
 	loadConfigFn func() (*cliconfig.Config, tfdiags.Diagnostics),
+	fs vfs.FS,
 	opts ...ConfigOption,
 ) (*Config, error) {
 	cfg, diag := loadConfigFn()
@@ -22,7 +24,7 @@ func loadUserConfig(
 		return nil, diag.Err()
 	}
 
-	config := NewConfig().
+	config := NewConfig(fs).
 		WithPluginCacheDir(cfg.PluginCacheDir).
 		WithCredentials(getUserCredentials(cfg)).
 		WithCredentialsHelpers(getUserCredentialsHelpers(cfg)).

--- a/internal/venv/venv.go
+++ b/internal/venv/venv.go
@@ -142,6 +142,14 @@ func (v *Venv) WithHandler(h vexec.Handler) *Venv {
 	return &c
 }
 
+// WithHTTP returns a copy of v whose outbound HTTP client is c.
+func (v *Venv) WithHTTP(c vhttp.Client) *Venv {
+	cp := *v
+	cp.HTTP = c
+
+	return &cp
+}
+
 // WithSops returns a copy of v whose SOPS decrypter is d.
 func (v *Venv) WithSops(d vsops.Decrypter) *Venv {
 	c := *v

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/util"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"golang.org/x/sync/errgroup"
@@ -370,6 +370,7 @@ func (wp *WorktreePair) Expand() (filter.Filters, filter.Filters, error) {
 func NewWorktrees(
 	ctx context.Context,
 	l log.Logger,
+	v *venv.Venv,
 	opts WorktreeOpts,
 ) (*Worktrees, error) {
 	workingDir := opts.WorkingDir
@@ -390,7 +391,9 @@ func NewWorktrees(
 		outerErr  error
 	)
 
-	gitRunner, err := git.NewGitRunner(vexec.NewOSExec())
+	v.RequireExec()
+
+	gitRunner, err := git.NewGitRunner(v.Exec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Git runner for worktree creation: %w", err)
 	}

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -33,6 +34,7 @@ func TestNewWorktrees(t *testing.T) {
 	w, err := worktrees.NewWorktrees(
 		t.Context(),
 		logger.CreateLogger(),
+		venv.OSVenv(),
 		worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: filters.UniqueGitFilters()},
 	)
 	require.NoError(t, err)
@@ -68,6 +70,7 @@ func TestNewWorktreesWithInvalidReference(t *testing.T) {
 	_, err = worktrees.NewWorktrees(
 		t.Context(),
 		logger.CreateLogger(),
+		venv.OSVenv(),
 		worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: filters.UniqueGitFilters()},
 	)
 	require.Error(t, err)
@@ -668,6 +671,7 @@ func TestWorktreeCleanup(t *testing.T) {
 	_, err = worktrees.NewWorktrees(
 		t.Context(),
 		logger.CreateLogger(),
+		venv.OSVenv(),
 		worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: filters.UniqueGitFilters()},
 	)
 	require.Error(t, err)

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func run() (code int) {
 		log.WithFormatter(format.NewFormatter(format.NewPrettyFormatPlaceholders())),
 	)
 
-	reporter := panicreport.New()
+	reporter := panicreport.New(v.FS)
 	// Recover panics here so main owns os.Exit and any future main-level defers still run.
 	defer func() {
 		if reporter.PanicHandler(recover(), l, version.GetVersion, os.Args) {

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -41,7 +41,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vsops"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -1699,7 +1698,7 @@ func markGlobAsRead(
 		opts = append(opts, glob.WithBoundary(boundary))
 	}
 
-	matches, err := glob.Expand(vfs.NewOSFS(), pattern, opts...)
+	matches, err := glob.Expand(pctx.Venv.FS, pattern, opts...)
 	if err != nil {
 		if errors.Is(err, glob.ErrOutsideBoundary) {
 			return nil, fmt.Errorf(

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -283,7 +283,7 @@ func resolveStackAutoIncludes(
 	earlyFuncs := StackParseFunctionsFrom(prodEvalCtx.Functions, stackSourceDir)
 
 	parseResult, parseErr := inthclparse.ParseStackFile(
-		vfs.NewOSFS(),
+		scopedPctx.Venv.FS,
 		&inthclparse.ParseStackFileInput{
 			Src:       stackSrcBytes,
 			Filename:  filepath.Base(stackFilePath),

--- a/test/integration_cas_rustfs_test.go
+++ b/test/integration_cas_rustfs_test.go
@@ -52,7 +52,7 @@ func TestCAS_S3_RustFS_ProbeAvoidsRedownload(t *testing.T) { //nolint: parallelt
 
 	v := venv.OSVenv()
 
-	resolvers := tggetter.DefaultSourceResolvers(v.HTTP)
+	resolvers := tggetter.DefaultSourceResolvers(v.HTTP, v.Exec)
 	resolvers[tggetter.SchemeS3] = newRustFSS3Resolver(t, endpoint)
 
 	g := tggetter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds a lot more venv plumbing and adds a `forbidigo` rule to the linter to help reduce the likelihood that we have future venv leaks.

We still need to close some gaps documented in `.golangci-lint`, and there are some hidden gaps like the cloud SDKs constructing their own HTTP clients.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Commands now consistently honor the configured filesystem, network client, and execution environment.
  * Improved reliability for worktree creation, module downloads, filtering, configuration loading, and stack processing.
  * Panic reports are written using the configured filesystem.

* **Refactor**
  * Standardized environment handling across CLI commands and services.
  * Improved isolation and predictability when running with custom or in-memory environments.

* **Tests**
  * Expanded coverage for virtualized filesystems, HTTP clients, and execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->