### PR TITLE
chore: Cloud SDK `venv` plumbing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,6 +130,15 @@ linters:
           msg: walk the venv's vfs.FS via vfs.WalkDir or vfs.WalkDirParallel instead of the real filesystem
         - pattern: ^(vfs\.NewOSFS|vexec\.NewOSExec|vhttp\.NewOSClient|vsops\.NewOSDecrypter)$
           msg: take the handle from the venv already in scope rather than building a fresh OS-backed one
+        # Cloud SDKs build their own transport when handed no client, so these
+        # entry points leak past the venv without any net/http call of our own
+        # for the rules above to catch.
+        - pattern: ^config\.LoadDefaultConfig$
+          pkg: ^github.com/aws/aws-sdk-go-v2/config$
+          msg: build AWS config via awshelper.NewAWSConfigBuilder so requests ride the venv's HTTP client
+        - pattern: ^storage\.NewClient$
+          pkg: ^cloud.google.com/go/storage$
+          msg: build the GCS client via gcphelper.NewGCPConfigBuilder so requests ride the venv's HTTP client
     errcheck:
       check-type-assertions: false
       check-blank: false
@@ -220,7 +229,7 @@ linters:
         path: ^pkg/options/options\.go$
       - linters:
           - forbidigo
-        path: ^(internal/awshelper/config\.go|internal/discovery/helpers\.go|internal/discovery/phase_worktree\.go|internal/engine/engine\.go|internal/engine/verification\.go|internal/gcphelper/config\.go|internal/getter/tfrhelpers\.go|internal/git/git\.go|internal/panicreport/panicreport\.go|internal/remotestate/remote_state\.go|internal/remotestate/terraform_state_file\.go|internal/report/writer\.go|internal/services/catalog/module/doc\.go|internal/services/catalog/module/module\.go|internal/shell/git\.go|internal/shell/run_cmd\.go|internal/stacks/clean/clean\.go|internal/tfimpl/tfimpl\.go|internal/util/file\.go|internal/util/lockfile\.go|internal/worktrees/worktrees\.go)$
+        path: ^(internal/discovery/helpers\.go|internal/discovery/phase_worktree\.go|internal/engine/engine\.go|internal/engine/verification\.go|internal/getter/tfrhelpers\.go|internal/git/git\.go|internal/panicreport/panicreport\.go|internal/remotestate/remote_state\.go|internal/remotestate/terraform_state_file\.go|internal/report/writer\.go|internal/services/catalog/module/doc\.go|internal/services/catalog/module/module\.go|internal/shell/git\.go|internal/shell/run_cmd\.go|internal/stacks/clean/clean\.go|internal/tfimpl/tfimpl\.go|internal/util/file\.go|internal/util/lockfile\.go|internal/worktrees/worktrees\.go)$
       # We end up with duplicated content in this package to save us from duplicating code in other packages.
       - linters:
           - dupl

--- a/internal/awshelper/config.go
+++ b/internal/awshelper/config.go
@@ -4,7 +4,6 @@ package awshelper
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -19,7 +18,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/gruntwork-io/terragrunt/internal/iam"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/version"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
@@ -43,49 +44,51 @@ type AwsSessionConfig struct {
 	DisableComputeChecksums bool
 }
 
-type tokenFetcher string
+// TokenFetcher resolves a web identity token that was configured either as the
+// token itself or as the path to one on disk.
+type TokenFetcher struct {
+	FS    vfs.FS
+	Token string
+}
 
 // FetchToken implements the token fetcher interface.
 // Supports providing a token value or the path to a token on disk
-func (f tokenFetcher) FetchToken(_ context.Context) ([]byte, error) {
-	// Check if token is a raw value
-	if _, err := os.Stat(string(f)); err != nil {
-		// TODO: See if this lint error should be ignored
-		return []byte(f), nil //nolint: nilerr
+func (f TokenFetcher) FetchToken(_ context.Context) ([]byte, error) {
+	exists, err := vfs.FileExists(f.FS, f.Token)
+	if err != nil && !vfs.IsNameTooLong(err) {
+		return nil, fmt.Errorf("checking web identity token path %s: %w", f.Token, err)
 	}
 
-	token, err := os.ReadFile(string(f))
-	if err != nil {
-		return nil, err
+	// Nothing on disk at that path, so the configured value is the token itself.
+	if !exists {
+		return []byte(f.Token), nil
 	}
 
-	return token, nil
+	return vfs.ReadFile(f.FS, f.Token)
 }
 
 // AWSConfigBuilder builds an AWS config using the builder pattern.
 // Use NewAwsConfigBuilder to create, chain With* methods for optional parameters, then call Build().
 type AWSConfigBuilder struct {
 	sessionConfig *AwsSessionConfig
-	env           map[string]string
+	venv          *venv.Venv
 	iamRoleOpts   iam.RoleOptions
 }
 
-// NewAWSConfigBuilder creates a new builder for AWS config.
-func NewAWSConfigBuilder() *AWSConfigBuilder {
-	return &AWSConfigBuilder{
-		env: make(map[string]string),
-	}
+// NewAWSConfigBuilder creates a new builder for AWS config. Every AWS call
+// made through the resulting config rides v's HTTP client, and credentials
+// resolve against v's environment.
+func NewAWSConfigBuilder(v *venv.Venv) *AWSConfigBuilder {
+	v.RequireEnv()
+	v.RequireFS()
+	v.RequireHTTP()
+
+	return &AWSConfigBuilder{venv: v}
 }
 
 // WithSessionConfig sets the AWS session configuration (region, profile, credentials file, etc.).
 func (b *AWSConfigBuilder) WithSessionConfig(cfg *AwsSessionConfig) *AWSConfigBuilder {
 	b.sessionConfig = cfg
-	return b
-}
-
-// WithEnv sets environment variables used for credential and region resolution.
-func (b *AWSConfigBuilder) WithEnv(env map[string]string) *AWSConfigBuilder {
-	b.env = env
 	return b
 }
 
@@ -99,9 +102,13 @@ func (b *AWSConfigBuilder) WithIAMRoleOptions(opts iam.RoleOptions) *AWSConfigBu
 func (b *AWSConfigBuilder) Build(ctx context.Context, l log.Logger) (aws.Config, error) {
 	var configOptions []func(*config.LoadOptions) error
 
-	configOptions = append(configOptions, config.WithAppID("terragrunt/"+version.GetVersion()))
+	configOptions = append(
+		configOptions,
+		config.WithAppID("terragrunt/"+version.GetVersion()),
+		config.WithHTTPClient(b.venv.HTTP),
+	)
 
-	envCreds := createCredentialsFromEnv(b.env)
+	envCreds := createCredentialsFromEnv(b.venv.Env)
 
 	if envCreds != nil {
 		l.Debugf("Using AWS credentials from auth provider command")
@@ -120,7 +127,7 @@ func (b *AWSConfigBuilder) Build(ctx context.Context, l log.Logger) (aws.Config,
 	if b.sessionConfig != nil && b.sessionConfig.Region != "" {
 		region = b.sessionConfig.Region
 	} else {
-		region = getRegionFromEnv(b.env)
+		region = getRegionFromEnv(b.venv.Env)
 	}
 
 	if region == "" {
@@ -136,6 +143,7 @@ func (b *AWSConfigBuilder) Build(ctx context.Context, l log.Logger) (aws.Config,
 		)
 	}
 
+	//nolint:forbidigo // This is the wrapper the rule points callers at; configOptions carries the venv's client.
 	cfg, err := config.LoadDefaultConfig(ctx, configOptions...)
 	if err != nil {
 		return aws.Config{}, fmt.Errorf("error loading AWS config: %w", err)
@@ -157,7 +165,11 @@ func (b *AWSConfigBuilder) Build(ctx context.Context, l log.Logger) (aws.Config,
 
 	if mergedIAMRoleOptions.WebIdentityToken != "" {
 		l.Debugf("Assuming role %s using WebIdentity token", mergedIAMRoleOptions.RoleARN)
-		cfg.Credentials = getWebIdentityCredentialsFromIAMRoleOptions(cfg, mergedIAMRoleOptions)
+		cfg.Credentials = getWebIdentityCredentialsFromIAMRoleOptions(
+			cfg,
+			mergedIAMRoleOptions,
+			b.venv.FS,
+		)
 
 		return cfg, nil
 	}
@@ -203,10 +215,6 @@ func (b *AWSConfigBuilder) BuildS3Client(ctx context.Context, l log.Logger) (*s3
 
 // getRegionFromEnv extracts region from environment variables.
 func getRegionFromEnv(env map[string]string) string {
-	if len(env) == 0 {
-		return ""
-	}
-
 	if region := env["AWS_REGION"]; region != "" {
 		return region
 	}
@@ -247,26 +255,24 @@ func AssumeIamRole(
 	ctx context.Context,
 	iamRoleOpts iam.RoleOptions,
 	externalID string,
-	env map[string]string,
+	v *venv.Venv,
 ) (*types.Credentials, error) {
-	region := getRegionFromEnv(env)
-	if region == "" {
-		region = os.Getenv("AWS_REGION")
-	}
+	v.RequireEnv()
+	v.RequireFS()
+	v.RequireHTTP()
 
-	if region == "" {
-		region = os.Getenv("AWS_DEFAULT_REGION")
-	}
-
+	region := getRegionFromEnv(v.Env)
 	if region == "" {
 		region = "us-east-1"
 	}
 
 	// Set user agent to include terragrunt version
+	//nolint:forbidigo // This is the wrapper the rule points callers at; WithHTTPClient below carries the venv's client.
 	cfg, err := config.LoadDefaultConfig(
 		ctx,
 		config.WithRegion(region),
 		config.WithAppID("terragrunt/"+version.GetVersion()),
+		config.WithHTTPClient(v.HTTP),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error loading AWS config: %w", err)
@@ -286,7 +292,7 @@ func AssumeIamRole(
 
 	if iamRoleOpts.WebIdentityToken != "" {
 		// Use sts AssumeRoleWithWebIdentity
-		tb, err := tokenFetcher(iamRoleOpts.WebIdentityToken).FetchToken(ctx)
+		tb, err := TokenFetcher{FS: v.FS, Token: iamRoleOpts.WebIdentityToken}.FetchToken(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error reading web identity token file: %w", err)
 		}
@@ -426,6 +432,7 @@ func ValidatePublicAccessBlock(output *s3.GetPublicAccessBlockOutput) (bool, err
 func getWebIdentityCredentialsFromIAMRoleOptions(
 	cfg aws.Config,
 	iamRoleOptions iam.RoleOptions,
+	fs vfs.FS,
 ) aws.CredentialsProviderFunc {
 	roleSessionName := iamRoleOptions.AssumeRoleSessionName
 	if roleSessionName == "" {
@@ -436,7 +443,7 @@ func getWebIdentityCredentialsFromIAMRoleOptions(
 	return func(ctx context.Context) (aws.Credentials, error) {
 		stsClient := sts.NewFromConfig(cfg)
 
-		token, err := tokenFetcher(iamRoleOptions.WebIdentityToken).FetchToken(ctx)
+		token, err := TokenFetcher{FS: fs, Token: iamRoleOptions.WebIdentityToken}.FetchToken(ctx)
 		if err != nil {
 			return aws.Credentials{}, err
 		}

--- a/internal/awshelper/config_test.go
+++ b/internal/awshelper/config_test.go
@@ -13,7 +13,9 @@ import (
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/gruntwork-io/terragrunt/internal/awshelper"
 	"github.com/gruntwork-io/terragrunt/internal/iam"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +26,7 @@ func TestAwsSessionValidationFail(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	_, err := awshelper.NewAWSConfigBuilder().
+	_, err := awshelper.NewAWSConfigBuilder(venvtest.NewWithOSFS()).
 		WithSessionConfig(&awshelper.AwsSessionConfig{
 			Region:        "not-existing-region",
 			CredsFilename: "/tmp/not-existing-file",
@@ -95,8 +97,7 @@ func TestAwsConfigWithAuthProviderEnv(t *testing.T) {
 		"AWS_REGION":            "us-west-2",
 	}
 
-	cfg, err := awshelper.NewAWSConfigBuilder().
-		WithEnv(env).
+	cfg, err := awshelper.NewAWSConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).
 		Build(ctx, l)
 	require.NoError(t, err)
 	assert.Equal(t, "us-west-2", cfg.Region)
@@ -123,8 +124,7 @@ func TestAwsConfigWithAuthProviderEnvDefaultRegion(t *testing.T) {
 		"AWS_DEFAULT_REGION":    "eu-west-1",
 	}
 
-	cfg, err := awshelper.NewAWSConfigBuilder().
-		WithEnv(env).
+	cfg, err := awshelper.NewAWSConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).
 		Build(ctx, l)
 	require.NoError(t, err)
 	assert.Equal(t, "eu-west-1", cfg.Region)
@@ -163,8 +163,7 @@ func TestAwsConfigWithAuthProviderEnvChainsAssumeRole(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	baseCfg, err := awshelper.NewAWSConfigBuilder().
-		WithEnv(env).
+	baseCfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv().WithEnv(env)).
 		Build(t.Context(), l)
 	require.NoError(t, err)
 
@@ -173,8 +172,7 @@ func TestAwsConfigWithAuthProviderEnvChainsAssumeRole(t *testing.T) {
 
 	const sessionName = "terragrunt-chained-assume-role-test"
 
-	chainedCfg, err := awshelper.NewAWSConfigBuilder().
-		WithEnv(env).
+	chainedCfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv().WithEnv(env)).
 		WithSessionConfig(&awshelper.AwsSessionConfig{
 			RoleArn:     roleARN,
 			SessionName: sessionName,
@@ -293,8 +291,7 @@ func TestAwsConfigRoleSourcePermutations(t *testing.T) {
 
 			l := logger.CreateLogger()
 
-			cfg, err := awshelper.NewAWSConfigBuilder().
-				WithEnv(tc.env).
+			cfg, err := awshelper.NewAWSConfigBuilder(venvtest.NewWithOSFS().WithEnv(tc.env)).
 				WithSessionConfig(tc.sessionConfig).
 				WithIAMRoleOptions(tc.iamRoleOpts).
 				Build(t.Context(), l)
@@ -349,9 +346,8 @@ func TestAwsConfigRegionTakesPrecedenceOverEnvVars(t *testing.T) {
 		Region: "us-east-1", // This should override the env vars
 	}
 
-	cfg, err := awshelper.NewAWSConfigBuilder().
+	cfg, err := awshelper.NewAWSConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).
 		WithSessionConfig(awsCfg).
-		WithEnv(env).
 		Build(ctx, l)
 	require.NoError(t, err)
 

--- a/internal/awshelper/token_test.go
+++ b/internal/awshelper/token_test.go
@@ -1,0 +1,73 @@
+package awshelper_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/awshelper"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// oversizedToken stands in for the web identity tokens an OIDC provider issues.
+// Only the length matters: a real one runs past what any platform accepts as a
+// filename, which is what sends the stat down a different path than a miss.
+func oversizedToken() string {
+	return "not-a-real-web-identity-token-" + strings.Repeat("x", 700)
+}
+
+func TestFetchTokenReadsRawToken(t *testing.T) {
+	t.Parallel()
+
+	token := oversizedToken()
+
+	// The OS filesystem rather than a memory one, which reports a name this
+	// long as merely absent and would pass whether or not the length is
+	// handled.
+	got, err := awshelper.TokenFetcher{FS: vfs.NewOSFS(), Token: token}.FetchToken(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, token, string(got))
+}
+
+func TestFetchTokenReadsShortRawToken(t *testing.T) {
+	t.Parallel()
+
+	got, err := awshelper.TokenFetcher{FS: vfs.NewMemMapFS(), Token: "short-token"}.FetchToken(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "short-token", string(got))
+}
+
+func TestFetchTokenReadsTokenFile(t *testing.T) {
+	t.Parallel()
+
+	fs := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fs, "/tokens/web-identity", []byte("token-from-disk"), 0o600))
+
+	got, err := awshelper.TokenFetcher{FS: fs, Token: "/tokens/web-identity"}.FetchToken(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "token-from-disk", string(got))
+}
+
+func TestFetchTokenSurfacesStatFailure(t *testing.T) {
+	t.Parallel()
+
+	fs := &statErrorFS{FS: vfs.NewMemMapFS(), err: os.ErrPermission}
+
+	_, err := awshelper.TokenFetcher{FS: fs, Token: "/tokens/web-identity"}.FetchToken(t.Context())
+	require.Error(t, err)
+	require.ErrorIs(t, err, os.ErrPermission)
+	assert.False(t, vfs.IsNameTooLong(err))
+}
+
+// statErrorFS fails every stat, standing in for a path the caller genuinely
+// meant that the filesystem refuses to report on.
+type statErrorFS struct {
+	vfs.FS
+	err error
+}
+
+func (fsys *statErrorFS) Stat(string) (os.FileInfo, error) {
+	return nil, fsys.err
+}

--- a/internal/cli/commands/find/cli_test.go
+++ b/internal/cli/commands/find/cli_test.go
@@ -191,7 +191,7 @@ func TestNewFlagsHiddenFlagRunsTheStrictControl(t *testing.T) {
 				)
 			}
 
-			flags := find.NewFlags(newTestLogger(t), find.NewOptions(tgOpts), nil)
+			flags := find.NewFlags(newTestLogger(t), find.NewOptions(tgOpts), venvtest.New(), nil)
 			require.NoError(t, flags.Parse(clihelper.Args(tc.args)))
 
 			err := flags.RunActions(t.Context(), &clihelper.Context{})
@@ -233,7 +233,7 @@ func TestNewFlagsExternalFlagAddsAGraphFilter(t *testing.T) {
 
 			opts := find.NewOptions(options.NewTerragruntOptions())
 
-			flags := find.NewFlags(newTestLogger(t), opts, nil)
+			flags := find.NewFlags(newTestLogger(t), opts, venvtest.New(), nil)
 			require.NoError(t, flags.Parse(clihelper.Args(tc.args)))
 			require.NoError(t, flags.RunActions(t.Context(), &clihelper.Context{}))
 			assert.Len(t, opts.Filters, tc.wantFilters)

--- a/internal/cli/commands/list/cli_test.go
+++ b/internal/cli/commands/list/cli_test.go
@@ -228,7 +228,7 @@ func TestNewFlagsHiddenFlagRunsTheStrictControl(t *testing.T) {
 				)
 			}
 
-			flags := list.NewFlags(newTestLogger(t), list.NewOptions(tgOpts), nil)
+			flags := list.NewFlags(newTestLogger(t), list.NewOptions(tgOpts), venvtest.New(), nil)
 			require.NoError(t, flags.Parse(clihelper.Args(tc.args)))
 
 			err := flags.RunActions(t.Context(), &clihelper.Context{})
@@ -270,7 +270,7 @@ func TestNewFlagsExternalFlagAddsAGraphFilter(t *testing.T) {
 
 			opts := list.NewOptions(options.NewTerragruntOptions())
 
-			flags := list.NewFlags(newTestLogger(t), opts, nil)
+			flags := list.NewFlags(newTestLogger(t), opts, venvtest.New(), nil)
 			require.NoError(t, flags.Parse(clihelper.Args(tc.args)))
 			require.NoError(t, flags.RunActions(t.Context(), &clihelper.Context{}))
 			assert.Len(t, opts.Filters, tc.wantFilters)

--- a/internal/gcphelper/config.go
+++ b/internal/gcphelper/config.go
@@ -6,14 +6,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
+
+	"net/http"
 
 	"cloud.google.com/go/storage"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/jwt"
 	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
+	htransport "google.golang.org/api/transport/http"
 )
 
 const (
@@ -23,6 +27,10 @@ const (
 	credTypeAuthorizedUser             = "authorized_user"
 	credTypeImpersonatedServiceAccount = "impersonated_service_account"
 	credTypeExternalAccount            = "external_account"
+
+	// cloudPlatformScope pairs with storage.ScopeFullControl as the scope set
+	// storage.NewClient applies to clients it builds the transport for.
+	cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
 )
 
 // GCPSessionConfig is a representation of the configuration options for a GCP Config
@@ -36,12 +44,18 @@ type GCPSessionConfig struct {
 // GCPConfigBuilder constructs GCP client options using the builder pattern.
 type GCPConfigBuilder struct {
 	sessionConfig *GCPSessionConfig
-	env           map[string]string
+	venv          *venv.Venv
 }
 
-// NewGCPConfigBuilder creates a new GCPConfigBuilder.
-func NewGCPConfigBuilder() *GCPConfigBuilder {
-	return &GCPConfigBuilder{}
+// NewGCPConfigBuilder creates a new GCPConfigBuilder whose GCS requests, and
+// the OAuth token exchanges behind them, ride v's HTTP client. Credentials
+// resolve against v's environment and filesystem.
+func NewGCPConfigBuilder(v *venv.Venv) *GCPConfigBuilder {
+	v.RequireEnv()
+	v.RequireFS()
+	v.RequireHTTP()
+
+	return &GCPConfigBuilder{venv: v}
 }
 
 // WithSessionConfig sets the GCP session configuration.
@@ -50,20 +64,38 @@ func (b *GCPConfigBuilder) WithSessionConfig(config *GCPSessionConfig) *GCPConfi
 	return b
 }
 
-// WithEnv sets the environment variables to use for credential resolution.
-func (b *GCPConfigBuilder) WithEnv(env map[string]string) *GCPConfigBuilder {
-	b.env = env
-	return b
-}
-
 // BuildGCSClient builds a GCS storage client from the configured options.
 func (b *GCPConfigBuilder) BuildGCSClient(ctx context.Context) (*storage.Client, error) {
+	ctx = b.withOAuthClient(ctx)
+
 	clientOpts, err := b.Build(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	gcsClient, err := storage.NewClient(ctx, clientOpts...)
+	// Auth is layered over the venv's transport rather than the venv client
+	// being passed straight to storage.NewClient: a bare client carries no
+	// credentials, so every request would go out unauthenticated.
+	//
+	// Credentials resolve here rather than inside storage.NewClient, which is
+	// where the storage scopes would normally be applied, so they have to be
+	// named. Without them the token exchange asks for no scope at all and the
+	// provider rejects it. They lead so that a caller's own scopes still win.
+	transportOpts := append(
+		[]option.ClientOption{option.WithScopes(storage.ScopeFullControl, cloudPlatformScope)},
+		clientOpts...,
+	)
+
+	trans, err := htransport.NewTransport(ctx, b.venv.HTTP.Transport, transportOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("error building GCS transport: %w", err)
+	}
+
+	//nolint:forbidigo // This is the wrapper the rule points callers at; trans is built on the venv's transport.
+	gcsClient, err := storage.NewClient(
+		ctx,
+		option.WithHTTPClient(&http.Client{Transport: trans}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating GCS client: %w", err)
 	}
@@ -71,14 +103,21 @@ func (b *GCPConfigBuilder) BuildGCSClient(ctx context.Context) (*storage.Client,
 	return gcsClient, nil
 }
 
+// withOAuthClient points the oauth2 library at c. oauth2 mints tokens through
+// http.DefaultClient otherwise, independently of the transport the API client
+// is built on.
+func (b *GCPConfigBuilder) withOAuthClient(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, b.venv.HTTP)
+}
+
 // Build returns GCP client options from the configured session config and env.
 func (b *GCPConfigBuilder) Build(ctx context.Context) ([]option.ClientOption, error) {
 	gcpCfg := b.sessionConfig
-	env := b.env
+	env := b.venv.Env
 
 	var clientOpts []option.ClientOption
 
-	envCreds, err := createGCPCredentialsFromEnv(env)
+	envCreds, err := createGCPCredentialsFromEnv(b.venv.FS, env)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +126,7 @@ func (b *GCPConfigBuilder) Build(ctx context.Context) ([]option.ClientOption, er
 		clientOpts = append(clientOpts, envCreds)
 	} else if gcpCfg != nil && gcpCfg.Credentials != "" {
 		// Use credentials file from config
-		credOpt, err := credentialsFileOption(gcpCfg.Credentials)
+		credOpt, err := credentialsFileOption(b.venv.FS, gcpCfg.Credentials)
 		if err != nil {
 			return nil, err
 		}
@@ -140,23 +179,21 @@ func (b *GCPConfigBuilder) Build(ctx context.Context) ([]option.ClientOption, er
 // createGCPCredentialsFromEnv creates GCP credentials from GOOGLE_APPLICATION_CREDENTIALS environment variable in env
 // It looks for GOOGLE_APPLICATION_CREDENTIALS and returns a ClientOption that can be used
 // with Google Cloud clients. Returns nil if the environment variable is not set.
-func createGCPCredentialsFromEnv(env map[string]string) (option.ClientOption, error) {
-	if len(env) == 0 {
-		return nil, nil
-	}
-
+func createGCPCredentialsFromEnv(fs vfs.FS, env map[string]string) (option.ClientOption, error) {
 	credentialsFile := env["GOOGLE_APPLICATION_CREDENTIALS"]
 	if credentialsFile == "" {
 		return nil, nil
 	}
 
-	return credentialsFileOption(credentialsFile)
+	return credentialsFileOption(fs, credentialsFile)
 }
 
 // credentialsFileOption reads a GCP credentials JSON file, detects its type,
-// and returns the appropriate ClientOption.
-func credentialsFileOption(filename string) (option.ClientOption, error) {
-	data, err := os.ReadFile(filename)
+// and returns the appropriate ClientOption. The parsed bytes are handed to the
+// SDK rather than the path, so the file is read once, through fs, instead of
+// the SDK opening it again off the real disk.
+func credentialsFileOption(fs vfs.FS, filename string) (option.ClientOption, error) {
+	data, err := vfs.ReadFile(fs, filename)
 	if err != nil {
 		return nil, fmt.Errorf("error reading credentials file %s: %w", filename, err)
 	}
@@ -174,7 +211,7 @@ func credentialsFileOption(filename string) (option.ClientOption, error) {
 		return nil, err
 	}
 
-	return option.WithAuthCredentialsFile(credType, filename), nil
+	return option.WithAuthCredentialsJSON(credType, data), nil
 }
 
 // credentialsTypeFromString maps the "type" field in a GCP credentials JSON
@@ -227,5 +264,8 @@ func createGCPCredentialsFromGoogleCredentialsEnv(
 		TokenURL: tokenURL,
 	}
 
-	return option.WithHTTPClient(conf.Client(ctx)), nil
+	// A token source rather than conf.Client: the latter is a whole
+	// http.Client, which would displace the transport the caller layers auth
+	// onto. The source mints its tokens over the client in ctx.
+	return option.WithTokenSource(conf.TokenSource(ctx)), nil
 }

--- a/internal/gcphelper/config_test.go
+++ b/internal/gcphelper/config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/gcphelper"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,7 +29,7 @@ func TestGcpConfigWithApplicationCredentialsEnv(t *testing.T) {
 		"GOOGLE_APPLICATION_CREDENTIALS": credsFile,
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder().WithEnv(env).Build(ctx)
+	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).Build(ctx)
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
 }
@@ -42,7 +43,7 @@ func TestGcpConfigWithOAuthAccessTokenEnv(t *testing.T) {
 		"GOOGLE_OAUTH_ACCESS_TOKEN": "test-oauth-token",
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder().WithEnv(env).Build(ctx)
+	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).Build(ctx)
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
 }
@@ -68,7 +69,7 @@ func TestGcpConfigWithGoogleCredentialsEnv(t *testing.T) {
 		"GOOGLE_CREDENTIALS": credsJSON,
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder().WithEnv(env).Build(ctx)
+	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).Build(ctx)
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
 }
@@ -90,9 +91,8 @@ func TestGcpConfigWithCredentialsFileFromConfig(t *testing.T) {
 		Credentials: credsFile,
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder().
+	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).
 		WithSessionConfig(gcpCfg).
-		WithEnv(env).
 		Build(ctx)
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
@@ -109,9 +109,8 @@ func TestGcpConfigWithAccessTokenFromConfig(t *testing.T) {
 		AccessToken: "test-access-token",
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder().
+	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).
 		WithSessionConfig(gcpCfg).
-		WithEnv(env).
 		Build(ctx)
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
@@ -143,9 +142,8 @@ func TestGcpConfigEnvVarsTakePrecedenceOverConfig(t *testing.T) {
 		Credentials: configCredsFile, // This should be ignored in favor of env var
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder().
+	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).
 		WithSessionConfig(gcpCfg).
-		WithEnv(env).
 		Build(ctx)
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
@@ -171,7 +169,7 @@ func TestGcpConfigWithImpersonation(t *testing.T) {
 
 	// This will fail because we don't have real credentials, but we can verify
 	// that the impersonation configuration is attempted
-	_, err := gcphelper.NewGCPConfigBuilder().WithSessionConfig(gcpCfg).WithEnv(env).Build(ctx)
+	_, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).WithSessionConfig(gcpCfg).Build(ctx)
 	// We expect an error because impersonation requires valid base credentials
 	// The error should be about impersonation, not about missing credentials
 	require.Error(t, err)
@@ -186,7 +184,7 @@ func TestGcpConfigWithNoCredentials(t *testing.T) {
 	env := map[string]string{}
 
 	// No credentials provided - should return empty options (will use default credentials)
-	clientOpts, err := gcphelper.NewGCPConfigBuilder().WithEnv(env).Build(ctx)
+	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).Build(ctx)
 	require.NoError(t, err)
 	// Should return empty options when no credentials are provided
 	// (default credentials will be used by GCP client)
@@ -217,7 +215,7 @@ func TestGcpConfigWithGoogleCredentialsFile(t *testing.T) {
 		"GOOGLE_CREDENTIALS": credsFile,
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder().WithEnv(env).Build(ctx)
+	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).Build(ctx)
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
 }

--- a/internal/getter/resolver.go
+++ b/internal/getter/resolver.go
@@ -61,8 +61,8 @@ func DefaultSourceResolvers(
 	resolvers := map[string]SourceResolver{
 		SchemeHTTP:  httpRes,
 		SchemeHTTPS: httpsRes,
-		SchemeS3:    NewS3Resolver(),
-		SchemeGCS:   NewGCSResolver(),
+		SchemeS3:    NewS3Resolver(c),
+		SchemeGCS:   NewGCSResolver(c),
 		SchemeHg:    NewHgResolver(e),
 		SchemeTFR:   tfr,
 	}

--- a/internal/getter/resolver_gcs.go
+++ b/internal/getter/resolver_gcs.go
@@ -5,14 +5,19 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+	htransport "google.golang.org/api/transport/http"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 )
 
 // gcsResolverTimeout caps the Attrs call so a slow remote can't stall CAS
@@ -54,10 +59,14 @@ type GCSResolver struct {
 	// [storage.NewClient] with the ambient application default
 	// credentials.
 	NewClient func(ctx context.Context) (GCSClient, error)
+	// HTTPClient carries the SDK's requests. Required when NewClient is
+	// nil; [NewGCSResolver] takes it from the caller.
+	HTTPClient vhttp.Client
 }
 
-// NewGCSResolver returns a resolver wired to the ambient ADC.
-func NewGCSResolver() *GCSResolver { return &GCSResolver{} }
+// NewGCSResolver returns a resolver that reads object metadata over c, using
+// the ambient ADC for credentials.
+func NewGCSResolver(c vhttp.Client) *GCSResolver { return &GCSResolver{HTTPClient: c} }
 
 // Scheme returns "gcs".
 func (r *GCSResolver) Scheme() string { return "gcs" }
@@ -125,7 +134,17 @@ func (r *GCSResolver) client(ctx context.Context) (GCSClient, error) {
 		return r.NewClient(ctx)
 	}
 
-	c, err := storage.NewClient(ctx)
+	// Google's auth is layered over the venv transport rather than the venv
+	// client replacing it, so ADC still authenticates the probe.
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, r.HTTPClient)
+
+	trans, err := htransport.NewTransport(ctx, r.HTTPClient.Transport)
+	if err != nil {
+		return nil, err
+	}
+
+	//nolint:forbidigo // trans is built on the venv's transport, which is what the rule protects.
+	c, err := storage.NewClient(ctx, option.WithHTTPClient(&http.Client{Transport: trans}))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/getter/resolver_gcs_test.go
+++ b/internal/getter/resolver_gcs_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -279,7 +280,7 @@ func (c *fakeGCSClient) Object(_, name string) getter.GCSObject {
 func (c *fakeGCSClient) Close() error { return nil }
 
 func newGCSResolverWith(client *fakeGCSClient) *getter.GCSResolver {
-	r := getter.NewGCSResolver()
+	r := getter.NewGCSResolver(vhttp.NewNoNetworkClient())
 	r.NewClient = func(_ context.Context) (getter.GCSClient, error) {
 		return client, nil
 	}

--- a/internal/getter/resolver_s3.go
+++ b/internal/getter/resolver_s3.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 )
 
 // ErrS3UnrecognizedURL is returned when an amazonaws.com URL does not match
@@ -75,10 +76,13 @@ type S3Resolver struct {
 	// uses the AWS SDK default config (env, profile, IMDS) with a
 	// region derived from the URL.
 	NewClient func(ctx context.Context, region string) (S3API, error)
+	// HTTPClient carries the SDK's requests. Required when NewClient is
+	// nil; [NewS3Resolver] takes it from the caller.
+	HTTPClient vhttp.Client
 }
 
-// NewS3Resolver returns a resolver wired to the default AWS SDK config.
-func NewS3Resolver() *S3Resolver { return &S3Resolver{} }
+// NewS3Resolver returns a resolver whose SDK requests ride c.
+func NewS3Resolver(c vhttp.Client) *S3Resolver { return &S3Resolver{HTTPClient: c} }
 
 // Scheme returns "s3".
 func (r *S3Resolver) Scheme() string { return "s3" }
@@ -145,7 +149,12 @@ func (r *S3Resolver) client(ctx context.Context, region string) (S3API, error) {
 		return r.NewClient(ctx, region)
 	}
 
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	//nolint:forbidigo // WithHTTPClient below carries the venv's client, which is what the rule protects.
+	cfg, err := config.LoadDefaultConfig(
+		ctx,
+		config.WithRegion(region),
+		config.WithHTTPClient(r.HTTPClient),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/getter/resolver_s3_test.go
+++ b/internal/getter/resolver_s3_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -164,7 +165,7 @@ func TestS3Resolver_AcceptsModernURLForms(t *testing.T) {
 
 			var gotRegion string
 
-			r := getter.NewS3Resolver()
+			r := getter.NewS3Resolver(vhttp.NewNoNetworkClient())
 			r.NewClient = func(_ context.Context, region string) (getter.S3API, error) {
 				gotRegion = region
 				return head, nil
@@ -341,7 +342,7 @@ func TestS3Resolver_RejectsS3CompatibleURLWithoutKey(t *testing.T) {
 }
 
 func newS3ResolverWith(head getter.S3API) *getter.S3Resolver {
-	r := getter.NewS3Resolver()
+	r := getter.NewS3Resolver(vhttp.NewNoNetworkClient())
 	r.NewClient = func(_ context.Context, _ string) (getter.S3API, error) {
 		return head, nil
 	}

--- a/internal/remotestate/backend/gcs/client.go
+++ b/internal/remotestate/backend/gcs/client.go
@@ -38,9 +38,8 @@ func NewClient(
 	config *ExtendedRemoteStateConfigGCS,
 	opts *backend.Options,
 ) (*Client, error) {
-	gcsClient, err := gcphelper.NewGCPConfigBuilder().
+	gcsClient, err := gcphelper.NewGCPConfigBuilder(v).
 		WithSessionConfig(config.GetGCPSessionConfig()).
-		WithEnv(v.Env).
 		BuildGCSClient(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/remotestate/backend/s3/client.go
+++ b/internal/remotestate/backend/s3/client.go
@@ -89,9 +89,8 @@ func NewClient(
 ) (*Client, error) {
 	awsConfig := config.GetAwsSessionConfig()
 
-	builder := awshelper.NewAWSConfigBuilder().
+	builder := awshelper.NewAWSConfigBuilder(v).
 		WithSessionConfig(awsConfig).
-		WithEnv(v.Env).
 		WithIAMRoleOptions(opts.IAMRoleOptions)
 
 	cfg, err := builder.Build(ctx, l)

--- a/internal/remotestate/backend/s3/client_test.go
+++ b/internal/remotestate/backend/s3/client_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend"
 	s3backend "github.com/gruntwork-io/terragrunt/internal/remotestate/backend/s3"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
-	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,7 +42,7 @@ func CreateS3ClientForTest(t *testing.T) *s3backend.Client {
 
 	l := logger.CreateLogger()
 
-	client, err := s3backend.NewClient(t.Context(), l, venvtest.New(), extS3Cfg, mockOptions)
+	client, err := s3backend.NewClient(t.Context(), l, venv.OSVenv(), extS3Cfg, mockOptions)
 	require.NoError(t, err, "Error creating S3 client")
 
 	return client

--- a/internal/runner/run/creds/providers/amazonsts/provider.go
+++ b/internal/runner/run/creds/providers/amazonsts/provider.go
@@ -39,13 +39,12 @@ func (provider *Provider) Name() string {
 	return "API calls to Amazon STS"
 }
 
-// GetCredentials implements providers.GetCredentials. v is unused for
-// amazonsts because it talks to AWS via the SDK, not a subprocess; it is
-// accepted to satisfy the providers.Provider interface contract.
+// GetCredentials implements providers.GetCredentials. The STS call rides v's
+// HTTP client.
 func (provider *Provider) GetCredentials(
 	ctx context.Context,
 	l log.Logger,
-	_ *venv.Venv,
+	v *venv.Venv,
 ) (*providers.Credentials, error) {
 	iamRoleOpts := provider.iamRoleOpts
 	if iamRoleOpts.RoleARN == "" {
@@ -69,7 +68,7 @@ func (provider *Provider) GetCredentials(
 	}, func(ctx context.Context, l log.Logger) error {
 		var assumeErr error
 
-		resp, assumeErr = awshelper.AssumeIamRole(ctx, iamRoleOpts, "", provider.env)
+		resp, assumeErr = awshelper.AssumeIamRole(ctx, iamRoleOpts, "", v)
 
 		return assumeErr
 	})

--- a/internal/vfs/nametoolong_test.go
+++ b/internal/vfs/nametoolong_test.go
@@ -1,0 +1,40 @@
+package vfs_test
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TooLongName is a name well past any platform's per-component limit.
+const TooLongName = 700
+
+func TestIsNameTooLongClassifiesUnusableName(t *testing.T) {
+	t.Parallel()
+
+	// Stat'd for real so the error is whatever the OS produces rather than a
+	// stand-in. Platforms disagree on which code that is: what has to hold
+	// everywhere is that a name too long to use never reaches a caller as a
+	// failure to read something that might have been there.
+	_, err := os.Stat(strings.Repeat("A", TooLongName))
+	require.Error(t, err)
+
+	assert.True(t, vfs.IsNameTooLong(err) || errors.Is(err, fs.ErrNotExist))
+}
+
+func TestIsNameTooLongRejectsOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := os.Stat("does-not-exist")
+	require.Error(t, err)
+
+	assert.False(t, vfs.IsNameTooLong(err))
+	assert.False(t, vfs.IsNameTooLong(os.ErrPermission))
+	assert.False(t, vfs.IsNameTooLong(nil))
+}

--- a/internal/vfs/nametoolong_unix.go
+++ b/internal/vfs/nametoolong_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package vfs
+
+import (
+	"errors"
+	"syscall"
+)
+
+// IsNameTooLong reports whether err is a filesystem error meaning the path was
+// too long to name a file, as opposed to naming one that could not be reached.
+// Callers that accept either a path or an inline value use it to tell the two
+// apart without swallowing genuine failures such as a permission denial.
+func IsNameTooLong(err error) bool {
+	return errors.Is(err, syscall.ENAMETOOLONG)
+}

--- a/internal/vfs/nametoolong_unix_test.go
+++ b/internal/vfs/nametoolong_unix_test.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package vfs_test
+
+import (
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNameTooLongIsDistinctFromNotExist(t *testing.T) {
+	t.Parallel()
+
+	_, err := os.Stat(strings.Repeat("A", TooLongName))
+	require.Error(t, err)
+
+	// The distinction the callers rely on: too long is not the same as absent,
+	// so a not-exist check alone cannot stand in for this one.
+	assert.True(t, vfs.IsNameTooLong(err))
+	assert.NotErrorIs(t, err, fs.ErrNotExist)
+}

--- a/internal/vfs/nametoolong_windows.go
+++ b/internal/vfs/nametoolong_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package vfs
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// IsNameTooLong reports whether err is a filesystem error meaning the path was
+// too long to name a file, as opposed to naming one that could not be reached.
+// Callers that accept either a path or an inline value use it to tell the two
+// apart without swallowing genuine failures such as a permission denial.
+//
+// Windows reports an unusable name through its own error codes; the
+// ENAMETOOLONG that other platforms return is defined but never produced here.
+func IsNameTooLong(err error) bool {
+	return errors.Is(err, windows.ERROR_INVALID_NAME) ||
+		errors.Is(err, windows.ERROR_FILENAME_EXCED_RANGE)
+}

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -997,8 +997,7 @@ func getAWSField(
 	l log.Logger,
 	fetchFn func(context.Context, *aws.Config) (string, error),
 ) (string, error) {
-	awsConfig, err := awshelper.NewAWSConfigBuilder().
-		WithEnv(pctx.Venv.Env).
+	awsConfig, err := awshelper.NewAWSConfigBuilder(pctx.Venv).
 		WithIAMRoleOptions(pctx.IAMRoleOptions).
 		Build(ctx, l)
 	if err != nil {

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1766,9 +1766,8 @@ func getTerragruntOutputJSONFromRemoteStateS3(
 
 			sessionConfig := s3ConfigExtended.GetAwsSessionConfig()
 
-			s3Client, err := awshelper.NewAWSConfigBuilder().
+			s3Client, err := awshelper.NewAWSConfigBuilder(pctx.Venv).
 				WithSessionConfig(sessionConfig).
-				WithEnv(pctx.Venv.Env).
 				WithIAMRoleOptions(pctx.IAMRoleOptions).
 				BuildS3Client(ctx, l)
 			if err != nil {

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -258,7 +258,7 @@ func CreateS3ClientForTest(
 
 	awsConfig := &awshelper.AwsSessionConfig{Region: awsRegion}
 
-	cfg, err := awshelper.NewAWSConfigBuilder().
+	cfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).
 		WithSessionConfig(awsConfig).
 		WithIAMRoleOptions(mockOptions.IAMRoleOptions).
 		Build(t.Context(), logger.CreateLogger())
@@ -283,7 +283,7 @@ func CreateDynamoDBClientForTest(
 		RoleArn: iamRoleArn,
 	}
 
-	cfg, err := awshelper.NewAWSConfigBuilder().
+	cfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).
 		WithSessionConfig(sessionConfig).
 		WithIAMRoleOptions(mockOptions.IAMRoleOptions).
 		Build(t.Context(), logger.CreateLogger())

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -1746,7 +1746,7 @@ func TestAwsGetAccountAliasFunctions(t *testing.T) {
 	)
 
 	// Get values from STS
-	awsCfg, err := awshelper.NewAWSConfigBuilder().Build(t.Context(), createLogger())
+	awsCfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).Build(t.Context(), createLogger())
 	if err != nil {
 		t.Fatalf("Error while creating AWS config: %v", err)
 	}
@@ -1792,7 +1792,7 @@ func TestAwsGetCallerIdentityFunctions(t *testing.T) {
 	)
 
 	// Get values from STS
-	awsCfg, err := awshelper.NewAWSConfigBuilder().Build(t.Context(), createLogger())
+	awsCfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).Build(t.Context(), createLogger())
 	if err != nil {
 		t.Fatalf("Error while creating AWS config: %v", err)
 	}
@@ -2864,8 +2864,7 @@ func TestAwsAssumeRole(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	cfg, err := awshelper.NewAWSConfigBuilder().
-		WithEnv(venv.OSVenv().Env).
+	cfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).
 		WithIAMRoleOptions(opts.IAMRoleOptions).
 		Build(t.Context(), l)
 	require.NoError(t, err)
@@ -2922,8 +2921,7 @@ func TestAwsAssumeRoleWithExternalIDWithComma(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	cfg, err := awshelper.NewAWSConfigBuilder().
-		WithEnv(venv.OSVenv().Env).
+	cfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).
 		WithIAMRoleOptions(opts.IAMRoleOptions).
 		Build(t.Context(), l)
 	require.NoError(t, err)
@@ -3089,7 +3087,7 @@ func TestAwsReadTerragruntConfigIamRole(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	cfg, err := awshelper.NewAWSConfigBuilder().Build(t.Context(), l)
+	cfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).Build(t.Context(), l)
 	require.NoError(t, err)
 
 	identityArn, err := awshelper.GetAWSIdentityArn(t.Context(), &cfg)

--- a/test/integration_cas_rustfs_test.go
+++ b/test/integration_cas_rustfs_test.go
@@ -23,6 +23,7 @@ import (
 	tgcas "github.com/gruntwork-io/terragrunt/internal/cas"
 	tggetter "github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
@@ -148,7 +149,9 @@ func newRustFSClientFor(ctx context.Context, endpoint string) (*s3.Client, error
 func newRustFSS3Resolver(t *testing.T, endpoint string) *tggetter.S3Resolver {
 	t.Helper()
 
-	r := tggetter.NewS3Resolver()
+	// NewClient below short-circuits the default chain, so the resolver never
+	// reaches for this client.
+	r := tggetter.NewS3Resolver(vhttp.NewNoNetworkClient())
 	r.NewClient = func(ctx context.Context, _ string) (tggetter.S3API, error) {
 		return newRustFSClientFor(ctx, endpoint)
 	}

--- a/test/integration_example_live_stacks_test.go
+++ b/test/integration_example_live_stacks_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gruntwork-io/terragrunt/internal/awshelper"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ import (
 func TestAwsExampleLiveStacks(t *testing.T) {
 	uniqueID := strings.ToLower(helpers.UniqueID())
 
-	awsCfg, err := awshelper.NewAWSConfigBuilder().Build(t.Context(), createLogger())
+	awsCfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).Build(t.Context(), createLogger())
 	require.NoError(t, err, "Error creating AWS config")
 
 	stsClient := sts.NewFromConfig(awsCfg)


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Plumbs through `venv` for cloud SDKs

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Cloud authentication and storage connections now consistently respect configured environment, network, and filesystem settings.
  * AWS and GCP credential handling now supports virtualized environments, including credential files and web identity tokens.
  * S3 and GCS operations use configured HTTP clients for more predictable connectivity and offline testing.
  * Improved detection and reporting of oversized filesystem names across supported platforms.

* **Tests**
  * Expanded coverage for credential handling, filesystem errors, and cloud storage integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->