### PR TITLE
chore: Plumbing venv into cloud getters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.5
+	cloud.google.com/go/auth v0.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/alecthomas/chroma/v2 v2.27.0
@@ -120,7 +121,6 @@ require (
 require (
 	cel.dev/expr v0.25.2 // indirect
 	cloud.google.com/go v0.123.0 // indirect
-	cloud.google.com/go/auth v0.22.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.11.0 // indirect

--- a/internal/awshelper/config.go
+++ b/internal/awshelper/config.go
@@ -76,6 +76,7 @@ func (f TokenFetcher) FetchToken(_ context.Context) ([]byte, error) {
 // Use NewAwsConfigBuilder to create, chain With* methods for optional parameters, then call Build().
 type AWSConfigBuilder struct {
 	sessionConfig *AwsSessionConfig
+	creds         aws.CredentialsProvider
 	iamRoleOpts   iam.RoleOptions
 }
 
@@ -87,6 +88,15 @@ func NewAWSConfigBuilder() *AWSConfigBuilder {
 // WithSessionConfig sets the AWS session configuration (region, profile, credentials file, etc.).
 func (b *AWSConfigBuilder) WithSessionConfig(cfg *AwsSessionConfig) *AWSConfigBuilder {
 	b.sessionConfig = cfg
+	return b
+}
+
+// WithCredentialsProvider pins the credentials, for a caller that carries its
+// own rather than resolving them from the environment. It outranks the
+// environment and any role the session config names, the way credentials
+// supplied inline outrank ambient ones everywhere else.
+func (b *AWSConfigBuilder) WithCredentialsProvider(creds aws.CredentialsProvider) *AWSConfigBuilder {
+	b.creds = creds
 	return b
 }
 
@@ -116,11 +126,14 @@ func (b *AWSConfigBuilder) Build(
 
 	envCreds := createCredentialsFromEnv(v.Env)
 
-	if envCreds != nil {
+	switch {
+	case b.creds != nil:
+		configOptions = append(configOptions, config.WithCredentialsProvider(b.creds))
+	case envCreds != nil:
 		l.Debugf("Using AWS credentials from auth provider command")
 
 		configOptions = append(configOptions, config.WithCredentialsProvider(envCreds))
-	} else if b.sessionConfig != nil && b.sessionConfig.CredsFilename != "" {
+	case b.sessionConfig != nil && b.sessionConfig.CredsFilename != "":
 		configOptions = append(
 			configOptions,
 			config.WithSharedConfigFiles([]string{b.sessionConfig.CredsFilename}),
@@ -156,7 +169,7 @@ func (b *AWSConfigBuilder) Build(
 	// are present, re-assuming that role here would make the role assume itself, so only the
 	// session config's role (assume_role in the remote_state block) is chained on top of them.
 	iamRoleOpts := b.iamRoleOpts
-	if envCreds != nil {
+	if envCreds != nil || b.creds != nil {
 		iamRoleOpts = iam.RoleOptions{}
 	}
 

--- a/internal/awshelper/config.go
+++ b/internal/awshelper/config.go
@@ -2,6 +2,7 @@
 package awshelper
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"strconv"
@@ -27,6 +28,10 @@ import (
 const (
 	// Minimum ARN parts required for a valid ARN
 	minARNParts = 2
+
+	// defaultAWSRegion is used when neither the session config nor the
+	// environment names one.
+	defaultAWSRegion = "us-east-1"
 )
 
 // AwsSessionConfig is a representation of the configuration options for an AWS Config
@@ -71,19 +76,12 @@ func (f TokenFetcher) FetchToken(_ context.Context) ([]byte, error) {
 // Use NewAwsConfigBuilder to create, chain With* methods for optional parameters, then call Build().
 type AWSConfigBuilder struct {
 	sessionConfig *AwsSessionConfig
-	venv          *venv.Venv
 	iamRoleOpts   iam.RoleOptions
 }
 
-// NewAWSConfigBuilder creates a new builder for AWS config. Every AWS call
-// made through the resulting config rides v's HTTP client, and credentials
-// resolve against v's environment.
-func NewAWSConfigBuilder(v *venv.Venv) *AWSConfigBuilder {
-	v.RequireEnv()
-	v.RequireFS()
-	v.RequireHTTP()
-
-	return &AWSConfigBuilder{venv: v}
+// NewAWSConfigBuilder creates a new builder for AWS config.
+func NewAWSConfigBuilder() *AWSConfigBuilder {
+	return &AWSConfigBuilder{}
 }
 
 // WithSessionConfig sets the AWS session configuration (region, profile, credentials file, etc.).
@@ -99,16 +97,24 @@ func (b *AWSConfigBuilder) WithIAMRoleOptions(opts iam.RoleOptions) *AWSConfigBu
 }
 
 // Build creates the AWS config from the builder's configuration.
-func (b *AWSConfigBuilder) Build(ctx context.Context, l log.Logger) (aws.Config, error) {
+func (b *AWSConfigBuilder) Build(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+) (aws.Config, error) {
+	v.RequireEnv()
+	v.RequireFS()
+	v.RequireHTTP()
+
 	var configOptions []func(*config.LoadOptions) error
 
 	configOptions = append(
 		configOptions,
 		config.WithAppID("terragrunt/"+version.GetVersion()),
-		config.WithHTTPClient(b.venv.HTTP),
+		config.WithHTTPClient(v.HTTP),
 	)
 
-	envCreds := createCredentialsFromEnv(b.venv.Env)
+	envCreds := createCredentialsFromEnv(v.Env)
 
 	if envCreds != nil {
 		l.Debugf("Using AWS credentials from auth provider command")
@@ -123,16 +129,12 @@ func (b *AWSConfigBuilder) Build(ctx context.Context, l log.Logger) (aws.Config,
 
 	// Prioritize configured region over environment variables
 	// This fixes the issue where AWS_REGION/AWS_DEFAULT_REGION env vars override the backend config region
-	var region string
-	if b.sessionConfig != nil && b.sessionConfig.Region != "" {
-		region = b.sessionConfig.Region
-	} else {
-		region = getRegionFromEnv(b.venv.Env)
+	var configured string
+	if b.sessionConfig != nil {
+		configured = b.sessionConfig.Region
 	}
 
-	if region == "" {
-		region = "us-east-1"
-	}
+	region := cmp.Or(configured, getRegionFromEnv(v.Env), defaultAWSRegion)
 
 	configOptions = append(configOptions, config.WithRegion(region))
 
@@ -166,9 +168,9 @@ func (b *AWSConfigBuilder) Build(ctx context.Context, l log.Logger) (aws.Config,
 	if mergedIAMRoleOptions.WebIdentityToken != "" {
 		l.Debugf("Assuming role %s using WebIdentity token", mergedIAMRoleOptions.RoleARN)
 		cfg.Credentials = getWebIdentityCredentialsFromIAMRoleOptions(
+			v.FS,
 			cfg,
 			mergedIAMRoleOptions,
-			b.venv.FS,
 		)
 
 		return cfg, nil
@@ -186,8 +188,12 @@ func (b *AWSConfigBuilder) Build(ctx context.Context, l log.Logger) (aws.Config,
 
 // BuildS3Client creates an S3 client from the builder's configuration.
 // The session config (set via WithSessionConfig) provides S3-specific options like custom endpoint and path style.
-func (b *AWSConfigBuilder) BuildS3Client(ctx context.Context, l log.Logger) (*s3.Client, error) {
-	cfg, err := b.Build(ctx, l)
+func (b *AWSConfigBuilder) BuildS3Client(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+) (*s3.Client, error) {
+	cfg, err := b.Build(ctx, l, v)
 	if err != nil {
 		return nil, err
 	}
@@ -215,11 +221,7 @@ func (b *AWSConfigBuilder) BuildS3Client(ctx context.Context, l log.Logger) (*s3
 
 // getRegionFromEnv extracts region from environment variables.
 func getRegionFromEnv(env map[string]string) string {
-	if region := env["AWS_REGION"]; region != "" {
-		return region
-	}
-
-	return env["AWS_DEFAULT_REGION"]
+	return cmp.Or(env["AWS_REGION"], env["AWS_DEFAULT_REGION"])
 }
 
 // getMergedIAMRoleOptions merges IAM role options from awsCfg and the provided IAM role options.
@@ -253,18 +255,15 @@ func getExternalID(awsCfg *AwsSessionConfig) string {
 // AssumeIamRole assumes an IAM role and returns the credentials.
 func AssumeIamRole(
 	ctx context.Context,
+	v *venv.Venv,
 	iamRoleOpts iam.RoleOptions,
 	externalID string,
-	v *venv.Venv,
 ) (*types.Credentials, error) {
 	v.RequireEnv()
 	v.RequireFS()
 	v.RequireHTTP()
 
-	region := getRegionFromEnv(v.Env)
-	if region == "" {
-		region = "us-east-1"
-	}
+	region := cmp.Or(getRegionFromEnv(v.Env), defaultAWSRegion)
 
 	// Set user agent to include terragrunt version
 	//nolint:forbidigo // This is the wrapper the rule points callers at; WithHTTPClient below carries the venv's client.
@@ -430,9 +429,9 @@ func ValidatePublicAccessBlock(output *s3.GetPublicAccessBlockOutput) (bool, err
 
 //nolint:gocritic // hugeParam: intentionally pass by value to avoid recursive credential resolution
 func getWebIdentityCredentialsFromIAMRoleOptions(
+	fsys vfs.FS,
 	cfg aws.Config,
 	iamRoleOptions iam.RoleOptions,
-	fs vfs.FS,
 ) aws.CredentialsProviderFunc {
 	roleSessionName := iamRoleOptions.AssumeRoleSessionName
 	if roleSessionName == "" {
@@ -443,7 +442,7 @@ func getWebIdentityCredentialsFromIAMRoleOptions(
 	return func(ctx context.Context) (aws.Credentials, error) {
 		stsClient := sts.NewFromConfig(cfg)
 
-		token, err := TokenFetcher{FS: fs, Token: iamRoleOptions.WebIdentityToken}.FetchToken(ctx)
+		token, err := TokenFetcher{FS: fsys, Token: iamRoleOptions.WebIdentityToken}.FetchToken(ctx)
 		if err != nil {
 			return aws.Credentials{}, err
 		}

--- a/internal/awshelper/config_test.go
+++ b/internal/awshelper/config_test.go
@@ -26,12 +26,12 @@ func TestAwsSessionValidationFail(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	_, err := awshelper.NewAWSConfigBuilder(venvtest.NewWithOSFS()).
+	_, err := awshelper.NewAWSConfigBuilder().
 		WithSessionConfig(&awshelper.AwsSessionConfig{
 			Region:        "not-existing-region",
 			CredsFilename: "/tmp/not-existing-file",
 		}).
-		Build(t.Context(), l)
+		Build(t.Context(), l, venvtest.NewWithOSFS())
 	assert.Error(t, err)
 }
 
@@ -97,8 +97,8 @@ func TestAwsConfigWithAuthProviderEnv(t *testing.T) {
 		"AWS_REGION":            "us-west-2",
 	}
 
-	cfg, err := awshelper.NewAWSConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).
-		Build(ctx, l)
+	cfg, err := awshelper.NewAWSConfigBuilder().
+		Build(ctx, l, venvtest.NewWithOSFS().WithEnv(env))
 	require.NoError(t, err)
 	assert.Equal(t, "us-west-2", cfg.Region)
 
@@ -124,8 +124,8 @@ func TestAwsConfigWithAuthProviderEnvDefaultRegion(t *testing.T) {
 		"AWS_DEFAULT_REGION":    "eu-west-1",
 	}
 
-	cfg, err := awshelper.NewAWSConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).
-		Build(ctx, l)
+	cfg, err := awshelper.NewAWSConfigBuilder().
+		Build(ctx, l, venvtest.NewWithOSFS().WithEnv(env))
 	require.NoError(t, err)
 	assert.Equal(t, "eu-west-1", cfg.Region)
 	assert.NotNil(t, cfg.Credentials)
@@ -163,8 +163,8 @@ func TestAwsConfigWithAuthProviderEnvChainsAssumeRole(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	baseCfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv().WithEnv(env)).
-		Build(t.Context(), l)
+	baseCfg, err := awshelper.NewAWSConfigBuilder().
+		Build(t.Context(), l, venv.OSVenv().WithEnv(env))
 	require.NoError(t, err)
 
 	baseARN, err := awshelper.GetAWSIdentityArn(t.Context(), &baseCfg)
@@ -172,12 +172,12 @@ func TestAwsConfigWithAuthProviderEnvChainsAssumeRole(t *testing.T) {
 
 	const sessionName = "terragrunt-chained-assume-role-test"
 
-	chainedCfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv().WithEnv(env)).
+	chainedCfg, err := awshelper.NewAWSConfigBuilder().
 		WithSessionConfig(&awshelper.AwsSessionConfig{
 			RoleArn:     roleARN,
 			SessionName: sessionName,
 		}).
-		Build(t.Context(), l)
+		Build(t.Context(), l, venv.OSVenv().WithEnv(env))
 	require.NoError(t, err)
 
 	chainedARN, err := awshelper.GetAWSIdentityArn(t.Context(), &chainedCfg)
@@ -291,10 +291,10 @@ func TestAwsConfigRoleSourcePermutations(t *testing.T) {
 
 			l := logger.CreateLogger()
 
-			cfg, err := awshelper.NewAWSConfigBuilder(venvtest.NewWithOSFS().WithEnv(tc.env)).
+			cfg, err := awshelper.NewAWSConfigBuilder().
 				WithSessionConfig(tc.sessionConfig).
 				WithIAMRoleOptions(tc.iamRoleOpts).
-				Build(t.Context(), l)
+				Build(t.Context(), l, venvtest.NewWithOSFS().WithEnv(tc.env))
 			require.NoError(t, err)
 			require.NotNil(t, cfg.Credentials)
 
@@ -346,9 +346,9 @@ func TestAwsConfigRegionTakesPrecedenceOverEnvVars(t *testing.T) {
 		Region: "us-east-1", // This should override the env vars
 	}
 
-	cfg, err := awshelper.NewAWSConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).
+	cfg, err := awshelper.NewAWSConfigBuilder().
 		WithSessionConfig(awsCfg).
-		Build(ctx, l)
+		Build(ctx, l, venvtest.NewWithOSFS().WithEnv(env))
 	require.NoError(t, err)
 
 	// Verify that the config uses the region from awsCfg, not from environment variables

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -268,7 +268,7 @@ func Prepare(
 		Collect(ctx, l, "scaffold_get_module", map[string]any{
 			"module_url": resolvedURL,
 		}, func(ctx context.Context, l log.Logger) error {
-			if _, getErr := getter.GetAny(ctx, tempDir, resolvedURL); getErr != nil {
+			if _, getErr := getter.GetAny(ctx, v, tempDir, resolvedURL); getErr != nil {
 				return fmt.Errorf("downloading scaffold module from %s: %w", resolvedURL, getErr)
 			}
 
@@ -685,7 +685,7 @@ func downloadTemplate(
 		Collect(ctx, l, "scaffold_get_template", map[string]any{
 			"template_url": baseURL.String(),
 		}, func(ctx context.Context, l log.Logger) error {
-			if _, getErr := getter.GetAny(ctx, templateDir, baseURL.String()); getErr != nil {
+			if _, getErr := getter.GetAny(ctx, v, templateDir, baseURL.String()); getErr != nil {
 				return fmt.Errorf(
 					"downloading scaffold template from %s: %w",
 					baseURL.String(),

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -388,7 +388,7 @@ func downloadEngine(
 		// Create download client and download assets
 		downloadClient := github.NewGitHubReleasesDownloadClient(github.WithLogger(l))
 
-		result, err := downloadClient.DownloadReleaseAssets(ctx, assets)
+		result, err := downloadClient.DownloadReleaseAssets(ctx, v, assets)
 		if err != nil {
 			return fmt.Errorf("failed to download engine assets: %w", err)
 		}

--- a/internal/gcphelper/config.go
+++ b/internal/gcphelper/config.go
@@ -129,7 +129,7 @@ func (b *GCPConfigBuilder) Build(
 
 	var clientOpts []option.ClientOption
 
-	envCreds, err := createGCPCredentialsFromEnv(v, env)
+	envCreds, err := createGCPCredentialsFromEnv(v)
 	if err != nil {
 		return nil, err
 	}
@@ -188,11 +188,11 @@ func (b *GCPConfigBuilder) Build(
 	return clientOpts, nil
 }
 
-// createGCPCredentialsFromEnv creates GCP credentials from GOOGLE_APPLICATION_CREDENTIALS environment variable in env
-// It looks for GOOGLE_APPLICATION_CREDENTIALS and returns a ClientOption that can be used
-// with Google Cloud clients. Returns nil if the environment variable is not set.
-func createGCPCredentialsFromEnv(v *venv.Venv, env map[string]string) (option.ClientOption, error) {
-	credentialsFile := env["GOOGLE_APPLICATION_CREDENTIALS"]
+// createGCPCredentialsFromEnv creates GCP credentials from the
+// GOOGLE_APPLICATION_CREDENTIALS variable in v's environment. Returns nil when
+// the variable is not set.
+func createGCPCredentialsFromEnv(v *venv.Venv) (option.ClientOption, error) {
+	credentialsFile := v.Env["GOOGLE_APPLICATION_CREDENTIALS"]
 	if credentialsFile == "" {
 		return nil, nil
 	}

--- a/internal/gcphelper/config.go
+++ b/internal/gcphelper/config.go
@@ -28,8 +28,6 @@ const (
 	credTypeImpersonatedServiceAccount = "impersonated_service_account"
 	credTypeExternalAccount            = "external_account"
 
-	// cloudPlatformScope pairs with storage.ScopeFullControl as the scope set
-	// storage.NewClient applies to clients it builds the transport for.
 	cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
 )
 
@@ -44,18 +42,11 @@ type GCPSessionConfig struct {
 // GCPConfigBuilder constructs GCP client options using the builder pattern.
 type GCPConfigBuilder struct {
 	sessionConfig *GCPSessionConfig
-	venv          *venv.Venv
 }
 
-// NewGCPConfigBuilder creates a new GCPConfigBuilder whose GCS requests, and
-// the OAuth token exchanges behind them, ride v's HTTP client. Credentials
-// resolve against v's environment and filesystem.
-func NewGCPConfigBuilder(v *venv.Venv) *GCPConfigBuilder {
-	v.RequireEnv()
-	v.RequireFS()
-	v.RequireHTTP()
-
-	return &GCPConfigBuilder{venv: v}
+// NewGCPConfigBuilder creates a new GCPConfigBuilder.
+func NewGCPConfigBuilder() *GCPConfigBuilder {
+	return &GCPConfigBuilder{}
 }
 
 // WithSessionConfig sets the GCP session configuration.
@@ -65,10 +56,17 @@ func (b *GCPConfigBuilder) WithSessionConfig(config *GCPSessionConfig) *GCPConfi
 }
 
 // BuildGCSClient builds a GCS storage client from the configured options.
-func (b *GCPConfigBuilder) BuildGCSClient(ctx context.Context) (*storage.Client, error) {
-	ctx = b.withOAuthClient(ctx)
+func (b *GCPConfigBuilder) BuildGCSClient(
+	ctx context.Context,
+	v *venv.Venv,
+) (*storage.Client, error) {
+	v.RequireEnv()
+	v.RequireFS()
+	v.RequireHTTP()
 
-	clientOpts, err := b.Build(ctx)
+	ctx = withOAuthClient(ctx, v)
+
+	clientOpts, err := b.Build(ctx, v)
 	if err != nil {
 		return nil, err
 	}
@@ -77,16 +75,10 @@ func (b *GCPConfigBuilder) BuildGCSClient(ctx context.Context) (*storage.Client,
 	// being passed straight to storage.NewClient: a bare client carries no
 	// credentials, so every request would go out unauthenticated.
 	//
-	// Credentials resolve here rather than inside storage.NewClient, which is
-	// where the storage scopes would normally be applied, so they have to be
-	// named. Without them the token exchange asks for no scope at all and the
-	// provider rejects it. They lead so that a caller's own scopes still win.
-	transportOpts := append(
-		[]option.ClientOption{option.WithScopes(storage.ScopeFullControl, cloudPlatformScope)},
-		clientOpts...,
-	)
+	// The scopes lead so that a caller's own scopes still win.
+	transportOpts := append([]option.ClientOption{GCSScopes()}, clientOpts...)
 
-	trans, err := htransport.NewTransport(ctx, b.venv.HTTP.Transport, transportOpts...)
+	trans, err := htransport.NewTransport(ctx, v.HTTP.Transport, transportOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error building GCS transport: %w", err)
 	}
@@ -103,21 +95,33 @@ func (b *GCPConfigBuilder) BuildGCSClient(ctx context.Context) (*storage.Client,
 	return gcsClient, nil
 }
 
-// withOAuthClient points the oauth2 library at c. oauth2 mints tokens through
-// http.DefaultClient otherwise, independently of the transport the API client
-// is built on.
-func (b *GCPConfigBuilder) withOAuthClient(ctx context.Context) context.Context {
-	return context.WithValue(ctx, oauth2.HTTPClient, b.venv.HTTP)
+// GCSScopes returns the scopes storage.NewClient applies to clients whose
+// transport it builds itself. Credentials resolve while the transport is being
+// built, which is where those scopes would normally be attached, so anything
+// building the transport has to name them. Without them the token exchange asks
+// for no scope at all and Google rejects it with `invalid_scope`.
+func GCSScopes() option.ClientOption {
+	return option.WithScopes(storage.ScopeFullControl, cloudPlatformScope)
+}
+
+// withOAuthClient points the oauth2 library at v's client. oauth2 mints tokens
+// through http.DefaultClient otherwise, independently of the transport the API
+// client is built on.
+func withOAuthClient(ctx context.Context, v *venv.Venv) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, v.HTTP)
 }
 
 // Build returns GCP client options from the configured session config and env.
-func (b *GCPConfigBuilder) Build(ctx context.Context) ([]option.ClientOption, error) {
+func (b *GCPConfigBuilder) Build(
+	ctx context.Context,
+	v *venv.Venv,
+) ([]option.ClientOption, error) {
 	gcpCfg := b.sessionConfig
-	env := b.venv.Env
+	env := v.Env
 
 	var clientOpts []option.ClientOption
 
-	envCreds, err := createGCPCredentialsFromEnv(b.venv.FS, env)
+	envCreds, err := createGCPCredentialsFromEnv(v.FS, env)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +130,7 @@ func (b *GCPConfigBuilder) Build(ctx context.Context) ([]option.ClientOption, er
 		clientOpts = append(clientOpts, envCreds)
 	} else if gcpCfg != nil && gcpCfg.Credentials != "" {
 		// Use credentials file from config
-		credOpt, err := credentialsFileOption(b.venv.FS, gcpCfg.Credentials)
+		credOpt, err := credentialsFileOption(v.FS, gcpCfg.Credentials)
 		if err != nil {
 			return nil, err
 		}
@@ -179,21 +183,21 @@ func (b *GCPConfigBuilder) Build(ctx context.Context) ([]option.ClientOption, er
 // createGCPCredentialsFromEnv creates GCP credentials from GOOGLE_APPLICATION_CREDENTIALS environment variable in env
 // It looks for GOOGLE_APPLICATION_CREDENTIALS and returns a ClientOption that can be used
 // with Google Cloud clients. Returns nil if the environment variable is not set.
-func createGCPCredentialsFromEnv(fs vfs.FS, env map[string]string) (option.ClientOption, error) {
+func createGCPCredentialsFromEnv(fsys vfs.FS, env map[string]string) (option.ClientOption, error) {
 	credentialsFile := env["GOOGLE_APPLICATION_CREDENTIALS"]
 	if credentialsFile == "" {
 		return nil, nil
 	}
 
-	return credentialsFileOption(fs, credentialsFile)
+	return credentialsFileOption(fsys, credentialsFile)
 }
 
 // credentialsFileOption reads a GCP credentials JSON file, detects its type,
 // and returns the appropriate ClientOption. The parsed bytes are handed to the
-// SDK rather than the path, so the file is read once, through fs, instead of
+// SDK rather than the path, so the file is read once, through fsys, instead of
 // the SDK opening it again off the real disk.
-func credentialsFileOption(fs vfs.FS, filename string) (option.ClientOption, error) {
-	data, err := vfs.ReadFile(fs, filename)
+func credentialsFileOption(fsys vfs.FS, filename string) (option.ClientOption, error) {
+	data, err := vfs.ReadFile(fsys, filename)
 	if err != nil {
 		return nil, fmt.Errorf("error reading credentials file %s: %w", filename, err)
 	}

--- a/internal/gcphelper/config.go
+++ b/internal/gcphelper/config.go
@@ -9,6 +9,7 @@ import (
 
 	"net/http"
 
+	"cloud.google.com/go/auth/credentials"
 	"cloud.google.com/go/storage"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
@@ -22,11 +23,6 @@ import (
 
 const (
 	tokenURL = "https://oauth2.googleapis.com/token"
-
-	credTypeServiceAccount             = "service_account"
-	credTypeAuthorizedUser             = "authorized_user"
-	credTypeImpersonatedServiceAccount = "impersonated_service_account"
-	credTypeExternalAccount            = "external_account"
 
 	cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
 )
@@ -101,7 +97,11 @@ func (b *GCPConfigBuilder) BuildGCSClient(
 // building the transport has to name them. Without them the token exchange asks
 // for no scope at all and Google rejects it with `invalid_scope`.
 func GCSScopes() option.ClientOption {
-	return option.WithScopes(storage.ScopeFullControl, cloudPlatformScope)
+	return option.WithScopes(gcsScopes()...)
+}
+
+func gcsScopes() []string {
+	return []string{storage.ScopeFullControl, cloudPlatformScope}
 }
 
 // withOAuthClient points the oauth2 library at v's client. oauth2 mints tokens
@@ -129,7 +129,7 @@ func (b *GCPConfigBuilder) Build(
 
 	var clientOpts []option.ClientOption
 
-	envCreds, err := createGCPCredentialsFromEnv(v.FS, env)
+	envCreds, err := createGCPCredentialsFromEnv(v, env)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (b *GCPConfigBuilder) Build(
 		clientOpts = append(clientOpts, envCreds)
 	} else if gcpCfg != nil && gcpCfg.Credentials != "" {
 		// Use credentials file from config
-		credOpt, err := credentialsFileOption(v.FS, gcpCfg.Credentials)
+		credOpt, err := credentialsFileOption(v, gcpCfg.Credentials)
 		if err != nil {
 			return nil, err
 		}
@@ -191,56 +191,46 @@ func (b *GCPConfigBuilder) Build(
 // createGCPCredentialsFromEnv creates GCP credentials from GOOGLE_APPLICATION_CREDENTIALS environment variable in env
 // It looks for GOOGLE_APPLICATION_CREDENTIALS and returns a ClientOption that can be used
 // with Google Cloud clients. Returns nil if the environment variable is not set.
-func createGCPCredentialsFromEnv(fsys vfs.FS, env map[string]string) (option.ClientOption, error) {
+func createGCPCredentialsFromEnv(v *venv.Venv, env map[string]string) (option.ClientOption, error) {
 	credentialsFile := env["GOOGLE_APPLICATION_CREDENTIALS"]
 	if credentialsFile == "" {
 		return nil, nil
 	}
 
-	return credentialsFileOption(fsys, credentialsFile)
+	return credentialsFileOption(v, credentialsFile)
 }
 
-// credentialsFileOption reads a GCP credentials JSON file, detects its type,
-// and returns the appropriate ClientOption. The parsed bytes are handed to the
-// SDK rather than the path, so the file is read once, through fsys, instead of
-// the SDK opening it again off the real disk.
-func credentialsFileOption(fsys vfs.FS, filename string) (option.ClientOption, error) {
-	data, err := vfs.ReadFile(fsys, filename)
+// credentialsFileOption reads a GCP credentials JSON file and returns the
+// option that authenticates with it. The parsed bytes are handed to the SDK
+// rather than the path, so the file is read once, through v's filesystem,
+// instead of the SDK opening it again off the real disk.
+func credentialsFileOption(v *venv.Venv, filename string) (option.ClientOption, error) {
+	data, err := vfs.ReadFile(v.FS, filename)
 	if err != nil {
 		return nil, fmt.Errorf("error reading credentials file %s: %w", filename, err)
 	}
 
-	var meta struct {
-		Type string `json:"type"`
-	}
-
-	if err := json.Unmarshal(data, &meta); err != nil {
-		return nil, fmt.Errorf("error parsing credentials file %s: %w", filename, err)
-	}
-
-	credType, err := credentialsTypeFromString(meta.Type)
-	if err != nil {
-		return nil, err
-	}
-
-	return option.WithAuthCredentialsJSON(credType, data), nil
+	return credentialsJSONOption(v, data)
 }
 
-// credentialsTypeFromString maps the "type" field in a GCP credentials JSON
-// file to the corresponding option.CredentialsType.
-func credentialsTypeFromString(t string) (option.CredentialsType, error) {
-	switch t {
-	case credTypeServiceAccount:
-		return option.ServiceAccount, nil
-	case credTypeAuthorizedUser:
-		return option.AuthorizedUser, nil
-	case credTypeImpersonatedServiceAccount:
-		return option.ImpersonatedServiceAccount, nil
-	case credTypeExternalAccount:
-		return option.ExternalAccount, nil
-	default:
-		return "", fmt.Errorf("unsupported GCP credentials type: %q", t)
+// credentialsJSONOption authenticates with a credentials JSON payload.
+//
+// The credentials are detected here rather than by the SDK, which detects with
+// a client of its own making (google.golang.org/api/internal.creds) and would
+// put the token exchange on a transport the venv never sees. Detection also
+// covers every credential type the JSON can name, so the type does not have to
+// be recognized up front.
+func credentialsJSONOption(v *venv.Venv, data []byte) (option.ClientOption, error) {
+	creds, err := credentials.DetectDefault(&credentials.DetectOptions{
+		CredentialsJSON: data,
+		Scopes:          gcsScopes(),
+		Client:          v.HTTP,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error detecting GCP credentials: %w", err)
 	}
+
+	return option.WithAuthCredentials(creds), nil
 }
 
 // createGCPCredentialsFromGoogleCredentialsEnv creates GCP credentials from GOOGLE_CREDENTIALS environment variable.

--- a/internal/gcphelper/config.go
+++ b/internal/gcphelper/config.go
@@ -116,6 +116,14 @@ func (b *GCPConfigBuilder) Build(
 	ctx context.Context,
 	v *venv.Venv,
 ) ([]option.ClientOption, error) {
+	v.RequireEnv()
+	v.RequireFS()
+	v.RequireHTTP()
+
+	// Impersonation mints its token inside Build, so the oauth2 client has to be
+	// in place before the transport the caller builds from these options.
+	ctx = withOAuthClient(ctx, v)
+
 	gcpCfg := b.sessionConfig
 	env := v.Env
 

--- a/internal/gcphelper/config_test.go
+++ b/internal/gcphelper/config_test.go
@@ -4,6 +4,11 @@ package gcphelper_test
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,6 +19,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// serviceAccountJSON builds a complete service-account credentials payload.
+// Credentials are validated where they are detected, so a payload naming only
+// its type is rejected before it can stand in for a real one.
+func serviceAccountJSON(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	sa, err := json.Marshal(map[string]string{
+		"type":         "service_account",
+		"project_id":   "test-project",
+		"client_email": "test@test-project.iam.gserviceaccount.com",
+		"token_uri":    "https://oauth2.googleapis.com/token",
+		"private_key": string(pem.EncodeToMemory(&pem.Block{
+			Type:  "PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(key),
+		})),
+	})
+	require.NoError(t, err)
+
+	return sa
+}
+
 func TestGcpConfigWithApplicationCredentialsEnv(t *testing.T) {
 	t.Parallel()
 
@@ -22,7 +51,7 @@ func TestGcpConfigWithApplicationCredentialsEnv(t *testing.T) {
 	// Create a temporary credentials file
 	tmpDir := t.TempDir()
 	credsFile := filepath.Join(tmpDir, "credentials.json")
-	err := os.WriteFile(credsFile, []byte(`{"type":"service_account"}`), 0644)
+	err := os.WriteFile(credsFile, serviceAccountJSON(t), 0644)
 	require.NoError(t, err)
 
 	env := map[string]string{
@@ -82,7 +111,7 @@ func TestGcpConfigWithCredentialsFileFromConfig(t *testing.T) {
 	// Create a temporary credentials file
 	tmpDir := t.TempDir()
 	credsFile := filepath.Join(tmpDir, "credentials.json")
-	err := os.WriteFile(credsFile, []byte(`{"type":"service_account"}`), 0644)
+	err := os.WriteFile(credsFile, serviceAccountJSON(t), 0644)
 	require.NoError(t, err)
 
 	env := map[string]string{}
@@ -126,10 +155,10 @@ func TestGcpConfigEnvVarsTakePrecedenceOverConfig(t *testing.T) {
 	envCredsFile := filepath.Join(tmpDir, "env-credentials.json")
 	configCredsFile := filepath.Join(tmpDir, "config-credentials.json")
 
-	err := os.WriteFile(envCredsFile, []byte(`{"type":"service_account"}`), 0644)
+	err := os.WriteFile(envCredsFile, serviceAccountJSON(t), 0644)
 	require.NoError(t, err)
 
-	err = os.WriteFile(configCredsFile, []byte(`{"type":"service_account"}`), 0644)
+	err = os.WriteFile(configCredsFile, serviceAccountJSON(t), 0644)
 	require.NoError(t, err)
 
 	// Set environment variable - this should take precedence over config

--- a/internal/gcphelper/config_test.go
+++ b/internal/gcphelper/config_test.go
@@ -29,7 +29,7 @@ func TestGcpConfigWithApplicationCredentialsEnv(t *testing.T) {
 		"GOOGLE_APPLICATION_CREDENTIALS": credsFile,
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).Build(ctx)
+	clientOpts, err := gcphelper.NewGCPConfigBuilder().Build(ctx, venvtest.NewWithOSFS().WithEnv(env))
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
 }
@@ -43,7 +43,7 @@ func TestGcpConfigWithOAuthAccessTokenEnv(t *testing.T) {
 		"GOOGLE_OAUTH_ACCESS_TOKEN": "test-oauth-token",
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).Build(ctx)
+	clientOpts, err := gcphelper.NewGCPConfigBuilder().Build(ctx, venvtest.NewWithOSFS().WithEnv(env))
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
 }
@@ -69,7 +69,7 @@ func TestGcpConfigWithGoogleCredentialsEnv(t *testing.T) {
 		"GOOGLE_CREDENTIALS": credsJSON,
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).Build(ctx)
+	clientOpts, err := gcphelper.NewGCPConfigBuilder().Build(ctx, venvtest.NewWithOSFS().WithEnv(env))
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
 }
@@ -91,9 +91,9 @@ func TestGcpConfigWithCredentialsFileFromConfig(t *testing.T) {
 		Credentials: credsFile,
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).
+	clientOpts, err := gcphelper.NewGCPConfigBuilder().
 		WithSessionConfig(gcpCfg).
-		Build(ctx)
+		Build(ctx, venvtest.NewWithOSFS().WithEnv(env))
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
 }
@@ -109,9 +109,9 @@ func TestGcpConfigWithAccessTokenFromConfig(t *testing.T) {
 		AccessToken: "test-access-token",
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).
+	clientOpts, err := gcphelper.NewGCPConfigBuilder().
 		WithSessionConfig(gcpCfg).
-		Build(ctx)
+		Build(ctx, venvtest.NewWithOSFS().WithEnv(env))
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
 }
@@ -142,9 +142,9 @@ func TestGcpConfigEnvVarsTakePrecedenceOverConfig(t *testing.T) {
 		Credentials: configCredsFile, // This should be ignored in favor of env var
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).
+	clientOpts, err := gcphelper.NewGCPConfigBuilder().
 		WithSessionConfig(gcpCfg).
-		Build(ctx)
+		Build(ctx, venvtest.NewWithOSFS().WithEnv(env))
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
 
@@ -169,7 +169,7 @@ func TestGcpConfigWithImpersonation(t *testing.T) {
 
 	// This will fail because we don't have real credentials, but we can verify
 	// that the impersonation configuration is attempted
-	_, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).WithSessionConfig(gcpCfg).Build(ctx)
+	_, err := gcphelper.NewGCPConfigBuilder().WithSessionConfig(gcpCfg).Build(ctx, venvtest.NewWithOSFS().WithEnv(env))
 	// We expect an error because impersonation requires valid base credentials
 	// The error should be about impersonation, not about missing credentials
 	require.Error(t, err)
@@ -184,7 +184,7 @@ func TestGcpConfigWithNoCredentials(t *testing.T) {
 	env := map[string]string{}
 
 	// No credentials provided - should return empty options (will use default credentials)
-	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).Build(ctx)
+	clientOpts, err := gcphelper.NewGCPConfigBuilder().Build(ctx, venvtest.NewWithOSFS().WithEnv(env))
 	require.NoError(t, err)
 	// Should return empty options when no credentials are provided
 	// (default credentials will be used by GCP client)
@@ -215,7 +215,7 @@ func TestGcpConfigWithGoogleCredentialsFile(t *testing.T) {
 		"GOOGLE_CREDENTIALS": credsFile,
 	}
 
-	clientOpts, err := gcphelper.NewGCPConfigBuilder(venvtest.NewWithOSFS().WithEnv(env)).Build(ctx)
+	clientOpts, err := gcphelper.NewGCPConfigBuilder().Build(ctx, venvtest.NewWithOSFS().WithEnv(env))
 	require.NoError(t, err)
 	assert.NotEmpty(t, clientOpts)
 }

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -108,7 +108,7 @@ func WithDefaultGenericDispatch(opts ...GenericFetcherOption) CASGetterOption {
 		g.fetchers = DefaultGenericFetchers(
 			g.Venv,
 			slices.Concat(opts, []GenericFetcherOption{WithHTTPClient(c)})...)
-		g.resolvers = DefaultSourceResolvers(c, g.Venv.Exec, opts...)
+		g.resolvers = DefaultSourceResolvers(g.Venv, c, opts...)
 	}
 }
 

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -108,7 +108,7 @@ func WithDefaultGenericDispatch(opts ...GenericFetcherOption) CASGetterOption {
 		g.fetchers = DefaultGenericFetchers(
 			g.Venv,
 			slices.Concat(opts, []GenericFetcherOption{WithHTTPClient(c)})...)
-		g.resolvers = DefaultSourceResolvers(g.Venv, c, opts...)
+		g.resolvers = DefaultSourceResolvers(g.Venv.WithHTTP(c), opts...)
 	}
 }
 

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -106,6 +106,7 @@ func WithDefaultGenericDispatch(opts ...GenericFetcherOption) CASGetterOption {
 		g.Venv.RequireExec()
 
 		g.fetchers = DefaultGenericFetchers(
+			g.Venv,
 			slices.Concat(opts, []GenericFetcherOption{WithHTTPClient(c)})...)
 		g.resolvers = DefaultSourceResolvers(c, g.Venv.Exec, opts...)
 	}
@@ -561,8 +562,10 @@ func pinnedOCIURL(rawURL, digestValue string) string {
 // default protocol set is available for [RegistryGetter]'s delegated
 // archive download. Every other scheme uses a single-getter client.
 func defaultInnerClientBuilder(bare getter.Getter, scheme string) *getter.Client {
-	if scheme == SchemeTFR {
-		return NewClient(WithCustomGettersPrepended(bare))
+	// The bare tfr getter carries the venv its delegated archive download
+	// needs; the fallback client builds s3 and gcs getters that require one.
+	if tfr, ok := bare.(*RegistryGetter); ok && scheme == SchemeTFR {
+		return NewClient(tfr.Venv, WithCustomGettersPrepended(bare))
 	}
 
 	return &getter.Client{Getters: []getter.Getter{bare}}

--- a/internal/getter/casgetter_tfr_test.go
+++ b/internal/getter/casgetter_tfr_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // TestCASGetter_TFRRoutesThroughCAS_FirstRunDownloads pins that a
@@ -38,7 +38,7 @@ func TestCASGetter_TFRRoutesThroughCAS(t *testing.T) {
 	l := logger.CreateLogger()
 	httpClient := server.Client()
 
-	tfr := getter.NewRegistryGetter(l, vfs.NewOSFS(), httpClient).
+	tfr := getter.NewRegistryGetter(l, venvtest.NewWithOSFS().WithHTTP(httpClient)).
 		WithTofuImplementation(tfimpl.Terraform)
 
 	resolver := getter.NewTFRResolver().
@@ -59,10 +59,11 @@ func TestCASGetter_TFRRoutesThroughCAS(t *testing.T) {
 	// not need this hook — the default builder uses the standard
 	// HttpGetter, which is fine for a real registry.
 	innerBuilder := func(bare gogetter.Getter, _ string) *gogetter.Client {
-		return getter.NewClient(getter.WithCustomGettersPrepended(
-			bare,
-			&gogetter.HttpGetter{Client: httpClient, Netrc: true},
-		))
+		return getter.NewClient(venvtest.NewWithOSFS(),
+			getter.WithCustomGettersPrepended(
+				bare,
+				&gogetter.HttpGetter{Client: httpClient, Netrc: true},
+			))
 	}
 
 	g := getter.NewCASGetter(l, c, v, &tgcas.CloneOptions{},

--- a/internal/getter/client.go
+++ b/internal/getter/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	getter "github.com/hashicorp/go-getter/v2"
+
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 )
 
 // NewClient returns a *go-getter/v2.Client configured for Terragrunt.
@@ -12,8 +14,8 @@ import (
 // directly, as it will consistently configure the client with the
 // default protocol set (s3, gcs, git, hg, smb, http(s), file) plus
 // the FileCopy and tfr customizations.
-func NewClient(opts ...Option) *getter.Client {
-	b := &builder{}
+func NewClient(v *venv.Venv, opts ...Option) *getter.Client {
+	b := &builder{v: v}
 	for _, opt := range opts {
 		opt(b)
 	}
@@ -30,8 +32,13 @@ func NewClient(opts ...Option) *getter.Client {
 }
 
 // Get is a convenience wrapper for downloading directories.
-func Get(ctx context.Context, dst, src string, opts ...Option) (*GetResult, error) {
-	return NewClient(opts...).Get(ctx, &Request{
+func Get(
+	ctx context.Context,
+	v *venv.Venv,
+	dst, src string,
+	opts ...Option,
+) (*GetResult, error) {
+	return NewClient(v, opts...).Get(ctx, &Request{
 		Src:     src,
 		Dst:     dst,
 		GetMode: ModeDir,
@@ -40,8 +47,13 @@ func Get(ctx context.Context, dst, src string, opts ...Option) (*GetResult, erro
 
 // GetAny is a convenience wrapper for downloading either files or directories
 // through a Terragrunt-configured client whose getter list includes s3 and gcs.
-func GetAny(ctx context.Context, dst, src string, opts ...Option) (*GetResult, error) {
-	return NewClient(opts...).Get(ctx, &Request{
+func GetAny(
+	ctx context.Context,
+	v *venv.Venv,
+	dst, src string,
+	opts ...Option,
+) (*GetResult, error) {
+	return NewClient(v, opts...).Get(ctx, &Request{
 		Src:     src,
 		Dst:     dst,
 		GetMode: ModeAny,
@@ -49,8 +61,13 @@ func GetAny(ctx context.Context, dst, src string, opts ...Option) (*GetResult, e
 }
 
 // GetFile is a convenience wrapper for downloading a single file.
-func GetFile(ctx context.Context, dst, src string, opts ...Option) (*GetResult, error) {
-	return NewClient(opts...).Get(ctx, &Request{
+func GetFile(
+	ctx context.Context,
+	v *venv.Venv,
+	dst, src string,
+	opts ...Option,
+) (*GetResult, error) {
+	return NewClient(v, opts...).Get(ctx, &Request{
 		Src:     src,
 		Dst:     dst,
 		GetMode: ModeFile,

--- a/internal/getter/client_test.go
+++ b/internal/getter/client_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +30,7 @@ func TestGetFileConvenience(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "out.txt")
-	res, err := getter.GetFile(t.Context(), dst, server.URL+"/blob")
+	res, err := getter.GetFile(t.Context(), venvtest.NewWithOSFS(), dst, server.URL+"/blob")
 	require.NoError(t, err)
 	assert.Equal(t, dst, res.Dst)
 
@@ -47,7 +48,7 @@ func TestGetAnyConvenience(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(src, "main.tf"), []byte("# fixture\n"), 0644))
 
 	dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "copy")
-	_, err := getter.GetAny(t.Context(), dst, "file://"+src,
+	_, err := getter.GetAny(t.Context(), venvtest.NewWithOSFS(), dst, "file://"+src,
 		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
 	)
 	require.NoError(t, err)
@@ -65,7 +66,7 @@ func TestGetConvenience(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(src, "main.tf"), []byte("# fixture\n"), 0644))
 
 	dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "copy")
-	_, err := getter.Get(t.Context(), dst, "file://"+src,
+	_, err := getter.Get(t.Context(), venvtest.NewWithOSFS(), dst, "file://"+src,
 		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
 	)
 	require.NoError(t, err)
@@ -78,10 +79,13 @@ func TestGetConvenience(t *testing.T) {
 func TestNewClientWithDecompressorsEmptyMap(t *testing.T) {
 	t.Parallel()
 
-	disabled := getter.NewClient(getter.WithDecompressors(map[string]getter.Decompressor{}))
+	disabled := getter.NewClient(venvtest.NewWithOSFS(),
+		getter.WithDecompressors(map[string]getter.Decompressor{}),
+	)
 	require.NotNil(t, disabled.Decompressors)
 	assert.Empty(t, disabled.Decompressors)
 
-	def := getter.NewClient(getter.WithDecompressors(nil))
+	def := getter.NewClient(venvtest.NewWithOSFS(),
+		getter.WithDecompressors(nil))
 	assert.Nil(t, def.Decompressors, "nil map must leave the v2 default decompressors untouched")
 }

--- a/internal/getter/defaults.go
+++ b/internal/getter/defaults.go
@@ -269,7 +269,7 @@ func buildGetters(b *builder) []Getter {
 			NewCASProtocolGetter(b.logger, b.casStore, b.v),
 			NewCASGetter(b.logger, b.casStore, b.v, b.casCloneOpts,
 				WithGenericFetchers(fetchers),
-				WithGenericResolvers(DefaultSourceResolvers(b.httpClient, b.v.Exec, resolverOpts...)),
+				WithGenericResolvers(DefaultSourceResolvers(b.v, b.httpClient, resolverOpts...)),
 			),
 		)
 	}

--- a/internal/getter/defaults.go
+++ b/internal/getter/defaults.go
@@ -269,7 +269,7 @@ func buildGetters(b *builder) []Getter {
 			NewCASProtocolGetter(b.logger, b.casStore, b.v),
 			NewCASGetter(b.logger, b.casStore, b.v, b.casCloneOpts,
 				WithGenericFetchers(fetchers),
-				WithGenericResolvers(DefaultSourceResolvers(b.v, b.httpClient, resolverOpts...)),
+				WithGenericResolvers(DefaultSourceResolvers(b.v.WithHTTP(b.httpClient), resolverOpts...)),
 			),
 		)
 	}

--- a/internal/getter/defaults.go
+++ b/internal/getter/defaults.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	gcs "github.com/hashicorp/go-getter/gcs/v2"
 	getter "github.com/hashicorp/go-getter/v2"
 )
 
@@ -142,15 +141,15 @@ func WithTFRConfig(impl tfimpl.Type) GenericFetcherOption {
 // uses on a cache miss. Exported so callers that build dedicated
 // CAS-only clients (the CAS-experiment path in
 // runner/run/download_source.go) share the fetcher set NewClient uses.
-func DefaultGenericFetchers(opts ...GenericFetcherOption) map[string]getter.Getter {
+func DefaultGenericFetchers(v *venv.Venv, opts ...GenericFetcherOption) map[string]getter.Getter {
 	var cfg genericFetcherConfig
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 
 	m := map[string]getter.Getter{
-		SchemeS3:    new(S3Getter),
-		SchemeGCS:   new(gcs.Getter),
+		SchemeS3:    NewS3Getter(v),
+		SchemeGCS:   NewGCSGetter(v),
 		SchemeHTTP:  &HTTPSchemeGetter{Inner: newHTTPGetter(cfg.httpClient, cfg.httpExtra), Scheme: SchemeHTTP},
 		SchemeHTTPS: &HTTPSchemeGetter{Inner: newHTTPGetter(cfg.httpClient, cfg.httpsExtra), Scheme: SchemeHTTPS},
 		SchemeHg:    new(getter.HgGetter),
@@ -166,7 +165,7 @@ func DefaultGenericFetchers(opts ...GenericFetcherOption) map[string]getter.Gett
 			)
 		}
 
-		m[SchemeTFR] = NewRegistryGetter(cfg.logger, cfg.fs, cfg.httpClient).
+		m[SchemeTFR] = NewRegistryGetter(cfg.logger, v).
 			WithEnv(cfg.env).
 			WithTofuImplementation(cfg.tfrImpl)
 	}
@@ -231,8 +230,9 @@ func buildGetters(b *builder) []Getter {
 	hgGetter := new(getter.HgGetter)
 	smbClientGetter := new(getter.SmbClientGetter)
 	smbMountGetter := new(getter.SmbMountGetter)
-	s3Getter := new(S3Getter)
-	gcsGetter := new(gcs.Getter)
+
+	s3Getter := NewS3Getter(b.v)
+	gcsGetter := NewGCSGetter(b.v)
 
 	if b.casStore != nil {
 		if b.httpClient == nil {
@@ -255,8 +255,8 @@ func buildGetters(b *builder) []Getter {
 			resolverOpts = append(
 				resolverOpts,
 				WithDispatchLogger(b.logger),
-				WithDispatchFS(b.tfRegistry.FS),
-				WithDispatchEnv(b.tfRegistry.Env),
+				WithDispatchFS(b.tfRegistry.Venv.FS),
+				WithDispatchEnv(b.tfRegistry.Venv.Env),
 				WithTFRConfig(b.tfRegistry.TofuImplementation),
 			)
 		}
@@ -266,10 +266,10 @@ func buildGetters(b *builder) []Getter {
 		}
 
 		out = append(out,
-			NewCASProtocolGetter(b.logger, b.casStore, b.casVenv),
-			NewCASGetter(b.logger, b.casStore, b.casVenv, b.casCloneOpts,
+			NewCASProtocolGetter(b.logger, b.casStore, b.v),
+			NewCASGetter(b.logger, b.casStore, b.v, b.casCloneOpts,
 				WithGenericFetchers(fetchers),
-				WithGenericResolvers(DefaultSourceResolvers(b.httpClient, b.casVenv.Exec, resolverOpts...)),
+				WithGenericResolvers(DefaultSourceResolvers(b.httpClient, b.v.Exec, resolverOpts...)),
 			),
 		)
 	}

--- a/internal/getter/defaults_test.go
+++ b/internal/getter/defaults_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ import (
 func TestDefaultClientRegistersS3GCS(t *testing.T) {
 	t.Parallel()
 
-	client := getter.NewClient()
+	client := getter.NewClient(venvtest.NewWithOSFS())
 
 	assert.True(
 		t,
@@ -37,7 +38,7 @@ func TestDefaultClientRegistersS3GCS(t *testing.T) {
 func TestDefaultClientCoversCanonicalProtocols(t *testing.T) {
 	t.Parallel()
 
-	client := getter.NewClient()
+	client := getter.NewClient(venvtest.NewWithOSFS())
 
 	assert.True(t, hasGetter[*getter.GitGetter](client.Getters), "git")
 	assert.True(t, hasGetter[*getter.HgGetter](client.Getters), "hg")
@@ -52,7 +53,9 @@ func TestDefaultClientCoversCanonicalProtocols(t *testing.T) {
 func TestWithFileCopyReplacesFileGetter(t *testing.T) {
 	t.Parallel()
 
-	client := getter.NewClient(getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())))
+	client := getter.NewClient(venvtest.NewWithOSFS(),
+		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
+	)
 
 	assert.True(
 		t,
@@ -94,7 +97,8 @@ func TestForcedGettersRouteToTheirGetter(t *testing.T) {
 			t.Parallel()
 
 			stub := &forcedRecordingGetter{forced: tc.forced}
-			client := getter.NewClient(getter.WithCustomGettersPrepended(stub))
+			client := getter.NewClient(venvtest.NewWithOSFS(),
+				getter.WithCustomGettersPrepended(stub))
 
 			_, err := client.Get(t.Context(), &getter.Request{
 				Src:     tc.src,

--- a/internal/getter/gcs.go
+++ b/internal/getter/gcs.go
@@ -1,0 +1,207 @@
+package getter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	upstreamgcs "github.com/hashicorp/go-getter/gcs/v2"
+	getter "github.com/hashicorp/go-getter/v2"
+	"google.golang.org/api/iterator"
+
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+)
+
+// ErrGCSInvalidFetchURL is returned when a GCS URL does not carry both a
+// bucket and an object.
+var ErrGCSInvalidFetchURL = errors.New("not a valid GCS URL")
+
+// gcsCanonicalParts is the segment count from splitting
+// `/storage/<version>/<bucket>/<object>` on "/" with limit 5.
+const gcsCanonicalParts = 5
+
+// Compile-time proof both getters still satisfy the interface.
+var (
+	_ getter.Getter = (*GCSGetter)(nil)
+	_ getter.Getter = (*S3Getter)(nil)
+)
+
+// GCSGetter is Terragrunt's gcs-protocol getter.
+//
+// Detection is delegated to the upstream go-getter/gcs/v2 Getter, which does
+// no I/O. Fetching is not, because the upstream Getter calls storage.NewClient
+// with no options, which would put every object download on a transport the
+// venv never sees.
+type GCSGetter struct {
+	v             *venv.Venv
+	detector      upstreamgcs.Getter
+	modeScanLimit int
+}
+
+// NewGCSGetter returns a gcs-protocol getter.
+func NewGCSGetter(v *venv.Venv) *GCSGetter {
+	v.RequireFS()
+	v.RequireHTTP()
+
+	return &GCSGetter{v: v, modeScanLimit: DefaultModeScanLimit}
+}
+
+// WithModeScanLimit caps how many objects [GCSGetter.Mode] inspects before it
+// gives up with [ErrModeScanLimit].
+func (g *GCSGetter) WithModeScanLimit(limit int) *GCSGetter {
+	g.modeScanLimit = limit
+	return g
+}
+
+// Detect delegates to the upstream getter.
+func (g *GCSGetter) Detect(req *getter.Request) (bool, error) {
+	return g.detector.Detect(req)
+}
+
+// Mode reports whether the URL names a single object or a prefix. Anything
+// matching the prefix that is not exactly the requested object makes it a
+// directory.
+func (g *GCSGetter) Mode(ctx context.Context, u *url.URL) (_ getter.Mode, retErr error) {
+	bucket, object, err := ParseGCSFetchURL(u)
+	if err != nil {
+		return 0, err
+	}
+
+	client, err := g.client(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	defer CloseOnSuccess(client, &retErr)
+
+	objects := client.Bucket(bucket).Objects(ctx, &storage.Query{Prefix: object})
+
+	mode, err := ScanMode(g.modeScanLimit,
+		func(yield func(string, error) bool) {
+			for {
+				attrs, err := objects.Next()
+				if errors.Is(err, iterator.Done) {
+					return
+				}
+
+				if err != nil {
+					yield("", err)
+					return
+				}
+
+				if !yield(attrs.Name, nil) {
+					return
+				}
+			}
+		},
+		func(name string) (getter.Mode, bool) {
+			if strings.HasSuffix(name, "/") || name != object {
+				return getter.ModeDir, true
+			}
+
+			return 0, false
+		},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %q", err, object)
+	}
+
+	return mode, nil
+}
+
+// Get downloads every object under the URL's prefix into req.Dst, preserving
+// each object's path relative to that prefix.
+func (g *GCSGetter) Get(ctx context.Context, req *getter.Request) (retErr error) {
+	bucket, object, err := ParseGCSFetchURL(req.URL())
+	if err != nil {
+		return err
+	}
+
+	client, err := g.client(ctx)
+	if err != nil {
+		return err
+	}
+
+	defer CloseOnSuccess(client, &retErr)
+
+	if err := ResetGetterDst(g.v.FS, req); err != nil {
+		return err
+	}
+
+	prefix := ListPrefix(object)
+	objects := client.Bucket(bucket).Objects(ctx, &storage.Query{Prefix: prefix})
+
+	for {
+		attrs, err := objects.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+
+		// A name ending in "/" is a directory placeholder, not content.
+		if strings.HasSuffix(attrs.Name, "/") {
+			continue
+		}
+
+		body, err := client.Bucket(bucket).Object(attrs.Name).NewReader(ctx)
+		if err != nil {
+			return err
+		}
+
+		dst := ObjectDst(req.Dst, prefix, attrs.Name)
+		if err := WriteGetterObject(g.v.FS, req, dst, body); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// GetFile downloads the single object the URL names into req.Dst.
+func (g *GCSGetter) GetFile(ctx context.Context, req *getter.Request) (retErr error) {
+	bucket, object, err := ParseGCSFetchURL(req.URL())
+	if err != nil {
+		return err
+	}
+
+	client, err := g.client(ctx)
+	if err != nil {
+		return err
+	}
+
+	defer CloseOnSuccess(client, &retErr)
+
+	body, err := client.Bucket(bucket).Object(object).NewReader(ctx)
+	if err != nil {
+		return err
+	}
+
+	return WriteGetterObject(g.v.FS, req, req.Dst, body)
+}
+
+// ParseGCSFetchURL extracts the bucket and object from the canonical
+// `https://www.googleapis.com/storage/<version>/<bucket>/<object>` form the
+// upstream detector produces.
+func ParseGCSFetchURL(u *url.URL) (bucket, object string, err error) {
+	if !strings.Contains(u.Host, "googleapis.com") {
+		return "", "", fmt.Errorf("%w: %q", ErrGCSInvalidFetchURL, u.String())
+	}
+
+	parts := strings.SplitN(strings.TrimPrefix(u.Path, "/"), "/", gcsCanonicalParts-1)
+	if len(parts) != gcsCanonicalParts-1 || parts[0] != "storage" ||
+		parts[2] == "" || parts[3] == "" {
+		return "", "", fmt.Errorf("%w: %q", ErrGCSInvalidFetchURL, u.String())
+	}
+
+	return parts[2], parts[3], nil
+}
+
+func (g *GCSGetter) client(ctx context.Context) (*storage.Client, error) {
+	return newVenvGCSClient(ctx, g.v.HTTP)
+}

--- a/internal/getter/gcs.go
+++ b/internal/getter/gcs.go
@@ -61,9 +61,8 @@ func (g *GCSGetter) Detect(req *getter.Request) (bool, error) {
 	return g.detector.Detect(req)
 }
 
-// Mode reports whether the URL names a single object or a prefix. Anything
-// matching the prefix that is not exactly the requested object makes it a
-// directory.
+// Mode reports whether the URL names a single object or a prefix, deciding
+// each listed name with [ObjectMode].
 func (g *GCSGetter) Mode(ctx context.Context, u *url.URL) (_ getter.Mode, retErr error) {
 	bucket, object, err := ParseGCSFetchURL(u)
 	if err != nil {
@@ -98,11 +97,7 @@ func (g *GCSGetter) Mode(ctx context.Context, u *url.URL) (_ getter.Mode, retErr
 			}
 		},
 		func(name string) (getter.Mode, bool) {
-			if strings.HasSuffix(name, "/") || name != object {
-				return getter.ModeDir, true
-			}
-
-			return 0, false
+			return ObjectMode(name, object)
 		},
 	)
 	if err != nil {
@@ -149,12 +144,16 @@ func (g *GCSGetter) Get(ctx context.Context, req *getter.Request) (retErr error)
 			continue
 		}
 
+		dst, err := ObjectDst(req.Dst, prefix, attrs.Name)
+		if err != nil {
+			return err
+		}
+
 		body, err := client.Bucket(bucket).Object(attrs.Name).NewReader(ctx)
 		if err != nil {
 			return err
 		}
 
-		dst := ObjectDst(req.Dst, prefix, attrs.Name)
 		if err := WriteGetterObject(g.v.FS, req, dst, body); err != nil {
 			return err
 		}

--- a/internal/getter/gcs.go
+++ b/internal/getter/gcs.go
@@ -12,6 +12,7 @@ import (
 	getter "github.com/hashicorp/go-getter/v2"
 	"google.golang.org/api/iterator"
 
+	"github.com/gruntwork-io/terragrunt/internal/gcphelper"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 )
 
@@ -43,6 +44,7 @@ type GCSGetter struct {
 
 // NewGCSGetter returns a gcs-protocol getter.
 func NewGCSGetter(v *venv.Venv) *GCSGetter {
+	v.RequireEnv()
 	v.RequireFS()
 	v.RequireHTTP()
 
@@ -202,5 +204,5 @@ func ParseGCSFetchURL(u *url.URL) (bucket, object string, err error) {
 }
 
 func (g *GCSGetter) client(ctx context.Context) (*storage.Client, error) {
-	return newVenvGCSClient(ctx, g.v.HTTP)
+	return gcphelper.NewGCPConfigBuilder().BuildGCSClient(ctx, g.v)
 }

--- a/internal/getter/gcs_http_test.go
+++ b/internal/getter/gcs_http_test.go
@@ -1,0 +1,261 @@
+package getter_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+)
+
+// gcsStubBucket is the object store a stubbed GCS answers from: name to
+// content.
+type gcsStubBucket map[string]string
+
+// gcsTokenScopes returns the scopes the assertion in a token request asks for.
+func gcsTokenScopes(t *testing.T, req *http.Request) string {
+	t.Helper()
+
+	body, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+
+	form, err := url.ParseQuery(string(body))
+	require.NoError(t, err)
+
+	segments := strings.Split(form.Get("assertion"), ".")
+	require.Len(t, segments, 3, "assertion must be a JWT")
+
+	payload, err := base64.RawURLEncoding.DecodeString(segments[1])
+	require.NoError(t, err)
+
+	var claims struct {
+		Scope string `json:"scope"`
+	}
+
+	require.NoError(t, json.Unmarshal(payload, &claims))
+
+	return claims.Scope
+}
+
+// TestGCSGetterRequestsStorageScopes pins the scopes the token exchange asks
+// for. Building the transport is what resolves the credentials, so the storage
+// scopes have to be named there; asking for none leaves the provider rejecting
+// the exchange, which no listing or download fixture would reveal.
+//
+//nolint:paralleltest // stubGCPCredentials calls t.Setenv, which bars t.Parallel.
+func TestGCSGetterRequestsStorageScopes(t *testing.T) {
+	stubGCPCredentials(t)
+
+	var scopes string
+
+	v := &venv.Venv{
+		FS: vfs.NewMemMapFS(),
+		HTTP: vhttp.NewMemClient(func(ctx context.Context, req *http.Request) (*http.Response, error) {
+			if req.URL.Host == "oauth2.googleapis.com" {
+				scopes = gcsTokenScopes(t, req)
+			}
+
+			return gcsStubHandler(t, gcsStubBucket{"mod.txt": "body"})(ctx, req)
+		}),
+		Env: map[string]string{},
+	}
+
+	client := &getter.Client{Getters: []getter.Getter{getter.NewGCSGetter(v)}}
+
+	_, err := client.Get(t.Context(), &getter.Request{
+		Src:     "gcs::https://www.googleapis.com/storage/v1/bucket/mod.txt",
+		Dst:     filepath.Join("out", "module"),
+		GetMode: getter.ModeAny,
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, scopes, "https://www.googleapis.com/auth/devstorage.full_control")
+	assert.Contains(t, scopes, "https://www.googleapis.com/auth/cloud-platform")
+}
+
+// gcsStubHandler answers the token exchange, the objects listing, and each
+// object download out of bucket, so a fetch runs end to end without a network.
+// Names list in sorted order, which is the order GCS itself returns and what
+// the mode scan reads.
+func gcsStubHandler(t *testing.T, bucket gcsStubBucket) vhttp.Handler {
+	t.Helper()
+
+	return func(_ context.Context, req *http.Request) (*http.Response, error) {
+		jsonHeader := http.Header{"Content-Type": {"application/json"}}
+
+		if req.URL.Host == "oauth2.googleapis.com" {
+			body, err := json.Marshal(map[string]any{
+				"access_token": "stub-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+			require.NoError(t, err)
+
+			return vhttp.Respond(http.StatusOK, body, jsonHeader), nil
+		}
+
+		if strings.HasPrefix(req.URL.Path, "/storage/v1/b/") {
+			prefix := req.URL.Query().Get("prefix")
+
+			names := make([]string, 0, len(bucket))
+
+			for name := range bucket {
+				if strings.HasPrefix(name, prefix) {
+					names = append(names, name)
+				}
+			}
+
+			sort.Strings(names)
+
+			items := make([]map[string]any, 0, len(names))
+			for _, name := range names {
+				items = append(items, map[string]any{"name": name})
+			}
+
+			body, err := json.Marshal(map[string]any{"kind": "storage#objects", "items": items})
+			require.NoError(t, err)
+
+			return vhttp.Respond(http.StatusOK, body, jsonHeader), nil
+		}
+
+		object := strings.TrimPrefix(req.URL.Path, "/bucket/")
+
+		content, ok := bucket[object]
+		if !ok {
+			return vhttp.Respond(http.StatusNotFound, []byte(""), nil), nil
+		}
+
+		return vhttp.Respond(http.StatusOK, []byte(content), nil), nil
+	}
+}
+
+// stubGCPCredentials writes a synthetic service-account key and points the
+// ambient credential lookup at it. The GCS getter resolves credentials the way
+// the SDK does, from the process environment and the real filesystem, so the
+// token exchange only reaches the stub handler once a key is there to sign the
+// assertion with.
+func stubGCPCredentials(t *testing.T) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	sa, err := json.Marshal(map[string]string{
+		"type":         "service_account",
+		"project_id":   "stub-project",
+		"client_email": "stub@stub-project.iam.gserviceaccount.com",
+		"token_uri":    "https://oauth2.googleapis.com/token",
+		"private_key": string(pem.EncodeToMemory(&pem.Block{
+			Type:  "PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(key),
+		})),
+	})
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "service-account.json")
+	require.NoError(t, os.WriteFile(path, sa, 0o600))
+
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", path)
+}
+
+// TestGCSGetterFetchesThroughVenvClient drives the gcs getter over an
+// in-memory HTTP client: the token exchange, the mode scan, the listing, and
+// every object body ride the venv's client, and the results land on the venv's
+// filesystem. The bucket holds an object that is also a prefix, and a sibling
+// whose name starts with that object's name, which is what separates the two
+// modes.
+//
+//nolint:paralleltest // stubGCPCredentials calls t.Setenv, which bars t.Parallel.
+func TestGCSGetterFetchesThroughVenvClient(t *testing.T) {
+	stubGCPCredentials(t)
+
+	bucket := gcsStubBucket{
+		"modules/vpc":                 "vpc-object",
+		"modules/vpc/":                "",
+		"modules/vpc/main.tf":         "main",
+		"modules/vpc/sub/nested.tf":   "nested",
+		"modules/vpc-old/main.tf":     "old",
+		"modules/app/main.tf":         "app-main",
+		"modules/app-old/main.tf":     "app-old",
+		"modules/esc/../../escape.tf": "escape",
+	}
+
+	tests := []struct {
+		want    map[string]string
+		wantErr error
+		name    string
+		object  string
+	}{
+		{
+			// The sibling is what the mode scan reaches after the exact name,
+			// so this fails the moment a listed name that merely starts with
+			// the object's name is read as proof of a directory.
+			name:   "name matching an object downloads that object",
+			object: "modules/vpc",
+			want:   map[string]string{"vpc": "vpc-object"},
+		},
+		{
+			name:   "prefix without a trailing separator downloads the tree",
+			object: "modules/app",
+			want:   map[string]string{"main.tf": "app-main"},
+		},
+		{
+			name:   "prefix with a trailing separator downloads the tree",
+			object: "modules/vpc/",
+			want: map[string]string{
+				"main.tf":       "main",
+				"sub/nested.tf": "nested",
+			},
+		},
+		{
+			name:    "name escaping the destination is refused",
+			object:  "modules/esc/",
+			wantErr: getter.ErrObjectEscapesDst,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &venv.Venv{
+				FS:   vfs.NewMemMapFS(),
+				HTTP: vhttp.NewMemClient(gcsStubHandler(t, bucket)),
+				Env:  map[string]string{},
+			}
+
+			client := &getter.Client{Getters: []getter.Getter{getter.NewGCSGetter(v)}}
+			dst := filepath.Join("out", "module")
+
+			_, err := client.Get(t.Context(), &getter.Request{
+				Src:     "gcs::https://www.googleapis.com/storage/v1/bucket/" + tc.object,
+				Dst:     dst,
+				GetMode: getter.ModeAny,
+			})
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assertDownloadedTree(t, v.FS, dst, tc.want)
+		})
+	}
+}

--- a/internal/getter/gcs_http_test.go
+++ b/internal/getter/gcs_http_test.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -59,24 +58,18 @@ func gcsTokenScopes(t *testing.T, req *http.Request) string {
 // for. Building the transport is what resolves the credentials, so the storage
 // scopes have to be named there; asking for none leaves the provider rejecting
 // the exchange, which no listing or download fixture would reveal.
-//
-//nolint:paralleltest // stubGCPCredentials calls t.Setenv, which bars t.Parallel.
 func TestGCSGetterRequestsStorageScopes(t *testing.T) {
-	stubGCPCredentials(t)
+	t.Parallel()
 
 	var scopes string
 
-	v := &venv.Venv{
-		FS: vfs.NewMemMapFS(),
-		HTTP: vhttp.NewMemClient(func(ctx context.Context, req *http.Request) (*http.Response, error) {
-			if req.URL.Host == "oauth2.googleapis.com" {
-				scopes = gcsTokenScopes(t, req)
-			}
+	v := stubGCPVenv(t, func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "oauth2.googleapis.com" {
+			scopes = gcsTokenScopes(t, req)
+		}
 
-			return gcsStubHandler(t, gcsStubBucket{"mod.txt": "body"})(ctx, req)
-		}),
-		Env: map[string]string{},
-	}
+		return gcsStubHandler(t, gcsStubBucket{"mod.txt": "body"})(ctx, req)
+	})
 
 	client := &getter.Client{Getters: []getter.Getter{getter.NewGCSGetter(v)}}
 
@@ -147,12 +140,11 @@ func gcsStubHandler(t *testing.T, bucket gcsStubBucket) vhttp.Handler {
 	}
 }
 
-// stubGCPCredentials writes a synthetic service-account key and points the
-// ambient credential lookup at it. The GCS getter resolves credentials the way
-// the SDK does, from the process environment and the real filesystem, so the
-// token exchange only reaches the stub handler once a key is there to sign the
-// assertion with.
-func stubGCPCredentials(t *testing.T) {
+// stubGCPVenv returns a venv holding a synthetic service-account key, the
+// variable naming it, and h as the client. Credentials resolve against the
+// venv, so the key never touches the real filesystem or the process
+// environment and the test stays parallel.
+func stubGCPVenv(t *testing.T, h vhttp.Handler) *venv.Venv {
 	t.Helper()
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -170,10 +162,14 @@ func stubGCPCredentials(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	path := filepath.Join(t.TempDir(), "service-account.json")
-	require.NoError(t, os.WriteFile(path, sa, 0o600))
+	fsys := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fsys, "/creds/service-account.json", sa, 0o600))
 
-	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", path)
+	return &venv.Venv{
+		FS:   fsys,
+		HTTP: vhttp.NewMemClient(h),
+		Env:  map[string]string{"GOOGLE_APPLICATION_CREDENTIALS": "/creds/service-account.json"},
+	}
 }
 
 // TestGCSGetterFetchesThroughVenvClient drives the gcs getter over an
@@ -182,10 +178,8 @@ func stubGCPCredentials(t *testing.T) {
 // filesystem. The bucket holds an object that is also a prefix, and a sibling
 // whose name starts with that object's name, which is what separates the two
 // modes.
-//
-//nolint:paralleltest // stubGCPCredentials calls t.Setenv, which bars t.Parallel.
 func TestGCSGetterFetchesThroughVenvClient(t *testing.T) {
-	stubGCPCredentials(t)
+	t.Parallel()
 
 	bucket := gcsStubBucket{
 		"modules/vpc":                 "vpc-object",
@@ -234,11 +228,9 @@ func TestGCSGetterFetchesThroughVenvClient(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			v := &venv.Venv{
-				FS:   vfs.NewMemMapFS(),
-				HTTP: vhttp.NewMemClient(gcsStubHandler(t, bucket)),
-				Env:  map[string]string{},
-			}
+			t.Parallel()
+
+			v := stubGCPVenv(t, gcsStubHandler(t, bucket))
 
 			client := &getter.Client{Getters: []getter.Getter{getter.NewGCSGetter(v)}}
 			dst := filepath.Join("out", "module")

--- a/internal/getter/objectstore.go
+++ b/internal/getter/objectstore.go
@@ -7,6 +7,7 @@ package getter
 import (
 	"cmp"
 	"errors"
+	"fmt"
 	"io"
 	"iter"
 	"os"
@@ -30,6 +31,10 @@ const DefaultModeScanLimit = 1000
 // its first object or send a directory fetch at a single key, so the scan
 // reports the prefix instead of picking.
 var ErrModeScanLimit = errors.New("too many objects under prefix to determine getter mode")
+
+// ErrObjectEscapesDst is returned when an object key resolves to a path
+// outside the download's destination.
+var ErrObjectEscapesDst = errors.New("object key escapes the destination directory")
 
 // Permissions the object-store getters create with before the request's umask
 // is applied. They match the values go-getter passes to its own copy helpers,
@@ -68,18 +73,48 @@ func ScanMode(
 	return getter.ModeFile, nil
 }
 
+// ObjectMode reports the mode a listed name resolves for a requested object.
+// A name only makes the object a directory by sitting below it: a prefix
+// listing also returns siblings like `modules-old/main.tf`, and reading one of
+// those as proof that `modules` is a directory would send the download at a
+// prefix with nothing under it.
+//
+// An object written with a trailing slash already names a prefix, so the
+// listing is measured against one separator either way.
+func ObjectMode(name, object string) (getter.Mode, bool) {
+	if strings.HasPrefix(name, ListPrefix(object)) {
+		return getter.ModeDir, true
+	}
+
+	if name == object {
+		return getter.ModeFile, true
+	}
+
+	return 0, false
+}
+
 // ObjectDst maps an object key to its destination path, keeping the key's
 // layout below prefix. Keys are always forward-slashed, so the conversion to
 // host separators happens here rather than by joining the raw key.
-func ObjectDst(dst, prefix, key string) string {
+//
+// A key is remote input, so one that climbs out of dst is refused.
+func ObjectDst(dst, prefix, key string) (string, error) {
 	rel := cmp.Or(strings.TrimPrefix(strings.TrimPrefix(key, prefix), "/"), path.Base(key))
 
-	return filepath.Join(dst, filepath.FromSlash(rel))
+	local := filepath.FromSlash(rel)
+	if !filepath.IsLocal(local) {
+		return "", fmt.Errorf("%w: %q", ErrObjectEscapesDst, key)
+	}
+
+	return filepath.Join(dst, local), nil
 }
 
 // ResetGetterDst clears a directory download's destination. Get is documented
 // as always fetching the latest, so a stale tree left from a previous run
 // would otherwise merge into the new one.
+//
+// A prefix holding nothing but directory placeholders writes no files, and the
+// caller is still owed the directory it asked for.
 func ResetGetterDst(fsys vfs.FS, req *getter.Request) error {
 	exists, err := vfs.FileExists(fsys, req.Dst)
 	if err != nil {
@@ -92,7 +127,7 @@ func ResetGetterDst(fsys vfs.FS, req *getter.Request) error {
 		}
 	}
 
-	return fsys.MkdirAll(filepath.Dir(req.Dst), req.Mode(objectDirMode))
+	return fsys.MkdirAll(req.Dst, req.Mode(objectDirMode))
 }
 
 // WriteGetterObject copies body to dst, creating parent directories, and

--- a/internal/getter/objectstore.go
+++ b/internal/getter/objectstore.go
@@ -1,0 +1,147 @@
+// Filesystem helpers shared by the object-store getters (s3, gcs). They
+// reimplement what go-getter's Request helpers do against the real OS
+// filesystem, routed through the venv's vfs.FS instead.
+
+package getter
+
+import (
+	"cmp"
+	"errors"
+	"io"
+	"iter"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	getter "github.com/hashicorp/go-getter/v2"
+
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+)
+
+// DefaultModeScanLimit caps how many keys Mode inspects while deciding between
+// file and directory mode. A single S3 list page returns at most this many, so
+// the default only trips on a prefix with a pathological number of siblings.
+// Getters take a lower one through WithModeScanLimit.
+const DefaultModeScanLimit = 1000
+
+// ErrModeScanLimit is returned when a mode scan hits its limit without
+// resolving a mode. Guessing one would either truncate a directory download to
+// its first object or send a directory fetch at a single key, so the scan
+// reports the prefix instead of picking.
+var ErrModeScanLimit = errors.New("too many objects under prefix to determine getter mode")
+
+// Permissions the object-store getters create with before the request's umask
+// is applied. They match the values go-getter passes to its own copy helpers,
+// so a download lands with the same mode it did before.
+const (
+	objectDirMode  os.FileMode = 0755
+	objectFileMode os.FileMode = 0666
+)
+
+// ScanMode walks at most limit names and returns the first mode decide
+// resolves. A listing that runs out first means nothing below the prefix
+// looked like a directory, so the prefix names a file. decide reports false to
+// keep scanning.
+func ScanMode(
+	limit int,
+	names iter.Seq2[string, error],
+	decide func(name string) (getter.Mode, bool),
+) (getter.Mode, error) {
+	var scanned int
+
+	for name, err := range names {
+		if err != nil {
+			return 0, err
+		}
+
+		if mode, ok := decide(name); ok {
+			return mode, nil
+		}
+
+		scanned++
+		if scanned >= limit {
+			return 0, ErrModeScanLimit
+		}
+	}
+
+	return getter.ModeFile, nil
+}
+
+// ObjectDst maps an object key to its destination path, keeping the key's
+// layout below prefix. Keys are always forward-slashed, so the conversion to
+// host separators happens here rather than by joining the raw key.
+func ObjectDst(dst, prefix, key string) string {
+	rel := cmp.Or(strings.TrimPrefix(strings.TrimPrefix(key, prefix), "/"), path.Base(key))
+
+	return filepath.Join(dst, filepath.FromSlash(rel))
+}
+
+// ResetGetterDst clears a directory download's destination. Get is documented
+// as always fetching the latest, so a stale tree left from a previous run
+// would otherwise merge into the new one.
+func ResetGetterDst(fsys vfs.FS, req *getter.Request) error {
+	exists, err := vfs.FileExists(fsys, req.Dst)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		if err := fsys.RemoveAll(req.Dst); err != nil {
+			return err
+		}
+	}
+
+	return fsys.MkdirAll(filepath.Dir(req.Dst), req.Mode(objectDirMode))
+}
+
+// WriteGetterObject copies body to dst, creating parent directories, and
+// closes body. The explicit Chmod matches go-getter: creating the file only
+// applies the process umask, which may differ from the request's.
+func WriteGetterObject(
+	fsys vfs.FS,
+	req *getter.Request,
+	dst string,
+	body io.ReadCloser,
+) (retErr error) {
+	defer func() {
+		if err := body.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
+
+	if err := fsys.MkdirAll(filepath.Dir(dst), req.Mode(objectDirMode)); err != nil {
+		return err
+	}
+
+	f, err := fsys.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, objectFileMode)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(f, body); err != nil {
+		return errors.Join(err, f.Close())
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	return fsys.Chmod(dst, req.Mode(objectFileMode))
+}
+
+// ListPrefix returns the listing prefix for a directory download. Get is only
+// reached once Mode has decided the key names a directory, which it does by
+// finding keys below `<key>/`.
+func ListPrefix(key string) string {
+	return strings.TrimSuffix(key, "/") + "/"
+}
+
+// CloseOnSuccess closes c, reporting its error through retErr only when the
+// operation otherwise succeeded. On failure the primary error already explains
+// the outcome, and joining a close error would bury it.
+func CloseOnSuccess(c io.Closer, retErr *error) {
+	if err := c.Close(); err != nil && *retErr == nil {
+		*retErr = err
+	}
+}

--- a/internal/getter/objectstore_test.go
+++ b/internal/getter/objectstore_test.go
@@ -1,0 +1,291 @@
+package getter_test
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	upstream "github.com/hashicorp/go-getter/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+)
+
+// TestObjectDst pins how an object key maps onto a destination path. The
+// prefix is stripped and the remainder keeps its layout, so a prefix download
+// reproduces the bucket's tree rather than flattening it.
+func TestObjectDst(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		dst    string
+		prefix string
+		key    string
+		want   string
+	}{
+		{
+			name:   "nested key keeps its layout below the prefix",
+			dst:    "/out",
+			prefix: "modules/vpc",
+			key:    "modules/vpc/sub/main.tf",
+			want:   filepath.Join("/out", "sub", "main.tf"),
+		},
+		{
+			name:   "prefix with trailing slash does not leave a leading separator",
+			dst:    "/out",
+			prefix: "modules/vpc/",
+			key:    "modules/vpc/main.tf",
+			want:   filepath.Join("/out", "main.tf"),
+		},
+		{
+			name:   "key equal to the prefix falls back to the base name",
+			dst:    "/out",
+			prefix: "modules/vpc/main.tf",
+			key:    "modules/vpc/main.tf",
+			want:   filepath.Join("/out", "main.tf"),
+		},
+		{
+			name:   "empty prefix keeps the whole key",
+			dst:    "/out",
+			prefix: "",
+			key:    "a/b/c.tf",
+			want:   filepath.Join("/out", "a", "b", "c.tf"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, getter.ObjectDst(tc.dst, tc.prefix, tc.key))
+		})
+	}
+}
+
+// TestWriteGetterObject pins that a downloaded object lands on the supplied
+// filesystem with its parent directories created, and that the request's
+// umask reaches the resulting file mode.
+func TestWriteGetterObject(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	dst := filepath.Join("out", "nested", "main.tf")
+
+	req := &upstream.Request{}
+
+	err := getter.WriteGetterObject(
+		fsys,
+		req,
+		dst,
+		io.NopCloser(strings.NewReader("hello")),
+	)
+	require.NoError(t, err)
+
+	got, err := vfs.ReadFile(fsys, dst)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(got))
+}
+
+// TestWriteGetterObjectAppliesUmask pins that the request's umask masks the
+// mode the object is written with, matching what go-getter's own copy helper
+// does for the getters this replaced.
+func TestWriteGetterObjectAppliesUmask(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	dst := filepath.Join("out", "main.tf")
+
+	req := &upstream.Request{Umask: 0o022}
+
+	require.NoError(t, getter.WriteGetterObject(
+		fsys,
+		req,
+		dst,
+		io.NopCloser(strings.NewReader("x")),
+	))
+
+	info, err := fsys.Stat(dst)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}
+
+// TestWriteGetterObjectClosesBody pins that the body is closed even when the
+// copy target cannot be created, so a failed download does not leak the
+// SDK's response connection back into the pool unread.
+func TestWriteGetterObjectClosesBody(t *testing.T) {
+	t.Parallel()
+
+	body := &closeTrackingReader{Reader: strings.NewReader("x")}
+
+	fsys := openFailFS{FS: vfs.NewMemMapFS()}
+
+	err := getter.WriteGetterObject(fsys, &upstream.Request{}, "out/main.tf", body)
+	require.ErrorIs(t, err, errOpenFail)
+	assert.True(t, body.closed, "body must be closed even when the write fails")
+}
+
+var errOpenFail = errors.New("open refused")
+
+// openFailFS fails every file creation so the write path can be exercised
+// without a real filesystem that refuses writes.
+type openFailFS struct {
+	vfs.FS
+}
+
+func (openFailFS) OpenFile(string, int, os.FileMode) (vfs.File, error) {
+	return nil, errOpenFail
+}
+
+type closeTrackingReader struct {
+	io.Reader
+	closed bool
+}
+
+func (r *closeTrackingReader) Close() error {
+	r.closed = true
+	return nil
+}
+
+// TestListPrefix pins the prefix a directory download lists under. Mode
+// decides a key names a directory by finding keys below `<key>/`, so the
+// listing has to use that same trailing separator or it would also match a
+// sibling key the requested one is a prefix of.
+func TestListPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{
+			name: "bare key gains a separator",
+			key:  "modules",
+			want: "modules/",
+		},
+		{
+			name: "nested key gains a separator",
+			key:  "modules/vpc/sub",
+			want: "modules/vpc/sub/",
+		},
+		{
+			name: "key already ending in a separator is unchanged",
+			key:  "modules/vpc/",
+			want: "modules/vpc/",
+		},
+		{
+			name: "only one trailing separator is collapsed",
+			key:  "modules/vpc//",
+			want: "modules/vpc//",
+		},
+		{
+			name: "empty key lists the whole bucket",
+			key:  "",
+			want: "/",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, getter.ListPrefix(tc.key))
+		})
+	}
+}
+
+// TestCloseOnSuccess pins which error survives when closing the client fails.
+// A close error only reaches the caller when the operation itself succeeded,
+// so the reason a download failed is never displaced by the cleanup.
+func TestCloseOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	errPrimary := errors.New("download failed")
+	errClose := errors.New("close failed")
+
+	tests := []struct {
+		primary  error
+		closeErr error
+		want     error
+		name     string
+	}{
+		{
+			name: "clean close on a successful operation reports nothing",
+		},
+		{
+			name:     "close error surfaces when the operation succeeded",
+			closeErr: errClose,
+			want:     errClose,
+		},
+		{
+			name:    "primary error survives a clean close",
+			primary: errPrimary,
+			want:    errPrimary,
+		},
+		{
+			name:     "primary error outranks a close error",
+			primary:  errPrimary,
+			closeErr: errClose,
+			want:     errPrimary,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &stubCloser{err: tc.closeErr}
+
+			err := tc.primary
+			getter.CloseOnSuccess(c, &err)
+
+			assert.True(t, c.closed, "the closer must run whatever the operation returned")
+
+			if tc.want == nil {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorIs(t, err, tc.want)
+
+			if tc.primary != nil && tc.closeErr != nil {
+				require.NotErrorIs(t, err, tc.closeErr,
+					"a close error must not be joined onto the error that explains the failure")
+			}
+		})
+	}
+}
+
+type stubCloser struct {
+	err    error
+	closed bool
+}
+
+func (c *stubCloser) Close() error {
+	c.closed = true
+	return c.err
+}
+
+// TestResetGetterDst pins that a directory download clears a stale tree from
+// a previous run instead of merging into it.
+func TestResetGetterDst(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+
+	stale := filepath.Join("out", "stale.tf")
+	require.NoError(t, fsys.MkdirAll(filepath.Dir(stale), 0o755))
+	require.NoError(t, vfs.WriteFile(fsys, stale, []byte("old"), 0o644))
+
+	require.NoError(t, getter.ResetGetterDst(fsys, &upstream.Request{Dst: "out"}))
+
+	exists, err := vfs.FileExists(fsys, stale)
+	require.NoError(t, err)
+	assert.False(t, exists, "a stale tree must not survive into the new download")
+}

--- a/internal/getter/objectstore_test.go
+++ b/internal/getter/objectstore_test.go
@@ -63,7 +63,126 @@ func TestObjectDst(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, tc.want, getter.ObjectDst(tc.dst, tc.prefix, tc.key))
+			got, err := getter.ObjectDst(tc.dst, tc.prefix, tc.key)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestObjectDstRejectsEscapingKeys pins that a key climbing out of the
+// destination is refused rather than written wherever it points.
+func TestObjectDstRejectsEscapingKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		prefix string
+		key    string
+	}{
+		{
+			name:   "key climbs above the destination",
+			prefix: "modules/vpc",
+			key:    "modules/vpc/../../../etc/passwd",
+		},
+		{
+			name:   "key outside the prefix climbs from the whole key",
+			prefix: "modules/vpc",
+			key:    "../../etc/passwd",
+		},
+		{
+			name:   "single parent segment still escapes",
+			prefix: "modules/vpc/",
+			key:    "modules/vpc/../sibling.tf",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := getter.ObjectDst("/out", tc.prefix, tc.key)
+			require.ErrorIs(t, err, getter.ErrObjectEscapesDst)
+		})
+	}
+}
+
+// TestObjectMode pins the rule both getters decide file-vs-directory with,
+// siblings sharing the object's name as a prefix included.
+func TestObjectMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		listed   string
+		object   string
+		want     upstream.Mode
+		wantDone bool
+	}{
+		{
+			name:     "exact match is a file",
+			listed:   "modules/vpc",
+			object:   "modules/vpc",
+			want:     upstream.ModeFile,
+			wantDone: true,
+		},
+		{
+			name:     "name below the object is a directory",
+			listed:   "modules/vpc/main.tf",
+			object:   "modules/vpc",
+			want:     upstream.ModeDir,
+			wantDone: true,
+		},
+		{
+			name:     "directory placeholder is a directory",
+			listed:   "modules/vpc/",
+			object:   "modules/vpc",
+			want:     upstream.ModeDir,
+			wantDone: true,
+		},
+		{
+			name:     "name below a trailing-slash object is a directory",
+			listed:   "modules/vpc/main.tf",
+			object:   "modules/vpc/",
+			want:     upstream.ModeDir,
+			wantDone: true,
+		},
+		{
+			name:     "trailing-slash object matching its own placeholder is a directory",
+			listed:   "modules/vpc/",
+			object:   "modules/vpc/",
+			want:     upstream.ModeDir,
+			wantDone: true,
+		},
+		{
+			name:   "sibling sharing the prefix decides nothing",
+			listed: "modules/vpc-old/main.tf",
+			object: "modules/vpc",
+		},
+		{
+			name:   "sibling of a trailing-slash object decides nothing",
+			listed: "modules/vpc-old/main.tf",
+			object: "modules/vpc/",
+		},
+		{
+			name:   "sibling with no separator decides nothing",
+			listed: "modules/vpcfoo",
+			object: "modules/vpc",
+		},
+		{
+			name:   "unrelated name decides nothing",
+			listed: "other/main.tf",
+			object: "modules/vpc",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, done := getter.ObjectMode(tc.listed, tc.object)
+			assert.Equal(t, tc.wantDone, done)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -288,4 +407,8 @@ func TestResetGetterDst(t *testing.T) {
 	exists, err := vfs.FileExists(fsys, stale)
 	require.NoError(t, err)
 	assert.False(t, exists, "a stale tree must not survive into the new download")
+
+	exists, err = vfs.FileExists(fsys, "out")
+	require.NoError(t, err)
+	assert.True(t, exists, "the destination must exist after a reset")
 }

--- a/internal/getter/oci_registry_test.go
+++ b/internal/getter/oci_registry_test.go
@@ -169,7 +169,9 @@ func TestOCIGetterAgainstLocalRegistryRepositoryNamedLikeAPIPath(t *testing.T) {
 
 // ociRegistryClient builds the production getter chain resolving through v.
 func ociRegistryClient(v *venv.Venv) *getter.Client {
-	return getter.NewClient(getter.WithOCI(getter.NewOCIGetter(logger.CreateLogger(), v)))
+	return getter.NewClient(venvtest.NewWithOSFS(),
+		getter.WithOCI(getter.NewOCIGetter(logger.CreateLogger(), v)),
+	)
 }
 
 // ociRegistryLayer resolves the published manifest down to its single module-zip layer.

--- a/internal/getter/oci_test.go
+++ b/internal/getter/oci_test.go
@@ -850,7 +850,7 @@ func TestNewClientWithOCIDetectOrdering(t *testing.T) {
 	manifestBytes, manifestDesc := manifestFor(t, getter.ArtifactTypeModulePkg, layer)
 	store := newFakeStore(manifestBytes, &manifestDesc, zipBytes, &layer)
 
-	client := getter.NewClient(
+	client := getter.NewClient(venvtest.NewWithOSFS(),
 		getter.WithLogger(logger.CreateLogger()),
 		getter.WithOCI(newTestOCIGetter(staticStore(store))),
 	)
@@ -873,7 +873,8 @@ func TestNewClientWithOCIDetectOrdering(t *testing.T) {
 func TestNewClientWithoutOCIRejectsOCISources(t *testing.T) {
 	t.Parallel()
 
-	client := getter.NewClient(getter.WithLogger(logger.CreateLogger()))
+	client := getter.NewClient(venvtest.NewWithOSFS(),
+		getter.WithLogger(logger.CreateLogger()))
 	dst := filepath.Join(t.TempDir(), "module")
 
 	_, err := client.Get(t.Context(), &gogetter.Request{
@@ -890,11 +891,13 @@ func TestNewClientWithoutOCIRejectsOCISources(t *testing.T) {
 func TestDefaultGenericFetchersOCIConfig(t *testing.T) {
 	t.Parallel()
 
-	_, found := getter.DefaultGenericFetchers()[getter.SchemeOCI]
+	v := venvtest.New()
+
+	_, found := getter.DefaultGenericFetchers(v)[getter.SchemeOCI]
 	assert.False(t, found, "oci fetcher must be absent without WithOCIConfig")
 
-	v := venvtest.New()
 	fetchers := getter.DefaultGenericFetchers(
+		v,
 		getter.WithDispatchLogger(logger.CreateLogger()),
 		getter.WithDispatchFS(v.FS),
 		getter.WithOCIConfig(v),
@@ -1002,7 +1005,8 @@ func newTestOCIGetter(newStore getter.OCINewStoreFunc) *getter.OCIGetter {
 }
 
 func newOCITestClient(g *getter.OCIGetter) *gogetter.Client {
-	return getter.NewClient(getter.WithCustomGettersPrepended(g))
+	return getter.NewClient(venvtest.NewWithOSFS(),
+		getter.WithCustomGettersPrepended(g))
 }
 
 // moduleZipBytes builds an in-memory zip holding files keyed by relative path.

--- a/internal/getter/options.go
+++ b/internal/getter/options.go
@@ -36,13 +36,12 @@ func WithOCI(g *OCIGetter) Option {
 }
 
 // WithCAS registers CASGetter, which intercepts git/file sources and routes
-// them through Terragrunt's content-addressable storage. v supplies the
-// filesystem and process executor used by every CAS operation; [WithHTTP]
-// must also be set since the CAS dispatch probes over HTTP.
-func WithCAS(c *cas.CAS, v *venv.Venv, cloneOpts *cas.CloneOptions) Option {
+// them through Terragrunt's content-addressable storage. Every CAS operation
+// uses the venv [NewClient] was given; [WithHTTP] must also be set since the
+// CAS dispatch probes over HTTP.
+func WithCAS(c *cas.CAS, cloneOpts *cas.CloneOptions) Option {
 	return func(b *builder) {
 		b.casStore = c
-		b.casVenv = v
 		b.casCloneOpts = cloneOpts
 	}
 }
@@ -102,7 +101,7 @@ type builder struct {
 	oci              *OCIGetter
 	casStore         *cas.CAS
 	casCloneOpts     *cas.CloneOptions
-	casVenv          *venv.Venv
+	v                *venv.Venv
 	httpClient       vhttp.Client
 	httpExtraHeader  http.Header
 	httpsExtraHeader http.Header

--- a/internal/getter/options_test.go
+++ b/internal/getter/options_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // TestWithCASRegistersCASGetter pins the wiring: WithCAS adds a CASGetter
@@ -33,8 +34,8 @@ func TestWithCASRegistersCASGetter(t *testing.T) {
 
 	v := venv.OSVenv()
 
-	client := getter.NewClient(
-		getter.WithCAS(c, v, &cas.CloneOptions{}),
+	client := getter.NewClient(v,
+		getter.WithCAS(c, &cas.CloneOptions{}),
 		getter.WithHTTP(vhttp.NewNoNetworkClient()),
 	)
 
@@ -58,8 +59,8 @@ func TestWithCASRoutesCASProtocolURLs(t *testing.T) {
 
 	v := venv.OSVenv()
 
-	client := getter.NewClient(
-		getter.WithCAS(c, v, &cas.CloneOptions{}),
+	client := getter.NewClient(v,
+		getter.WithCAS(c, &cas.CloneOptions{}),
 		getter.WithHTTP(vhttp.NewNoNetworkClient()),
 	)
 
@@ -103,7 +104,7 @@ func TestWithHTTPSAuthHeaderReachesServer(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := getter.NewClient(
+	client := getter.NewClient(venvtest.NewWithOSFS(),
 		getter.WithHTTPSAuth(http.Header{"Authorization": {want}}),
 		getter.WithCustomGettersPrepended(&gogetter.HttpGetter{
 			Client: server.Client(),
@@ -132,7 +133,7 @@ func TestHTTPSchemeRoutingChoosesAuthSlot(t *testing.T) {
 	httpsHeader := http.Header{"X-Auth": {"https-token"}}
 	httpHeader := http.Header{"X-Auth": {"http-token"}}
 
-	client := getter.NewClient(
+	client := getter.NewClient(venvtest.NewWithOSFS(),
 		getter.WithHTTPSAuth(httpsHeader),
 		getter.WithHTTPAuth(httpHeader),
 	)
@@ -189,7 +190,8 @@ func TestWithHTTPSAuthSetsBuilderField(t *testing.T) {
 	t.Parallel()
 
 	header := http.Header{"X-Test": {"yes"}}
-	client := getter.NewClient(getter.WithHTTPSAuth(header))
+	client := getter.NewClient(venvtest.NewWithOSFS(),
+		getter.WithHTTPSAuth(header))
 
 	httpGetters := allHTTPGetters(client.Getters)
 	require.Len(t, httpGetters, 2, "client must register both http and https getters")
@@ -217,7 +219,8 @@ func TestFileCopyGetIncludeExcludeFiltersHonor(t *testing.T) {
 		WithLogger(logger.CreateLogger()).
 		WithExcludeFromCopy("*.txt")
 
-	client := getter.NewClient(getter.WithFileCopy(fcg))
+	client := getter.NewClient(venvtest.NewWithOSFS(),
+		getter.WithFileCopy(fcg))
 
 	_, err := client.Get(t.Context(), &getter.Request{
 		Src:     "file://" + src,
@@ -237,7 +240,9 @@ func TestFileCopyGetMissingPath(t *testing.T) {
 
 	missing := filepath.Join(helpers.TmpDirWOSymlinks(t), "does-not-exist")
 
-	client := getter.NewClient(getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())))
+	client := getter.NewClient(venvtest.NewWithOSFS(),
+		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
+	)
 	_, err := client.Get(t.Context(), &getter.Request{
 		Src:     "file://" + missing,
 		Dst:     filepath.Join(helpers.TmpDirWOSymlinks(t), "out"),
@@ -255,7 +260,9 @@ func TestFileCopyGetSourceIsFile(t *testing.T) {
 	srcFile := filepath.Join(helpers.TmpDirWOSymlinks(t), "main.tf")
 	require.NoError(t, writeFile(srcFile, "# main\n"))
 
-	client := getter.NewClient(getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())))
+	client := getter.NewClient(venvtest.NewWithOSFS(),
+		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
+	)
 	_, err := client.Get(t.Context(), &getter.Request{
 		Src:     "file://" + srcFile,
 		Dst:     filepath.Join(helpers.TmpDirWOSymlinks(t), "out"),
@@ -273,7 +280,9 @@ func TestFileCopyGetFileSourceIsDir(t *testing.T) {
 	srcDir := helpers.TmpDirWOSymlinks(t)
 	require.NoError(t, writeFile(filepath.Join(srcDir, "main.tf"), "# main\n"))
 
-	client := getter.NewClient(getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())))
+	client := getter.NewClient(venvtest.NewWithOSFS(),
+		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
+	)
 	_, err := client.Get(t.Context(), &getter.Request{
 		Src:     "file://" + srcDir,
 		Dst:     filepath.Join(helpers.TmpDirWOSymlinks(t), "out"),
@@ -294,7 +303,9 @@ func TestFileCopyGetFileDelegates(t *testing.T) {
 
 	dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "out.tf")
 
-	client := getter.NewClient(getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())))
+	client := getter.NewClient(venvtest.NewWithOSFS(),
+		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
+	)
 	_, err := client.Get(t.Context(), &getter.Request{
 		Src:     "file://" + srcFile,
 		Dst:     dst,

--- a/internal/getter/resolver.go
+++ b/internal/getter/resolver.go
@@ -24,17 +24,16 @@ type SourceResolver = cas.SourceResolver
 // so the probe and the fetch resolve against the same registry host, and
 // [WithDispatchEnv] so the probe carries the same registry credentials.
 //
-// The http, https, and tfr resolvers all probe over c, and the hg resolver
-// spawns `hg` through v's executor. [CASGetter] callers normally go through
-// [WithDefaultGenericDispatch], which supplies both.
+// Every resolver rides v: the http, https, and tfr probes go over its client
+// and the hg resolver spawns `hg` through its executor. A caller overriding the
+// probe client passes a venv carrying it ([venv.Venv.WithHTTP]), which is what
+// [WithDefaultGenericDispatch] does.
 func DefaultSourceResolvers(
 	v *venv.Venv,
-	c vhttp.Client,
 	opts ...GenericFetcherOption,
 ) map[string]SourceResolver {
-	// The probe client rather than v's own: a caller that overrode it expects
-	// the probe to ride the override, and everything else still comes from v.
-	rv := v.WithHTTP(c)
+	v.RequireExec()
+	v.RequireHTTP()
 
 	var cfg genericFetcherConfig
 	for _, opt := range opts {
@@ -42,7 +41,7 @@ func DefaultSourceResolvers(
 	}
 
 	tfr := NewTFRResolver().
-		WithHTTPClient(vhttp.WithTimeout(c, tfrResolverTimeout)).
+		WithHTTPClient(vhttp.WithTimeout(v.HTTP, tfrResolverTimeout)).
 		WithAuth(RegistryAuth{Env: cfg.env, ReadUserConfig: vfs.IsOSFS(cfg.fs)})
 
 	if cfg.tfrEnabled {
@@ -54,7 +53,7 @@ func DefaultSourceResolvers(
 		tfr.WithTofuImplementation(cfg.tfrImpl)
 	}
 
-	probeClient := vhttp.WithTimeout(c, httpResolverTimeout)
+	probeClient := vhttp.WithTimeout(v.HTTP, httpResolverTimeout)
 
 	httpRes := NewHTTPResolver()
 	httpRes.Client = probeClient
@@ -65,9 +64,9 @@ func DefaultSourceResolvers(
 	resolvers := map[string]SourceResolver{
 		SchemeHTTP:  httpRes,
 		SchemeHTTPS: httpsRes,
-		SchemeS3:    NewS3Resolver(rv),
-		SchemeGCS:   NewGCSResolver(rv),
-		SchemeHg:    NewHgResolver(rv.Exec),
+		SchemeS3:    NewS3Resolver(v),
+		SchemeGCS:   NewGCSResolver(v),
+		SchemeHg:    NewHgResolver(v.Exec),
 		SchemeTFR:   tfr,
 	}
 

--- a/internal/getter/resolver.go
+++ b/internal/getter/resolver.go
@@ -2,7 +2,7 @@ package getter
 
 import (
 	"github.com/gruntwork-io/terragrunt/internal/cas"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 )
@@ -25,13 +25,17 @@ type SourceResolver = cas.SourceResolver
 // [WithDispatchEnv] so the probe carries the same registry credentials.
 //
 // The http, https, and tfr resolvers all probe over c, and the hg resolver
-// spawns `hg` through e. [CASGetter] callers normally go through
-// [WithDefaultGenericDispatch], which supplies the venv's client and executor.
+// spawns `hg` through v's executor. [CASGetter] callers normally go through
+// [WithDefaultGenericDispatch], which supplies both.
 func DefaultSourceResolvers(
+	v *venv.Venv,
 	c vhttp.Client,
-	e vexec.Exec,
 	opts ...GenericFetcherOption,
 ) map[string]SourceResolver {
+	// The probe client rather than v's own: a caller that overrode it expects
+	// the probe to ride the override, and everything else still comes from v.
+	rv := v.WithHTTP(c)
+
 	var cfg genericFetcherConfig
 	for _, opt := range opts {
 		opt(&cfg)
@@ -61,9 +65,9 @@ func DefaultSourceResolvers(
 	resolvers := map[string]SourceResolver{
 		SchemeHTTP:  httpRes,
 		SchemeHTTPS: httpsRes,
-		SchemeS3:    NewS3Resolver(c),
-		SchemeGCS:   NewGCSResolver(c),
-		SchemeHg:    NewHgResolver(e),
+		SchemeS3:    NewS3Resolver(rv),
+		SchemeGCS:   NewGCSResolver(rv),
+		SchemeHg:    NewHgResolver(rv.Exec),
 		SchemeTFR:   tfr,
 	}
 

--- a/internal/getter/resolver_gcs.go
+++ b/internal/getter/resolver_gcs.go
@@ -17,6 +17,7 @@ import (
 	htransport "google.golang.org/api/transport/http"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/gcphelper"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 )
 
@@ -134,22 +135,28 @@ func (r *GCSResolver) client(ctx context.Context) (GCSClient, error) {
 		return r.NewClient(ctx)
 	}
 
-	// Google's auth is layered over the venv transport rather than the venv
-	// client replacing it, so ADC still authenticates the probe.
-	ctx = context.WithValue(ctx, oauth2.HTTPClient, r.HTTPClient)
-
-	trans, err := htransport.NewTransport(ctx, r.HTTPClient.Transport)
-	if err != nil {
-		return nil, err
-	}
-
-	//nolint:forbidigo // trans is built on the venv's transport, which is what the rule protects.
-	c, err := storage.NewClient(ctx, option.WithHTTPClient(&http.Client{Transport: trans}))
+	c, err := newVenvGCSClient(ctx, r.HTTPClient)
 	if err != nil {
 		return nil, err
 	}
 
 	return &storageClientAdapter{c: c}, nil
+}
+
+// newVenvGCSClient builds a GCS client whose API calls and OAuth token
+// exchanges both ride c. Google's auth is layered over c's transport rather
+// than c replacing it: a bare client carries no credentials, so every request
+// would go out unauthenticated.
+func newVenvGCSClient(ctx context.Context, c vhttp.Client) (*storage.Client, error) {
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, c)
+
+	trans, err := htransport.NewTransport(ctx, c.Transport, gcphelper.GCSScopes())
+	if err != nil {
+		return nil, err
+	}
+
+	//nolint:forbidigo // trans is built on the venv's transport, which is what the rule protects.
+	return storage.NewClient(ctx, option.WithHTTPClient(&http.Client{Transport: trans}))
 }
 
 // pickGCSCacheKey walks the cascade MD5 → CRC32C and returns the

--- a/internal/getter/resolver_gcs.go
+++ b/internal/getter/resolver_gcs.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -155,8 +154,13 @@ func newVenvGCSClient(ctx context.Context, c vhttp.Client) (*storage.Client, err
 		return nil, err
 	}
 
+	// A copy of c, so its Timeout, Jar, and CheckRedirect still govern the
+	// calls the SDK makes.
+	authed := *c
+	authed.Transport = trans
+
 	//nolint:forbidigo // trans is built on the venv's transport, which is what the rule protects.
-	return storage.NewClient(ctx, option.WithHTTPClient(&http.Client{Transport: trans}))
+	return storage.NewClient(ctx, option.WithHTTPClient(&authed))
 }
 
 // pickGCSCacheKey walks the cascade MD5 → CRC32C and returns the

--- a/internal/getter/resolver_gcs.go
+++ b/internal/getter/resolver_gcs.go
@@ -11,13 +11,9 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"golang.org/x/oauth2"
-	"google.golang.org/api/option"
-	htransport "google.golang.org/api/transport/http"
-
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/gcphelper"
-	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 )
 
 // gcsResolverTimeout caps the Attrs call so a slow remote can't stall CAS
@@ -55,18 +51,17 @@ type GCSClient interface {
 // GCSResolver is a [cas.SourceResolver] for objects in Google Cloud
 // Storage.
 type GCSResolver struct {
-	// NewClient builds a GCS client per request. Nil means
-	// [storage.NewClient] with the ambient application default
-	// credentials.
+	// NewClient builds a GCS client per request. Nil means a client built
+	// from Venv.
 	NewClient func(ctx context.Context) (GCSClient, error)
-	// HTTPClient carries the SDK's requests. Required when NewClient is
-	// nil; [NewGCSResolver] takes it from the caller.
-	HTTPClient vhttp.Client
+	// Venv carries the SDK's requests, credentials, and filesystem.
+	// Required when NewClient is nil; [NewGCSResolver] takes it from the
+	// caller.
+	Venv *venv.Venv
 }
 
-// NewGCSResolver returns a resolver that reads object metadata over c, using
-// the ambient ADC for credentials.
-func NewGCSResolver(c vhttp.Client) *GCSResolver { return &GCSResolver{HTTPClient: c} }
+// NewGCSResolver returns a resolver that reads object metadata through v.
+func NewGCSResolver(v *venv.Venv) *GCSResolver { return &GCSResolver{Venv: v} }
 
 // Scheme returns "gcs".
 func (r *GCSResolver) Scheme() string { return "gcs" }
@@ -134,33 +129,12 @@ func (r *GCSResolver) client(ctx context.Context) (GCSClient, error) {
 		return r.NewClient(ctx)
 	}
 
-	c, err := newVenvGCSClient(ctx, r.HTTPClient)
+	c, err := gcphelper.NewGCPConfigBuilder().BuildGCSClient(ctx, r.Venv)
 	if err != nil {
 		return nil, err
 	}
 
 	return &storageClientAdapter{c: c}, nil
-}
-
-// newVenvGCSClient builds a GCS client whose API calls and OAuth token
-// exchanges both ride c. Google's auth is layered over c's transport rather
-// than c replacing it: a bare client carries no credentials, so every request
-// would go out unauthenticated.
-func newVenvGCSClient(ctx context.Context, c vhttp.Client) (*storage.Client, error) {
-	ctx = context.WithValue(ctx, oauth2.HTTPClient, c)
-
-	trans, err := htransport.NewTransport(ctx, c.Transport, gcphelper.GCSScopes())
-	if err != nil {
-		return nil, err
-	}
-
-	// A copy of c, so its Timeout, Jar, and CheckRedirect still govern the
-	// calls the SDK makes.
-	authed := *c
-	authed.Transport = trans
-
-	//nolint:forbidigo // trans is built on the venv's transport, which is what the rule protects.
-	return storage.NewClient(ctx, option.WithHTTPClient(&authed))
 }
 
 // pickGCSCacheKey walks the cascade MD5 → CRC32C and returns the

--- a/internal/getter/resolver_gcs_test.go
+++ b/internal/getter/resolver_gcs_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -280,7 +280,7 @@ func (c *fakeGCSClient) Object(_, name string) getter.GCSObject {
 func (c *fakeGCSClient) Close() error { return nil }
 
 func newGCSResolverWith(client *fakeGCSClient) *getter.GCSResolver {
-	r := getter.NewGCSResolver(vhttp.NewNoNetworkClient())
+	r := getter.NewGCSResolver(venvtest.New())
 	r.NewClient = func(_ context.Context) (getter.GCSClient, error) {
 		return client, nil
 	}

--- a/internal/getter/resolver_oci_test.go
+++ b/internal/getter/resolver_oci_test.go
@@ -243,12 +243,11 @@ func TestDefaultSourceResolversOCIConfig(t *testing.T) {
 
 	v := venvtest.New()
 
-	_, found := getter.DefaultSourceResolvers(v, v.HTTP)[getter.SchemeOCI]
+	_, found := getter.DefaultSourceResolvers(v)[getter.SchemeOCI]
 	assert.False(t, found, "oci resolver must be absent without WithOCIConfig")
 
 	resolvers := getter.DefaultSourceResolvers(
 		v,
-		v.HTTP,
 		getter.WithDispatchLogger(logger.CreateLogger()),
 		getter.WithDispatchFS(v.FS),
 		getter.WithOCIConfig(v),

--- a/internal/getter/resolver_oci_test.go
+++ b/internal/getter/resolver_oci_test.go
@@ -243,12 +243,12 @@ func TestDefaultSourceResolversOCIConfig(t *testing.T) {
 
 	v := venvtest.New()
 
-	_, found := getter.DefaultSourceResolvers(v.HTTP, v.Exec)[getter.SchemeOCI]
+	_, found := getter.DefaultSourceResolvers(v, v.HTTP)[getter.SchemeOCI]
 	assert.False(t, found, "oci resolver must be absent without WithOCIConfig")
 
 	resolvers := getter.DefaultSourceResolvers(
+		v,
 		v.HTTP,
-		v.Exec,
 		getter.WithDispatchLogger(logger.CreateLogger()),
 		getter.WithDispatchFS(v.FS),
 		getter.WithOCIConfig(v),

--- a/internal/getter/resolver_s3.go
+++ b/internal/getter/resolver_s3.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
-	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
 // ErrS3UnrecognizedURL is returned when an amazonaws.com URL does not match
@@ -72,17 +72,20 @@ type S3API interface {
 // [S3Getter] canonicalizes the rest before the fetch, so probe support
 // here stays aligned with fetch support there.
 type S3Resolver struct {
-	// NewClient builds an S3 client per request. Nil means the resolver
-	// uses the AWS SDK default config (env, profile, IMDS) with a
-	// region derived from the URL.
+	// NewClient builds an S3 client per request. Nil means a client built
+	// from Venv, with a region derived from the URL.
 	NewClient func(ctx context.Context, region string) (S3API, error)
-	// HTTPClient carries the SDK's requests. Required when NewClient is
-	// nil; [NewS3Resolver] takes it from the caller.
-	HTTPClient vhttp.Client
+	// Venv carries the SDK's requests, credentials, and filesystem.
+	// Required when NewClient is nil; [NewS3Resolver] takes it from the
+	// caller.
+	Venv *venv.Venv
+	// Logger routes the debug lines credential resolution emits. Nil
+	// discards them.
+	Logger log.Logger
 }
 
-// NewS3Resolver returns a resolver whose SDK requests ride c.
-func NewS3Resolver(c vhttp.Client) *S3Resolver { return &S3Resolver{HTTPClient: c} }
+// NewS3Resolver returns a resolver whose SDK requests ride v.
+func NewS3Resolver(v *venv.Venv) *S3Resolver { return &S3Resolver{Venv: v, Logger: discardLog()} }
 
 // Scheme returns "s3".
 func (r *S3Resolver) Scheme() string { return "s3" }
@@ -149,17 +152,7 @@ func (r *S3Resolver) client(ctx context.Context, region string) (S3API, error) {
 		return r.NewClient(ctx, region)
 	}
 
-	//nolint:forbidigo // WithHTTPClient below carries the venv's client, which is what the rule protects.
-	cfg, err := config.LoadDefaultConfig(
-		ctx,
-		config.WithRegion(region),
-		config.WithHTTPClient(r.HTTPClient),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return s3.NewFromConfig(cfg), nil
+	return S3ClientForTarget(ctx, r.Logger, r.Venv, &S3FetchTarget{Region: region})
 }
 
 // pickS3CacheKey walks the checksum cascade and returns the cache key

--- a/internal/getter/resolver_s3.go
+++ b/internal/getter/resolver_s3.go
@@ -223,7 +223,7 @@ func parseS3URL(u *url.URL) (s3Target, error) {
 			// host belongs to a different AWS service (e.g.
 			// iam.amazonaws.com) and we must not silently parse it
 			// as path-style S3 with a bogus region.
-			region, ok := s3RegionFromHostLabel(hostParts[0])
+			region, ok := S3RegionFromHostLabel(hostParts[0])
 			if !ok {
 				return s3Target{}, fmt.Errorf("%w: %q", ErrS3UnrecognizedURL, u.String())
 			}
@@ -263,7 +263,7 @@ func parseS3URL(u *url.URL) (s3Target, error) {
 			// hostParts[1] must identify S3 the same way as the
 			// path-style case, otherwise the host belongs to a
 			// non-S3 service (e.g. bucket.iam.amazonaws.com).
-			region, ok := s3RegionFromHostLabel(hostParts[1])
+			region, ok := S3RegionFromHostLabel(hostParts[1])
 			if !ok {
 				return s3Target{}, fmt.Errorf("%w: %q", ErrS3UnrecognizedURL, u.String())
 			}
@@ -308,13 +308,13 @@ func parseS3URL(u *url.URL) (s3Target, error) {
 	return s3Target{Region: region, Bucket: pathParts[1], Key: pathParts[2], Version: version}, nil
 }
 
-// s3RegionFromHostLabel parses an S3-identifying host label and
+// S3RegionFromHostLabel parses an S3-identifying host label and
 // returns the AWS region it encodes. The exact label "s3" is the
 // global path-style endpoint and maps to us-east-1. A label of the
 // form "s3-<region>" maps to that region. Any other label is rejected
 // (ok = false) so non-S3 amazonaws.com hosts (iam, sts, ec2, ...) do
 // not silently parse as S3 with a bogus region.
-func s3RegionFromHostLabel(label string) (region string, ok bool) {
+func S3RegionFromHostLabel(label string) (region string, ok bool) {
 	if label == "s3" {
 		return "us-east-1", true
 	}
@@ -356,17 +356,17 @@ func canonicalAWSS3HTTPSURL(u *url.URL) (string, bool) {
 
 	canonical := *u
 	canonical.Scheme = "https"
-	canonical.Host = s3HostLabelForRegion(target.Region) + ".amazonaws.com"
+	canonical.Host = S3HostLabelForRegion(target.Region) + ".amazonaws.com"
 	canonical.Path = "/" + target.Bucket + "/" + target.Key
 
 	return canonical.String(), true
 }
 
-// s3HostLabelForRegion returns the path-style host label for an AWS
+// S3HostLabelForRegion returns the path-style host label for an AWS
 // region. us-east-1 maps to the global "s3" label so probes against
 // region-unspecified URLs stay on the global endpoint instead of
 // silently shifting to us-east-1's regional form.
-func s3HostLabelForRegion(region string) string {
+func S3HostLabelForRegion(region string) string {
 	if region == "us-east-1" {
 		return "s3"
 	}

--- a/internal/getter/resolver_s3_test.go
+++ b/internal/getter/resolver_s3_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -165,7 +165,7 @@ func TestS3Resolver_AcceptsModernURLForms(t *testing.T) {
 
 			var gotRegion string
 
-			r := getter.NewS3Resolver(vhttp.NewNoNetworkClient())
+			r := getter.NewS3Resolver(venvtest.New())
 			r.NewClient = func(_ context.Context, region string) (getter.S3API, error) {
 				gotRegion = region
 				return head, nil
@@ -342,7 +342,7 @@ func TestS3Resolver_RejectsS3CompatibleURLWithoutKey(t *testing.T) {
 }
 
 func newS3ResolverWith(head getter.S3API) *getter.S3Resolver {
-	r := getter.NewS3Resolver(vhttp.NewNoNetworkClient())
+	r := getter.NewS3Resolver(venvtest.New())
 	r.NewClient = func(_ context.Context, _ string) (getter.S3API, error) {
 		return head, nil
 	}

--- a/internal/getter/s3.go
+++ b/internal/getter/s3.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"strings"
 
@@ -85,10 +86,10 @@ func (g *S3Getter) Detect(req *getter.Request) (bool, error) {
 	return true, nil
 }
 
-// Mode reports whether the URL names a single object or a prefix. An exact
-// key match is a file; any key below `<key>/` makes it a directory. A prefix
-// matching nothing reports file mode so the download surfaces S3's own
-// not-found error rather than a synthesized one.
+// Mode reports whether the URL names a single object or a prefix, deciding
+// each listed key with [ObjectMode]. A prefix matching nothing reports file
+// mode so the download surfaces S3's own not-found error rather than a
+// synthesized one.
 func (g *S3Getter) Mode(ctx context.Context, u *url.URL) (getter.Mode, error) {
 	target, err := ParseS3FetchURL(u)
 	if err != nil {
@@ -100,9 +101,12 @@ func (g *S3Getter) Mode(ctx context.Context, u *url.URL) (getter.Mode, error) {
 		return 0, err
 	}
 
+	// Without MaxKeys a scan limit above the page size ends at the page
+	// boundary, and ScanMode reads the truncated listing as a file.
 	out, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket: aws.String(target.Bucket),
-		Prefix: aws.String(target.Key),
+		Bucket:  aws.String(target.Bucket),
+		Prefix:  aws.String(target.Key),
+		MaxKeys: aws.Int32(int32(min(g.modeScanLimit, math.MaxInt32))),
 	})
 	if err != nil {
 		return 0, err
@@ -117,15 +121,7 @@ func (g *S3Getter) Mode(ctx context.Context, u *url.URL) (getter.Mode, error) {
 			}
 		},
 		func(key string) (getter.Mode, bool) {
-			if key == target.Key {
-				return getter.ModeFile, true
-			}
-
-			if strings.HasPrefix(key, target.Key+"/") {
-				return getter.ModeDir, true
-			}
-
-			return 0, false
+			return ObjectMode(key, target.Key)
 		},
 	)
 	if err != nil {
@@ -173,7 +169,10 @@ func (g *S3Getter) Get(ctx context.Context, req *getter.Request) error {
 				continue
 			}
 
-			dst := ObjectDst(req.Dst, prefix, key)
+			dst, err := ObjectDst(req.Dst, prefix, key)
+			if err != nil {
+				return err
+			}
 
 			body, err := g.object(ctx, client, &target, key, "")
 			if err != nil {
@@ -220,6 +219,15 @@ type S3FetchTarget struct {
 	Endpoint string
 }
 
+// redactedURL renders u for an error message with its query dropped. An S3
+// URL carries credentials there, and a rejected URL still reaches logs.
+func redactedURL(u *url.URL) string {
+	clean := *u
+	clean.RawQuery = ""
+
+	return clean.String()
+}
+
 // ParseS3FetchURL resolves a path-style S3 URL. Detect has already rewritten
 // the AWS virtual-host and modern path-style forms, so only
 // `<host>/<bucket>/<key>` reaches here.
@@ -231,7 +239,7 @@ type S3FetchTarget struct {
 func ParseS3FetchURL(u *url.URL) (S3FetchTarget, error) {
 	pathParts := strings.SplitN(u.Path, "/", s3PathParts)
 	if len(pathParts) != s3PathParts || pathParts[1] == "" || pathParts[2] == "" {
-		return S3FetchTarget{}, fmt.Errorf("%w: %q", ErrS3InvalidFetchURL, u.String())
+		return S3FetchTarget{}, fmt.Errorf("%w: %q", ErrS3InvalidFetchURL, redactedURL(u))
 	}
 
 	q := u.Query()
@@ -272,12 +280,15 @@ func S3Region(u *url.URL) (string, error) {
 
 	hostParts := strings.Split(u.Host, ".")
 	if len(hostParts) != s3AWSHostParts {
-		return "", fmt.Errorf("%w: %q", ErrS3InvalidFetchURL, u.String())
+		return "", fmt.Errorf("%w: %q", ErrS3InvalidFetchURL, redactedURL(u))
 	}
 
-	region := strings.TrimPrefix(strings.TrimPrefix(hostParts[0], "s3-"), "s3")
+	region, ok := S3RegionFromHostLabel(hostParts[0])
+	if !ok {
+		return "", fmt.Errorf("%w: %q", ErrS3InvalidFetchURL, redactedURL(u))
+	}
 
-	return cmp.Or(region, s3DefaultRegion), nil
+	return region, nil
 }
 
 // object opens the object body. The caller closes it via writeGetterObject.

--- a/internal/getter/s3.go
+++ b/internal/getter/s3.go
@@ -1,30 +1,77 @@
 package getter
 
 import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"io"
 	"net/url"
+	"strings"
 
-	s3 "github.com/hashicorp/go-getter/s3/v2"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	upstreams3 "github.com/hashicorp/go-getter/s3/v2"
 	getter "github.com/hashicorp/go-getter/v2"
+
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 )
 
-// S3Getter is Terragrunt's s3-protocol getter. It wraps the upstream
-// go-getter/s3/v2 Getter, whose URL parser only accepts legacy
-// path-style hostnames (`s3.amazonaws.com`, `s3-<region>.amazonaws.com`),
-// and canonicalizes the other AWS S3 endpoint forms — virtual-host style
-// and modern path style — into that shape so they fetch instead of
-// failing URL validation.
+// ErrS3InvalidFetchURL is returned when an s3:// URL does not carry both a
+// bucket and a key once Detect has canonicalized it to path style.
+var ErrS3InvalidFetchURL = errors.New("not a valid S3 URL")
+
+// s3DefaultRegion matches the region the upstream getter assumes when the URL
+// names none, so an S3-compatible service that ignores the region keeps working.
+const s3DefaultRegion = "us-east-1"
+
+// s3PathParts is the segment count from splitting `/bucket/key` on "/" with
+// limit 3: ["", "bucket", "key"].
+const s3PathParts = 3
+
+// s3AWSHostParts is the label count of a path-style AWS S3 host, which Detect
+// has already canonicalized to `s3[-<region>].amazonaws.com`.
+const s3AWSHostParts = 3
+
+// S3Getter is Terragrunt's s3-protocol getter.
+//
+// Detection is delegated to the upstream go-getter/s3/v2 Getter, which does no
+// I/O. Its URL parser only accepts legacy path-style hostnames
+// (`s3.amazonaws.com`, `s3-<region>.amazonaws.com`), so [S3Getter.Detect]
+// canonicalizes the other AWS endpoint forms into that shape. Fetching is not
+// delegated, because the upstream Getter builds its own AWS session, which
+// would put every object download on a transport the venv never sees.
 type S3Getter struct {
-	s3.Getter
+	v             *venv.Venv
+	detector      upstreams3.Getter
+	modeScanLimit int
+}
+
+// NewS3Getter returns an s3-protocol getter.
+func NewS3Getter(v *venv.Venv) *S3Getter {
+	v.RequireFS()
+	v.RequireHTTP()
+
+	return &S3Getter{v: v, modeScanLimit: DefaultModeScanLimit}
+}
+
+// WithModeScanLimit caps how many keys [S3Getter.Mode] inspects before it
+// gives up with [ErrModeScanLimit].
+func (g *S3Getter) WithModeScanLimit(limit int) *S3Getter {
+	g.modeScanLimit = limit
+	return g
 }
 
 // Detect delegates to the upstream getter and, when the request is
-// claimed, rewrites an AWS S3 URL to the path-style form the upstream
-// Get/GetFile/Mode parser accepts. Detect is the only hook where a
-// getter may rewrite the source: Client.Get re-parses req.Src into the
-// request URL after detection, while later mutation would be ignored.
-// Non-AWS (S3-compatible) hosts pass through untouched.
+// claimed, rewrites an AWS S3 URL to the path-style form the fetch
+// methods below parse. Detect is the only hook where a getter may rewrite
+// the source: Client.Get re-parses req.Src into the request URL after
+// detection, while later mutation would be ignored. Non-AWS
+// (S3-compatible) hosts pass through untouched.
 func (g *S3Getter) Detect(req *getter.Request) (bool, error) {
-	ok, err := g.Getter.Detect(req)
+	ok, err := g.detector.Detect(req)
 	if err != nil || !ok {
 		return ok, err
 	}
@@ -36,4 +83,250 @@ func (g *S3Getter) Detect(req *getter.Request) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// Mode reports whether the URL names a single object or a prefix. An exact
+// key match is a file; any key below `<key>/` makes it a directory. A prefix
+// matching nothing reports file mode so the download surfaces S3's own
+// not-found error rather than a synthesized one.
+func (g *S3Getter) Mode(ctx context.Context, u *url.URL) (getter.Mode, error) {
+	target, err := ParseS3FetchURL(u)
+	if err != nil {
+		return 0, err
+	}
+
+	client, err := g.client(ctx, &target)
+	if err != nil {
+		return 0, err
+	}
+
+	out, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket: aws.String(target.Bucket),
+		Prefix: aws.String(target.Key),
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	mode, err := ScanMode(g.modeScanLimit,
+		func(yield func(string, error) bool) {
+			for _, obj := range out.Contents {
+				if !yield(aws.ToString(obj.Key), nil) {
+					return
+				}
+			}
+		},
+		func(key string) (getter.Mode, bool) {
+			if key == target.Key {
+				return getter.ModeFile, true
+			}
+
+			if strings.HasPrefix(key, target.Key+"/") {
+				return getter.ModeDir, true
+			}
+
+			return 0, false
+		},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %q", err, target.Key)
+	}
+
+	return mode, nil
+}
+
+// Get downloads every object under the URL's key prefix into req.Dst,
+// preserving each object's path relative to that prefix.
+func (g *S3Getter) Get(ctx context.Context, req *getter.Request) error {
+	target, err := ParseS3FetchURL(req.URL())
+	if err != nil {
+		return err
+	}
+
+	client, err := g.client(ctx, &target)
+	if err != nil {
+		return err
+	}
+
+	if err := ResetGetterDst(g.v.FS, req); err != nil {
+		return err
+	}
+
+	prefix := ListPrefix(target.Key)
+
+	pages := s3.NewListObjectsV2Paginator(client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(target.Bucket),
+		Prefix: aws.String(prefix),
+	})
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, obj := range page.Contents {
+			key := aws.ToString(obj.Key)
+
+			// A key ending in "/" is a directory placeholder, not content.
+			if strings.HasSuffix(key, "/") {
+				continue
+			}
+
+			dst := ObjectDst(req.Dst, prefix, key)
+
+			body, err := g.object(ctx, client, &target, key, "")
+			if err != nil {
+				return err
+			}
+
+			if err := WriteGetterObject(g.v.FS, req, dst, body); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// GetFile downloads the single object the URL names into req.Dst.
+func (g *S3Getter) GetFile(ctx context.Context, req *getter.Request) error {
+	target, err := ParseS3FetchURL(req.URL())
+	if err != nil {
+		return err
+	}
+
+	client, err := g.client(ctx, &target)
+	if err != nil {
+		return err
+	}
+
+	body, err := g.object(ctx, client, &target, target.Key, target.Version)
+	if err != nil {
+		return err
+	}
+
+	return WriteGetterObject(g.v.FS, req, req.Dst, body)
+}
+
+// S3FetchTarget is a path-style s3:// URL resolved into what the SDK needs.
+type S3FetchTarget struct {
+	Creds    aws.CredentialsProvider
+	Region   string
+	Bucket   string
+	Key      string
+	Version  string
+	Profile  string
+	Endpoint string
+}
+
+// ParseS3FetchURL resolves a path-style S3 URL. Detect has already rewritten
+// the AWS virtual-host and modern path-style forms, so only
+// `<host>/<bucket>/<key>` reaches here.
+//
+// Credentials supplied in the query are also the signal that the URL names an
+// S3-compatible service rather than AWS, so they pin the endpoint to the URL's
+// own host in path style. That mirrors the upstream getter, which callers rely
+// on to reach non-AWS object stores.
+func ParseS3FetchURL(u *url.URL) (S3FetchTarget, error) {
+	pathParts := strings.SplitN(u.Path, "/", s3PathParts)
+	if len(pathParts) != s3PathParts || pathParts[1] == "" || pathParts[2] == "" {
+		return S3FetchTarget{}, fmt.Errorf("%w: %q", ErrS3InvalidFetchURL, u.String())
+	}
+
+	q := u.Query()
+
+	target := S3FetchTarget{
+		Bucket:  pathParts[1],
+		Key:     pathParts[2],
+		Version: q.Get("version"),
+		Profile: q.Get("aws_profile"),
+	}
+
+	region, err := S3Region(u)
+	if err != nil {
+		return S3FetchTarget{}, err
+	}
+
+	target.Region = region
+
+	keyID := q.Get("aws_access_key_id")
+	secret := q.Get("aws_access_key_secret")
+	token := q.Get("aws_access_token")
+
+	if cmp.Or(keyID, secret, token) != "" {
+		target.Creds = credentials.NewStaticCredentialsProvider(keyID, secret, token)
+		target.Endpoint = u.Scheme + "://" + u.Host
+	}
+
+	return target, nil
+}
+
+// S3Region resolves the region for u. An AWS host encodes it in the first
+// label; any other host belongs to an S3-compatible service, which carries it
+// in the query instead.
+func S3Region(u *url.URL) (string, error) {
+	if !strings.Contains(u.Host, "amazonaws.com") {
+		return cmp.Or(u.Query().Get("region"), s3DefaultRegion), nil
+	}
+
+	hostParts := strings.Split(u.Host, ".")
+	if len(hostParts) != s3AWSHostParts {
+		return "", fmt.Errorf("%w: %q", ErrS3InvalidFetchURL, u.String())
+	}
+
+	region := strings.TrimPrefix(strings.TrimPrefix(hostParts[0], "s3-"), "s3")
+
+	return cmp.Or(region, s3DefaultRegion), nil
+}
+
+// object opens the object body. The caller closes it via writeGetterObject.
+func (g *S3Getter) object(
+	ctx context.Context,
+	client *s3.Client,
+	target *S3FetchTarget,
+	key, version string,
+) (io.ReadCloser, error) {
+	in := &s3.GetObjectInput{
+		Bucket: aws.String(target.Bucket),
+		Key:    aws.String(key),
+	}
+	if version != "" {
+		in.VersionId = aws.String(version)
+	}
+
+	out, err := client.GetObject(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	return out.Body, nil
+}
+
+func (g *S3Getter) client(ctx context.Context, target *S3FetchTarget) (*s3.Client, error) {
+	opts := []func(*awsconfig.LoadOptions) error{
+		awsconfig.WithRegion(target.Region),
+		awsconfig.WithHTTPClient(g.v.HTTP),
+	}
+
+	if target.Profile != "" {
+		opts = append(opts, awsconfig.WithSharedConfigProfile(target.Profile))
+	}
+
+	if target.Creds != nil {
+		opts = append(opts, awsconfig.WithCredentialsProvider(target.Creds))
+	}
+
+	//nolint:forbidigo // WithHTTPClient above carries the venv's client, which is what the rule protects.
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if target.Endpoint != "" {
+			o.BaseEndpoint = aws.String(target.Endpoint)
+			o.UsePathStyle = true
+		}
+	}), nil
 }

--- a/internal/getter/s3.go
+++ b/internal/getter/s3.go
@@ -11,13 +11,14 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	upstreams3 "github.com/hashicorp/go-getter/s3/v2"
 	getter "github.com/hashicorp/go-getter/v2"
 
+	"github.com/gruntwork-io/terragrunt/internal/awshelper"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
 // ErrS3InvalidFetchURL is returned when an s3:// URL does not carry both a
@@ -45,6 +46,7 @@ const s3AWSHostParts = 3
 // delegated, because the upstream Getter builds its own AWS session, which
 // would put every object download on a transport the venv never sees.
 type S3Getter struct {
+	l             log.Logger
 	v             *venv.Venv
 	detector      upstreams3.Getter
 	modeScanLimit int
@@ -52,11 +54,23 @@ type S3Getter struct {
 
 // NewS3Getter returns an s3-protocol getter.
 func NewS3Getter(v *venv.Venv) *S3Getter {
+	v.RequireEnv()
 	v.RequireFS()
 	v.RequireHTTP()
 
-	return &S3Getter{v: v, modeScanLimit: DefaultModeScanLimit}
+	return &S3Getter{l: discardLog(), v: v, modeScanLimit: DefaultModeScanLimit}
 }
+
+// WithLogger routes the debug lines credential resolution emits. A getter or
+// resolver built without one discards them, since a client can be built
+// without a logger in reach ([GetAny]).
+func (g *S3Getter) WithLogger(l log.Logger) *S3Getter {
+	g.l = l
+	return g
+}
+
+// discardLog is the logger a getter or resolver built without one uses.
+func discardLog() log.Logger { return log.New(log.WithOutput(io.Discard)) }
 
 // WithModeScanLimit caps how many keys [S3Getter.Mode] inspects before it
 // gives up with [ErrModeScanLimit].
@@ -315,29 +329,28 @@ func (g *S3Getter) object(
 }
 
 func (g *S3Getter) client(ctx context.Context, target *S3FetchTarget) (*s3.Client, error) {
-	opts := []func(*awsconfig.LoadOptions) error{
-		awsconfig.WithRegion(target.Region),
-		awsconfig.WithHTTPClient(g.v.HTTP),
-	}
+	return S3ClientForTarget(ctx, g.l, g.v, target)
+}
 
-	if target.Profile != "" {
-		opts = append(opts, awsconfig.WithSharedConfigProfile(target.Profile))
-	}
+// S3ClientForTarget builds the S3 client a fetch or probe of target needs.
+// Credentials and region resolve against v rather than the process, and
+// anything the URL named outranks them.
+func S3ClientForTarget(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+	target *S3FetchTarget,
+) (*s3.Client, error) {
+	b := awshelper.NewAWSConfigBuilder().WithSessionConfig(&awshelper.AwsSessionConfig{
+		Region:           target.Region,
+		Profile:          target.Profile,
+		CustomS3Endpoint: target.Endpoint,
+		S3ForcePathStyle: target.Endpoint != "",
+	})
 
 	if target.Creds != nil {
-		opts = append(opts, awsconfig.WithCredentialsProvider(target.Creds))
+		b = b.WithCredentialsProvider(target.Creds)
 	}
 
-	//nolint:forbidigo // WithHTTPClient above carries the venv's client, which is what the rule protects.
-	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	return s3.NewFromConfig(cfg, func(o *s3.Options) {
-		if target.Endpoint != "" {
-			o.BaseEndpoint = aws.String(target.Endpoint)
-			o.UsePathStyle = true
-		}
-	}), nil
+	return b.BuildS3Client(ctx, l, v)
 }

--- a/internal/getter/s3_fetch_test.go
+++ b/internal/getter/s3_fetch_test.go
@@ -1,0 +1,248 @@
+package getter_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+)
+
+// TestParseS3FetchURL pins how the s3 getter resolves a path-style URL into
+// SDK inputs. Detect canonicalizes the AWS virtual-host and modern path-style
+// forms first, so only `<host>/<bucket>/<key>` reaches this.
+func TestParseS3FetchURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		raw          string
+		wantRegion   string
+		wantBucket   string
+		wantKey      string
+		wantVersion  string
+		wantProfile  string
+		wantEndpoint string
+		wantCreds    bool
+	}{
+		{
+			name:       "global path style defaults to us-east-1",
+			raw:        "s3://s3.amazonaws.com/bucket/path/to/mod",
+			wantRegion: "us-east-1",
+			wantBucket: "bucket",
+			wantKey:    "path/to/mod",
+		},
+		{
+			name:       "legacy regional host carries its region",
+			raw:        "s3://s3-eu-west-1.amazonaws.com/bucket/key",
+			wantRegion: "eu-west-1",
+			wantBucket: "bucket",
+			wantKey:    "key",
+		},
+		{
+			name:        "version query is preserved",
+			raw:         "s3://s3.amazonaws.com/bucket/key?version=abc123",
+			wantRegion:  "us-east-1",
+			wantBucket:  "bucket",
+			wantKey:     "key",
+			wantVersion: "abc123",
+		},
+		{
+			name:        "profile query is preserved",
+			raw:         "s3://s3.amazonaws.com/bucket/key?aws_profile=dev",
+			wantRegion:  "us-east-1",
+			wantBucket:  "bucket",
+			wantKey:     "key",
+			wantProfile: "dev",
+		},
+		{
+			name:       "s3-compatible host takes its region from the query",
+			raw:        "https://minio.example.com/bucket/key?region=us-west-2",
+			wantRegion: "us-west-2",
+			wantBucket: "bucket",
+			wantKey:    "key",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(tc.raw)
+			require.NoError(t, err)
+
+			got, err := getter.ParseS3FetchURL(u)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantRegion, got.Region)
+			assert.Equal(t, tc.wantBucket, got.Bucket)
+			assert.Equal(t, tc.wantKey, got.Key)
+			assert.Equal(t, tc.wantVersion, got.Version)
+			assert.Equal(t, tc.wantProfile, got.Profile)
+			assert.Equal(t, tc.wantEndpoint, got.Endpoint)
+			assert.Equal(t, tc.wantCreds, got.Creds != nil)
+		})
+	}
+}
+
+// TestParseS3FetchURLInURLCredentials pins the S3-compatible contract the
+// RustFS integration test depends on: credentials in the query are also the
+// signal to pin the endpoint to the URL's own host in path style, so the
+// request reaches that service instead of real AWS.
+func TestParseS3FetchURLInURLCredentials(t *testing.T) {
+	t.Parallel()
+
+	u, err := url.Parse(
+		"http://127.0.0.1:9000/bucket/modules/example.tar.gz" +
+			"?aws_access_key_id=key&aws_access_key_secret=secret",
+	)
+	require.NoError(t, err)
+
+	got, err := getter.ParseS3FetchURL(u)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bucket", got.Bucket)
+	assert.Equal(t, "modules/example.tar.gz", got.Key)
+	assert.Equal(t, "http://127.0.0.1:9000", got.Endpoint)
+	require.NotNil(t, got.Creds)
+
+	creds, err := got.Creds.Retrieve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "key", creds.AccessKeyID)
+	assert.Equal(t, "secret", creds.SecretAccessKey)
+}
+
+// TestParseS3FetchURLRejectsIncomplete pins that a URL naming no key is
+// rejected up front rather than turning into a bucket-wide prefix download.
+func TestParseS3FetchURLRejectsIncomplete(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		"s3://s3.amazonaws.com/bucket",
+		"s3://s3.amazonaws.com/bucket/",
+		"s3://s3.amazonaws.com/",
+		"s3://s3.amazonaws.com//key",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(raw)
+			require.NoError(t, err)
+
+			_, err = getter.ParseS3FetchURL(u)
+			require.ErrorIs(t, err, getter.ErrS3InvalidFetchURL)
+		})
+	}
+}
+
+// TestParseS3FetchURLRejectsUncanonicalizedHost pins that a URL whose path is
+// well formed but whose host still carries the region in a later label is
+// rejected, instead of being fetched from whatever region the first label
+// happens to spell. Detect rewrites that host, so one arriving here means the
+// rewrite was skipped.
+func TestParseS3FetchURLRejectsUncanonicalizedHost(t *testing.T) {
+	t.Parallel()
+
+	u, err := url.Parse("https://s3.us-west-2.amazonaws.com/bucket/key")
+	require.NoError(t, err)
+
+	_, err = getter.ParseS3FetchURL(u)
+	require.ErrorIs(t, err, getter.ErrS3InvalidFetchURL)
+}
+
+// TestParseGCSFetchURL pins the canonical GCS form the upstream detector
+// produces. Everything after the bucket is the object name, separators
+// included, so a nested object keeps its layout instead of being truncated at
+// the first slash.
+func TestParseGCSFetchURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		raw        string
+		wantBucket string
+		wantObject string
+	}{
+		{
+			name:       "canonical URL splits into bucket and object",
+			raw:        "https://www.googleapis.com/storage/v1/bucket/path/to/mod",
+			wantBucket: "bucket",
+			wantObject: "path/to/mod",
+		},
+		{
+			name:       "single-segment object",
+			raw:        "https://www.googleapis.com/storage/v1/bucket/mod.tar.gz",
+			wantBucket: "bucket",
+			wantObject: "mod.tar.gz",
+		},
+		{
+			name:       "storage version is not pinned to v1",
+			raw:        "https://www.googleapis.com/storage/v2/bucket/key",
+			wantBucket: "bucket",
+			wantObject: "key",
+		},
+		{
+			name:       "download host is accepted alongside the API host",
+			raw:        "https://storage.googleapis.com/storage/v1/bucket/key",
+			wantBucket: "bucket",
+			wantObject: "key",
+		},
+		{
+			name:       "query string is not part of the object name",
+			raw:        "https://www.googleapis.com/storage/v1/bucket/key?generation=17",
+			wantBucket: "bucket",
+			wantObject: "key",
+		},
+		{
+			name:       "object keeps a trailing separator so a prefix download lists under it",
+			raw:        "https://www.googleapis.com/storage/v1/bucket/modules/",
+			wantBucket: "bucket",
+			wantObject: "modules/",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(tc.raw)
+			require.NoError(t, err)
+
+			bucket, object, err := getter.ParseGCSFetchURL(u)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantBucket, bucket)
+			assert.Equal(t, tc.wantObject, object)
+		})
+	}
+}
+
+// TestParseGCSFetchURLRejectsIncomplete pins that a URL missing either half
+// of the object's address is rejected up front: no object would turn into a
+// bucket-wide prefix download, and no bucket reaches the SDK as a request
+// with nowhere to go. Only Google-hosted URLs in the canonical shape are
+// claimed at all.
+func TestParseGCSFetchURLRejectsIncomplete(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		"https://www.googleapis.com/storage/v1/bucket",
+		"https://www.googleapis.com/storage/v1/bucket/",
+		"https://www.googleapis.com/storage/v1",
+		"https://www.googleapis.com/storage/v1//key",
+		"https://www.googleapis.com/notstorage/v1/bucket/key",
+		"https://example.com/storage/v1/bucket/key",
+		"gs://bucket/key",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(raw)
+			require.NoError(t, err)
+
+			_, _, err = getter.ParseGCSFetchURL(u)
+			require.ErrorIs(t, err, getter.ErrGCSInvalidFetchURL)
+		})
+	}
+}

--- a/internal/getter/s3_http_test.go
+++ b/internal/getter/s3_http_test.go
@@ -75,7 +75,7 @@ func s3StubHandler(t *testing.T, bucket s3StubBucket) vhttp.Handler {
 			return vhttp.Respond(http.StatusOK, body, nil), nil
 		}
 
-		key := strings.TrimPrefix(req.URL.Path, "/bucket/")
+		key := strings.TrimPrefix(strings.TrimPrefix(req.URL.Path, "/bucket"), "/")
 
 		content, ok := bucket[key]
 		if !ok {
@@ -175,6 +175,40 @@ func TestS3GetterFetchesThroughVenvClient(t *testing.T) {
 			assertDownloadedTree(t, v.FS, dst, tc.want)
 		})
 	}
+}
+
+// TestS3GetterUsesVenvEnvironmentCredentials pins where the credentials come
+// from when the URL names none: the venv's environment, not the process's. The
+// request's signature carries the access key ID, so the venv's key reaching the
+// wire is what proves it.
+func TestS3GetterUsesVenvEnvironmentCredentials(t *testing.T) {
+	t.Parallel()
+
+	var auth string
+
+	v := &venv.Venv{
+		FS: vfs.NewMemMapFS(),
+		HTTP: vhttp.NewMemClient(func(ctx context.Context, req *http.Request) (*http.Response, error) {
+			auth = req.Header.Get("Authorization")
+
+			return s3StubHandler(t, s3StubBucket{"mod.txt": "body"})(ctx, req)
+		}),
+		Env: map[string]string{
+			"AWS_ACCESS_KEY_ID":     "AKIAVENVKEY",
+			"AWS_SECRET_ACCESS_KEY": "venv-secret",
+		},
+	}
+
+	client := &getter.Client{Getters: []getter.Getter{getter.NewS3Getter(v)}}
+
+	_, err := client.Get(t.Context(), &getter.Request{
+		Src:     "s3::https://s3-us-east-1.amazonaws.com/bucket/mod.txt",
+		Dst:     filepath.Join("out", "module"),
+		GetMode: getter.ModeAny,
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, auth, "AKIAVENVKEY")
 }
 
 // assertDownloadedTree compares everything under dst against want, which is

--- a/internal/getter/s3_http_test.go
+++ b/internal/getter/s3_http_test.go
@@ -1,0 +1,210 @@
+package getter_test
+
+import (
+	"context"
+	"encoding/xml"
+	"io/fs"
+	"net/http"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+)
+
+// s3StubBucket is the object store a stubbed S3 answers from: key to content.
+type s3StubBucket map[string]string
+
+// s3ListResult mirrors the ListObjectsV2 response the SDK parses.
+type s3ListResult struct {
+	XMLName  xml.Name `xml:"ListBucketResult"`
+	Name     string   `xml:"Name"`
+	Prefix   string   `xml:"Prefix"`
+	Contents []struct {
+		Key  string `xml:"Key"`
+		Size int    `xml:"Size"`
+	} `xml:"Contents"`
+	KeyCount    int  `xml:"KeyCount"`
+	MaxKeys     int  `xml:"MaxKeys"`
+	IsTruncated bool `xml:"IsTruncated"`
+}
+
+// s3StubHandler answers ListObjectsV2 and GetObject out of bucket, so a fetch
+// runs end to end without a network or credentials. Keys list in sorted order,
+// which is the order S3 itself returns and what the mode scan reads.
+func s3StubHandler(t *testing.T, bucket s3StubBucket) vhttp.Handler {
+	t.Helper()
+
+	return func(_ context.Context, req *http.Request) (*http.Response, error) {
+		if req.URL.Query().Get("list-type") == "2" {
+			prefix := req.URL.Query().Get("prefix")
+
+			keys := make([]string, 0, len(bucket))
+
+			for key := range bucket {
+				if strings.HasPrefix(key, prefix) {
+					keys = append(keys, key)
+				}
+			}
+
+			sort.Strings(keys)
+
+			var result s3ListResult
+			for _, key := range keys {
+				result.Contents = append(result.Contents, struct {
+					Key  string `xml:"Key"`
+					Size int    `xml:"Size"`
+				}{Key: key, Size: len(bucket[key])})
+			}
+
+			result.Name = "bucket"
+			result.Prefix = prefix
+			result.KeyCount = len(keys)
+			result.MaxKeys = len(keys)
+
+			body, err := xml.Marshal(result)
+			require.NoError(t, err)
+
+			return vhttp.Respond(http.StatusOK, body, nil), nil
+		}
+
+		key := strings.TrimPrefix(req.URL.Path, "/bucket/")
+
+		content, ok := bucket[key]
+		if !ok {
+			return vhttp.Respond(http.StatusNotFound, []byte(""), nil), nil
+		}
+
+		return vhttp.Respond(http.StatusOK, []byte(content), nil), nil
+	}
+}
+
+// s3StubSrc addresses key on the stubbed service. Credentials in the query
+// pin the endpoint to that host, so the SDK signs with them instead of
+// resolving the ambient credential chain.
+func s3StubSrc(key string) string {
+	return "s3::https://s3.stub.example/bucket/" + key +
+		"?aws_access_key_id=stub&aws_access_key_secret=stub&region=us-east-1"
+}
+
+// TestS3GetterFetchesThroughVenvClient drives the s3 getter over an in-memory
+// HTTP client: the mode scan, the listing, and every object body ride the
+// venv's client, and the results land on the venv's filesystem. The bucket
+// holds an object that is also a prefix, and a sibling whose name starts with
+// that object's name, which is what separates the two modes.
+func TestS3GetterFetchesThroughVenvClient(t *testing.T) {
+	t.Parallel()
+
+	bucket := s3StubBucket{
+		"modules/vpc":                 "vpc-object",
+		"modules/vpc/":                "",
+		"modules/vpc/main.tf":         "main",
+		"modules/vpc/sub/nested.tf":   "nested",
+		"modules/vpc-old/main.tf":     "old",
+		"modules/app/main.tf":         "app-main",
+		"modules/app-old/main.tf":     "app-old",
+		"modules/esc/../../escape.tf": "escape",
+	}
+
+	tests := []struct {
+		want    map[string]string
+		wantErr error
+		name    string
+		key     string
+	}{
+		{
+			// The sibling is what the mode scan reaches after the exact key,
+			// so this fails the moment a listed name that merely starts with
+			// the key is read as proof of a directory.
+			name: "key naming an object downloads that object",
+			key:  "modules/vpc",
+			want: map[string]string{"vpc": "vpc-object"},
+		},
+		{
+			name: "prefix without a trailing separator downloads the tree",
+			key:  "modules/app",
+			want: map[string]string{"main.tf": "app-main"},
+		},
+		{
+			name: "prefix with a trailing separator downloads the tree",
+			key:  "modules/vpc/",
+			want: map[string]string{
+				"main.tf":       "main",
+				"sub/nested.tf": "nested",
+			},
+		},
+		{
+			name:    "key escaping the destination is refused",
+			key:     "modules/esc/",
+			wantErr: getter.ErrObjectEscapesDst,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := &venv.Venv{
+				FS:   vfs.NewMemMapFS(),
+				HTTP: vhttp.NewMemClient(s3StubHandler(t, bucket)),
+				Env:  map[string]string{},
+			}
+
+			client := &getter.Client{Getters: []getter.Getter{getter.NewS3Getter(v)}}
+			dst := filepath.Join("out", "module")
+
+			_, err := client.Get(t.Context(), &getter.Request{
+				Src:     s3StubSrc(tc.key),
+				Dst:     dst,
+				GetMode: getter.ModeAny,
+			})
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assertDownloadedTree(t, v.FS, dst, tc.want)
+		})
+	}
+}
+
+// assertDownloadedTree compares everything under dst against want, which is
+// keyed by slash-separated path relative to dst. Comparing the whole tree
+// rather than each wanted file catches a sibling key or a directory
+// placeholder that landed alongside the requested objects.
+func assertDownloadedTree(t *testing.T, fsys vfs.FS, dst string, want map[string]string) {
+	t.Helper()
+
+	got := map[string]string{}
+
+	require.NoError(t, vfs.WalkDir(fsys, dst, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+
+		content, err := vfs.ReadFile(fsys, path)
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(dst, path)
+		if err != nil {
+			return err
+		}
+
+		got[filepath.ToSlash(rel)] = string(content)
+
+		return nil
+	}))
+
+	assert.Equal(t, want, got)
+}

--- a/internal/getter/s3_region_test.go
+++ b/internal/getter/s3_region_test.go
@@ -133,13 +133,10 @@ func TestS3RegionRejectsUncanonicalizedAWSHosts(t *testing.T) {
 	}
 }
 
-// TestS3RegionAcceptsHostsTheProbeRejects records where the two paths
-// disagree rather than endorsing it: the fetch path reads any three-label
-// amazonaws.com host as path-style S3 and hands back its first label as the
-// region, while the probe path rejects the same host outright. Reaching the
-// fetch path at all takes an explicitly forced s3 URL, since Detect claims
-// those without inspecting the host.
-func TestS3RegionAcceptsHostsTheProbeRejects(t *testing.T) {
+// TestS3RegionRejectsNonS3AWSHosts pins that the fetch path rejects the hosts
+// the probe path does. An explicitly forced s3 URL reaches here, since Detect
+// claims those without inspecting the host.
+func TestS3RegionRejectsNonS3AWSHosts(t *testing.T) {
 	t.Parallel()
 
 	for _, host := range []string{"iam", "sts", "ec2"} {
@@ -149,14 +146,27 @@ func TestS3RegionAcceptsHostsTheProbeRejects(t *testing.T) {
 			u, err := url.Parse("https://" + host + ".amazonaws.com/bucket/key")
 			require.NoError(t, err)
 
-			got, err := getter.S3Region(u)
-			require.NoError(t, err)
-			assert.Equal(t, host, got)
-
-			_, ok := getter.S3RegionFromHostLabel(host)
-			assert.False(t, ok)
+			_, err = getter.S3Region(u)
+			require.ErrorIs(t, err, getter.ErrS3InvalidFetchURL)
 		})
 	}
+}
+
+// TestS3RegionRedactsCredentials pins that a rejected URL does not carry the
+// credentials it was given into the error text, which reaches logs.
+func TestS3RegionRedactsCredentials(t *testing.T) {
+	t.Parallel()
+
+	u, err := url.Parse(
+		"https://iam.amazonaws.com/bucket/key" +
+			"?aws_access_key_id=AKIAEXAMPLE&aws_access_key_secret=super-secret",
+	)
+	require.NoError(t, err)
+
+	_, err = getter.S3Region(u)
+	require.ErrorIs(t, err, getter.ErrS3InvalidFetchURL)
+	assert.NotContains(t, err.Error(), "super-secret")
+	assert.NotContains(t, err.Error(), "AKIAEXAMPLE")
 }
 
 // TestS3RegionFromHostLabel pins which host labels identify S3. Anything else

--- a/internal/getter/s3_region_test.go
+++ b/internal/getter/s3_region_test.go
@@ -1,0 +1,300 @@
+package getter_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+)
+
+// awsRegions covers the shapes an AWS region name takes: the global default,
+// an ordinary regional name, and the longer partition-qualified form.
+var awsRegions = []string{"us-east-1", "us-west-2", "eu-west-1", "ap-south-1", "us-gov-west-1"}
+
+// TestS3Region pins the region the fetch path resolves for each URL shape it
+// accepts. Detect canonicalizes the AWS virtual-host forms to path style
+// first, so only `s3[-<region>].amazonaws.com` and S3-compatible hosts reach
+// this.
+func TestS3Region(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "global path-style host is us-east-1",
+			raw:  "s3://s3.amazonaws.com/bucket/key",
+			want: "us-east-1",
+		},
+		{
+			name: "legacy regional host carries its region",
+			raw:  "s3://s3-eu-west-1.amazonaws.com/bucket/key",
+			want: "eu-west-1",
+		},
+		{
+			name: "region keeps every hyphenated segment",
+			raw:  "s3://s3-us-gov-west-1.amazonaws.com/bucket/key",
+			want: "us-gov-west-1",
+		},
+		{
+			name: "port on an AWS host does not disturb the region",
+			raw:  "https://s3-ap-south-1.amazonaws.com:443/bucket/key",
+			want: "ap-south-1",
+		},
+		{
+			name: "AWS host outranks a region query",
+			raw:  "s3://s3-eu-west-1.amazonaws.com/bucket/key?region=us-west-2",
+			want: "eu-west-1",
+		},
+		{
+			name: "s3-compatible host takes the region from the query",
+			raw:  "https://minio.example.com/bucket/key?region=us-west-2",
+			want: "us-west-2",
+		},
+		{
+			name: "s3-compatible host without a region falls back to us-east-1",
+			raw:  "https://minio.example.com/bucket/key",
+			want: "us-east-1",
+		},
+		{
+			name: "empty region query falls back to us-east-1",
+			raw:  "https://minio.example.com/bucket/key?region=",
+			want: "us-east-1",
+		},
+		{
+			name: "host and port of a local service falls back to us-east-1",
+			raw:  "http://127.0.0.1:9000/bucket/key",
+			want: "us-east-1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(tc.raw)
+			require.NoError(t, err)
+
+			got, err := getter.S3Region(u)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestS3RegionRejectsUncanonicalizedAWSHosts pins that an AWS host carrying
+// its region anywhere but the first label is rejected rather than guessed at.
+// Those forms are Detect's job to rewrite, so one reaching the fetch path
+// means the rewrite did not happen.
+func TestS3RegionRejectsUncanonicalizedAWSHosts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "modern path style",
+			raw:  "https://s3.us-west-2.amazonaws.com/bucket/key",
+		},
+		{
+			name: "modern virtual-host style",
+			raw:  "https://bucket.s3.us-west-2.amazonaws.com/key",
+		},
+		{
+			name: "legacy virtual-host style",
+			raw:  "https://bucket.s3-us-west-2.amazonaws.com/key",
+		},
+		{
+			name: "no host label at all",
+			raw:  "https://amazonaws.com/bucket/key",
+		},
+		{
+			name: "host that merely embeds the AWS domain",
+			raw:  "https://evil.notamazonaws.com.test/bucket/key",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(tc.raw)
+			require.NoError(t, err)
+
+			_, err = getter.S3Region(u)
+			require.ErrorIs(t, err, getter.ErrS3InvalidFetchURL)
+		})
+	}
+}
+
+// TestS3RegionAcceptsHostsTheProbeRejects records where the two paths
+// disagree rather than endorsing it: the fetch path reads any three-label
+// amazonaws.com host as path-style S3 and hands back its first label as the
+// region, while the probe path rejects the same host outright. Reaching the
+// fetch path at all takes an explicitly forced s3 URL, since Detect claims
+// those without inspecting the host.
+func TestS3RegionAcceptsHostsTheProbeRejects(t *testing.T) {
+	t.Parallel()
+
+	for _, host := range []string{"iam", "sts", "ec2"} {
+		t.Run(host, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse("https://" + host + ".amazonaws.com/bucket/key")
+			require.NoError(t, err)
+
+			got, err := getter.S3Region(u)
+			require.NoError(t, err)
+			assert.Equal(t, host, got)
+
+			_, ok := getter.S3RegionFromHostLabel(host)
+			assert.False(t, ok)
+		})
+	}
+}
+
+// TestS3RegionFromHostLabel pins which host labels identify S3. Anything else
+// belongs to another AWS service and must not parse as S3 with a region taken
+// from the label.
+func TestS3RegionFromHostLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		label  string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "bare s3 is the global endpoint",
+			label:  "s3",
+			want:   "us-east-1",
+			wantOK: true,
+		},
+		{
+			name:   "regional prefix carries its region",
+			label:  "s3-eu-west-1",
+			want:   "eu-west-1",
+			wantOK: true,
+		},
+		{
+			name:   "region keeps every hyphenated segment",
+			label:  "s3-us-gov-east-1",
+			want:   "us-gov-east-1",
+			wantOK: true,
+		},
+		{
+			name:  "regional prefix with no region is rejected",
+			label: "s3-",
+		},
+		{
+			name:  "label that merely starts with s3 is rejected",
+			label: "s3x",
+		},
+		{
+			name:  "another AWS service is rejected",
+			label: "iam",
+		},
+		{
+			name:  "empty label is rejected",
+			label: "",
+		},
+		{
+			name:  "matching is case-sensitive",
+			label: "S3",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := getter.S3RegionFromHostLabel(tc.label)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestS3HostLabelForRegion pins the host label a canonicalized URL is built
+// with. us-east-1 stays on the global label so a region-less URL keeps
+// probing the endpoint it named.
+func TestS3HostLabelForRegion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		region string
+		want   string
+	}{
+		{
+			name:   "us-east-1 is the global label",
+			region: "us-east-1",
+			want:   "s3",
+		},
+		{
+			name:   "any other region gets the regional label",
+			region: "eu-west-1",
+			want:   "s3-eu-west-1",
+		},
+		{
+			name:   "region keeps every hyphenated segment",
+			region: "us-gov-west-1",
+			want:   "s3-us-gov-west-1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, getter.S3HostLabelForRegion(tc.region))
+		})
+	}
+}
+
+// TestS3HostLabelRegionRoundTrip pins that a host label built for a region
+// parses back to that region, so a canonicalized URL probes the region the
+// original URL named.
+func TestS3HostLabelRegionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, region := range awsRegions {
+		t.Run(region, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := getter.S3RegionFromHostLabel(getter.S3HostLabelForRegion(region))
+			require.True(t, ok)
+			assert.Equal(t, region, got)
+		})
+	}
+}
+
+// TestS3RegionReadsCanonicalizedHosts is the contract between the two halves
+// of an S3 download: Detect rewrites the host with [getter.S3HostLabelForRegion]
+// and the fetch path reads it back with [getter.S3Region]. A region that
+// survives one but not the other would download from the wrong endpoint.
+func TestS3RegionReadsCanonicalizedHosts(t *testing.T) {
+	t.Parallel()
+
+	for _, region := range awsRegions {
+		t.Run(region, func(t *testing.T) {
+			t.Parallel()
+
+			host := getter.S3HostLabelForRegion(region) + ".amazonaws.com"
+
+			u, err := url.Parse("https://" + host + "/bucket/key")
+			require.NoError(t, err)
+
+			got, err := getter.S3Region(u)
+			require.NoError(t, err)
+			assert.Equal(t, region, got)
+		})
+	}
+}

--- a/internal/getter/s3_test.go
+++ b/internal/getter/s3_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/aws/session" //nolint:staticcheck
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	gogetter "github.com/hashicorp/go-getter/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,7 +80,7 @@ func TestDefaultClientCanonicalizesS3SourceURLs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			client := getter.NewClient()
+			client := getter.NewClient(venvtest.NewWithOSFS())
 			req := &gogetter.Request{Src: tt.src, GetMode: getter.ModeAny}
 
 			claimed := false

--- a/internal/getter/scanmode_test.go
+++ b/internal/getter/scanmode_test.go
@@ -1,0 +1,97 @@
+package getter_test
+
+import (
+	"errors"
+	"iter"
+	"strings"
+	"testing"
+
+	upstream "github.com/hashicorp/go-getter/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+)
+
+// namesFrom returns a sequence over names for [getter.ScanMode], plus a
+// counter of how many the scan actually pulled.
+func namesFrom(names []string) (iter.Seq2[string, error], *int) {
+	var yielded int
+
+	return func(yield func(string, error) bool) {
+		for _, name := range names {
+			yielded++
+
+			if !yield(name, nil) {
+				return
+			}
+		}
+	}, &yielded
+}
+
+// dirOnPrefix resolves directory mode for anything below key/ and file mode on
+// an exact match, mirroring what the s3 getter asks of the scan.
+func dirOnPrefix(key string) func(string) (upstream.Mode, bool) {
+	return func(name string) (upstream.Mode, bool) {
+		if name == key {
+			return upstream.ModeFile, true
+		}
+
+		if strings.HasPrefix(name, key+"/") {
+			return upstream.ModeDir, true
+		}
+
+		return 0, false
+	}
+}
+
+// TestScanModeStopsAtLimit pins that the scan gives up rather than guessing
+// once it has inspected limit entries, and that it stops pulling at exactly
+// that many.
+func TestScanModeStopsAtLimit(t *testing.T) {
+	t.Parallel()
+
+	next, pulled := namesFrom([]string{"mod1", "mod2", "mod3", "mod4"})
+
+	_, err := getter.ScanMode(2, next, dirOnPrefix("mod"))
+	require.ErrorIs(t, err, getter.ErrModeScanLimit)
+	assert.Equal(t, 2, *pulled, "the scan must stop pulling at the limit")
+}
+
+// TestScanModeResolvesWithinLimit pins that a decision reached before the cap
+// wins, so a low limit does not turn a resolvable prefix into an error.
+func TestScanModeResolvesWithinLimit(t *testing.T) {
+	t.Parallel()
+
+	next, _ := namesFrom([]string{"mod/a.tf", "mod/b.tf"})
+
+	mode, err := getter.ScanMode(2, next, dirOnPrefix("mod"))
+	require.NoError(t, err)
+	assert.Equal(t, upstream.ModeDir, mode)
+}
+
+// TestScanModeExhaustedIsFile pins that a listing that runs out without
+// resolving means the prefix names a file, matching what the getters relied on
+// before the cap existed.
+func TestScanModeExhaustedIsFile(t *testing.T) {
+	t.Parallel()
+
+	next, _ := namesFrom([]string{"modular", "moderate"})
+
+	mode, err := getter.ScanMode(getter.DefaultModeScanLimit, next, dirOnPrefix("mod"))
+	require.NoError(t, err)
+	assert.Equal(t, upstream.ModeFile, mode)
+}
+
+// TestScanModePropagatesListError pins that a listing failure surfaces as
+// itself rather than as a limit error.
+func TestScanModePropagatesListError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("list failed")
+	failing := func(yield func(string, error) bool) { yield("", sentinel) }
+
+	_, err := getter.ScanMode(getter.DefaultModeScanLimit, failing, dirOnPrefix("mod"))
+	require.ErrorIs(t, err, sentinel)
+	require.NotErrorIs(t, err, getter.ErrModeScanLimit)
+}

--- a/internal/getter/tfr.go
+++ b/internal/getter/tfr.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
-	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	getter "github.com/hashicorp/go-getter/v2"
 )
@@ -41,10 +41,8 @@ const versionQueryKey = "version"
 // [tfimpl.DefaultRegistryDomain] and
 // [github.com/gruntwork-io/terragrunt/internal/tf/cliconfig] for the rest.
 type RegistryGetter struct {
-	HTTPClient         vhttp.Client
 	Logger             log.Logger
-	FS                 vfs.FS
-	Env                map[string]string
+	Venv               *venv.Venv
 	TofuImplementation tfimpl.Type
 }
 
@@ -52,20 +50,22 @@ type RegistryGetter struct {
 // The user's CLI config lives on the real disk, so it is only consulted when
 // the getter is running against the OS filesystem.
 func (r *RegistryGetter) auth() RegistryAuth {
-	return RegistryAuth{Env: r.Env, ReadUserConfig: vfs.IsOSFS(r.FS)}
+	return RegistryAuth{Env: r.Venv.Env, ReadUserConfig: vfs.IsOSFS(r.Venv.FS)}
 }
 
 // NewRegistryGetter returns a [RegistryGetter] that issues registry-protocol
-// requests through c, logs diagnostics to l, expands archives onto fs, and
+// requests and expands archives through v, logs diagnostics to l, and
 // defaults to [tfimpl.OpenTofu]. A logger is required because this package
 // does not consistently guard against a nil logger, so requiring one at
 // construction time prevents nil-pointer panics at call time. Use the With*
 // methods to customize other behavior.
-func NewRegistryGetter(l log.Logger, fs vfs.FS, c vhttp.Client) *RegistryGetter {
+func NewRegistryGetter(l log.Logger, v *venv.Venv) *RegistryGetter {
+	v.RequireFS()
+	v.RequireHTTP()
+
 	return &RegistryGetter{
-		HTTPClient:         c,
 		Logger:             l,
-		FS:                 fs,
+		Venv:               v,
 		TofuImplementation: tfimpl.OpenTofu,
 	}
 }
@@ -79,13 +79,7 @@ func (r *RegistryGetter) WithTofuImplementation(impl tfimpl.Type) *RegistryGette
 
 // WithEnv sets the environment the registry auth token is read from.
 func (r *RegistryGetter) WithEnv(env map[string]string) *RegistryGetter {
-	r.Env = env
-	return r
-}
-
-// WithFS sets the filesystem used for archive extraction and its cleanup.
-func (r *RegistryGetter) WithFS(fs vfs.FS) *RegistryGetter {
-	r.FS = fs
+	r.Venv = r.Venv.WithEnv(env)
 	return r
 }
 
@@ -127,7 +121,7 @@ func (r *RegistryGetter) Get(ctx context.Context, req *getter.Request) error {
 	moduleRegistryBasePath, err := GetModuleRegistryURLBasePath(
 		ctx,
 		r.Logger,
-		r.HTTPClient,
+		r.Venv.HTTP,
 		r.auth(),
 		registryDomain,
 	)
@@ -151,7 +145,7 @@ func (r *RegistryGetter) Get(ctx context.Context, req *getter.Request) error {
 		return err
 	}
 
-	terraformGet, err := GetTerraformGetHeader(ctx, r.Logger, r.HTTPClient, r.auth(), moduleURL)
+	terraformGet, err := GetTerraformGetHeader(ctx, r.Logger, r.Venv.HTTP, r.auth(), moduleURL)
 	if err != nil {
 		return err
 	}
@@ -184,7 +178,7 @@ func (r *RegistryGetter) GetFile(_ context.Context, _ *getter.Request) error {
 func (r *RegistryGetter) delegateGet(ctx context.Context, dst, src string) error {
 	parent := getter.ClientFromContext(ctx)
 	if parent == nil {
-		parent = NewClient()
+		parent = NewClient(r.Venv)
 	}
 
 	_, err := parent.Get(ctx, &getter.Request{
@@ -207,13 +201,13 @@ func (r *RegistryGetter) getSubdir(
 	// Hand the consumer a non-existent path inside an existing parent so
 	// go-getter can create the destination itself, and clean up the parent
 	// on return.
-	parent, err := vfs.MkdirTemp(r.FS, "", "getter")
+	parent, err := vfs.MkdirTemp(r.Venv.FS, "", "getter")
 	if err != nil {
 		return err
 	}
 
 	defer func() {
-		if err := r.FS.RemoveAll(parent); err != nil {
+		if err := r.Venv.FS.RemoveAll(parent); err != nil {
 			l.Warnf("Error removing temporary directory %s: %v", parent, err)
 		}
 	}()
@@ -224,7 +218,7 @@ func (r *RegistryGetter) getSubdir(
 		return fmt.Errorf("downloading registry module archive from %s: %w", sourceURL, err)
 	}
 
-	return copySubdirContents(l, r.FS, tempdirPath, subDir, dstPath, sourceURL)
+	return copySubdirContents(l, r.Venv.FS, tempdirPath, subDir, dstPath, sourceURL)
 }
 
 // copySubdirContents resolves subDir under srcRoot and copies its contents
@@ -295,7 +289,7 @@ func (r *RegistryGetter) resolveVersion(
 	latestVersion, err := GetLatestModuleVersion(
 		ctx,
 		r.Logger,
-		r.HTTPClient,
+		r.Venv.HTTP,
 		r.auth(),
 		registryDomain,
 		moduleRegistryBasePath,

--- a/internal/getter/tfr_test.go
+++ b/internal/getter/tfr_test.go
@@ -9,13 +9,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
-
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	gogetter "github.com/hashicorp/go-getter/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -227,10 +226,10 @@ func newRegistryTestClient(t *testing.T, httpClient *http.Client, impl tfimpl.Ty
 
 	l := logger.CreateLogger()
 
-	tfr := getter.NewRegistryGetter(l, vfs.NewOSFS(), httpClient).
+	tfr := getter.NewRegistryGetter(l, venvtest.NewWithOSFS().WithHTTP(httpClient)).
 		WithTofuImplementation(impl)
 
-	return getter.NewClient(
+	return getter.NewClient(venvtest.NewWithOSFS(),
 		getter.WithCustomGettersPrepended(
 			tfr,
 			&gogetter.HttpGetter{Client: httpClient, Netrc: true},

--- a/internal/getter/types.go
+++ b/internal/getter/types.go
@@ -40,13 +40,12 @@ type (
 
 // Concrete getter type aliases for callers that need to assert on the
 // underlying getter type (typically tests pinning the protocol set). The
-// git and s3 slots are intentionally absent: GitGetter and S3Getter are
-// Terragrunt's own types (defined in git.go and s3.go), not the upstream
-// go-getter/v2 getters.
+// git, s3 and gcs slots are intentionally absent: GitGetter, S3Getter and
+// GCSGetter are Terragrunt's own types (defined in git.go, s3.go and gcs.go),
+// not the upstream go-getter/v2 getters.
 type (
 	HgGetter        = getter.HgGetter
 	SmbClientGetter = getter.SmbClientGetter
 	SmbMountGetter  = getter.SmbMountGetter
 	FileGetter      = getter.FileGetter
-	GCSGetter       = gcs.Getter
 )

--- a/internal/getter/types_test.go
+++ b/internal/getter/types_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -21,7 +20,7 @@ import (
 func TestRegistryGetterMode(t *testing.T) {
 	t.Parallel()
 
-	r := getter.NewRegistryGetter(logger.CreateLogger(), vfs.NewOSFS(), vhttp.NewOSClient())
+	r := getter.NewRegistryGetter(logger.CreateLogger(), venvtest.NewWithOSFS().WithHTTP(vhttp.NewOSClient()))
 
 	mode, err := r.Mode(t.Context(), &url.URL{Scheme: "tfr"})
 	require.NoError(t, err)
@@ -33,7 +32,7 @@ func TestRegistryGetterMode(t *testing.T) {
 func TestRegistryGetterGetFile(t *testing.T) {
 	t.Parallel()
 
-	r := getter.NewRegistryGetter(logger.CreateLogger(), vfs.NewOSFS(), vhttp.NewOSClient())
+	r := getter.NewRegistryGetter(logger.CreateLogger(), venvtest.NewWithOSFS().WithHTTP(vhttp.NewOSClient()))
 
 	err := r.GetFile(t.Context(), &getter.Request{})
 	require.Error(t, err)
@@ -44,7 +43,7 @@ func TestRegistryGetterGetFile(t *testing.T) {
 func TestRegistryGetterDetect(t *testing.T) {
 	t.Parallel()
 
-	r := getter.NewRegistryGetter(logger.CreateLogger(), vfs.NewOSFS(), vhttp.NewOSClient())
+	r := getter.NewRegistryGetter(logger.CreateLogger(), venvtest.NewWithOSFS().WithHTTP(vhttp.NewOSClient()))
 
 	tests := []struct {
 		req  *getter.Request

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -234,6 +235,7 @@ func NewGitHubReleasesDownloadClient(
 // from GitHub releases using the standard GitHub releases URL format.
 func (c *GitHubReleasesDownloadClient) DownloadReleaseAssets(
 	ctx context.Context,
+	v *venv.Venv,
 	assets *ReleaseAssets,
 ) (*DownloadResult, error) {
 	if assets.Repository == "" {
@@ -315,7 +317,7 @@ func (c *GitHubReleasesDownloadClient) DownloadReleaseAssets(
 				}
 			}
 
-			if _, err := getter.GetFile(downloadCtx, localPath, url, opts...); err != nil {
+			if _, err := getter.GetFile(downloadCtx, v, localPath, url, opts...); err != nil {
 				return fmt.Errorf("failed to download %s: %w", url, err)
 			}
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -292,7 +293,7 @@ func TestDownloadReleaseAssetsValidation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := client.DownloadReleaseAssets(ctx, tc.assets)
+			_, err := client.DownloadReleaseAssets(ctx, venvtest.NewWithOSFS(), tc.assets)
 			require.Error(t, err)
 			assert.ErrorContains(t, err, tc.errorMsg)
 		})
@@ -342,7 +343,7 @@ func TestDownloadReleaseAssetsGitHubRelease(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	result, err := client.DownloadReleaseAssets(ctx, assets)
+	result, err := client.DownloadReleaseAssets(ctx, venvtest.NewWithOSFS(), assets)
 	require.NoError(t, err)
 
 	// Verify result
@@ -407,7 +408,7 @@ func TestDownloadReleaseAssetsGitHubReleaseUsesToken(t *testing.T) {
 			// Direct URLs don't use checksum files
 		}
 
-		_, err := client.DownloadReleaseAssets(ctx, assets)
+		_, err := client.DownloadReleaseAssets(ctx, venvtest.NewWithOSFS(), assets)
 		require.NoError(t, err)
 	})
 
@@ -430,7 +431,7 @@ func TestDownloadReleaseAssetsGitHubReleaseUsesToken(t *testing.T) {
 			PackageFile: filepath.Join(tempDir, "package.zip"),
 			// Direct URLs don't use checksum files
 		}
-		_, err := client.DownloadReleaseAssets(ctx, assets)
+		_, err := client.DownloadReleaseAssets(ctx, venvtest.NewWithOSFS(), assets)
 		require.NoError(t, err)
 	})
 }
@@ -455,7 +456,7 @@ func TestDownloadReleaseAssetsDirectURL(t *testing.T) {
 		// Note: No Version, ChecksumFile, or ChecksumSigFile for direct URLs
 	}
 
-	result, err := client.DownloadReleaseAssets(t.Context(), assets)
+	result, err := client.DownloadReleaseAssets(t.Context(), venvtest.NewWithOSFS(), assets)
 	require.NoError(t, err)
 
 	// Verify result

--- a/internal/panicreport/panicreport.go
+++ b/internal/panicreport/panicreport.go
@@ -119,11 +119,11 @@ type RecoveredError struct {
 	stack []byte
 }
 
-// New returns a Reporter that writes its crash report through fs and reads
+// New returns a Reporter that writes its crash report through fsys and reads
 // the remaining process details from the OS.
-func New(fs vfs.FS) *Reporter {
+func New(fsys vfs.FS) *Reporter {
 	return &Reporter{
-		FS:        fs,
+		FS:        fsys,
 		Now:       time.Now,
 		Getwd:     os.Getwd,
 		GetPID:    os.Getpid,

--- a/internal/remotestate/backend/gcs/client.go
+++ b/internal/remotestate/backend/gcs/client.go
@@ -38,9 +38,9 @@ func NewClient(
 	config *ExtendedRemoteStateConfigGCS,
 	opts *backend.Options,
 ) (*Client, error) {
-	gcsClient, err := gcphelper.NewGCPConfigBuilder(v).
+	gcsClient, err := gcphelper.NewGCPConfigBuilder().
 		WithSessionConfig(config.GetGCPSessionConfig()).
-		BuildGCSClient(ctx)
+		BuildGCSClient(ctx, v)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/remotestate/backend/s3/client.go
+++ b/internal/remotestate/backend/s3/client.go
@@ -89,11 +89,11 @@ func NewClient(
 ) (*Client, error) {
 	awsConfig := config.GetAwsSessionConfig()
 
-	builder := awshelper.NewAWSConfigBuilder(v).
+	builder := awshelper.NewAWSConfigBuilder().
 		WithSessionConfig(awsConfig).
 		WithIAMRoleOptions(opts.IAMRoleOptions)
 
-	cfg, err := builder.Build(ctx, l)
+	cfg, err := builder.Build(ctx, l, v)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func NewClient(
 		}
 	}
 
-	s3Client, err := builder.BuildS3Client(ctx, l)
+	s3Client, err := builder.BuildS3Client(ctx, l, v)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runner/run/creds/providers/amazonsts/provider.go
+++ b/internal/runner/run/creds/providers/amazonsts/provider.go
@@ -68,7 +68,7 @@ func (provider *Provider) GetCredentials(
 	}, func(ctx context.Context, l log.Logger) error {
 		var assumeErr error
 
-		resp, assumeErr = awshelper.AssumeIamRole(ctx, iamRoleOpts, "", v)
+		resp, assumeErr = awshelper.AssumeIamRole(ctx, v, iamRoleOpts, "")
 
 		return assumeErr
 	})

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -722,7 +722,7 @@ func BuildDownloadClient(
 			WithIncludeInCopy(cfg.Terraform.IncludeInCopy...).
 			WithExcludeFromCopy(cfg.Terraform.ExcludeFromCopy...).
 			WithFastCopy(controls.IsFastCopyEnabled(opts.StrictControls))),
-		getter.WithTFRegistry(getter.NewRegistryGetter(l, v.FS, v.HTTP).
+		getter.WithTFRegistry(getter.NewRegistryGetter(l, v).
 			WithEnv(v.Env).
 			WithTofuImplementation(opts.TofuImplementation)),
 	}
@@ -731,7 +731,7 @@ func BuildDownloadClient(
 		clientOpts = append(clientOpts, getter.WithOCI(getter.NewOCIGetter(l, v)))
 	}
 
-	return getter.NewClient(clientOpts...), nil
+	return getter.NewClient(v, clientOpts...), nil
 }
 
 // ValidateWorkingDir checks if working terraformSource.WorkingDir exists and is a directory

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -515,11 +515,11 @@ func (repo *Repo) performClone(
 
 		clientOpts = append(
 			clientOpts,
-			getter.WithCAS(casStore, v, &cloneOpts),
+			getter.WithCAS(casStore, &cloneOpts),
 		)
 	}
 
-	client := getter.NewClient(clientOpts...)
+	client := getter.NewClient(v, clientOpts...)
 
 	sourceURL, err := tf.ToSourceURL(opts.SourceURL, "")
 	if err != nil {

--- a/internal/tf/cache/services/provider_cache.go
+++ b/internal/tf/cache/services/provider_cache.go
@@ -569,7 +569,7 @@ func NewProviderService(
 	userCacheDir string,
 	credsSource *cliconfig.CredentialsSource,
 	l log.Logger,
-	fs vfs.FS,
+	fsys vfs.FS,
 	c vhttp.Client,
 	opts ...ProviderServiceOption,
 ) *ProviderService {
@@ -579,7 +579,7 @@ func NewProviderService(
 		providerCacheWarmUpCh: make(chan *ProviderCache, providerCacheWarmUpChBufferSize),
 		credsSource:           credsSource,
 		logger:                l,
-		fs:                    fs,
+		fs:                    fsys,
 		httpClient:            c,
 	}
 

--- a/internal/tf/cliconfig/config.go
+++ b/internal/tf/cliconfig/config.go
@@ -40,10 +40,10 @@ func WithFS(fs vfs.FS) ConfigOption {
 	}
 }
 
-// NewConfig creates a new Config that saves through fs.
-func NewConfig(fs vfs.FS) *Config {
+// NewConfig creates a new Config that saves through fsys.
+func NewConfig(fsys vfs.FS) *Config {
 	return &Config{
-		fs: fs,
+		fs: fsys,
 	}
 }
 

--- a/internal/tf/cliconfig/user_config.go
+++ b/internal/tf/cliconfig/user_config.go
@@ -10,13 +10,13 @@ import (
 
 // LoadUserConfig loads the user configuration is read as raw data and stored at the top of the saved configuration file.
 // The location of the default config is different for each OS https://developer.hashicorp.com/terraform/cli/config/config-file#locations
-func LoadUserConfig(fs vfs.FS, opts ...ConfigOption) (*Config, error) {
-	return loadUserConfig(cliconfig.LoadConfig, fs, opts...)
+func LoadUserConfig(fsys vfs.FS, opts ...ConfigOption) (*Config, error) {
+	return loadUserConfig(cliconfig.LoadConfig, fsys, opts...)
 }
 
 func loadUserConfig(
 	loadConfigFn func() (*cliconfig.Config, tfdiags.Diagnostics),
-	fs vfs.FS,
+	fsys vfs.FS,
 	opts ...ConfigOption,
 ) (*Config, error) {
 	cfg, diag := loadConfigFn()
@@ -24,7 +24,7 @@ func loadUserConfig(
 		return nil, diag.Err()
 	}
 
-	config := NewConfig(fs).
+	config := NewConfig(fsys).
 		WithPluginCacheDir(cfg.PluginCacheDir).
 		WithCredentials(getUserCredentials(cfg)).
 		WithCredentialsHelpers(getUserCredentialsHelpers(cfg)).

--- a/internal/view/tui/form/form.go
+++ b/internal/view/tui/form/form.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -1649,32 +1648,17 @@ var (
 	formErrorStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#FF5555"))
 
-	// Set bool values get a clear positive/negative color so the user
-	// can see at a glance which checkboxes they flipped. True is fixed;
-	// false ships three variants (selectable via [EnvScaffoldFalseStyle])
-	// while we workshop which reads best alongside the required-red tag
-	// and validation-error red. Once a winner is picked the env knob and
-	// the unused variants get deleted; see TODO in [falseStyle].
+	// Set bool values get a clear positive/negative color so the user can
+	// see at a glance which checkboxes they flipped.
 	formBoolTrueStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#50FA7B")).
 				Bold(true)
 
-	// neutral: same muted gray as `(default)` / `(unset)`. Removes any
-	// warning vibe; false reads as a plain value alongside true.
-	formBoolFalseNeutralStyle = lipgloss.NewStyle().
-					Foreground(lipgloss.Color("#A8ACB1")).
-					Bold(true)
-
-	// muted: keeps the red family but desaturates it deeply so it no
-	// longer competes with the required/error red.
-	formBoolFalseMutedStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#7A2A2A")).
-				Bold(true)
-
-	// cool: pairs green true with a cool cyan false, reserving red for
-	// required/error semantics only.
-	formBoolFalseCoolStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#63C5DA")).
+	// The same muted gray as `(default)` / `(unset)`: false reads as a
+	// plain value rather than a warning competing with the required tag
+	// and validation errors, which own the reds.
+	formBoolFalseStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#A8ACB1")).
 				Bold(true)
 
 	formDefaultHintStyle = lipgloss.NewStyle().
@@ -1787,41 +1771,13 @@ func typeStyle(typeStr string) lipgloss.Style {
 	return formTypeStyle
 }
 
-// renderCheckbox produces the visual for a Set bool-mode field. True is
-// rendered in fixed green; false picks one of three workshop variants
-// (see [falseStyle]) so reviewers can compare them side by side without
-// a rebuild.
+// renderCheckbox produces the visual for a Set bool-mode field.
 func renderCheckbox(checked bool) string {
 	if checked {
 		return formBoolTrueStyle.Render("[x] true")
 	}
 
-	return falseStyle().Render("[ ] false")
-}
-
-// EnvScaffoldFalseStyle is a temporary, undocumented environment variable
-// used during development to A/B the three checkbox `false` color variants.
-// Do NOT rely on it: it can be removed or have its name changed at any time
-// without notice and is not part of Terragrunt's user-facing configuration
-// surface. Once a winner is picked, drop this constant, the helper that
-// reads it, and the two unused style variants.
-const EnvScaffoldFalseStyle = "TG_TMP_CATALOG_SCAFFOLD_FALSE_STYLE"
-
-// falseStyle resolves which of the three workshop variants renders the
-// `false` value. The selection is read from [EnvScaffoldFalseStyle] on
-// every call so the user can flip variants between launches without
-// recompiling. Default is "neutral" because it's the only variant that
-// fully eliminates the false-as-warning read flagged in review. Once a
-// winner is agreed on, drop this helper and inline the chosen style.
-func falseStyle() lipgloss.Style {
-	switch os.Getenv(EnvScaffoldFalseStyle) {
-	case "muted":
-		return formBoolFalseMutedStyle
-	case "cool":
-		return formBoolFalseCoolStyle
-	}
-
-	return formBoolFalseNeutralStyle
+	return formBoolFalseStyle.Render("[ ] false")
 }
 
 // View renders the form. When the rendered body exceeds the available

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -997,9 +997,9 @@ func getAWSField(
 	l log.Logger,
 	fetchFn func(context.Context, *aws.Config) (string, error),
 ) (string, error) {
-	awsConfig, err := awshelper.NewAWSConfigBuilder(pctx.Venv).
+	awsConfig, err := awshelper.NewAWSConfigBuilder().
 		WithIAMRoleOptions(pctx.IAMRoleOptions).
-		Build(ctx, l)
+		Build(ctx, l, pctx.Venv)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1766,10 +1766,10 @@ func getTerragruntOutputJSONFromRemoteStateS3(
 
 			sessionConfig := s3ConfigExtended.GetAwsSessionConfig()
 
-			s3Client, err := awshelper.NewAWSConfigBuilder(pctx.Venv).
+			s3Client, err := awshelper.NewAWSConfigBuilder().
 				WithSessionConfig(sessionConfig).
 				WithIAMRoleOptions(pctx.IAMRoleOptions).
-				BuildS3Client(ctx, l)
+				BuildS3Client(ctx, l, pctx.Venv)
 			if err != nil {
 				return fmt.Errorf("building s3 client for s3://%s/%s: %w", bucket, key, err)
 			}

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -963,7 +963,7 @@ func copyFiles(
 			return fmt.Errorf("failed to create directory %s for %s %w", cp.dest, cp.identifier, err)
 		}
 
-		if _, err := getter.GetAny(ctx, cp.dest, cp.src, stackGetterOptions(l, v, opts)...); err != nil {
+		if _, err := getter.GetAny(ctx, v, cp.dest, cp.src, stackGetterOptions(l, v, opts)...); err != nil {
 			return fmt.Errorf("failed to fetch %s %s for %s %w", cp.src, cp.dest, cp.identifier, err)
 		}
 

--- a/test/cloud_getter_helpers_test.go
+++ b/test/cloud_getter_helpers_test.go
@@ -1,0 +1,61 @@
+//go:build aws || gcp
+
+package test_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+)
+
+// cloudGetterLayout is the bucket contents the S3 and GCS mode cases read.
+// `modules/vpc` is an object and a prefix at once, and `modules/vpc-old` is a
+// sibling whose name starts with it, which is the pair that separates file
+// mode from directory mode.
+var cloudGetterLayout = map[string]string{
+	"modules/vpc":               "vpc-object",
+	"modules/vpc/":              "",
+	"modules/vpc/main.tf":       "main",
+	"modules/vpc/sub/nested.tf": "nested",
+	"modules/vpc-old/main.tf":   "old",
+	"modules/app/main.tf":       "app-main",
+	"modules/app-old/main.tf":   "app-old",
+}
+
+// assertCloudDownloadTree compares everything under dst against want, which is
+// keyed by slash-separated path relative to dst. Comparing the whole tree
+// catches a sibling object or a directory placeholder that landed alongside
+// the requested ones.
+func assertCloudDownloadTree(t *testing.T, v *venv.Venv, dst string, want map[string]string) {
+	t.Helper()
+
+	got := map[string]string{}
+
+	require.NoError(t, vfs.WalkDir(v.FS, dst, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+
+		content, err := vfs.ReadFile(v.FS, path)
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(dst, path)
+		if err != nil {
+			return err
+		}
+
+		got[filepath.ToSlash(rel)] = string(content)
+
+		return nil
+	}))
+
+	assert.Equal(t, want, got)
+}

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -258,10 +258,10 @@ func CreateS3ClientForTest(
 
 	awsConfig := &awshelper.AwsSessionConfig{Region: awsRegion}
 
-	cfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).
+	cfg, err := awshelper.NewAWSConfigBuilder().
 		WithSessionConfig(awsConfig).
 		WithIAMRoleOptions(mockOptions.IAMRoleOptions).
-		Build(t.Context(), logger.CreateLogger())
+		Build(t.Context(), logger.CreateLogger(), venv.OSVenv())
 	require.NoError(t, err, "Error creating S3 client")
 
 	return s3.NewFromConfig(cfg)
@@ -283,10 +283,10 @@ func CreateDynamoDBClientForTest(
 		RoleArn: iamRoleArn,
 	}
 
-	cfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).
+	cfg, err := awshelper.NewAWSConfigBuilder().
 		WithSessionConfig(sessionConfig).
 		WithIAMRoleOptions(mockOptions.IAMRoleOptions).
-		Build(t.Context(), logger.CreateLogger())
+		Build(t.Context(), logger.CreateLogger(), venv.OSVenv())
 	require.NoError(t, err, "Error creating DynamoDB client")
 
 	return dynamodb.NewFromConfig(cfg)

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -1746,7 +1746,7 @@ func TestAwsGetAccountAliasFunctions(t *testing.T) {
 	)
 
 	// Get values from STS
-	awsCfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).Build(t.Context(), createLogger())
+	awsCfg, err := awshelper.NewAWSConfigBuilder().Build(t.Context(), createLogger(), venv.OSVenv())
 	if err != nil {
 		t.Fatalf("Error while creating AWS config: %v", err)
 	}
@@ -1792,7 +1792,7 @@ func TestAwsGetCallerIdentityFunctions(t *testing.T) {
 	)
 
 	// Get values from STS
-	awsCfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).Build(t.Context(), createLogger())
+	awsCfg, err := awshelper.NewAWSConfigBuilder().Build(t.Context(), createLogger(), venv.OSVenv())
 	if err != nil {
 		t.Fatalf("Error while creating AWS config: %v", err)
 	}
@@ -2864,9 +2864,9 @@ func TestAwsAssumeRole(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	cfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).
+	cfg, err := awshelper.NewAWSConfigBuilder().
 		WithIAMRoleOptions(opts.IAMRoleOptions).
-		Build(t.Context(), l)
+		Build(t.Context(), l, venv.OSVenv())
 	require.NoError(t, err)
 
 	identityARN, err := awshelper.GetAWSIdentityArn(t.Context(), &cfg)
@@ -2921,9 +2921,9 @@ func TestAwsAssumeRoleWithExternalIDWithComma(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	cfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).
+	cfg, err := awshelper.NewAWSConfigBuilder().
 		WithIAMRoleOptions(opts.IAMRoleOptions).
-		Build(t.Context(), l)
+		Build(t.Context(), l, venv.OSVenv())
 	require.NoError(t, err)
 
 	identityARN, err := awshelper.GetAWSIdentityArn(t.Context(), &cfg)
@@ -3087,7 +3087,7 @@ func TestAwsReadTerragruntConfigIamRole(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	cfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).Build(t.Context(), l)
+	cfg, err := awshelper.NewAWSConfigBuilder().Build(t.Context(), l, venv.OSVenv())
 	require.NoError(t, err)
 
 	identityArn, err := awshelper.GetAWSIdentityArn(t.Context(), &cfg)

--- a/test/integration_cas_rustfs_test.go
+++ b/test/integration_cas_rustfs_test.go
@@ -24,9 +24,9 @@ import (
 	tgcas "github.com/gruntwork-io/terragrunt/internal/cas"
 	tggetter "github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
-	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // TestCAS_S3_RustFS_ProbeAvoidsRedownload verifies the S3 → CAS path
@@ -54,7 +54,7 @@ func TestCAS_S3_RustFS_ProbeAvoidsRedownload(t *testing.T) { //nolint: parallelt
 
 	v := venv.OSVenv()
 
-	resolvers := tggetter.DefaultSourceResolvers(v.HTTP, v.Exec)
+	resolvers := tggetter.DefaultSourceResolvers(v, v.HTTP)
 	resolvers[tggetter.SchemeS3] = newRustFSS3Resolver(t, endpoint)
 
 	g := tggetter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},
@@ -151,8 +151,8 @@ func newRustFSS3Resolver(t *testing.T, endpoint string) *tggetter.S3Resolver {
 	t.Helper()
 
 	// NewClient below short-circuits the default chain, so the resolver never
-	// reaches for this client.
-	r := tggetter.NewS3Resolver(vhttp.NewNoNetworkClient())
+	// reaches for this venv.
+	r := tggetter.NewS3Resolver(venvtest.New())
 	r.NewClient = func(ctx context.Context, _ string) (tggetter.S3API, error) {
 		return newRustFSClientFor(ctx, endpoint)
 	}

--- a/test/integration_cas_rustfs_test.go
+++ b/test/integration_cas_rustfs_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -57,7 +58,7 @@ func TestCAS_S3_RustFS_ProbeAvoidsRedownload(t *testing.T) { //nolint: parallelt
 	resolvers[tggetter.SchemeS3] = newRustFSS3Resolver(t, endpoint)
 
 	g := tggetter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},
-		tggetter.WithGenericFetchers(tggetter.DefaultGenericFetchers()),
+		tggetter.WithGenericFetchers(tggetter.DefaultGenericFetchers(v)),
 		tggetter.WithGenericResolvers(resolvers),
 	)
 
@@ -203,4 +204,55 @@ func rustfsSourceURL(t *testing.T, endpoint, bucket, key string) string {
 	}
 
 	return "s3::" + out.String()
+}
+
+// TestS3PrefixDownloadReproducesLayout drives the s3 getter's directory path
+// against RustFS: a source naming a key prefix rather than a single object
+// must list every key below it and land each one at its position relative to
+// that prefix, nesting included.
+//
+// The single-object test above resolves to ModeFile and never reaches
+// S3Getter.Get, so this is what covers the paginated listing and the
+// key-to-path mapping.
+func TestS3PrefixDownloadReproducesLayout(t *testing.T) { //nolint: paralleltest
+	endpoint := setupRustFSForCAS(t)
+
+	bucket := "prefix-test-" + strings.ToLower(helpers.UniqueID())
+	prefix := "modules/vpc"
+
+	s3Client := newRustFSClient(t, endpoint)
+	createRustFSBucket(t, s3Client, bucket)
+
+	// A nested key must keep its subdirectory below the destination.
+	want := map[string]string{
+		"main.tf":       "# root",
+		"variables.tf":  "# vars",
+		"sub/nested.tf": "# nested",
+	}
+
+	for name, body := range want {
+		uploadRustFSObject(t, s3Client, bucket, prefix+"/"+name, []byte(body))
+	}
+
+	// Shares the prefix's leading characters but not its path segment, so it
+	// must stay out of the download.
+	uploadRustFSObject(t, s3Client, bucket, prefix+"-sibling.tf", []byte("# excluded"))
+
+	v := venv.OSVenv()
+	dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "module")
+
+	_, err := tggetter.NewClient(v).Get(t.Context(), &tggetter.Request{
+		Src:     rustfsSourceURL(t, endpoint, bucket, prefix),
+		Dst:     dst,
+		GetMode: tggetter.ModeAny,
+	})
+	require.NoError(t, err)
+
+	for name, body := range want {
+		got, readErr := os.ReadFile(filepath.Join(dst, filepath.FromSlash(name)))
+		require.NoError(t, readErr, "expected %s below the prefix", name)
+		require.Equal(t, body, string(got))
+	}
+
+	require.NoFileExists(t, filepath.Join(dst, "-sibling.tf"))
 }

--- a/test/integration_cas_rustfs_test.go
+++ b/test/integration_cas_rustfs_test.go
@@ -54,7 +54,7 @@ func TestCAS_S3_RustFS_ProbeAvoidsRedownload(t *testing.T) { //nolint: parallelt
 
 	v := venv.OSVenv()
 
-	resolvers := tggetter.DefaultSourceResolvers(v, v.HTTP)
+	resolvers := tggetter.DefaultSourceResolvers(v)
 	resolvers[tggetter.SchemeS3] = newRustFSS3Resolver(t, endpoint)
 
 	g := tggetter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},

--- a/test/integration_cas_rustfs_test.go
+++ b/test/integration_cas_rustfs_test.go
@@ -33,7 +33,7 @@ import (
 // against an in-Docker RustFS instance: a second CASGetter request for
 // the same object skips the download when HeadObject reports the same
 // version metadata.
-func TestCAS_S3_RustFS_ProbeAvoidsRedownload(t *testing.T) { //nolint: paralleltest
+func TestCAS_S3_RustFS_ProbeAvoidsRedownload(t *testing.T) { //nolint: paralleltest // setupRustFSForCAS calls t.Setenv, which bars t.Parallel.
 	endpoint := setupRustFSForCAS(t)
 
 	bucket := "cas-test-" + strings.ToLower(helpers.UniqueID())
@@ -214,7 +214,7 @@ func rustfsSourceURL(t *testing.T, endpoint, bucket, key string) string {
 // The single-object test above resolves to ModeFile and never reaches
 // S3Getter.Get, so this is what covers the paginated listing and the
 // key-to-path mapping.
-func TestS3PrefixDownloadReproducesLayout(t *testing.T) { //nolint: paralleltest
+func TestS3PrefixDownloadReproducesLayout(t *testing.T) { //nolint: paralleltest // setupRustFSForCAS calls t.Setenv, which bars t.Parallel.
 	endpoint := setupRustFSForCAS(t)
 
 	bucket := "prefix-test-" + strings.ToLower(helpers.UniqueID())

--- a/test/integration_engine_test.go
+++ b/test/integration_engine_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 
 	"github.com/gruntwork-io/terragrunt/pkg/config"
@@ -512,7 +513,7 @@ func setupLocalEngine(t *testing.T) string {
 		require.NoError(t, err)
 	}
 
-	_, err := getter.GetAny(t.Context(), engineDir, downloadURL)
+	_, err := getter.GetAny(t.Context(), venv.OSVenv(), engineDir, downloadURL)
 	require.NoError(t, err)
 
 	helpers.CopyAndFillMapPlaceholders(

--- a/test/integration_example_live_stacks_test.go
+++ b/test/integration_example_live_stacks_test.go
@@ -22,7 +22,7 @@ import (
 func TestAwsExampleLiveStacks(t *testing.T) {
 	uniqueID := strings.ToLower(helpers.UniqueID())
 
-	awsCfg, err := awshelper.NewAWSConfigBuilder(venv.OSVenv()).Build(t.Context(), createLogger())
+	awsCfg, err := awshelper.NewAWSConfigBuilder().Build(t.Context(), createLogger(), venv.OSVenv())
 	require.NoError(t, err, "Error creating AWS config")
 
 	stsClient := sts.NewFromConfig(awsCfg)

--- a/test/integration_gcs_getter_test.go
+++ b/test/integration_gcs_getter_test.go
@@ -1,0 +1,140 @@
+//go:build gcp
+
+package test_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/stretchr/testify/require"
+
+	tggetter "github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+)
+
+// TestGcpGCSGetterModes downloads from a real GCS bucket in each shape a
+// `source` can name: an object, a prefix, and a prefix written with a
+// trailing separator. Real GCS supplies the listing order and the directory
+// placeholder that the mode scan reads, which no stub can vouch for.
+func TestGcpGCSGetterModes(t *testing.T) {
+	t.Parallel()
+
+	bucket := provisionGCSGetterLayout(t, cloudGetterLayout)
+
+	tests := []struct {
+		want   map[string]string
+		name   string
+		object string
+	}{
+		{
+			name:   "name matching an object downloads that object",
+			object: "modules/vpc",
+			want:   map[string]string{"vpc": "vpc-object"},
+		},
+		{
+			name:   "prefix without a trailing separator downloads the tree",
+			object: "modules/app",
+			want:   map[string]string{"main.tf": "app-main"},
+		},
+		{
+			name:   "prefix with a trailing separator downloads the tree",
+			object: "modules/vpc/",
+			want:   map[string]string{"main.tf": "main", "sub/nested.tf": "nested"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := venv.OSVenv()
+			client := &tggetter.Client{Getters: []tggetter.Getter{tggetter.NewGCSGetter(v)}}
+			dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "module")
+
+			_, err := client.Get(t.Context(), &tggetter.Request{
+				Src:     "gcs::https://www.googleapis.com/storage/v1/" + bucket + "/" + tc.object,
+				Dst:     dst,
+				GetMode: tggetter.ModeAny,
+			})
+			require.NoError(t, err)
+
+			assertCloudDownloadTree(t, v, dst, tc.want)
+		})
+	}
+}
+
+// TestGcpGCSGetterRejectsEscapingKey pins that an object name climbing out of
+// the destination is refused against a real bucket, where the name travels
+// through the GCS listing rather than a fixture.
+func TestGcpGCSGetterRejectsEscapingKey(t *testing.T) {
+	t.Parallel()
+
+	bucket := provisionGCSGetterLayout(t, map[string]string{"modules/esc/keep.tf": "keep"})
+
+	escaping := "modules/esc/../../../escape.tf"
+	if err := putGCSObject(t, bucket, escaping, "escape"); err != nil {
+		t.Skipf("GCS refused the name %q, so it cannot reach a download: %v", escaping, err)
+	}
+
+	v := venv.OSVenv()
+	client := &tggetter.Client{Getters: []tggetter.Getter{tggetter.NewGCSGetter(v)}}
+
+	_, err := client.Get(t.Context(), &tggetter.Request{
+		Src:     "gcs::https://www.googleapis.com/storage/v1/" + bucket + "/modules/esc/",
+		Dst:     filepath.Join(helpers.TmpDirWOSymlinks(t), "module"),
+		GetMode: tggetter.ModeAny,
+	})
+	require.ErrorIs(t, err, tggetter.ErrObjectEscapesDst)
+}
+
+// putGCSObject writes body to bucket/object and returns the failure rather
+// than ending the test, so a caller can tell a name GCS refuses outright from
+// a download that mishandled one.
+func putGCSObject(t *testing.T, bucket, object, body string) error {
+	t.Helper()
+
+	c, err := storage.NewClient(t.Context())
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err := c.Close(); err != nil {
+			t.Logf("close GCS client: %v", err)
+		}
+	}()
+
+	w := c.Bucket(bucket).Object(object).NewWriter(t.Context())
+
+	if _, err := w.Write([]byte(body)); err != nil {
+		return err
+	}
+
+	return w.Close()
+}
+
+// provisionGCSGetterLayout creates a throwaway bucket holding every object in
+// layout, registers cleanup, and returns the bucket name.
+func provisionGCSGetterLayout(t *testing.T, layout map[string]string) string {
+	t.Helper()
+
+	project := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	if project == "" {
+		t.Skip("GOOGLE_CLOUD_PROJECT not set; skipping real-GCP test")
+	}
+
+	bucket := "terragrunt-getter-test-" + strings.ToLower(helpers.UniqueID())
+
+	createGCSBucket(t, project, terraformRemoteStateGcpRegion, bucket)
+	t.Cleanup(func() { deleteGCSBucket(t, bucket) })
+
+	for object, body := range layout {
+		uploadGCSObjectForCAS(t, bucket, object, []byte(body))
+	}
+
+	return bucket
+}

--- a/test/integration_s3_getter_test.go
+++ b/test/integration_s3_getter_test.go
@@ -1,0 +1,138 @@
+//go:build aws
+
+package test_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/require"
+
+	tggetter "github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+)
+
+// TestAwsS3GetterModes downloads from a real S3 bucket in each shape a
+// `source` can name: an object, a prefix, and a prefix written with a
+// trailing separator. Real S3 supplies the listing order and the directory
+// placeholder that the mode scan reads, which no stub can vouch for.
+func TestAwsS3GetterModes(t *testing.T) {
+	t.Parallel()
+
+	region := helpers.TerraformRemoteStateS3Region
+	bucket := provisionS3GetterLayout(t, region, cloudGetterLayout)
+
+	tests := []struct {
+		want map[string]string
+		name string
+		key  string
+	}{
+		{
+			name: "key naming an object downloads that object",
+			key:  "modules/vpc",
+			want: map[string]string{"vpc": "vpc-object"},
+		},
+		{
+			name: "prefix without a trailing separator downloads the tree",
+			key:  "modules/app",
+			want: map[string]string{"main.tf": "app-main"},
+		},
+		{
+			name: "prefix with a trailing separator downloads the tree",
+			key:  "modules/vpc/",
+			want: map[string]string{"main.tf": "main", "sub/nested.tf": "nested"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := venv.OSVenv()
+			client := &tggetter.Client{Getters: []tggetter.Getter{tggetter.NewS3Getter(v)}}
+			dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "module")
+
+			_, err := client.Get(t.Context(), &tggetter.Request{
+				Src:     "s3::https://s3-" + region + ".amazonaws.com/" + bucket + "/" + tc.key,
+				Dst:     dst,
+				GetMode: tggetter.ModeAny,
+			})
+			require.NoError(t, err)
+
+			assertCloudDownloadTree(t, v, dst, tc.want)
+		})
+	}
+}
+
+// TestAwsS3GetterRejectsEscapingKey pins that a key climbing out of the
+// destination is refused against a real bucket, where the key travels through
+// S3's own listing rather than a fixture.
+func TestAwsS3GetterRejectsEscapingKey(t *testing.T) {
+	t.Parallel()
+
+	region := helpers.TerraformRemoteStateS3Region
+	bucket := provisionS3GetterLayout(t, region, map[string]string{"modules/esc/keep.tf": "keep"})
+
+	escaping := "modules/esc/../../../escape.tf"
+
+	client := helpers.CreateS3ClientForTest(t, region)
+
+	_, err := client.PutObject(t.Context(), &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(escaping),
+		Body:   strings.NewReader("escape"),
+	})
+	if err != nil {
+		t.Skipf("S3 refused the key %q, so it cannot reach a download: %v", escaping, err)
+	}
+
+	v := venv.OSVenv()
+	getterClient := &tggetter.Client{Getters: []tggetter.Getter{tggetter.NewS3Getter(v)}}
+
+	_, err = getterClient.Get(t.Context(), &tggetter.Request{
+		Src:     "s3::https://s3-" + region + ".amazonaws.com/" + bucket + "/modules/esc/",
+		Dst:     filepath.Join(helpers.TmpDirWOSymlinks(t), "module"),
+		GetMode: tggetter.ModeAny,
+	})
+	require.ErrorIs(t, err, tggetter.ErrObjectEscapesDst)
+}
+
+// provisionS3GetterLayout creates a throwaway bucket in region holding every
+// key in layout, registers cleanup, and returns the bucket name.
+func provisionS3GetterLayout(t *testing.T, region string, layout map[string]string) string {
+	t.Helper()
+
+	bucket := "terragrunt-getter-test-" + strings.ToLower(helpers.UniqueID())
+
+	client := helpers.CreateS3ClientForTest(t, region)
+
+	_, err := client.CreateBucket(t.Context(), &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+		CreateBucketConfiguration: &types.CreateBucketConfiguration{
+			LocationConstraint: types.BucketLocationConstraint(region),
+		},
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if err := helpers.DeleteS3Bucket(t, region, bucket); err != nil {
+			t.Logf("delete bucket %s: %v", bucket, err)
+		}
+	})
+
+	for key, body := range layout {
+		_, err := client.PutObject(t.Context(), &s3.PutObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+			Body:   strings.NewReader(body),
+		})
+		require.NoError(t, err, "putting %s", key)
+	}
+
+	return bucket
+}

--- a/test/integration_s3_source_test.go
+++ b/test/integration_s3_source_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
 	tggetter "github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/require"
 )
@@ -52,7 +53,7 @@ func TestAwsS3SourceURLForms(t *testing.T) {
 
 			dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "module")
 
-			_, err := tggetter.GetAny(t.Context(), dst, tt.src)
+			_, err := tggetter.GetAny(t.Context(), venv.OSVenv(), dst, tt.src)
 			require.NoError(t, err)
 			require.FileExists(t, filepath.Join(dst, "main.tf"))
 		})


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Creates internal S3 and GCS getters to allow for venv injection of HTTP clients.

Probably some of the most impactful changes made as part of this whole venv update.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Cloud Storage downloads for individual files and directory prefixes.
  * Enhanced S3 downloads with prefix handling, URL validation, version selection, custom endpoints, and credential options.
  * Preserved directory structure while excluding unrelated objects.
  * Added configurable limits for identifying file and directory sources.
* **Bug Fixes**
  * Improved invalid URL handling, destination cleanup, nested directories, and download error reporting.
  * Cloud downloads now consistently honor active environment settings, credentials, and region configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->