### PR TITLE
perf: Refactor default `--tf-path` resolution

### DIFF
--- a/docs/src/data/changelog/v1.1.3/default-tf-path-lookup.mdx
+++ b/docs/src/data/changelog/v1.1.3/default-tf-path-lookup.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.3"
+category: "performance-improvements"
+---
+
+#### Faster startup when `--tf-path` is not set
+
+When you don't set [`--tf-path`](/reference/cli/commands/run#tf-path), Terragrunt picks the binary it wraps by looking for `tofu` on your `PATH` and falling back to `terraform` when it isn't there. Terragrunt used to make that choice by running `tofu -version`, which meant launching a process at the start of every command, including commands like `find` and `list` that never run the binary. That process launch is gone, and a `terragrunt --version` benchmark runs roughly 1.7x faster as a result.
+
+This changes what happens when `tofu` is on your `PATH` but can't run: Terragrunt now selects it and reports the failure rather than silently falling back to `terraform`. Set `--tf-path` or `TG_TF_PATH` to pick the binary yourself.

--- a/docs/src/data/changelog/v1.1.4/default-tf-path-lookup.mdx
+++ b/docs/src/data/changelog/v1.1.4/default-tf-path-lookup.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.1.3"
+version: "v1.1.4"
 category: "performance-improvements"
 ---
 

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -670,9 +670,9 @@ func createConfig(
 	// other than the version probe is a regression: fail loudly rather
 	// than silently absorb it.
 	versionExec := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
-		// DefaultWrappedPath resolves to either tofu or terraform depending
-		// on what's on the host PATH; accept both so the assertion stays
-		// host-independent.
+		// IdentifyDefaultWrappedExecutable resolves to either tofu or terraform
+		// depending on what's on the host PATH; accept both so the assertion
+		// stays host-independent.
 		if (inv.Name != "tofu" && inv.Name != "terraform") ||
 			!slices.Contains(inv.Args, "-version") {
 			assert.Fail(t, "unexpected invocation during PopulateTFVersion",

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -63,8 +63,6 @@ const (
 )
 
 var (
-	DefaultWrappedPath = identifyDefaultWrappedExecutable(context.Background())
-
 	defaultVersionManagerFileName = []string{
 		".terraform-version",
 		".tool-versions",
@@ -333,7 +331,7 @@ func WithIAMWebIdentityToken(token string) TerragruntOptionsFunc {
 // reasonable defaults for real usage.
 func NewTerragruntOptions() *TerragruntOptions {
 	return &TerragruntOptions{
-		TFPath:                   DefaultWrappedPath,
+		TFPath:                   IdentifyDefaultWrappedExecutable(vexec.NewOSExec()),
 		ExcludesFile:             defaultExcludesFile,
 		FiltersFile:              defaultFiltersFile,
 		AutoInit:                 true,
@@ -572,12 +570,17 @@ func (opts *TerragruntOptions) DataDir(env map[string]string) string {
 	return filepath.Join(opts.WorkingDir, tfDataDir)
 }
 
-// identifyDefaultWrappedExecutable returns default path used for wrapped executable.
-func identifyDefaultWrappedExecutable(ctx context.Context) string {
-	if util.IsCommandExecutable(vexec.NewOSExec(), ctx, TofuDefaultPath, "-version") {
+// IdentifyDefaultWrappedExecutable returns the IaC binary Terragrunt wraps by
+// default, preferring OpenTofu and falling back to Terraform.
+//
+// Every command resolves this during startup, so the choice comes from a PATH
+// lookup alone. Spawning the candidate to confirm it runs costs more than the
+// rest of startup combined, and commands that never wrap it would pay too.
+func IdentifyDefaultWrappedExecutable(e vexec.Exec) string {
+	if _, err := e.LookPath(TofuDefaultPath); err == nil {
 		return TofuDefaultPath
 	}
-	// fallback to Terraform if tofu is not available
+
 	return TerraformDefaultPath
 }
 

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/assert"
 )
@@ -83,4 +84,25 @@ func TestNewTerragruntOptions_DefaultCASCloneDepth(t *testing.T) {
 
 	opts := options.NewTerragruntOptions()
 	assert.Equal(t, cas.DefaultCASCloneDepth, opts.CASCloneDepth)
+}
+
+// TestIdentifyDefaultWrappedExecutableDoesNotSpawn guards the PATH-lookup-only
+// contract: NewNoSpawnExec resolves LookPath but errors on any process launch,
+// so a probe that spawns falls through to Terraform here.
+func TestIdentifyDefaultWrappedExecutableDoesNotSpawn(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(
+		t,
+		options.TofuDefaultPath,
+		options.IdentifyDefaultWrappedExecutable(vexec.NewNoSpawnExec()),
+	)
+}
+
+func TestIdentifyDefaultWrappedExecutableFallsBackToTerraform(t *testing.T) {
+	t.Parallel()
+
+	e := &vexec.NoLookPathExec{Exec: vexec.NewNoSpawnExec()}
+
+	assert.Equal(t, options.TerraformDefaultPath, options.IdentifyDefaultWrappedExecutable(e))
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Moving `identifyDefaultWrappedExecutable` out of package initialization so that it's evaluated during `TerragruntOptions` construction instead, and replacing the `-version` call with a path lookup instead.

Removes the `tofu` invocation when it isn't necessary for commands like `find` and `list` and makes it so that we use the cheaper PATH lookup instead of calling `-version` on tofu.

Comparing `terragrunt --version` on main vs this PR:

```
Benchmark 1: main
  Time (mean ± σ):      55.2 ms ±   2.2 ms    [User: 49.4 ms, System: 21.2 ms]
  Range (min … max):    51.7 ms …  63.8 ms    52 runs

Benchmark 2: this PR
  Time (mean ± σ):      32.3 ms ±   1.4 ms    [User: 32.6 ms, System: 9.6 ms]
  Range (min … max):    30.3 ms …  39.9 ms    75 runs

Summary
  this PR ran
    1.71 ± 0.10 times faster than main
```

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster startup when no Terraform path is specified by checking for OpenTofu without launching it.
  * Automatically falls back to Terraform when OpenTofu is unavailable.
* **Bug Fixes**
  * Clearer errors are reported when a detected OpenTofu executable cannot run.
* **Documentation**
  * Added changelog guidance for automatic executable selection and overrides using `--tf-path` or `TG_TF_PATH`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->