### PR TITLE
perf: Reducing allocations in tree parse

### DIFF
--- a/internal/git/tree.go
+++ b/internal/git/tree.go
@@ -1,17 +1,15 @@
 package git
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io"
 	"strings"
 )
 
-const (
-	// The minimum number of parts in the stdout of the `git ls-tree` command
-	minTreePartsLength = 4
-)
+// newline is hoisted so splitting and counting entries do not allocate a
+// separator on every parse.
+var newline = []byte{'\n'}
 
 // Tree entry types as printed by `git ls-tree` and carried in
 // [TreeEntry.Type].
@@ -73,29 +71,19 @@ func (t *Tree) Data() []byte {
 
 // ParseTree parses the stdout of git ls-tree [-r] into a Tree object.
 func ParseTree(output []byte, path string) (*Tree, error) {
-	entries := make([]TreeEntry, 0, bytes.Count(output, []byte("\n"))+1)
+	entries := make([]TreeEntry, 0, bytes.Count(output, newline)+1)
 
-	scanner := bufio.NewScanner(bytes.NewReader(output))
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
+	for line := range bytes.SplitSeq(output, newline) {
+		if len(line) == 0 {
 			continue
 		}
 
-		entry, err := ParseTreeEntry(line)
+		entry, err := ParseTreeEntry(string(line))
 		if err != nil {
 			return nil, err
 		}
 
 		entries = append(entries, entry)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, &WrappedError{
-			Op:      "parse_tree",
-			Context: "failed to read tree output",
-			Err:     err,
-		}
 	}
 
 	return &Tree{
@@ -105,22 +93,54 @@ func ParseTree(output []byte, path string) (*Tree, error) {
 	}, nil
 }
 
-// ParseTreeEntry parses a single line from git ls-tree output
+// ParseTreeEntry parses a single "<mode> <type> <hash>\t<path>" line from git
+// ls-tree output. A space is accepted in place of the tab so trees written by
+// [Tree.Write] round-trip.
 func ParseTreeEntry(line string) (TreeEntry, error) {
-	// Format: <mode> <type> <hash> <path>
-	parts := strings.Fields(line)
-	if len(parts) < minTreePartsLength {
-		return TreeEntry{}, &WrappedError{
-			Op:      "parse_tree_entry",
-			Context: "invalid tree entry format",
-			Err:     ErrParseTree,
-		}
+	mode, rest, ok := strings.Cut(line, " ")
+	if !ok {
+		return TreeEntry{}, errInvalidTreeEntry()
+	}
+
+	typ, rest, ok := strings.Cut(rest, " ")
+	if !ok {
+		return TreeEntry{}, errInvalidTreeEntry()
+	}
+
+	hash, path, ok := cutHashFromPath(rest)
+	if !ok || path == "" {
+		return TreeEntry{}, errInvalidTreeEntry()
 	}
 
 	return TreeEntry{
-		Mode: parts[0],
-		Type: parts[1],
-		Hash: parts[2],
-		Path: strings.Join(parts[3:], " "), // Handle paths with spaces
+		Mode: mode,
+		Type: typ,
+		Hash: hash,
+		Path: path,
 	}, nil
+}
+
+// cutHashFromPath splits a hash from the path that follows it, accepting
+// either delimiter git may have used. strings.IndexAny would read more
+// naturally but scans a byte at a time, whereas each IndexByte call is
+// vectorized, so two passes beat one.
+func cutHashFromPath(s string) (hash, path string, found bool) {
+	i := strings.IndexByte(s, '\t')
+	if j := strings.IndexByte(s, ' '); j >= 0 && (i < 0 || j < i) {
+		i = j
+	}
+
+	if i < 0 {
+		return s, "", false
+	}
+
+	return s[:i], s[i+1:], true
+}
+
+func errInvalidTreeEntry() error {
+	return &WrappedError{
+		Op:      "parse_tree_entry",
+		Context: "invalid tree entry format",
+		Err:     ErrParseTree,
+	}
 }

--- a/internal/git/tree_bench_test.go
+++ b/internal/git/tree_bench_test.go
@@ -1,0 +1,129 @@
+package git_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/git"
+)
+
+// lsTreeOutput builds realistic `git ls-tree -r` output with n entries, using
+// the nesting depth and name lengths typical of an infrastructure monorepo.
+func lsTreeOutput(n int) []byte {
+	var buf bytes.Buffer
+
+	envs := []string{"dev", "stage", "prod"}
+	regions := []string{"us-east-1", "us-west-2", "eu-central-1"}
+	units := []string{"vpc", "eks", "rds", "s3-bucket", "iam-roles", "route53"}
+	files := []string{"terragrunt.hcl", "main.tf", "variables.tf", "outputs.tf", "README.md"}
+
+	for i := range n {
+		fmt.Fprintf(&buf, "100644 blob %040x\tinfrastructure-live/%s/%s/%s-%d/%s\n",
+			i*2654435761,
+			envs[i%len(envs)],
+			regions[i/len(envs)%len(regions)],
+			units[i%len(units)],
+			i,
+			files[i%len(files)],
+		)
+	}
+
+	return buf.Bytes()
+}
+
+func TestParseTreeTabDelimited(t *testing.T) {
+	t.Parallel()
+
+	tree, err := git.ParseTree(lsTreeOutput(3), "repo")
+	require.NoError(t, err)
+
+	entries := tree.Entries()
+	require.Len(t, entries, 3)
+
+	assert.Equal(t, "100644", entries[0].Mode)
+	assert.Equal(t, git.EntryTypeBlob, entries[0].Type)
+	assert.Equal(t, "infrastructure-live/dev/us-east-1/vpc-0/terragrunt.hcl", entries[0].Path)
+}
+
+// TestParseTreeEntryPreservesRepeatedSpaces pins the fix for paths whose names
+// contain consecutive spaces. The previous strings.Fields parser split on
+// whitespace runs and rejoined with a single space, silently renaming them.
+func TestParseTreeEntryPreservesRepeatedSpaces(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "tab delimited with repeated spaces",
+			line: "100644 blob a1b2c3d4\tmy  spaced  file.tf",
+			want: "my  spaced  file.tf",
+		},
+		{
+			name: "space delimited with single spaces",
+			line: "100644 blob a1b2c3d4 path with spaces.txt",
+			want: "path with spaces.txt",
+		},
+		{
+			name: "path containing a tab",
+			line: "100644 blob a1b2c3d4\tweird\tname.tf",
+			want: "weird\tname.tf",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			entry, err := git.ParseTreeEntry(tt.line)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, entry.Path)
+		})
+	}
+}
+
+func TestParseTreeEntryRejectsMalformed(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name string
+		line string
+	}{
+		{name: "no delimiters", line: "garbage"},
+		{name: "missing hash and path", line: "100644 blob"},
+		{name: "missing path", line: "100644 blob abc123"},
+		{name: "empty path", line: "100644 blob abc123\t"},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := git.ParseTreeEntry(tt.line)
+			require.ErrorIs(t, err, git.ErrParseTree)
+		})
+	}
+}
+
+func BenchmarkParseTree(b *testing.B) {
+	for _, n := range []int{1_000, 10_000, 100_000} {
+		output := lsTreeOutput(n)
+
+		b.Run(fmt.Sprintf("entries_%d", n), func(b *testing.B) {
+			b.SetBytes(int64(len(output)))
+			b.ReportAllocs()
+
+			for b.Loop() {
+				tree, err := git.ParseTree(output, ".")
+				require.NoError(b, err)
+				require.Len(b, tree.Entries(), n)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Reducing allocations in `ParseTree`.

I was hunting more significant gains, but this seems good enough to merge:


Before:

```
goos: darwin
goarch: arm64
pkg: github.com/gruntwork-io/terragrunt/internal/git
cpu: Apple M3 Max
BenchmarkParseTree/entries_1000-16         	   15825	    151709 ns/op	 731.33 MB/s	  250217 B/op	    2005 allocs/op
BenchmarkParseTree/entries_1000-16         	   15894	    152632 ns/op	 726.91 MB/s	  250217 B/op	    2005 allocs/op
BenchmarkParseTree/entries_1000-16         	   15253	    158303 ns/op	 700.87 MB/s	  250217 B/op	    2005 allocs/op
BenchmarkParseTree/entries_1000-16         	   15322	    156215 ns/op	 710.24 MB/s	  250217 B/op	    2005 allocs/op
BenchmarkParseTree/entries_1000-16         	   15014	    157720 ns/op	 703.46 MB/s	  250217 B/op	    2005 allocs/op
BenchmarkParseTree/entries_1000-16         	   15672	    154986 ns/op	 715.87 MB/s	  250217 B/op	    2005 allocs/op
BenchmarkParseTree/entries_10000-16        	    1573	   1589230 ns/op	 704.46 MB/s	 2468656 B/op	   20005 allocs/op
BenchmarkParseTree/entries_10000-16        	    1503	   1568178 ns/op	 713.92 MB/s	 2468656 B/op	   20005 allocs/op
BenchmarkParseTree/entries_10000-16        	    1509	   1578900 ns/op	 709.07 MB/s	 2468655 B/op	   20005 allocs/op
BenchmarkParseTree/entries_10000-16        	    1562	   1542610 ns/op	 725.75 MB/s	 2468656 B/op	   20005 allocs/op
BenchmarkParseTree/entries_10000-16        	    1569	   1534152 ns/op	 729.75 MB/s	 2468657 B/op	   20005 allocs/op
BenchmarkParseTree/entries_10000-16        	    1561	   1538518 ns/op	 727.68 MB/s	 2468656 B/op	   20005 allocs/op
BenchmarkParseTree/entries_100000-16       	     159	  14981782 ns/op	 753.95 MB/s	24691669 B/op	  200005 allocs/op
BenchmarkParseTree/entries_100000-16       	     159	  14958959 ns/op	 755.10 MB/s	24691667 B/op	  200005 allocs/op
BenchmarkParseTree/entries_100000-16       	     160	  14959688 ns/op	 755.07 MB/s	24691632 B/op	  200005 allocs/op
BenchmarkParseTree/entries_100000-16       	     159	  15003225 ns/op	 752.87 MB/s	24691635 B/op	  200005 allocs/op
BenchmarkParseTree/entries_100000-16       	     157	  15221850 ns/op	 742.06 MB/s	24691636 B/op	  200005 allocs/op
BenchmarkParseTree/entries_100000-16       	     158	  15030897 ns/op	 751.49 MB/s	24691634 B/op	  200005 allocs/op
PASS
ok  	github.com/gruntwork-io/terragrunt/internal/git	43.414s

```

```
goos: darwin
goarch: arm64
pkg: github.com/gruntwork-io/terragrunt/internal/git
cpu: Apple M3 Max
BenchmarkParseTree/entries_1000-16         	   44929	     53396 ns/op	2077.89 MB/s	  182073 B/op	    1003 allocs/op
BenchmarkParseTree/entries_1000-16         	   43550	     55423 ns/op	2001.88 MB/s	  182072 B/op	    1003 allocs/op
BenchmarkParseTree/entries_1000-16         	   45103	     54057 ns/op	2052.47 MB/s	  182072 B/op	    1003 allocs/op
BenchmarkParseTree/entries_1000-16         	   44607	     54017 ns/op	2053.98 MB/s	  182072 B/op	    1003 allocs/op
BenchmarkParseTree/entries_1000-16         	   44133	     54282 ns/op	2043.94 MB/s	  182072 B/op	    1003 allocs/op
BenchmarkParseTree/entries_1000-16         	   44126	     54986 ns/op	2017.78 MB/s	  182072 B/op	    1003 allocs/op
BenchmarkParseTree/entries_10000-16        	    4530	    538709 ns/op	2078.21 MB/s	 1824516 B/op	   10003 allocs/op
BenchmarkParseTree/entries_10000-16        	    4496	    528360 ns/op	2118.92 MB/s	 1824516 B/op	   10003 allocs/op
BenchmarkParseTree/entries_10000-16        	    4560	    526673 ns/op	2125.70 MB/s	 1824517 B/op	   10003 allocs/op
BenchmarkParseTree/entries_10000-16        	    4515	    536161 ns/op	2088.09 MB/s	 1824517 B/op	   10003 allocs/op
BenchmarkParseTree/entries_10000-16        	    4570	    539323 ns/op	2075.84 MB/s	 1824517 B/op	   10003 allocs/op
BenchmarkParseTree/entries_10000-16        	    4363	    535291 ns/op	2091.48 MB/s	 1824516 B/op	   10003 allocs/op
BenchmarkParseTree/entries_100000-16       	     488	   4877988 ns/op	2315.62 MB/s	18287497 B/op	  100003 allocs/op
BenchmarkParseTree/entries_100000-16       	     492	   4865292 ns/op	2321.66 MB/s	18287501 B/op	  100003 allocs/op
BenchmarkParseTree/entries_100000-16       	     499	   4871844 ns/op	2318.54 MB/s	18287490 B/op	  100003 allocs/op
BenchmarkParseTree/entries_100000-16       	     460	   5199682 ns/op	2172.35 MB/s	18287500 B/op	  100003 allocs/op
BenchmarkParseTree/entries_100000-16       	     466	   5028605 ns/op	2246.26 MB/s	18287487 B/op	  100003 allocs/op
BenchmarkParseTree/entries_100000-16       	     476	   5134631 ns/op	2199.88 MB/s	18287488 B/op	  100003 allocs/op
PASS
ok  	github.com/gruntwork-io/terragrunt/internal/git	43.588s

```


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git tree parsing for tab-delimited entries and paths containing repeated spaces or embedded tabs.
  * Added validation for malformed entries and missing paths, providing clearer error handling.
  * Preserved complete path content during parsing.

* **Performance**
  * Improved parsing efficiency for large Git tree outputs by reducing overhead and optimizing entry allocation.

* **Tests**
  * Added coverage for valid, malformed, and large Git tree inputs.
  * Added benchmarks to measure parsing throughput and memory allocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->