### PR TITLE
chore: Resolve env var defined flags from venv

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -203,14 +203,6 @@ linters:
       - linters:
           - forbidigo
         path: ^(internal/cli/commands/browse/tui/model\.go|internal/cli/commands/catalog/cli\.go|internal/view/tui/form/form\.go|internal/cli/commands/catalog/tui/tags_layout\.go|internal/cli/commands/commands\.go|internal/cli/commands/hcl/validate/validate\.go|internal/cli/commands/help/cli\.go|internal/cli/commands/render/render\.go|internal/cli/commands/scaffold/cli\.go|internal/cli/commands/scaffold/scaffold\.go)$
-      # Env-var-backed flags resolve against the process environment rather
-      # than the venv's Env map, so every flag parsed from an env var bypasses
-      # the seam.
-      #
-      # TODO: Update LookupEnvFunc to close this.
-      - linters:
-          - forbidigo
-        path: ^(internal/clihelper/app\.go|internal/clihelper/flag\.go|internal/clihelper/map_flag\.go|internal/clihelper/slice_flag\.go)$
       - linters:
           - forbidigo
         path: ^(internal/tf/cache/handlers/filesystem_mirror_provider\.go|internal/tf/cache/helpers/http\.go|internal/tf/cliconfig/credentials\.go|internal/tf/getproviders/constraints\.go|internal/tf/getproviders/hash\.go|internal/tf/getproviders/lock\.go|internal/tf/getproviders/package_authentication\.go|internal/tf/source\.go|internal/tf/tf\.go)$

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -47,11 +47,12 @@ type App struct {
 // NewApp creates the Terragrunt CLI App. The supplied [venv.Venv] is the
 // root virtualized environment; it is threaded through to the command
 // constructors and captured by their Action closures rather than held on
-// the App, so virtualized handlers stay function parameters.
+// the App, so virtualized handlers stay function parameters. Its environment
+// map is what env-var-backed flags resolve against.
 func NewApp(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *App {
 	terragruntCommands := commands.New(l, opts, v)
 
-	app := clihelper.NewApp()
+	app := clihelper.NewApp(v.Env)
 	app.Name = AppName
 	app.Usage = "Terragrunt is a flexible orchestration tool that allows Infrastructure as Code written in OpenTofu/Terraform to scale.\nFor documentation, see https://docs.terragrunt.com/."
 	app.Author = "Gruntwork <www.gruntwork.io>"

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
-	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1035,15 +1034,17 @@ func runAppTest(
 ) (*options.TerragruntOptions, error) {
 	emptyAction := func(ctx context.Context, cliCtx *clihelper.Context) error { return nil }
 
-	terragruntCommands := commands.New(l, opts, venv.OSVenv())
+	testV := venv.OSVenv()
+
+	terragruntCommands := commands.New(l, opts, testV)
 	setCommandAction(emptyAction, terragruntCommands...)
 
-	app := clihelper.NewApp()
+	app := clihelper.NewApp(testV.Env)
 	app.Writer = &bytes.Buffer{}
 	app.ErrWriter = &bytes.Buffer{}
 
-	app.Flags = append(global.NewFlags(l, opts, nil), run.NewFlags(l, opts, venvtest.New(), nil)...)
-	app.Commands = terragruntCommands.WrapAction(commands.WrapWithTelemetry(l, opts, venv.OSVenv()))
+	app.Flags = append(global.NewFlags(l, opts, nil), run.NewFlags(l, opts, testV, nil)...)
+	app.Commands = terragruntCommands.WrapAction(commands.WrapWithTelemetry(l, opts, testV))
 	app.OsExiter = cli.OSExiter
 	app.Action = func(ctx context.Context, cliCtx *clihelper.Context) error {
 		for _, arg := range cliCtx.Args() {

--- a/internal/cli/commands/catalog/cli_test.go
+++ b/internal/cli/commands/catalog/cli_test.go
@@ -81,7 +81,10 @@ func TestNewCommandBeforeGatesNonInteractiveFormats(t *testing.T) {
 			}
 
 			cmd := catalog.NewCommand(logger.CreateLogger(), opts, venvtest.New())
-			require.NoError(t, cmd.Flags.Parse(clihelper.Args{"--" + catalog.FormatFlagName, tc.format}))
+			require.NoError(
+				t,
+				cmd.Flags.Parse(clihelper.Args{"--" + catalog.FormatFlagName, tc.format}, map[string]string{}),
+			)
 
 			err := cmd.Before(t.Context(), &clihelper.Context{})
 
@@ -119,6 +122,7 @@ func TestNewCommandActionLoadsThePositionalSource(t *testing.T) {
 
 	require.NoError(t, cmd.Flags.Parse(
 		clihelper.Args{"--" + catalog.FormatFlagName, catalog.FormatJSONL},
+		map[string]string{},
 	))
 	require.NoError(t, cmd.Before(t.Context(), &clihelper.Context{}))
 	require.NoError(t, cmd.Action(
@@ -190,6 +194,7 @@ func TestNewFlagsIgnoreFileAction(t *testing.T) {
 			flags := catalog.NewFlags(opts, nil)
 			require.NoError(t, flags.Parse(
 				clihelper.Args{"--" + catalog.IgnoreFileFlagName, tc.value(dir)},
+				map[string]string{},
 			))
 
 			err := flags.RunActions(t.Context(), &clihelper.Context{})

--- a/internal/cli/commands/find/cli_test.go
+++ b/internal/cli/commands/find/cli_test.go
@@ -134,7 +134,7 @@ func TestNewCommandBeforeResolvesFormatAndMode(t *testing.T) {
 			tgOpts.RootWorkingDir = root
 
 			cmd := find.NewCommand(newTestLogger(t), tgOpts, v)
-			require.NoError(t, cmd.Flags.Parse(clihelper.Args(tc.args)))
+			require.NoError(t, cmd.Flags.Parse(clihelper.Args(tc.args), map[string]string{}))
 
 			err := cmd.Before(t.Context(), &clihelper.Context{})
 			if tc.wantErr {
@@ -192,7 +192,7 @@ func TestNewFlagsHiddenFlagRunsTheStrictControl(t *testing.T) {
 			}
 
 			flags := find.NewFlags(newTestLogger(t), find.NewOptions(tgOpts), venvtest.New(), nil)
-			require.NoError(t, flags.Parse(clihelper.Args(tc.args)))
+			require.NoError(t, flags.Parse(clihelper.Args(tc.args), map[string]string{}))
 
 			err := flags.RunActions(t.Context(), &clihelper.Context{})
 			if tc.wantErr {
@@ -234,7 +234,7 @@ func TestNewFlagsExternalFlagAddsAGraphFilter(t *testing.T) {
 			opts := find.NewOptions(options.NewTerragruntOptions())
 
 			flags := find.NewFlags(newTestLogger(t), opts, venvtest.New(), nil)
-			require.NoError(t, flags.Parse(clihelper.Args(tc.args)))
+			require.NoError(t, flags.Parse(clihelper.Args(tc.args), map[string]string{}))
 			require.NoError(t, flags.RunActions(t.Context(), &clihelper.Context{}))
 			assert.Len(t, opts.Filters, tc.wantFilters)
 		})

--- a/internal/cli/commands/list/cli_test.go
+++ b/internal/cli/commands/list/cli_test.go
@@ -103,7 +103,7 @@ func TestNewCommandBeforeResolvesTheFormat(t *testing.T) {
 			var buf strings.Builder
 
 			cmd := newListCommand(t, &buf)
-			require.NoError(t, cmd.Flags.Parse(clihelper.Args(tc.args)))
+			require.NoError(t, cmd.Flags.Parse(clihelper.Args(tc.args), map[string]string{}))
 
 			err := cmd.Before(t.Context(), &clihelper.Context{})
 			if tc.wantErr {
@@ -156,7 +156,7 @@ func TestNewCommandBeforeResolvesTheMode(t *testing.T) {
 			var buf strings.Builder
 
 			cmd := newListCommand(t, &buf)
-			require.NoError(t, cmd.Flags.Parse(clihelper.Args(tc.args)))
+			require.NoError(t, cmd.Flags.Parse(clihelper.Args(tc.args), map[string]string{}))
 			require.NoError(t, cmd.Before(t.Context(), &clihelper.Context{}))
 			require.NoError(t, cmd.Action(t.Context(), &clihelper.Context{}))
 			assert.Equal(t, tc.wantPaths, strings.Fields(buf.String()))
@@ -184,7 +184,7 @@ func TestNewCommandTreeFlagRendersATree(t *testing.T) {
 			var buf strings.Builder
 
 			cmd := newListCommand(t, &buf)
-			require.NoError(t, cmd.Flags.Parse(clihelper.Args(tc.args)))
+			require.NoError(t, cmd.Flags.Parse(clihelper.Args(tc.args), map[string]string{}))
 			require.NoError(t, cmd.Before(t.Context(), &clihelper.Context{}))
 			require.NoError(t, cmd.Action(t.Context(), &clihelper.Context{}))
 			assert.Equal(t, []string{".", "alpha", "zulu"}, treeLabels(buf.String()))
@@ -229,7 +229,7 @@ func TestNewFlagsHiddenFlagRunsTheStrictControl(t *testing.T) {
 			}
 
 			flags := list.NewFlags(newTestLogger(t), list.NewOptions(tgOpts), venvtest.New(), nil)
-			require.NoError(t, flags.Parse(clihelper.Args(tc.args)))
+			require.NoError(t, flags.Parse(clihelper.Args(tc.args), map[string]string{}))
 
 			err := flags.RunActions(t.Context(), &clihelper.Context{})
 			if tc.wantErr {
@@ -271,7 +271,7 @@ func TestNewFlagsExternalFlagAddsAGraphFilter(t *testing.T) {
 			opts := list.NewOptions(options.NewTerragruntOptions())
 
 			flags := list.NewFlags(newTestLogger(t), opts, venvtest.New(), nil)
-			require.NoError(t, flags.Parse(clihelper.Args(tc.args)))
+			require.NoError(t, flags.Parse(clihelper.Args(tc.args), map[string]string{}))
 			require.NoError(t, flags.RunActions(t.Context(), &clihelper.Context{}))
 			assert.Len(t, opts.Filters, tc.wantFilters)
 		})

--- a/internal/cli/commands/run/flags_test.go
+++ b/internal/cli/commands/run/flags_test.go
@@ -20,7 +20,7 @@ func TestNoHooksFlagRequiresExperiment(t *testing.T) {
 	opts := options.NewTerragruntOptions()
 	flags := runcommand.NewFlags(logger.CreateLogger(), opts, venvtest.New(), nil)
 
-	require.NoError(t, flags.Parse(clihelper.Args{"--no-hooks"}))
+	require.NoError(t, flags.Parse(clihelper.Args{"--no-hooks"}, map[string]string{}))
 
 	err := flags.RunActions(context.Background(), &clihelper.Context{})
 
@@ -35,7 +35,7 @@ func TestNoHooksFlagAllowedWithExperiment(t *testing.T) {
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.OptionalHooks))
 	flags := runcommand.NewFlags(logger.CreateLogger(), opts, venvtest.New(), nil)
 
-	require.NoError(t, flags.Parse(clihelper.Args{"--no-hooks"}))
+	require.NoError(t, flags.Parse(clihelper.Args{"--no-hooks"}, map[string]string{}))
 	require.NoError(t, flags.RunActions(context.Background(), &clihelper.Context{}))
 	assert.True(t, opts.NoRunHooks)
 }
@@ -46,7 +46,7 @@ func TestNoDependencyOutputsFlagRequiresExperiment(t *testing.T) {
 	opts := options.NewTerragruntOptions()
 	flags := runcommand.NewFlags(logger.CreateLogger(), opts, venvtest.New(), nil)
 
-	require.NoError(t, flags.Parse(clihelper.Args{"--no-dependency-outputs"}))
+	require.NoError(t, flags.Parse(clihelper.Args{"--no-dependency-outputs"}, map[string]string{}))
 
 	err := flags.RunActions(context.Background(), &clihelper.Context{})
 
@@ -61,7 +61,7 @@ func TestNoDependencyOutputsFlagAllowedWithExperiment(t *testing.T) {
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.OptionalDependencyOutputs))
 	flags := runcommand.NewFlags(logger.CreateLogger(), opts, venvtest.New(), nil)
 
-	require.NoError(t, flags.Parse(clihelper.Args{"--no-dependency-outputs"}))
+	require.NoError(t, flags.Parse(clihelper.Args{"--no-dependency-outputs"}, map[string]string{}))
 	require.NoError(t, flags.RunActions(context.Background(), &clihelper.Context{}))
 	assert.True(t, opts.SkipOutput)
 }

--- a/internal/cli/commands/run/help.go
+++ b/internal/cli/commands/run/help.go
@@ -39,7 +39,7 @@ See also:
 // ShowTFHelp prints TF help for the given `cliCtx.Command` command.
 func ShowTFHelp(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) clihelper.HelpFunc {
 	return func(ctx context.Context, cliCtx *clihelper.Context) error {
-		if err := shared.NewTFPathFlag(opts).Parse(cliCtx.Args()); err != nil {
+		if err := shared.NewTFPathFlag(opts).Parse(cliCtx.Args(), v.Env); err != nil {
 			return err
 		}
 

--- a/internal/cli/flags/error_handler_test.go
+++ b/internal/cli/flags/error_handler_test.go
@@ -38,7 +38,7 @@ func TestErrorHandler(t *testing.T) {
 	// newRootCtx creates a context at the root (global) level,
 	// where ctx.Parent().Command is nil.
 	newRootCtx := func() *clihelper.Context {
-		app := clihelper.NewApp()
+		app := clihelper.NewApp(map[string]string{})
 		appCtx := clihelper.NewAppContext(app, nil)
 		rootCmd := &clihelper.Command{Name: "terragrunt", IsRoot: true}
 
@@ -48,7 +48,7 @@ func TestErrorHandler(t *testing.T) {
 	// newCommandCtx creates a context for a named subcommand,
 	// where ctx.Parent().Command is the root command (non-nil).
 	newCommandCtx := func(name string) *clihelper.Context {
-		app := clihelper.NewApp()
+		app := clihelper.NewApp(map[string]string{})
 		appCtx := clihelper.NewAppContext(app, nil)
 		rootCmd := &clihelper.Command{Name: "terragrunt", IsRoot: true}
 		rootCtx := appCtx.NewCommandContext(rootCmd, nil)
@@ -60,7 +60,7 @@ func TestErrorHandler(t *testing.T) {
 	// newRunSubcommandCtx creates a context for a subcommand of "run"
 	// (e.g., "providers" in "terragrunt run providers lock -platform ...").
 	newRunSubcommandCtx := func(name string) *clihelper.Context {
-		app := clihelper.NewApp()
+		app := clihelper.NewApp(map[string]string{})
 		appCtx := clihelper.NewAppContext(app, nil)
 		rootCmd := &clihelper.Command{Name: "terragrunt", IsRoot: true}
 		rootCtx := appCtx.NewCommandContext(rootCmd, nil)

--- a/internal/cli/flags/flag.go
+++ b/internal/cli/flags/flag.go
@@ -102,21 +102,21 @@ func (newFlag *Flag) Value() clihelper.FlagValue {
 }
 
 // Apply implements `clihelper.Flag` interface.
-func (newFlag *Flag) Apply(set *flag.FlagSet) error {
-	if err := newFlag.Flag.Apply(set); err != nil {
+func (newFlag *Flag) Apply(set *flag.FlagSet, env map[string]string) error {
+	if err := newFlag.Flag.Apply(set, env); err != nil {
 		return err
 	}
 
 	for _, deprecated := range newFlag.deprecatedFlags {
 		if deprecated.Flag == newFlag.Flag {
-			if err := clihelper.ApplyFlag(deprecated, set); err != nil {
+			if err := clihelper.ApplyFlag(deprecated, set, env); err != nil {
 				return err
 			}
 
 			continue
 		}
 
-		if err := deprecated.Apply(set); err != nil {
+		if err := deprecated.Apply(set, env); err != nil {
 			return err
 		}
 	}
@@ -152,14 +152,15 @@ func (newFlag *Flag) RunAction(ctx context.Context, cliCtx *clihelper.Context) e
 	return newFlag.Flag.RunAction(ctx, cliCtx)
 }
 
-// Parse parses the given `args` for the flag value and env vars values specified in the flag.
+// Parse parses the given `args` for the flag value and the values of the env
+// vars specified in the flag, resolved against `env`.
 // The value will be assigned to the `Destination` field.
 // The value can also be retrieved using `flag.Value().Get()`.
-func (newFlag *Flag) Parse(args clihelper.Args) error {
+func (newFlag *Flag) Parse(args clihelper.Args, env map[string]string) error {
 	flagSet := flag.NewFlagSet("", flag.ContinueOnError)
 	flagSet.SetOutput(io.Discard)
 
-	if err := newFlag.Apply(flagSet); err != nil {
+	if err := newFlag.Apply(flagSet, env); err != nil {
 		return err
 	}
 

--- a/internal/cli/flags/flag_test.go
+++ b/internal/cli/flags/flag_test.go
@@ -65,7 +65,7 @@ func TestFlag_TakesValue(t *testing.T) {
 
 			testFlag := flags.NewFlag(tc.flag)
 
-			err := testFlag.Apply(new(flag.FlagSet))
+			err := testFlag.Apply(new(flag.FlagSet), map[string]string{})
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expected, testFlag.TakesValue())
@@ -145,7 +145,7 @@ func TestFlag_Evaluate(t *testing.T) {
 			ctx = log.ContextWithLogger(ctx, logger)
 
 			for _, testFlag := range tc.flags {
-				err := testFlag.flag.Apply(new(flag.FlagSet))
+				err := testFlag.flag.Apply(new(flag.FlagSet), map[string]string{})
 				require.NoError(t, err)
 
 				if testFlag.arg != "" {

--- a/internal/cli/flags/global/flags_test.go
+++ b/internal/cli/flags/global/flags_test.go
@@ -42,7 +42,7 @@ func TestProfileFlagsParse(t *testing.T) {
 		"--profile-mem=mem.prof",
 		"--profile-goroutine=goroutine.prof",
 		"--profile-dir=profiles",
-	})
+	}, map[string]string{})
 	require.NoError(t, err)
 
 	assert.Equal(t, "cpu.prof", opts.ProfileCPU)
@@ -56,7 +56,7 @@ func TestProfileFlagsParseSpaceForm(t *testing.T) {
 
 	opts := options.NewTerragruntOptions()
 
-	err := global.NewProfileFlags(opts, nil).Parse([]string{"--profile-cpu", "cpu.prof"})
+	err := global.NewProfileFlags(opts, nil).Parse([]string{"--profile-cpu", "cpu.prof"}, map[string]string{})
 	require.NoError(t, err)
 
 	assert.Equal(t, "cpu.prof", opts.ProfileCPU)

--- a/internal/cli/flags/shared/filter_test.go
+++ b/internal/cli/flags/shared/filter_test.go
@@ -19,7 +19,7 @@ func TestDiscoveryBoundaryFlagRequiresExperiment(t *testing.T) {
 	opts := options.NewTerragruntOptions()
 	flags := shared.NewFilterFlags(logger.CreateLogger(), opts, venvtest.New())
 
-	require.NoError(t, flags.Parse(clihelper.Args{"--discovery-boundary", "."}))
+	require.NoError(t, flags.Parse(clihelper.Args{"--discovery-boundary", "."}, map[string]string{}))
 
 	err := flags.RunActions(t.Context(), &clihelper.Context{})
 
@@ -33,7 +33,7 @@ func TestDiscoveryBoundaryFlagAllowedWithExperiment(t *testing.T) {
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.BoundedDiscovery))
 	flags := shared.NewFilterFlags(logger.CreateLogger(), opts, venvtest.New())
 
-	require.NoError(t, flags.Parse(clihelper.Args{"--discovery-boundary", "."}))
+	require.NoError(t, flags.Parse(clihelper.Args{"--discovery-boundary", "."}, map[string]string{}))
 	require.NoError(t, flags.RunActions(t.Context(), &clihelper.Context{}))
 	assert.Equal(t, ".", opts.DiscoveryBoundary)
 }

--- a/internal/cli/flags/shared/parallelism_test.go
+++ b/internal/cli/flags/shared/parallelism_test.go
@@ -37,7 +37,7 @@ func TestParallelismFlag(t *testing.T) {
 
 			// necessary in order to initialise GenericFlag internals
 			fs.SetOutput(io.Discard) // avoid panics on invalid values
-			f.Apply(fs)
+			f.Apply(fs, map[string]string{})
 
 			err := fs.Parse(it.args)
 

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -26,7 +26,7 @@ func TestCommandHelpTemplate(t *testing.T) {
 
 	tgPrefix := flags.Prefix{flags.TgPrefix}
 
-	app := clihelper.NewApp()
+	app := clihelper.NewApp(map[string]string{})
 	app.Flags = clihelper.Flags{
 		&clihelper.GenericFlag[string]{
 			Name:    "working-dir",

--- a/internal/clihelper/app.go
+++ b/internal/clihelper/app.go
@@ -65,6 +65,9 @@ type App struct {
 	// AutocompleteUninstallFlag is the global flag name for uninstalling the autocompletion handlers for the user's shell.
 	AutocompleteUninstallFlag string
 
+	// Env is the environment the app resolves env-var-backed flags against.
+	Env map[string]string
+
 	// Commands is a list of commands to execute.
 	Commands Commands
 
@@ -84,8 +87,13 @@ type App struct {
 	DisabledErrorOnMultipleSetFlag bool
 }
 
-// NewApp returns app new App instance.
-func NewApp() *App {
+// NewApp returns app new App instance that resolves env-var-backed flags
+// against env.
+func NewApp(env map[string]string) *App {
+	if env == nil {
+		panic(ErrEnvUnset)
+	}
+
 	cliApp := cli.NewApp()
 	cliApp.ExitErrHandler = func(_ *cli.Context, _ error) {}
 	cliApp.HideHelp = true
@@ -100,6 +108,7 @@ func NewApp() *App {
 
 	return &App{
 		App:          cliApp,
+		Env:          env,
 		OsExiter:     os.Exit,
 		Autocomplete: true,
 	}
@@ -148,7 +157,7 @@ func (app *App) RunContext(ctx context.Context, arguments []string) (err error) 
 				return app.handleExitCoder(cliCtx, err)
 			}
 
-			if compLine := os.Getenv(envCompleteLine); compLine != "" {
+			if compLine := app.Env[envCompleteLine]; compLine != "" {
 				args = strings.Fields(compLine)
 				if args[0] == app.Name {
 					args = args[1:]

--- a/internal/clihelper/bool_flag.go
+++ b/internal/clihelper/bool_flag.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	libflag "flag"
 	"fmt"
-
-	"github.com/urfave/cli/v2"
 )
 
 // BoolFlag implements Flag
@@ -50,9 +48,9 @@ type BoolFlag struct {
 }
 
 // Apply applies Flag settings to the given flag set.
-func (flag *BoolFlag) Apply(set *libflag.FlagSet) error {
+func (flag *BoolFlag) Apply(set *libflag.FlagSet, env map[string]string) error {
 	if flag.FlagValue != nil {
-		return ApplyFlag(flag, set)
+		return ApplyFlag(flag, set, env)
 	}
 
 	if flag.Destination == nil {
@@ -68,7 +66,7 @@ func (flag *BoolFlag) Apply(set *libflag.FlagSet) error {
 		negative:         flag.Negative,
 	}
 
-	return ApplyFlag(flag, set)
+	return ApplyFlag(flag, set, env)
 }
 
 // GetHidden returns true if the flag should be hidden from the help.
@@ -103,7 +101,7 @@ func (flag *BoolFlag) GetDefaultText() string {
 
 // String returns a readable representation of this value (for usage defaults).
 func (flag *BoolFlag) String() string {
-	return cli.FlagStringer(flag)
+	return stringifyFlag(flag)
 }
 
 // Names returns the names of the flag.

--- a/internal/clihelper/bool_flag_test.go
+++ b/internal/clihelper/bool_flag_test.go
@@ -42,7 +42,7 @@ func TestBoolFlagApply(t *testing.T) {
 		{
 			flag:          clihelper.BoolFlag{Name: "foo", EnvVars: []string{"FOO"}},
 			args:          nil,
-			envs:          nil,
+			envs:          map[string]string{},
 			expectedValue: false,
 			expectedErr:   nil,
 		},
@@ -60,14 +60,14 @@ func TestBoolFlagApply(t *testing.T) {
 		{
 			flag:          clihelper.BoolFlag{Name: "foo", Destination: new(true)},
 			args:          nil,
-			envs:          nil,
+			envs:          map[string]string{},
 			expectedValue: true,
 			expectedErr:   nil,
 		},
 		{
 			flag:          clihelper.BoolFlag{Name: "foo", Destination: new(true), Negative: true},
 			args:          []string{"--foo"},
-			envs:          nil,
+			envs:          map[string]string{},
 			expectedValue: false,
 			expectedErr:   nil,
 		},
@@ -98,7 +98,7 @@ func TestBoolFlagApply(t *testing.T) {
 		{
 			flag:          clihelper.BoolFlag{Name: "foo", EnvVars: []string{"FOO"}},
 			args:          []string{"--foo", "--foo"},
-			envs:          nil,
+			envs:          map[string]string{},
 			expectedValue: false,
 			expectedErr:   errors.New(`invalid boolean flag foo: setting the flag multiple times`),
 		},
@@ -150,22 +150,10 @@ func testBoolFlagApply(
 
 	expectedDefaultValue = strconv.FormatBool(*flag.Destination)
 
-	flag.LookupEnvFunc = func(key string) []string {
-		if envs == nil {
-			return nil
-		}
-
-		if val, ok := envs[key]; ok {
-			return []string{val}
-		}
-
-		return nil
-	}
-
 	flagSet := libflag.NewFlagSet("test-cmd", libflag.ContinueOnError)
 	flagSet.SetOutput(io.Discard)
 
-	err := flag.Apply(flagSet)
+	err := flag.Apply(flagSet, envs)
 	if err == nil {
 		err = flagSet.Parse(args)
 	}

--- a/internal/clihelper/command.go
+++ b/internal/clihelper/command.go
@@ -195,13 +195,13 @@ func (cmd *Command) parseFlags(ctx *Context, args Args) ([]string, error) {
 		return err
 	}
 
-	flagSet, err := cmd.Flags.NewFlagSet(cmd.Name, errHandler)
+	flagSet, err := cmd.Flags.NewFlagSet(cmd.Name, ctx.Env, errHandler)
 	if err != nil {
 		return nil, err
 	}
 
 	flagSetWithSubcommandScope, err := cmd.Flags.WithSubcommandScope().
-		NewFlagSet(cmd.Name, errHandler)
+		NewFlagSet(cmd.Name, ctx.Env, errHandler)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/clihelper/command_test.go
+++ b/internal/clihelper/command_test.go
@@ -192,7 +192,10 @@ func TestCommandRun(t *testing.T) {
 
 			tc := tcFn(action, skip)
 
-			app := &clihelper.App{App: &urfaveCli.App{Writer: io.Discard}}
+			app := &clihelper.App{
+				App: &urfaveCli.App{Writer: io.Discard},
+				Env: map[string]string{},
+			}
 			cliCtx := clihelper.NewAppContext(app, tc.args)
 
 			err := tc.command.Run(t.Context(), cliCtx, tc.args)

--- a/internal/clihelper/flag.go
+++ b/internal/clihelper/flag.go
@@ -2,13 +2,19 @@ package clihelper
 
 import (
 	"context"
+	"errors"
 	libflag "flag"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/urfave/cli/v2"
 )
+
+// ErrEnvUnset is the panic value [NewApp] and [ApplyFlag] raise when the
+// environment map is nil. Flag values are resolved against the environment the
+// run was started with, so a nil map points at a caller that never wired one
+// rather than at a run whose environment happens to be empty.
+var ErrEnvUnset = errors.New("clihelper: flag environment is required but unset")
 
 var (
 	// FlagSplitter uses to separate arguments and env vars with multiple values.
@@ -70,8 +76,33 @@ type FlagValue interface {
 }
 
 type Flag interface {
-	// `urfave/cli/v2` uses to generate help
-	cli.DocGenerationFlag
+	fmt.Stringer
+
+	// Apply registers the flag with the given flag set, resolving any environment
+	// variable the flag declares against env.
+	Apply(set *libflag.FlagSet, env map[string]string) error
+
+	// Names returns the flag name along with its aliases.
+	Names() []string
+
+	// IsSet returns true if the flag was set either by env var or CLI arg.
+	IsSet() bool
+
+	// TakesValue returns true if the flag needs to be given a value.
+	TakesValue() bool
+
+	// GetUsage returns the usage string for the flag.
+	GetUsage() string
+
+	// GetValue returns the flag value as a string representation and an empty
+	// string if the flag takes no value at all.
+	GetValue() string
+
+	// GetDefaultText returns the default text for the flag.
+	GetDefaultText() string
+
+	// GetEnvVars returns the names of the environment variables the flag reads.
+	GetEnvVars() []string
 
 	// Value returns the `FlagValue` interface for interacting with the flag value.
 	Value() FlagValue
@@ -82,18 +113,16 @@ type Flag interface {
 	// RunAction runs the flag action.
 	RunAction(ctx context.Context, cliCtx *Context) error
 
-	// LookupEnv gets and splits the environment variable depending on the flag type: common, map, slice.
-	LookupEnv(envVar string) []string
+	// LookupEnv reads envVar from env and splits it depending on the flag type: common, map, slice.
+	LookupEnv(envVar string, env map[string]string) []string
 
 	// AllowedSubcommandScope returns true if the flag is allowed to be specified in subcommands,
 	// and not only after the command it belongs to.
 	AllowedSubcommandScope() bool
 
-	// Parse parses the given args and environment variables to set the flag value.
-	Parse(args Args) error
+	// Parse parses the given args and env to set the flag value.
+	Parse(args Args, env map[string]string) error
 }
-
-type LookupEnvFuncType func(key string) []string
 
 type FlagValueGetter interface {
 	libflag.Getter
@@ -220,26 +249,19 @@ func (flag *flagValue) Getter(name string) FlagValueGetter {
 // flag is a common flag related to parsing flags in cli.
 type flag struct {
 	FlagValue
-	LookupEnvFunc LookupEnvFuncType
 }
 
 // Parse implements `Flag` interface.
-func (flag *flag) Parse(args Args) error {
+func (flag *flag) Parse(args Args, env map[string]string) error {
 	return nil
 }
 
-func (flag *flag) LookupEnv(envVar string) []string {
-	if flag.LookupEnvFunc == nil {
-		flag.LookupEnvFunc = func(key string) []string {
-			if val, ok := os.LookupEnv(key); ok {
-				return []string{val}
-			}
-
-			return nil
-		}
+func (flag *flag) LookupEnv(envVar string, env map[string]string) []string {
+	if val, ok := env[envVar]; ok {
+		return []string{val}
 	}
 
-	return flag.LookupEnvFunc(envVar)
+	return nil
 }
 
 func (flag *flag) Value() FlagValue {
@@ -270,9 +292,13 @@ func (flag *flag) AllowedSubcommandScope() bool {
 	return true
 }
 
-func ApplyFlag(flag Flag, set *libflag.FlagSet) error {
+func ApplyFlag(flag Flag, set *libflag.FlagSet, env map[string]string) error {
+	if env == nil {
+		panic(ErrEnvUnset)
+	}
+
 	for _, name := range flag.GetEnvVars() {
-		for _, val := range flag.LookupEnv(name) {
+		for _, val := range flag.LookupEnv(name, env) {
 			if val == "" || (flag.Value().IsEnvSet() && !flag.Value().MultipleSet()) {
 				continue
 			}
@@ -289,5 +315,24 @@ func ApplyFlag(flag Flag, set *libflag.FlagSet) error {
 		}
 	}
 
+	return nil
+}
+
+// stringifyFlag renders flag as a help entry.
+func stringifyFlag(flag Flag) string {
+	return cli.FlagStringer(urfaveFlag{Flag: flag})
+}
+
+// urfaveFlag adapts a Flag to the narrower `cli.Flag` interface that
+// `urfave/cli`'s help machinery accepts. Terragrunt flags read environment
+// variables from the environment the run was started with, so their `Apply`
+// takes an argument `urfave/cli` knows nothing about.
+type urfaveFlag struct {
+	Flag
+}
+
+// Apply shadows the wrapped flag's own `Apply` to satisfy `cli.Flag`.
+// Rendering a help entry never registers anything with a flag set.
+func (flag urfaveFlag) Apply(*libflag.FlagSet) error {
 	return nil
 }

--- a/internal/clihelper/flag_test.go
+++ b/internal/clihelper/flag_test.go
@@ -1,0 +1,53 @@
+package clihelper_test
+
+import (
+	libflag "flag"
+	"io"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testFlagEnvVar = "TG_TEST_FLAG_ENV"
+
+func TestFlagIgnoresProcessEnv(t *testing.T) {
+	t.Setenv(testFlagEnvVar, "from-process")
+
+	flag := &clihelper.GenericFlag[string]{Name: "foo", EnvVars: []string{testFlagEnvVar}}
+
+	set := libflag.NewFlagSet("test-cmd", libflag.ContinueOnError)
+	set.SetOutput(io.Discard)
+
+	require.NoError(t, flag.Apply(set, map[string]string{}))
+
+	assert.False(t, flag.Value().IsEnvSet())
+	assert.Empty(t, flag.Value().Get())
+}
+
+func TestFlagPrefersSuppliedEnvOverProcessEnv(t *testing.T) {
+	t.Setenv(testFlagEnvVar, "from-process")
+
+	flag := &clihelper.GenericFlag[string]{Name: "foo", EnvVars: []string{testFlagEnvVar}}
+
+	set := libflag.NewFlagSet("test-cmd", libflag.ContinueOnError)
+	set.SetOutput(io.Discard)
+
+	require.NoError(t, flag.Apply(set, map[string]string{testFlagEnvVar: "from-venv"}))
+
+	assert.Equal(t, "from-venv", flag.Value().Get())
+}
+
+func TestApplyFlagPanicsOnUnsetEnv(t *testing.T) {
+	t.Parallel()
+
+	flag := &clihelper.GenericFlag[string]{Name: "foo", EnvVars: []string{testFlagEnvVar}}
+
+	set := libflag.NewFlagSet("test-cmd", libflag.ContinueOnError)
+	set.SetOutput(io.Discard)
+
+	assert.PanicsWithError(t, clihelper.ErrEnvUnset.Error(), func() {
+		require.NoError(t, flag.Apply(set, nil))
+	})
+}

--- a/internal/clihelper/flags.go
+++ b/internal/clihelper/flags.go
@@ -10,9 +10,9 @@ import (
 
 type Flags []Flag
 
-func (flags Flags) Parse(args Args) error {
+func (flags Flags) Parse(args Args, env map[string]string) error {
 	for _, flag := range flags {
-		if err := flag.Parse(args); err != nil {
+		if err := flag.Parse(args, env); err != nil {
 			return err
 		}
 	}
@@ -22,19 +22,24 @@ func (flags Flags) Parse(args Args) error {
 
 func (flags Flags) NewFlagSet(
 	cmdName string,
+	env map[string]string,
 	errHandler func(err error) error,
 ) (*libflag.FlagSet, error) {
 	flagSet := libflag.NewFlagSet(cmdName, libflag.ContinueOnError)
 	flagSet.SetOutput(io.Discard)
 
-	err := flags.Apply(flagSet, errHandler)
+	err := flags.Apply(flagSet, env, errHandler)
 
 	return flagSet, err
 }
 
-func (flags Flags) Apply(flagSet *libflag.FlagSet, errHandler func(err error) error) error {
+func (flags Flags) Apply(
+	flagSet *libflag.FlagSet,
+	env map[string]string,
+	errHandler func(err error) error,
+) error {
 	for _, flag := range flags {
-		if err := flag.Apply(flagSet); err != nil {
+		if err := flag.Apply(flagSet, env); err != nil {
 			if err = errHandler(err); err != nil {
 				return err
 			}

--- a/internal/clihelper/flags_test.go
+++ b/internal/clihelper/flags_test.go
@@ -77,7 +77,7 @@ func TestFalgsRunActions(t *testing.T) {
 	flagSet.SetOutput(io.Discard)
 
 	for _, flag := range mockFlags {
-		err := flag.Apply(flagSet)
+		err := flag.Apply(flagSet, map[string]string{})
 		require.NoError(t, err)
 
 		err = flag.Value().Set("value")

--- a/internal/clihelper/generic_flag.go
+++ b/internal/clihelper/generic_flag.go
@@ -5,8 +5,6 @@ import (
 	libflag "flag"
 	"fmt"
 	"strconv"
-
-	"github.com/urfave/cli/v2"
 )
 
 // GenericFlag implements Flag
@@ -48,9 +46,9 @@ type GenericFlag[T GenericType] struct {
 }
 
 // Apply applies Flag settings to the given flag set.
-func (flag *GenericFlag[T]) Apply(set *libflag.FlagSet) error {
+func (flag *GenericFlag[T]) Apply(set *libflag.FlagSet, env map[string]string) error {
 	if flag.FlagValue != nil {
-		return ApplyFlag(flag, set)
+		return ApplyFlag(flag, set, env)
 	}
 
 	if flag.Destination == nil {
@@ -65,7 +63,7 @@ func (flag *GenericFlag[T]) Apply(set *libflag.FlagSet) error {
 		initialTextValue: value.String(),
 	}
 
-	return ApplyFlag(flag, set)
+	return ApplyFlag(flag, set, env)
 }
 
 // GetHidden returns true if the flag should be hidden from the help.
@@ -94,7 +92,7 @@ func (flag *GenericFlag[T]) GetDefaultText() string {
 
 // String returns a readable representation of this value (for usage defaults).
 func (flag *GenericFlag[T]) String() string {
-	return cli.FlagStringer(flag)
+	return stringifyFlag(flag)
 }
 
 // Names returns the names of the flag.

--- a/internal/clihelper/generic_flag_test.go
+++ b/internal/clihelper/generic_flag_test.go
@@ -35,6 +35,7 @@ func TestGenericFlagStringApply(t *testing.T) {
 		},
 		{
 			flag: clihelper.GenericFlag[string]{Name: "foo", EnvVars: []string{"FOO"}},
+			envs: map[string]string{},
 		},
 		{
 			flag: clihelper.GenericFlag[string]{
@@ -51,10 +52,12 @@ func TestGenericFlagStringApply(t *testing.T) {
 				Name:        "foo",
 				Destination: new("default-value"),
 			},
+			envs:          map[string]string{},
 			expectedValue: "default-value",
 		},
 		{
 			flag: clihelper.GenericFlag[string]{Name: "foo", EnvVars: []string{"FOO"}},
+			envs: map[string]string{},
 			args: []string{"--foo", "arg-value1", "--foo", "arg-value2"},
 			expectedErr: errors.New(
 				`invalid value "arg-value2" for flag -foo: setting the flag multiple times`,
@@ -103,6 +106,7 @@ func TestGenericFlagIntApply(t *testing.T) {
 		},
 		{
 			flag:          clihelper.GenericFlag[int]{Name: "foo", Destination: new(55)},
+			envs:          map[string]string{},
 			expectedValue: 55,
 		},
 	}
@@ -148,6 +152,7 @@ func TestGenericFlagInt64Apply(t *testing.T) {
 		},
 		{
 			flag:          clihelper.GenericFlag[int64]{Name: "foo", Destination: new(int64(55))},
+			envs:          map[string]string{},
 			expectedValue: 55,
 		},
 	}
@@ -182,22 +187,10 @@ func testGenericFlagApply[T clihelper.GenericType](
 
 	expectedDefaultValue = fmt.Sprintf("%v", *flag.Destination)
 
-	flag.LookupEnvFunc = func(key string) []string {
-		if envs == nil {
-			return nil
-		}
-
-		if val, ok := envs[key]; ok {
-			return []string{val}
-		}
-
-		return nil
-	}
-
 	flagSet := libflag.NewFlagSet("test-cmd", libflag.ContinueOnError)
 	flagSet.SetOutput(io.Discard)
 
-	err := flag.Apply(flagSet)
+	err := flag.Apply(flagSet, envs)
 	if err == nil {
 		err = flagSet.Parse(args)
 	}

--- a/internal/clihelper/map_flag.go
+++ b/internal/clihelper/map_flag.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	libflag "flag"
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 
 	"maps"
-
-	"github.com/urfave/cli/v2"
 )
 
 // MapJoin formats m as "key<kvSep>value" entries joined by entrySep, sorted
@@ -85,9 +82,9 @@ type MapFlag[K MapFlagKeyType, V MapFlagValueType] struct {
 }
 
 // Apply applies Flag settings to the given flag set.
-func (flag *MapFlag[K, V]) Apply(set *libflag.FlagSet) error {
+func (flag *MapFlag[K, V]) Apply(set *libflag.FlagSet, env map[string]string) error {
 	if flag.FlagValue != nil {
-		return ApplyFlag(flag, set)
+		return ApplyFlag(flag, set, env)
 	}
 
 	if flag.Destination == nil {
@@ -105,16 +102,6 @@ func (flag *MapFlag[K, V]) Apply(set *libflag.FlagSet) error {
 
 	if flag.KeyValSep == "" {
 		flag.KeyValSep = MapFlagKeyValSep
-	}
-
-	if flag.LookupEnvFunc == nil {
-		flag.LookupEnvFunc = func(key string) []string {
-			if val, ok := os.LookupEnv(key); ok {
-				return flag.Splitter(val, flag.EnvVarSep)
-			}
-
-			return nil
-		}
 	}
 
 	keyType := FlagVariable[K](new(genericVar[K]))
@@ -136,7 +123,16 @@ func (flag *MapFlag[K, V]) Apply(set *libflag.FlagSet) error {
 		initialTextValue: value.String(),
 	}
 
-	return ApplyFlag(flag, set)
+	return ApplyFlag(flag, set, env)
+}
+
+// LookupEnv implements `Flag` interface.
+func (flag *MapFlag[K, V]) LookupEnv(envVar string, env map[string]string) []string {
+	if val, ok := env[envVar]; ok {
+		return flag.Splitter(val, flag.EnvVarSep)
+	}
+
+	return nil
 }
 
 // GetHidden returns true if the flag should be hidden from the help.
@@ -165,7 +161,7 @@ func (flag *MapFlag[K, V]) GetDefaultText() string {
 
 // String returns a readable representation of this value (for usage defaults).
 func (flag *MapFlag[K, V]) String() string {
-	return cli.FlagStringer(flag)
+	return stringifyFlag(flag)
 }
 
 // Names returns the names of the flag.

--- a/internal/clihelper/map_flag_test.go
+++ b/internal/clihelper/map_flag_test.go
@@ -39,6 +39,7 @@ func TestMapFlagStringStringApply(t *testing.T) {
 		},
 		{
 			flag:          clihelper.MapFlag[string, string]{Name: "foo", EnvVars: []string{"FOO"}},
+			envs:          map[string]string{},
 			expectedValue: map[string]string{},
 		},
 		{
@@ -66,6 +67,7 @@ func TestMapFlagStringStringApply(t *testing.T) {
 					},
 				),
 			},
+			envs: map[string]string{},
 			expectedValue: map[string]string{
 				"default1-key": "default1-value",
 				"default2-key": "default2-value",
@@ -119,6 +121,7 @@ func TestMapFlagStringIntApply(t *testing.T) {
 				Name:        "foo",
 				Destination: new(map[string]int{"default1-key": 50, "default2-key": 51}),
 			},
+			envs:          map[string]string{},
 			expectedValue: map[string]int{"default1-key": 50, "default2-key": 51},
 		},
 	}
@@ -155,22 +158,10 @@ func testMapFlagApply[K clihelper.MapFlagKeyType, V clihelper.MapFlagValueType](
 		expectedDefaultValue = *flag.Destination
 	}
 
-	flag.LookupEnvFunc = func(key string) []string {
-		if envs == nil {
-			return nil
-		}
-
-		if val, ok := envs[key]; ok {
-			return flag.Splitter(val, flag.EnvVarSep)
-		}
-
-		return nil
-	}
-
 	flagSet := libflag.NewFlagSet("test-cmd", libflag.ContinueOnError)
 	flagSet.SetOutput(io.Discard)
 
-	err := flag.Apply(flagSet)
+	err := flag.Apply(flagSet, envs)
 	require.NoError(t, err)
 
 	err = flagSet.Parse(args)

--- a/internal/clihelper/slice_flag.go
+++ b/internal/clihelper/slice_flag.go
@@ -3,10 +3,7 @@ package clihelper
 import (
 	"context"
 	libflag "flag"
-	"os"
 	"strings"
-
-	"github.com/urfave/cli/v2"
 )
 
 // SliceFlag implements Flag
@@ -59,9 +56,9 @@ type SliceFlag[T SliceFlagType] struct {
 }
 
 // Apply applies Flag settings to the given flag set.
-func (flag *SliceFlag[T]) Apply(set *libflag.FlagSet) error {
+func (flag *SliceFlag[T]) Apply(set *libflag.FlagSet, env map[string]string) error {
 	if flag.FlagValue != nil {
-		return ApplyFlag(flag, set)
+		return ApplyFlag(flag, set, env)
 	}
 
 	if flag.Destination == nil {
@@ -76,16 +73,6 @@ func (flag *SliceFlag[T]) Apply(set *libflag.FlagSet) error {
 		flag.EnvVarSep = SliceFlagEnvVarSep
 	}
 
-	if flag.LookupEnvFunc == nil {
-		flag.LookupEnvFunc = func(key string) []string {
-			if val, ok := os.LookupEnv(key); ok {
-				return flag.Splitter(val, flag.EnvVarSep)
-			}
-
-			return nil
-		}
-	}
-
 	valueType := FlagVariable[T](new(genericVar[T]))
 	value := newSliceValue(valueType, flag.EnvVarSep, flag.Destination, flag.Setter)
 
@@ -95,7 +82,16 @@ func (flag *SliceFlag[T]) Apply(set *libflag.FlagSet) error {
 		initialTextValue: value.String(),
 	}
 
-	return ApplyFlag(flag, set)
+	return ApplyFlag(flag, set, env)
+}
+
+// LookupEnv implements `Flag` interface.
+func (flag *SliceFlag[T]) LookupEnv(envVar string, env map[string]string) []string {
+	if val, ok := env[envVar]; ok {
+		return flag.Splitter(val, flag.EnvVarSep)
+	}
+
+	return nil
 }
 
 // GetHidden returns true if the flag should be hidden from the help.
@@ -124,7 +120,7 @@ func (flag *SliceFlag[T]) GetDefaultText() string {
 
 // String returns a readable representation of this value (for usage defaults).
 func (flag *SliceFlag[T]) String() string {
-	return cli.FlagStringer(flag)
+	return stringifyFlag(flag)
 }
 
 // Names returns the names of the flag.

--- a/internal/clihelper/slice_flag_test.go
+++ b/internal/clihelper/slice_flag_test.go
@@ -35,6 +35,7 @@ func TestSliceFlagStringApply(t *testing.T) {
 		},
 		{
 			flag: clihelper.SliceFlag[string]{Name: "foo", EnvVars: []string{"FOO"}},
+			envs: map[string]string{},
 		},
 		{
 			flag: clihelper.SliceFlag[string]{
@@ -51,6 +52,7 @@ func TestSliceFlagStringApply(t *testing.T) {
 				Name:        "foo",
 				Destination: new([]string{"default-value1", "default-value2"}),
 			},
+			envs:          map[string]string{},
 			expectedValue: []string{"default-value1", "default-value2"},
 		},
 	}
@@ -87,6 +89,7 @@ func TestSliceFlagIntApply(t *testing.T) {
 		},
 		{
 			flag:          clihelper.SliceFlag[int]{Name: "foo", Destination: new([]int{50, 51})},
+			envs:          map[string]string{},
 			expectedValue: []int{50, 51},
 		},
 	}
@@ -126,6 +129,7 @@ func TestSliceFlagInt64Apply(t *testing.T) {
 				Name:        "foo",
 				Destination: new([]int64{50, 51}),
 			},
+			envs:          map[string]string{},
 			expectedValue: []int64{50, 51},
 		},
 	}
@@ -162,22 +166,10 @@ func testSliceFlagApply[T clihelper.SliceFlagType](
 		expectedDefaultValue = *flag.Destination
 	}
 
-	flag.LookupEnvFunc = func(key string) []string {
-		if envs == nil {
-			return nil
-		}
-
-		if val, ok := envs[key]; ok {
-			return flag.Splitter(val, flag.EnvVarSep)
-		}
-
-		return nil
-	}
-
 	flagSet := libflag.NewFlagSet("test-cmd", libflag.ContinueOnError)
 	flagSet.SetOutput(io.Discard)
 
-	err := flag.Apply(flagSet)
+	err := flag.Apply(flagSet, envs)
 	require.NoError(t, err)
 
 	err = flagSet.Parse(args)

--- a/internal/strict/controls/deprecated_env_var_test.go
+++ b/internal/strict/controls/deprecated_env_var_test.go
@@ -42,9 +42,8 @@ func TestNewDeprecatedEnvVar(t *testing.T) {
 	})
 }
 
-// applyEnvVarFlag wires a fake env lookup into the provided flag and applies
-// it to a fresh flag set, so flag.Value().IsEnvSet() / GetName() reflect the
-// provided env value.
+// applyEnvVarFlag applies the provided flag to a fresh flag set against envs,
+// so flag.Value().IsEnvSet() / GetName() reflect the provided env value.
 func applyEnvVarFlag[T clihelper.GenericType](
 	t *testing.T,
 	flag *clihelper.GenericFlag[T],
@@ -52,33 +51,17 @@ func applyEnvVarFlag[T clihelper.GenericType](
 ) {
 	t.Helper()
 
-	flag.LookupEnvFunc = func(key string) []string {
-		if val, ok := envs[key]; ok {
-			return []string{val}
-		}
-
-		return nil
-	}
-
 	set := libflag.NewFlagSet("test", libflag.ContinueOnError)
 	set.SetOutput(io.Discard)
-	require.NoError(t, flag.Apply(set))
+	require.NoError(t, flag.Apply(set, envs))
 }
 
 func applyEnvVarBoolFlag(t *testing.T, flag *clihelper.BoolFlag, envs map[string]string) {
 	t.Helper()
 
-	flag.LookupEnvFunc = func(key string) []string {
-		if val, ok := envs[key]; ok {
-			return []string{val}
-		}
-
-		return nil
-	}
-
 	set := libflag.NewFlagSet("test", libflag.ContinueOnError)
 	set.SetOutput(io.Discard)
-	require.NoError(t, flag.Apply(set))
+	require.NoError(t, flag.Apply(set, envs))
 }
 
 func TestDeprecatedEnvVarEvaluateReturnsNilWhenNotEnvSet(t *testing.T) {
@@ -87,8 +70,8 @@ func TestDeprecatedEnvVarEvaluateReturnsNilWhenNotEnvSet(t *testing.T) {
 	deprecated := &clihelper.GenericFlag[string]{Name: "old", EnvVars: []string{"OLD_ENV"}}
 	newer := &clihelper.GenericFlag[string]{Name: "new", EnvVars: []string{"NEW_ENV"}}
 
-	applyEnvVarFlag(t, deprecated, nil)
-	applyEnvVarFlag(t, newer, nil)
+	applyEnvVarFlag(t, deprecated, map[string]string{})
+	applyEnvVarFlag(t, newer, map[string]string{})
 
 	ctrl := controls.NewDeprecatedEnvVar(deprecated, newer, "")
 	require.NoError(t, ctrl.Evaluate(t.Context()))
@@ -107,19 +90,12 @@ func TestDeprecatedEnvVarEvaluateReturnsNilWhenNameNotInDeprecatedEnvVars(t *tes
 	// arg so flag.name is overwritten to "old" (the flag name, not env var).
 	// This makes IsEnvSet=true while GetName() returns "old", which is not in
 	// GetEnvVars(), exercising the slices.Contains branch.
-	deprecated.LookupEnvFunc = func(key string) []string {
-		if key == "OLD_ENV" {
-			return []string{"envValue"}
-		}
-
-		return nil
-	}
 	set := libflag.NewFlagSet("test", libflag.ContinueOnError)
 	set.SetOutput(io.Discard)
-	require.NoError(t, deprecated.Apply(set))
+	require.NoError(t, deprecated.Apply(set, map[string]string{"OLD_ENV": "envValue"}))
 	require.NoError(t, set.Parse([]string{"--old", "argValue"}))
 
-	applyEnvVarFlag(t, newer, nil)
+	applyEnvVarFlag(t, newer, map[string]string{})
 
 	ctrl := controls.NewDeprecatedEnvVar(deprecated, newer, "")
 	require.NoError(t, ctrl.Evaluate(t.Context()))
@@ -132,7 +108,7 @@ func TestDeprecatedEnvVarEvaluateEnabledActiveReturnsError(t *testing.T) {
 	newer := &clihelper.GenericFlag[string]{Name: "new", EnvVars: []string{"NEW_ENV"}}
 
 	applyEnvVarFlag(t, deprecated, map[string]string{"OLD_ENV": "value"})
-	applyEnvVarFlag(t, newer, nil)
+	applyEnvVarFlag(t, newer, map[string]string{})
 
 	ctrl := controls.NewDeprecatedEnvVar(deprecated, newer, "")
 	ctrl.Control.Enabled = true
@@ -150,7 +126,7 @@ func TestDeprecatedEnvVarEvaluateEnabledCompletedReturnsNil(t *testing.T) {
 	newer := &clihelper.GenericFlag[string]{Name: "new", EnvVars: []string{"NEW_ENV"}}
 
 	applyEnvVarFlag(t, deprecated, map[string]string{"OLD_ENV": "value"})
-	applyEnvVarFlag(t, newer, nil)
+	applyEnvVarFlag(t, newer, map[string]string{})
 
 	ctrl := controls.NewDeprecatedEnvVar(deprecated, newer, "")
 	ctrl.Control.Enabled = true
@@ -166,7 +142,7 @@ func TestDeprecatedEnvVarEvaluateEnabledEmptyErrorFmtReturnsNil(t *testing.T) {
 	newer := &clihelper.GenericFlag[string]{Name: "new", EnvVars: []string{"NEW_ENV"}}
 
 	applyEnvVarFlag(t, deprecated, map[string]string{"OLD_ENV": "value"})
-	applyEnvVarFlag(t, newer, nil)
+	applyEnvVarFlag(t, newer, map[string]string{})
 
 	ctrl := controls.NewDeprecatedEnvVar(deprecated, newer, "")
 	ctrl.Control.Enabled = true
@@ -186,7 +162,7 @@ func TestDeprecatedEnvVarEvaluateDisabledWithLogger(t *testing.T) {
 	newer := &clihelper.GenericFlag[string]{Name: "new", EnvVars: []string{"NEW_ENV"}}
 
 	applyEnvVarFlag(t, deprecated, map[string]string{"OLD_ENV": "value"})
-	applyEnvVarFlag(t, newer, nil)
+	applyEnvVarFlag(t, newer, map[string]string{})
 
 	ctrl := controls.NewDeprecatedEnvVar(deprecated, newer, "")
 	require.NoError(t, ctrl.Evaluate(ctx))
@@ -202,7 +178,7 @@ func TestDeprecatedEnvVarEvaluateDisabledWithSuppression(t *testing.T) {
 	newer := &clihelper.GenericFlag[string]{Name: "new", EnvVars: []string{"NEW_ENV"}}
 
 	applyEnvVarFlag(t, deprecated, map[string]string{"OLD_ENV": "value"})
-	applyEnvVarFlag(t, newer, nil)
+	applyEnvVarFlag(t, newer, map[string]string{})
 
 	ctrl := controls.NewDeprecatedEnvVar(deprecated, newer, "")
 	ctrl.SuppressWarning()
@@ -216,7 +192,7 @@ func TestDeprecatedEnvVarEvaluateDisabledWithoutLogger(t *testing.T) {
 	newer := &clihelper.GenericFlag[string]{Name: "new", EnvVars: []string{"NEW_ENV"}}
 
 	applyEnvVarFlag(t, deprecated, map[string]string{"OLD_ENV": "value"})
-	applyEnvVarFlag(t, newer, nil)
+	applyEnvVarFlag(t, newer, map[string]string{})
 
 	ctrl := controls.NewDeprecatedEnvVar(deprecated, newer, "")
 	require.NoError(t, ctrl.Evaluate(t.Context()))
@@ -229,7 +205,7 @@ func TestDeprecatedEnvVarEvaluateNewFlagWithoutEnvVars(t *testing.T) {
 	newer := &clihelper.GenericFlag[string]{Name: "new"} // no env vars
 
 	applyEnvVarFlag(t, deprecated, map[string]string{"OLD_ENV": "value"})
-	applyEnvVarFlag(t, newer, nil)
+	applyEnvVarFlag(t, newer, map[string]string{})
 
 	ctrl := controls.NewDeprecatedEnvVar(deprecated, newer, "")
 	require.NoError(t, ctrl.Evaluate(t.Context()))
@@ -242,7 +218,7 @@ func TestDeprecatedEnvVarEvaluateFallsBackToDeprecatedValue(t *testing.T) {
 	newer := &clihelper.GenericFlag[string]{Name: "new", EnvVars: []string{"NEW_ENV"}}
 
 	applyEnvVarFlag(t, deprecated, map[string]string{"OLD_ENV": "deprecatedVal"})
-	applyEnvVarFlag(t, newer, nil) // newer has no value -> falls back
+	applyEnvVarFlag(t, newer, map[string]string{}) // newer has no value -> falls back
 
 	ctrl := controls.NewDeprecatedEnvVar(deprecated, newer, "")
 	ctrl.Control.Enabled = true

--- a/internal/strict/controls/deprecated_flag_name_test.go
+++ b/internal/strict/controls/deprecated_flag_name_test.go
@@ -49,22 +49,18 @@ func parseFlag[T clihelper.GenericType](
 ) {
 	t.Helper()
 
-	flag.LookupEnvFunc = func(key string) []string { return nil }
-
 	set := libflag.NewFlagSet("test", libflag.ContinueOnError)
 	set.SetOutput(io.Discard)
-	require.NoError(t, flag.Apply(set))
+	require.NoError(t, flag.Apply(set, map[string]string{}))
 	require.NoError(t, set.Parse(args))
 }
 
 func parseBoolFlag(t *testing.T, flag *clihelper.BoolFlag, args []string) {
 	t.Helper()
 
-	flag.LookupEnvFunc = func(key string) []string { return nil }
-
 	set := libflag.NewFlagSet("test", libflag.ContinueOnError)
 	set.SetOutput(io.Discard)
-	require.NoError(t, flag.Apply(set))
+	require.NoError(t, flag.Apply(set, map[string]string{}))
 	require.NoError(t, set.Parse(args))
 }
 

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func run() (code int) {
 		}
 	}()
 
-	if err := global.NewLogLevelFlag(l, opts, nil).Parse(os.Args); err != nil {
+	if err := global.NewLogLevelFlag(l, opts, nil).Parse(os.Args, v.Env); err != nil {
 		l.Errorf("An error has occurred: %v", err)
 		return 1
 	}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Ensures that flag resolution uses venv for loading env vars, just like everything else does.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Environment-backed CLI flags now resolve consistently against the active command environment.
  - Virtualized or explicitly supplied environment values are honored instead of unintentionally reading from the host process.
  - Improved handling of unset environment mappings prevents ambiguous flag behavior.
  - Flag parsing, help output, and command execution now use the same environment context for more predictable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->