### PR TITLE
chore: Virtualizing `util/file.go` functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -221,7 +221,7 @@ linters:
         path: ^pkg/options/options\.go$
       - linters:
           - forbidigo
-        path: ^(internal/discovery/helpers\.go|internal/discovery/phase_worktree\.go|internal/engine/engine\.go|internal/engine/verification\.go|internal/getter/tfrhelpers\.go|internal/git/git\.go|internal/panicreport/panicreport\.go|internal/remotestate/remote_state\.go|internal/remotestate/terraform_state_file\.go|internal/report/writer\.go|internal/services/catalog/module/doc\.go|internal/services/catalog/module/module\.go|internal/shell/git\.go|internal/shell/run_cmd\.go|internal/stacks/clean/clean\.go|internal/tfimpl/tfimpl\.go|internal/util/file\.go|internal/util/lockfile\.go|internal/worktrees/worktrees\.go)$
+        path: ^(internal/discovery/helpers\.go|internal/discovery/phase_worktree\.go|internal/engine/engine\.go|internal/engine/verification\.go|internal/getter/tfrhelpers\.go|internal/git/git\.go|internal/panicreport/panicreport\.go|internal/remotestate/remote_state\.go|internal/remotestate/terraform_state_file\.go|internal/report/writer\.go|internal/services/catalog/module/doc\.go|internal/services/catalog/module/module\.go|internal/shell/git\.go|internal/shell/run_cmd\.go|internal/stacks/clean/clean\.go|internal/tfimpl/tfimpl\.go|internal/util/lockfile\.go|internal/worktrees/worktrees\.go)$
       # We end up with duplicated content in this package to save us from duplicating code in other packages.
       - linters:
           - dupl

--- a/internal/cas/accessors_test.go
+++ b/internal/cas/accessors_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +15,7 @@ func TestCASStoreAccessors(t *testing.T) {
 
 	storePath := t.TempDir()
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	assert.Equal(t, storePath, c.StorePath())

--- a/internal/cas/benchmark_test.go
+++ b/internal/cas/benchmark_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func BenchmarkClone(b *testing.B) {
@@ -36,7 +37,7 @@ func BenchmarkClone(b *testing.B) {
 			storePath := filepath.Join(tempDir, "store", strconv.Itoa(i))
 			targetPath := filepath.Join(tempDir, "repo", strconv.Itoa(i))
 
-			c, err := cas.New(cas.WithStorePath(storePath))
+			c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 			require.NoError(b, err)
 
 			b.StartTimer()
@@ -51,7 +52,7 @@ func BenchmarkClone(b *testing.B) {
 		storePath := filepath.Join(tempDir, "store")
 
 		// First clone to populate store
-		c, err := cas.New(cas.WithStorePath(storePath))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 		require.NoError(b, err)
 
 		require.NoError(
@@ -67,7 +68,7 @@ func BenchmarkClone(b *testing.B) {
 
 			targetPath := filepath.Join(tempDir, "repo", strconv.Itoa(i))
 
-			c, err := cas.New(cas.WithStorePath(storePath))
+			c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 			require.NoError(b, err)
 
 			b.StartTimer()

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -123,7 +123,7 @@ func WithCloneDepth(depth int) Option {
 }
 
 // New creates a new CAS instance with the given options.
-func New(opts ...Option) (*CAS, error) {
+func New(v *venv.Venv, opts ...Option) (*CAS, error) {
 	c := &CAS{}
 
 	for _, opt := range opts {
@@ -131,7 +131,7 @@ func New(opts ...Option) (*CAS, error) {
 	}
 
 	if c.storePath == "" {
-		cacheDir, err := util.EnsureCacheDir()
+		cacheDir, err := util.EnsureCacheDir(v)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cas/cas_test.go
+++ b/internal/cas/cas_test.go
@@ -29,7 +29,7 @@ func TestCAS_Clone(t *testing.T) {
 		storePath := filepath.Join(tempDir, "store")
 		targetPath := filepath.Join(tempDir, "repo")
 
-		c, err := cas.New(cas.WithStorePath(storePath))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 		require.NoError(t, err)
 
 		err = c.Clone(t.Context(), l, v, repoURL, cas.WithDir(targetPath),
@@ -51,7 +51,7 @@ func TestCAS_Clone(t *testing.T) {
 		storePath := filepath.Join(tempDir, "store")
 		targetPath := filepath.Join(tempDir, "repo")
 
-		c, err := cas.New(cas.WithStorePath(storePath))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 		require.NoError(t, err)
 
 		err = c.Clone(t.Context(), l, v, repoURL, cas.WithDir(targetPath),
@@ -70,7 +70,7 @@ func TestCAS_Clone(t *testing.T) {
 		storePath := filepath.Join(tempDir, "store")
 		targetPath := filepath.Join(tempDir, "repo")
 
-		c, err := cas.New(cas.WithStorePath(storePath))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 		require.NoError(t, err)
 
 		err = c.Clone(t.Context(), l, v, repoURL, cas.WithDir(targetPath),
@@ -105,7 +105,7 @@ func TestCAS_FallbackWhenGitStoreFails(t *testing.T) {
 	entry := cas.EntryPathForURL(gitStoreRoot, repoURL)
 	require.NoError(t, os.WriteFile(entry, []byte("not a directory"), 0o644))
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -143,7 +143,7 @@ func TestCAS_CloneRepoWithSymlink(t *testing.T) {
 	storePath := filepath.Join(tempDir, "store")
 	targetPath := filepath.Join(tempDir, "repo")
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -184,7 +184,7 @@ func TestCASRejectsNonOSFilesystem(t *testing.T) {
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venvtest.New()

--- a/internal/cas/clone_e2e_test.go
+++ b/internal/cas/clone_e2e_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestCASClone_E2E_SymbolicRefSecondRunReusesCache(t *testing.T) {
@@ -23,7 +24,7 @@ func TestCASClone_E2E_SymbolicRefSecondRunReusesCache(t *testing.T) {
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	storePath := filepath.Join(tempDir, "store")
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -64,7 +65,7 @@ func TestCASClone_E2E_CommitFormRefRoundTrip(t *testing.T) {
 	headHash := resolveHeadE2E(t, repoURL)
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
-	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -93,7 +94,7 @@ func TestCASClone_E2E_ThroughCASGetter(t *testing.T) {
 	repoURL := startTestServer(t)
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
-	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -140,7 +141,7 @@ func TestCASClone_E2E_RemainsOfflineAfterFirstClone(t *testing.T) {
 	require.NoError(t, err)
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
-	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -178,7 +179,7 @@ func TestCASClone_E2E_MutableSetCopiesBlobs(t *testing.T) {
 	repoURL := startTestServer(t)
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
-	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/cas/commitref_test.go
+++ b/internal/cas/commitref_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestCASCloneByCommitRef(t *testing.T) {
@@ -30,7 +31,7 @@ func TestCASCloneByCommitRef(t *testing.T) {
 		t.Parallel()
 		tempDir := helpers.TmpDirWOSymlinks(t)
 
-		c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 		require.NoError(t, err)
 
 		targetPath := filepath.Join(tempDir, "repo")
@@ -47,7 +48,7 @@ func TestCASCloneByCommitRef(t *testing.T) {
 		t.Parallel()
 		tempDir := helpers.TmpDirWOSymlinks(t)
 
-		c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 		require.NoError(t, err)
 
 		targetPath := filepath.Join(tempDir, "repo")
@@ -65,7 +66,7 @@ func TestCASCloneByCommitRef(t *testing.T) {
 		tempDir := helpers.TmpDirWOSymlinks(t)
 		storePath := filepath.Join(tempDir, "store")
 
-		c, err := cas.New(cas.WithStorePath(storePath))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 		require.NoError(t, err)
 
 		// Prime the central git store.
@@ -94,7 +95,7 @@ func TestCASCloneByCommitRef(t *testing.T) {
 		t.Parallel()
 		tempDir := helpers.TmpDirWOSymlinks(t)
 
-		c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 		require.NoError(t, err)
 
 		err = c.Clone(t.Context(), l, v, repoURL, cas.WithDir(filepath.Join(tempDir, "repo")),
@@ -190,7 +191,7 @@ func TestCASClone_NonTipCommit(t *testing.T) {
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 
-	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -240,7 +241,7 @@ func TestCASClone_AbbreviatedHexBranchAdvancesAcrossClones(t *testing.T) {
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	storePath := filepath.Join(tempDir, "store")
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -293,7 +294,7 @@ func TestCASClone_HexBranchNameResolvesViaLsRemote(t *testing.T) {
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 
-	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -322,7 +323,7 @@ func TestCASClone_TagRef(t *testing.T) {
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 
-	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -480,7 +481,7 @@ func TestCASClone_OfflineWhenCommitCached(t *testing.T) {
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	storePath := filepath.Join(tempDir, "store")
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -516,7 +517,7 @@ func TestCASGetterGet_WithCommitRef(t *testing.T) {
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	storePath := filepath.Join(tempDir, "store")
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -557,7 +558,7 @@ func TestCAS_CommitRefFallbackWhenGitStoreFails(t *testing.T) {
 	blocker := cas.EntryPathForURL(gitStoreRoot, repoURL)
 	require.NoError(t, os.WriteFile(blocker, []byte("not a directory"), 0o644))
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -586,7 +587,7 @@ func TestCASCloneByCommitRefConcurrentWithRacing(t *testing.T) {
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	storePath := filepath.Join(tempDir, "store")
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/cas/getter_injection_test.go
+++ b/internal/cas/getter_injection_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // TestCASGetterRefOptionInjection checks the CAS git source path never runs a command from a crafted ref.
@@ -34,7 +35,7 @@ func TestCASGetterRefOptionInjection(t *testing.T) {
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/cas/getter_ssh_test.go
+++ b/internal/cas/getter_ssh_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestSSHCASGetterGet(t *testing.T) {
@@ -50,7 +51,7 @@ func TestSSHCASGetterGet(t *testing.T) {
 
 			tmpDir := helpers.TmpDirWOSymlinks(t)
 			storePath := filepath.Join(tmpDir, "store")
-			c, err := cas.New(cas.WithStorePath(storePath))
+			c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 			require.NoError(t, err)
 
 			v := venv.OSVenv()

--- a/internal/cas/getter_test.go
+++ b/internal/cas/getter_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestCASGetterMode(t *testing.T) {
@@ -109,7 +110,7 @@ func TestCASGetterGet(t *testing.T) {
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	storePath := filepath.Join(tempDir, "store")
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -161,7 +162,7 @@ func TestCASGetterLocalDir(t *testing.T) {
 	tmp := helpers.TmpDirWOSymlinks(t)
 	storePath := filepath.Join(tmp, "store")
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -217,7 +218,7 @@ func TestCASGetterLocalDir(t *testing.T) {
 func newTestCASGetter(t *testing.T, opts *cas.CloneOptions) *getter.CASGetter {
 	t.Helper()
 
-	c, err := cas.New(cas.WithStorePath(filepath.Join(helpers.TmpDirWOSymlinks(t), "store")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(helpers.TmpDirWOSymlinks(t), "store")))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/cas/integration_test.go
+++ b/internal/cas/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestIntegration_CloneAndReuse(t *testing.T) {
@@ -31,7 +32,7 @@ func TestIntegration_CloneAndReuse(t *testing.T) {
 
 		// First clone
 		firstClonePath := filepath.Join(tempDir, "first")
-		cas1, err := cas.New(cas.WithStorePath(storePath))
+		cas1, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 		require.NoError(t, err)
 		require.NoError(t, cas1.Clone(t.Context(), l, v, repoURL, cas.WithDir(firstClonePath),
 			cas.WithDepth(-1)))
@@ -43,7 +44,7 @@ func TestIntegration_CloneAndReuse(t *testing.T) {
 
 		// Second clone
 		secondClonePath := filepath.Join(tempDir, "second")
-		cas2, err := cas.New(cas.WithStorePath(storePath))
+		cas2, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 		require.NoError(t, err)
 		require.NoError(t, cas2.Clone(t.Context(), l, v, repoURL, cas.WithDir(secondClonePath),
 			cas.WithDepth(-1)))
@@ -65,7 +66,7 @@ func TestIntegration_CloneAndReuse(t *testing.T) {
 		t.Parallel()
 		tempDir := helpers.TmpDirWOSymlinks(t)
 
-		c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 		require.NoError(t, err)
 
 		err = c.Clone(t.Context(), l, v, repoURL, cas.WithDir(filepath.Join(tempDir, "repo")),
@@ -82,7 +83,7 @@ func TestIntegration_CloneAndReuse(t *testing.T) {
 		t.Parallel()
 		tempDir := helpers.TmpDirWOSymlinks(t)
 
-		c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 		require.NoError(t, err)
 
 		err = c.Clone(t.Context(), l, v, "http://127.0.0.1:1/nonexistent-repo.git",
@@ -107,7 +108,7 @@ func TestIntegration_TreeStorage(t *testing.T) {
 		storePath := filepath.Join(tempDir, "store")
 
 		// First clone to populate store
-		c, err := cas.New(cas.WithStorePath(storePath))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 		require.NoError(t, err)
 		require.NoError(t, c.Clone(ctx, l, v, repoURL, cas.WithDir(filepath.Join(tempDir, "repo")),
 			cas.WithDepth(-1)))

--- a/internal/cas/local_test.go
+++ b/internal/cas/local_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 const osWindows = "windows"
@@ -292,7 +293,7 @@ func newCAS(t *testing.T) (*cas.CAS, *venv.Venv) {
 	t.Helper()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/cas/materialize_test.go
+++ b/internal/cas/materialize_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestMaterializeTree_FromSynthStore(t *testing.T) {
@@ -47,7 +48,7 @@ func TestMaterializeTree_FromSynthStore(t *testing.T) {
 	require.NoError(t, synthContent.Store(l, v, treeHash, treeData))
 
 	// Build a CAS instance using the same store paths
-	c, err := cas.New(cas.WithStorePath(storeDir))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
 	destDir := helpers.TmpDirWOSymlinks(t)
@@ -90,7 +91,7 @@ func TestMaterializeTree_FromGitTreeStore(t *testing.T) {
 	treeContent := cas.NewContent(treeStore)
 	require.NoError(t, treeContent.Store(l, v, treeHash, treeData))
 
-	c, err := cas.New(cas.WithStorePath(storeDir))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
 	destDir := helpers.TmpDirWOSymlinks(t)
@@ -108,7 +109,7 @@ func TestMaterializeTree_NotFound(t *testing.T) {
 
 	storeDir := helpers.TmpDirWOSymlinks(t)
 
-	c, err := cas.New(cas.WithStorePath(storeDir))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -155,7 +156,7 @@ func TestMaterializeTree_SynthTakesPrecedence(t *testing.T) {
 	gitContent := cas.NewContent(treeStore)
 	require.NoError(t, gitContent.Store(l, v, hash, []byte("100644 blob blobB\tfile.txt\n")))
 
-	c, err := cas.New(cas.WithStorePath(storeDir))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
 	destDir := helpers.TmpDirWOSymlinks(t)
@@ -218,7 +219,7 @@ func TestCASProtocolGetterGet(t *testing.T) {
 	synthContent := cas.NewContent(synthStore)
 	require.NoError(t, synthContent.Store(l, v, treeHash, treeData))
 
-	c, err := cas.New(cas.WithStorePath(storeDir))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
 	g := getter.NewCASProtocolGetter(l, c, v)
@@ -273,7 +274,7 @@ func TestCASProtocolGetterGet_Mutable(t *testing.T) {
 	synthContent := cas.NewContent(synthStore)
 	require.NoError(t, synthContent.Store(l, v, treeHash, treeData))
 
-	c, err := cas.New(cas.WithStorePath(storeDir))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
 	g := getter.NewCASProtocolGetter(l, c, v)
@@ -306,7 +307,7 @@ func TestCASProtocolGetterGet_InvalidRef(t *testing.T) {
 
 	storeDir := helpers.TmpDirWOSymlinks(t)
 
-	c, err := cas.New(cas.WithStorePath(storeDir))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/cas/protocol_getter_test.go
+++ b/internal/cas/protocol_getter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestParseCASRef(t *testing.T) {
@@ -130,7 +131,7 @@ func TestCASProtocolGetterGet_MalformedHash(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			c, err := cas.New(cas.WithStorePath(t.TempDir()))
+			c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(t.TempDir()))
 			require.NoError(t, err)
 
 			v := venv.OSVenv()

--- a/internal/cas/race_test.go
+++ b/internal/cas/race_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestCASGetterGetWithRacing(t *testing.T) {
@@ -26,7 +27,7 @@ func TestCASGetterGetWithRacing(t *testing.T) {
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	storePath := filepath.Join(tempDir, "store")
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -82,7 +83,7 @@ func TestProcessStackComponentLocalSourceConcurrentWithRacing(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/cas/stacks_local_test.go
+++ b/internal/cas/stacks_local_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestProcessStackComponent_LocalSource_RewritesStackSources(t *testing.T) {
@@ -28,7 +29,7 @@ func TestProcessStackComponent_LocalSource_RewritesStackSources(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -70,7 +71,7 @@ func TestProcessStackComponent_LocalSource_RewritesUnitSources(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -118,7 +119,7 @@ func TestProcessStackComponent_LocalSource_DoesNotMutateInput(t *testing.T) {
 	before := snapshotTree(t, root)
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -144,7 +145,7 @@ func TestProcessStackComponent_LocalSource_DeterministicOutput(t *testing.T) {
 
 	readStackFile := func() string {
 		storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-		c, err := cas.New(cas.WithStorePath(storePath))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 		require.NoError(t, err)
 
 		source := root + "//stacks/my-stack"
@@ -194,7 +195,7 @@ func TestProcessStackComponent_LocalSource_ContentAddressedCacheKey(t *testing.T
 
 	runAndExtractServiceRef := func(root string) string {
 		storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-		c, err := cas.New(cas.WithStorePath(storePath))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 		require.NoError(t, err)
 
 		source := root + "//stacks/my-stack"
@@ -366,7 +367,7 @@ func TestProcessStackComponent_GitForcerRoutesRemote(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -427,7 +428,7 @@ func TestProcessStackComponent_LocalSource_MaterializeSynthTree(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -671,7 +672,7 @@ func TestProcessStackComponent_LocalSource_SharedUnitTemplate(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -723,7 +724,7 @@ func TestProcessStackComponent_LocalSource_SharedNestedStack(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/cas/stacks_test.go
+++ b/internal/cas/stacks_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestSplitSourceDoubleSlash(t *testing.T) {
@@ -155,7 +156,7 @@ func TestProcessStackComponent_RewritesStackSources(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -198,7 +199,7 @@ func TestProcessStackComponent_RewritesUnitSources(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -253,7 +254,7 @@ func TestProcessStackComponent_UnitSourceSyntheticTreeContainsSiblings(t *testin
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -314,7 +315,7 @@ func TestProcessStackComponent_UnitSourceWithoutDoubleSlash(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -373,7 +374,7 @@ func TestProcessStackComponent_CreatesSyntheticTrees(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -436,7 +437,7 @@ func TestProcessStackComponent_DeterministicOutput(t *testing.T) {
 
 	readStackFile := func() string {
 		storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-		c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 		require.NoError(t, err)
 
 		source := repoURL + "//stacks/my-stack?ref=main"
@@ -474,7 +475,7 @@ func TestProcessStackComponent_MaterializeSynthTree(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -525,7 +526,7 @@ func TestProcessStackComponent_InvalidRefFails(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -543,7 +544,7 @@ func TestProcessStackComponent_InvalidSubdirFails(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -562,7 +563,7 @@ func TestProcessStackComponent_BlobsStoredInCAS(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -597,7 +598,7 @@ func TestProcessStackComponent_AcceptsExplicitGitPrefix(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -618,7 +619,7 @@ func TestProcessStackComponent_ShorthandSourceReachesClone(t *testing.T) {
 	l := logger.CreateLogger()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := cas.New(cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/cas/submodule_test.go
+++ b/internal/cas/submodule_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // startSubmoduleServer commits the given files to a fresh test server,
@@ -62,7 +63,7 @@ func TestCAS_CloneRepoWithSubmodule(t *testing.T) {
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	storePath := filepath.Join(tempDir, "store")
 
-	c, err := cas.New(cas.WithStorePath(storePath))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	assertClone := func(t *testing.T, targetPath string) {
@@ -134,7 +135,7 @@ func TestCAS_CloneRepoWithNestedSubmodules(t *testing.T) {
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	targetPath := filepath.Join(tempDir, "repo")
 
-	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
 	err = c.Clone(
@@ -184,7 +185,7 @@ func TestCAS_CloneRepoWithUnregisteredGitlink(t *testing.T) {
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	targetPath := filepath.Join(tempDir, "repo")
 
-	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
 	err = c.Clone(
@@ -255,7 +256,7 @@ func TestCAS_CloneSubmoduleWithRelativeURL(t *testing.T) {
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	targetPath := filepath.Join(tempDir, "repo")
 
-	c, err := cas.New(cas.WithStorePath(filepath.Join(tempDir, "store")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
 	err = c.Clone(

--- a/internal/cli/commands/aws-provider-patch/aws-provider-patch.go
+++ b/internal/cli/commands/aws-provider-patch/aws-provider-patch.go
@@ -53,7 +53,7 @@ func runSingle(
 		return err
 	}
 
-	runCfg := prepared.Cfg.ToRunConfig(l)
+	runCfg := prepared.Cfg.ToRunConfig(l, v.FS)
 
 	if err := prepare.PrepareGenerate(ctx, l, v, updatedOpts, runCfg); err != nil {
 		return err

--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -198,7 +198,7 @@ func WrapWithTelemetry(
 				}
 			}()
 
-			if err := initialSetup(cliCtx, l, opts); err != nil {
+			if err := initialSetup(cliCtx, l, v, opts); err != nil {
 				return err
 			}
 
@@ -446,7 +446,7 @@ func setupAutoProviderCacheDir(
 	// Set up the provider cache directory
 	providerCacheDir := opts.ProviderCacheOptions.Dir
 	if providerCacheDir == "" {
-		cacheDir, err := util.EnsureCacheDir()
+		cacheDir, err := util.EnsureCacheDir(v)
 		if err != nil {
 			return fmt.Errorf("failed to get cache directory: %w", err)
 		}
@@ -476,7 +476,12 @@ func setupAutoProviderCacheDir(
 }
 
 // mostly preparing terragrunt options
-func initialSetup(cliCtx *clihelper.Context, l log.Logger, opts *options.TerragruntOptions) error {
+func initialSetup(
+	cliCtx *clihelper.Context,
+	l log.Logger,
+	v *venv.Venv,
+	opts *options.TerragruntOptions,
+) error {
 	// convert the rest flags (intended for terraform) to one dash, e.g. `--input=true` to `-input=true`
 	args := cliCtx.Args().WithoutBuiltinCmdSep().Normalize(clihelper.SingleDashFlag)
 	cmdName := cliCtx.Command.Name
@@ -565,7 +570,7 @@ func initialSetup(cliCtx *clihelper.Context, l log.Logger, opts *options.Terragr
 
 	var fileFilterStrings []string
 
-	excludeFiltersFromFile, err := util.ExcludeFiltersFromFile(opts.WorkingDir, opts.ExcludesFile)
+	excludeFiltersFromFile, err := util.ExcludeFiltersFromFile(v.FS, opts.WorkingDir, opts.ExcludesFile)
 	if err != nil {
 		return err
 	}
@@ -575,6 +580,7 @@ func initialSetup(cliCtx *clihelper.Context, l log.Logger, opts *options.Terragr
 	// Process filters file if the filters file is not disabled
 	if !opts.NoFiltersFile {
 		filtersFromFile, filtersFromFileErr := util.GetFiltersFromFile(
+			v.FS,
 			opts.WorkingDir,
 			opts.FiltersFile,
 		)

--- a/internal/cli/commands/exec/exec.go
+++ b/internal/cli/commands/exec/exec.go
@@ -37,7 +37,7 @@ func Run(
 		return err
 	}
 
-	runCfg := prepared.Cfg.ToRunConfig(l)
+	runCfg := prepared.Cfg.ToRunConfig(l, v.FS)
 
 	// Generate config
 	if err := prepare.PrepareGenerate(ctx, l, v, updatedOpts, runCfg); err != nil {

--- a/internal/cli/commands/hcl/validate/validate.go
+++ b/internal/cli/commands/hcl/validate/validate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 
 	"github.com/google/shlex"
@@ -29,7 +30,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/prepare"
 	"github.com/gruntwork-io/terragrunt/internal/report"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/view"
 	"github.com/gruntwork-io/terragrunt/internal/view/diagnostic"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
@@ -386,13 +386,13 @@ func RunValidateInputs(
 			l,
 			unitV,
 			updatedOpts,
-			prepared.Cfg.ToRunConfig(l),
+			prepared.Cfg.ToRunConfig(l, unitV.FS),
 		); err != nil {
 			errs = append(errs, err)
 			continue
 		}
 
-		if err := runValidateInputs(l, unitV.Env, updatedOpts, prepared.Cfg); err != nil {
+		if err := runValidateInputs(l, unitV, updatedOpts, prepared.Cfg); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -406,7 +406,7 @@ func RunValidateInputs(
 
 func runValidateInputs(
 	l log.Logger,
-	env map[string]string,
+	v *venv.Venv,
 	opts *options.TerragruntOptions,
 	cfg *config.TerragruntConfig,
 ) error {
@@ -417,7 +417,7 @@ func runValidateInputs(
 
 	allVars := slices.Concat(required, optional)
 
-	allInputs, err := getDefinedTerragruntInputs(l, env, opts, cfg)
+	allInputs, err := getDefinedTerragruntInputs(l, v, opts, cfg)
 	if err != nil {
 		return err
 	}
@@ -493,14 +493,14 @@ func runValidateInputs(
 // - automatically injected terraform vars (terraform.tfvars, terraform.tfvars.json, *.auto.tfvars, *.auto.tfvars.json)
 func getDefinedTerragruntInputs(
 	l log.Logger,
-	env map[string]string,
+	v *venv.Venv,
 	opts *options.TerragruntOptions,
 	cfg *config.TerragruntConfig,
 ) ([]string, error) {
-	envVarTFVars := getTerraformInputNamesFromEnvVar(env, cfg)
+	envVarTFVars := getTerraformInputNamesFromEnvVar(v.Env, cfg)
 	inputsTFVars := getTerraformInputNamesFromConfig(cfg)
 
-	varFileTFVars, err := getTerraformInputNamesFromVarFiles(l, cfg)
+	varFileTFVars, err := getTerraformInputNamesFromVarFiles(l, v.FS, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -510,7 +510,7 @@ func getDefinedTerragruntInputs(
 		return nil, err
 	}
 
-	autoVarFileTFVars, err := getTerraformInputNamesFromAutomaticVarFiles(l, opts)
+	autoVarFileTFVars, err := getTerraformInputNamesFromAutomaticVarFiles(l, v.FS, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -597,6 +597,7 @@ func getTerraformInputNamesFromConfig(terragruntConfig *config.TerragruntConfig)
 // extra_arguments block required_var_files and optional_var_files settings of the given terragrunt config.
 func getTerraformInputNamesFromVarFiles(
 	l log.Logger,
+	fsys vfs.FS,
 	terragruntConfig *config.TerragruntConfig,
 ) ([]string, error) {
 	if terragruntConfig.Terraform == nil {
@@ -605,7 +606,7 @@ func getTerraformInputNamesFromVarFiles(
 
 	varFiles := []string{}
 	for _, arg := range terragruntConfig.Terraform.ExtraArgs {
-		varFiles = append(varFiles, arg.GetVarFiles(l)...)
+		varFiles = append(varFiles, arg.GetVarFiles(l, fsys)...)
 	}
 
 	return getVarNamesFromVarFiles(l, varFiles)
@@ -651,18 +652,19 @@ func getTerraformInputNamesFromCLIArgs(
 // getTerraformInputNamesFromAutomaticVarFiles returns all the variables names
 func getTerraformInputNamesFromAutomaticVarFiles(
 	l log.Logger,
+	fsys vfs.FS,
 	opts *options.TerragruntOptions,
 ) ([]string, error) {
 	base := opts.WorkingDir
 	automaticVarFiles := []string{}
 
 	tfTFVarsFile := filepath.Join(base, "terraform.tfvars")
-	if util.FileExists(tfTFVarsFile) {
+	if vfs.Exists(fsys, tfTFVarsFile) {
 		automaticVarFiles = append(automaticVarFiles, tfTFVarsFile)
 	}
 
 	tfTFVarsJSONFile := filepath.Join(base, "terraform.tfvars.json")
-	if util.FileExists(tfTFVarsJSONFile) {
+	if vfs.Exists(fsys, tfTFVarsJSONFile) {
 		automaticVarFiles = append(automaticVarFiles, tfTFVarsJSONFile)
 	}
 

--- a/internal/cli/commands/render/render.go
+++ b/internal/cli/commands/render/render.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"os"
 	"path/filepath"
 
 	"errors"
@@ -16,8 +14,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/prepare"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/zclconf/go-cty/cty"
@@ -38,7 +36,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *Options) error {
 		return err
 	}
 
-	return runRender(l, v.Writers.Writer, opts, prepared.Cfg)
+	return runRender(l, v, opts, prepared.Cfg)
 }
 
 func runAll(ctx context.Context, l log.Logger, v *venv.Venv, opts *Options) error {
@@ -74,7 +72,7 @@ func runAll(ctx context.Context, l log.Logger, v *venv.Venv, opts *Options) erro
 			continue
 		}
 
-		if err := runRender(l, v.Writers.Writer, unitOpts, prepared.Cfg); err != nil {
+		if err := runRender(l, v, unitOpts, prepared.Cfg); err != nil {
 			if opts.FailFast {
 				return err
 			}
@@ -97,7 +95,7 @@ func runAll(ctx context.Context, l log.Logger, v *venv.Venv, opts *Options) erro
 	return nil
 }
 
-func runRender(l log.Logger, w io.Writer, opts *Options, cfg *config.TerragruntConfig) error {
+func runRender(l log.Logger, v *venv.Venv, opts *Options, cfg *config.TerragruntConfig) error {
 	if cfg == nil {
 		return errors.New(
 			"terragrunt was not able to render the config because it received no config. This is almost certainly a bug in Terragrunt. Please open an issue on github.com/gruntwork-io/terragrunt with this message and the contents of your terragrunt.hcl",
@@ -106,15 +104,15 @@ func runRender(l log.Logger, w io.Writer, opts *Options, cfg *config.TerragruntC
 
 	switch opts.Format {
 	case FormatJSON:
-		return renderJSON(l, w, opts, cfg)
+		return renderJSON(l, v, opts, cfg)
 	case FormatHCL:
-		return renderHCL(l, w, opts, cfg)
+		return renderHCL(l, v, opts, cfg)
 	default:
 		return fmt.Errorf("unsupported render format: %s", opts.Format)
 	}
 }
 
-func renderHCL(l log.Logger, w io.Writer, opts *Options, cfg *config.TerragruntConfig) error {
+func renderHCL(l log.Logger, v *venv.Venv, opts *Options, cfg *config.TerragruntConfig) error {
 	if opts.Write {
 		buf := new(bytes.Buffer)
 
@@ -123,12 +121,12 @@ func renderHCL(l log.Logger, w io.Writer, opts *Options, cfg *config.TerragruntC
 			return err
 		}
 
-		return writeRendered(l, opts, buf.Bytes())
+		return writeRendered(l, v.FS, opts, buf.Bytes())
 	}
 
 	l.Debugf("Rendering config %s", opts.TerragruntConfigPath)
 
-	_, err := cfg.WriteTo(w)
+	_, err := cfg.WriteTo(v.Writers.Writer)
 	if err != nil {
 		return err
 	}
@@ -136,7 +134,7 @@ func renderHCL(l log.Logger, w io.Writer, opts *Options, cfg *config.TerragruntC
 	return nil
 }
 
-func renderJSON(l log.Logger, w io.Writer, opts *Options, cfg *config.TerragruntConfig) error {
+func renderJSON(l log.Logger, v *venv.Venv, opts *Options, cfg *config.TerragruntConfig) error {
 	var terragruntConfigCty cty.Value
 
 	if opts.RenderMetadata {
@@ -161,12 +159,12 @@ func renderJSON(l log.Logger, w io.Writer, opts *Options, cfg *config.Terragrunt
 	}
 
 	if opts.Write {
-		return writeRendered(l, opts, jsonBytes)
+		return writeRendered(l, v.FS, opts, jsonBytes)
 	}
 
 	l.Debugf("Rendering config %s", opts.TerragruntConfigPath)
 
-	_, err = w.Write(jsonBytes)
+	_, err = v.Writers.Writer.Write(jsonBytes)
 	if err != nil {
 		return err
 	}
@@ -174,21 +172,21 @@ func renderJSON(l log.Logger, w io.Writer, opts *Options, cfg *config.Terragrunt
 	return nil
 }
 
-func writeRendered(l log.Logger, opts *Options, data []byte) error {
+func writeRendered(l log.Logger, fsys vfs.FS, opts *Options, data []byte) error {
 	outPath := opts.OutputPath
 	if !filepath.IsAbs(outPath) {
 		terragruntConfigDir := filepath.Dir(opts.TerragruntConfigPath)
 		outPath = filepath.Join(terragruntConfigDir, outPath)
 	}
 
-	if err := util.EnsureDirectory(filepath.Dir(outPath)); err != nil {
+	if err := vfs.EnsureDirectory(fsys, filepath.Dir(outPath)); err != nil {
 		return err
 	}
 
 	l.Debugf("Rendering config %s to %s", opts.TerragruntConfigPath, outPath)
 
 	const ownerWriteGlobalReadPerms = 0644
-	if err := os.WriteFile(outPath, data, ownerWriteGlobalReadPerms); err != nil {
+	if err := vfs.WriteFile(fsys, outPath, data, ownerWriteGlobalReadPerms); err != nil {
 		return err
 	}
 

--- a/internal/cli/commands/run/run.go
+++ b/internal/cli/commands/run/run.go
@@ -17,8 +17,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/tips"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -110,7 +110,7 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, v *
 		}
 	}
 
-	runCfg := cfg.ToRunConfig(l)
+	runCfg := cfg.ToRunConfig(l, v.FS)
 
 	unitPath := filepath.Clean(opts.RootWorkingDir)
 
@@ -185,7 +185,7 @@ func getTFPathFromConfig(
 	v *venv.Venv,
 	opts *options.TerragruntOptions,
 ) (string, error) {
-	if !util.FileExists(opts.TerragruntConfigPath) {
+	if !vfs.Exists(v.FS, opts.TerragruntConfigPath) {
 		l.Debugf("Did not find the config file %s", opts.TerragruntConfigPath)
 
 		return "", nil

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -207,7 +207,7 @@ func Prepare(
 	}
 
 	// scaffold only in empty directories
-	if empty, err := util.IsDirectoryEmpty(opts.WorkingDir); !empty || err != nil {
+	if empty, err := vfs.IsDirectoryEmpty(v.FS, opts.WorkingDir); !empty || err != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -738,7 +738,7 @@ func prepareBoilerplateFiles(
 	}
 
 	// if boilerplate dir is not found, create one with default template
-	if !util.IsDir(boilerplateDir) {
+	if !vfs.IsDir(v.FS, boilerplateDir) {
 		_, pctx := configbridge.NewParsingContext(ctx, l, v, opts)
 
 		config, err := config.ReadCatalogConfig(ctx, l, pctx)

--- a/internal/cli/commands/scaffold/scaffold_test.go
+++ b/internal/cli/commands/scaffold/scaffold_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gruntwork-io/boilerplate/variables"
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/scaffold"
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
-	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -104,7 +104,7 @@ func TestDefaultTemplateVariables(t *testing.T) {
 	err = templates.ProcessTemplate(l, boilerplateOpts, boilerplateOpts, emptyDep)
 	require.NoError(t, err)
 
-	content, err := util.ReadFileAsString(filepath.Join(outputDir, "terragrunt.hcl"))
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(outputDir, "terragrunt.hcl"))
 	require.NoError(t, err)
 	require.Contains(t, content, "required_var_1")
 	require.Contains(t, content, "optional_var_2")
@@ -196,7 +196,7 @@ func TestDefaultTemplateUserValueOverridesTODO(t *testing.T) {
 	emptyDep := &variables.Dependency{}
 	require.NoError(t, templates.ProcessTemplate(l, boilerplateOpts, boilerplateOpts, emptyDep))
 
-	content, err := util.ReadFileAsString(filepath.Join(outputDir, "terragrunt.hcl"))
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(outputDir, "terragrunt.hcl"))
 	require.NoError(t, err)
 
 	// Required field with a user value: HCL fragment emitted, no TODO line.
@@ -657,7 +657,7 @@ shell_output = "{{ shell "echo SHELL_EXECUTED" }}"
 	generatedFile := filepath.Join(outputDir, "test.txt")
 	require.FileExists(t, generatedFile)
 
-	content, err := util.ReadFileAsString(generatedFile)
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), generatedFile)
 	require.NoError(t, err)
 
 	// Verify that template variables were processed
@@ -731,7 +731,7 @@ shell_output = "{{ shell "echo" "SHELL_EXECUTED" }}"
 	generatedFile := filepath.Join(outputDir, "test.txt")
 	require.FileExists(t, generatedFile)
 
-	content, err := util.ReadFileAsString(generatedFile)
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), generatedFile)
 	require.NoError(t, err)
 
 	// Verify that template variables were processed
@@ -813,7 +813,7 @@ test_var = "{{ .TestVar }}"
 	generatedFile := filepath.Join(outputDir, "test.txt")
 	require.FileExists(t, generatedFile)
 
-	content, err := util.ReadFileAsString(generatedFile)
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), generatedFile)
 	require.NoError(t, err)
 	assert.Contains(t, content, "test-value", "Template variable should be processed")
 
@@ -892,7 +892,7 @@ test_var = "{{ .TestVar }}"
 	generatedFile := filepath.Join(outputDir, "test.txt")
 	require.FileExists(t, generatedFile)
 
-	content, err := util.ReadFileAsString(generatedFile)
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), generatedFile)
 	require.NoError(t, err)
 	assert.Contains(t, content, "test-value", "Template variable should be processed")
 
@@ -965,7 +965,7 @@ shell_result = "{{ shell "echo SHELL_EXECUTED" }}"
 	generatedFile := filepath.Join(outputDir, "test.txt")
 	require.FileExists(t, generatedFile)
 
-	content, err := util.ReadFileAsString(generatedFile)
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), generatedFile)
 	require.NoError(t, err)
 
 	// Verify that template variables were processed

--- a/internal/codegen/generate_test.go
+++ b/internal/codegen/generate_test.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/codegen"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -338,7 +338,7 @@ func TestFmtGeneratedFile(t *testing.T) {
 			err := codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config)
 			require.NoError(t, err)
 
-			assert.True(t, util.FileExists(tc.path))
+			assert.FileExists(t, tc.path)
 
 			fileContent, err := os.ReadFile(tc.path)
 			require.NoError(t, err)
@@ -394,9 +394,9 @@ func TestGenerateDisabling(t *testing.T) {
 			require.NoError(t, err)
 
 			if tc.disabled {
-				assert.True(t, util.FileNotExists(tc.path))
+				assert.NoFileExists(t, tc.path)
 			} else {
-				assert.True(t, util.FileExists(tc.path))
+				assert.FileExists(t, tc.path)
 			}
 		})
 	}
@@ -724,7 +724,7 @@ func TestWriteToFileDisabledRemovesReadOnlyFile(t *testing.T) {
 
 	l := logger.CreateLogger()
 	require.NoError(t, codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config))
-	assert.True(t, util.FileNotExists(targetPath))
+	assert.NoFileExists(t, targetPath)
 }
 
 // TestWriteToFileSignatureWithoutTrailingNewline verifies that a generated
@@ -771,7 +771,7 @@ func TestWriteToFileSignatureWithoutTrailingNewline(t *testing.T) {
 			require.NoError(t, codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config))
 
 			if tc.disable {
-				assert.True(t, util.FileNotExists(path))
+				assert.NoFileExists(t, path)
 
 				return
 			}
@@ -1138,7 +1138,7 @@ func TestWriteToFileSymlinkIsNotTerragruntGenerated(t *testing.T) {
 func newTestContentStore(t *testing.T, dir string) *cas.Content {
 	t.Helper()
 
-	c, err := cas.New(cas.WithStorePath(filepath.Join(dir, "cas")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(dir, "cas")))
 	require.NoError(t, err)
 
 	return cas.NewContent(c.BlobStore())

--- a/internal/discovery/phase_parse.go
+++ b/internal/discovery/phase_parse.go
@@ -16,8 +16,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -334,7 +334,7 @@ func parseComponent(
 			componentPath := c.Path()
 			workingDir := componentPath
 
-			if util.FileExists(componentPath) && !util.IsDir(componentPath) {
+			if vfs.Exists(v.FS, componentPath) && !vfs.IsDir(v.FS, componentPath) {
 				workingDir = filepath.Dir(componentPath)
 			}
 
@@ -349,7 +349,7 @@ func parseComponent(
 					break
 				}
 
-				if opts.TerragruntConfigPath != "" && !util.IsDir(opts.TerragruntConfigPath) {
+				if opts.TerragruntConfigPath != "" && !vfs.IsDir(v.FS, opts.TerragruntConfigPath) {
 					configFilename = filepath.Base(opts.TerragruntConfigPath)
 				}
 			}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -268,7 +268,7 @@ func createInstance(
 		return nil, err
 	}
 
-	terragruntEngine, client, err := createEngine(ctx, l, v.Exec, execOptions)
+	terragruntEngine, client, err := createEngine(ctx, l, v, execOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func downloadEngine(
 		return nil
 	}
 
-	if util.FileExists(e.Source) {
+	if vfs.Exists(v.FS, e.Source) {
 		// if source is a file, no need to download, exit
 		return nil
 	}
@@ -341,16 +341,16 @@ func downloadEngine(
 			}
 		}
 
-		path, err := engineDir(execOptions)
+		path, err := engineDir(v, execOptions)
 		if err != nil {
 			return err
 		}
 
-		if ensureErr := util.EnsureDirectory(path); ensureErr != nil {
+		if ensureErr := vfs.EnsureDirectory(v.FS, path); ensureErr != nil {
 			return ensureErr
 		}
 
-		localEngineFile := filepath.Join(path, engineFileName(e))
+		localEngineFile := filepath.Join(path, engineFileName(v.FS, e))
 
 		// lock downloading process for only one instance
 		locks, err := downloadLocksFromContext(ctx)
@@ -362,11 +362,11 @@ func downloadEngine(
 		locks.Lock(localEngineFile)
 		defer locks.Unlock(localEngineFile)
 
-		if util.FileExists(localEngineFile) {
+		if vfs.Exists(v.FS, localEngineFile) {
 			return nil
 		}
 
-		downloadFile := filepath.Join(path, enginePackageName(e))
+		downloadFile := filepath.Join(path, enginePackageName(v.FS, e))
 
 		// Prepare download assets
 		assets := &github.ReleaseAssets{
@@ -402,7 +402,7 @@ func downloadEngine(
 			checksumSigFile != "" {
 			l.Infof("Verifying checksum for %s", downloadFile)
 
-			if err := verifyFile(downloadFile, checksumFile, checksumSigFile); err != nil {
+			if err := verifyFile(v.FS, downloadFile, checksumFile, checksumSigFile); err != nil {
 				return err
 			}
 		} else {
@@ -530,9 +530,9 @@ func extractArchiveWithLimits(
 }
 
 // engineDir returns the directory path where engine files are stored.
-func engineDir(opts *ExecutionOptions) (string, error) {
+func engineDir(v *venv.Venv, opts *ExecutionOptions) (string, error) {
 	engine := opts.EngineConfig
-	if util.FileExists(engine.Source) {
+	if vfs.Exists(v.FS, engine.Source) {
 		return filepath.Dir(engine.Source), nil
 	}
 
@@ -552,7 +552,7 @@ func engineDir(opts *ExecutionOptions) (string, error) {
 		), nil
 	}
 
-	cacheDir, err := util.EnsureCacheDir()
+	cacheDir, err := util.EnsureCacheDir(v)
 	if err != nil {
 		return "", err
 	}
@@ -569,9 +569,9 @@ func engineDir(opts *ExecutionOptions) (string, error) {
 }
 
 // engineFileName returns the file name for the engine.
-func engineFileName(e *EngineConfig) string {
+func engineFileName(fsys vfs.FS, e *EngineConfig) string {
 	engineName := filepath.Base(e.Source)
-	if util.FileExists(e.Source) {
+	if vfs.Exists(fsys, e.Source) {
 		// return file name if source is absolute path
 		return engineName
 	}
@@ -598,8 +598,8 @@ func engineChecksumSigName(e *EngineConfig) string {
 }
 
 // enginePackageName returns the package name for the engine.
-func enginePackageName(e *EngineConfig) string {
-	return engineFileName(e) + ".zip"
+func enginePackageName(fsys vfs.FS, e *EngineConfig) string {
+	return engineFileName(fsys, e) + ".zip"
 }
 
 func isDirectURL(source string) bool {
@@ -797,7 +797,7 @@ func logEngineMessage(l log.Logger, logLevel proto.LogLevel, content string) {
 func createEngine(
 	ctx context.Context,
 	l log.Logger,
-	e vexec.Exec,
+	v *venv.Venv,
 	execOptions *ExecutionOptions,
 ) (*proto.EngineClient, *plugin.Client, error) {
 	if execOptions.EngineConfig == nil {
@@ -819,20 +819,21 @@ func createEngine(
 		"version":   execOptions.EngineConfig.Version,
 		"cache_dir": execOptions.CacheDir,
 	}, func(ctx context.Context, l log.Logger) error {
-		path, err := engineDir(execOptions)
+		path, err := engineDir(v, execOptions)
 		if err != nil {
 			return err
 		}
 
-		localEnginePath := filepath.Join(path, engineFileName(execOptions.EngineConfig))
+		localEnginePath := filepath.Join(path, engineFileName(v.FS, execOptions.EngineConfig))
 		localChecksumFile := filepath.Join(path, engineChecksumName(execOptions.EngineConfig))
 		localChecksumSigFile := filepath.Join(path, engineChecksumSigName(execOptions.EngineConfig))
 
 		// validate engine before loading if verification is not disabled
 		skipCheck := execOptions.EngineOptions.SkipChecksumCheck
-		if !skipCheck && util.FileExists(localEnginePath) && util.FileExists(localChecksumFile) &&
-			util.FileExists(localChecksumSigFile) {
+		if !skipCheck && vfs.Exists(v.FS, localEnginePath) && vfs.Exists(v.FS, localChecksumFile) &&
+			vfs.Exists(v.FS, localChecksumSigFile) {
 			if err = verifyFile(
+				v.FS,
 				localEnginePath,
 				localChecksumFile,
 				localChecksumSigFile,
@@ -867,7 +868,7 @@ func createEngine(
 		// We use without cancel here to ensure that the plugin isn't killed when the main context is cancelled,
 		// like it is in the RunCommandWithOutput function. This ensures that we don't cancel the shutdown
 		// when the command is cancelled.
-		cmd := e.Command(context.WithoutCancel(ctx), localEnginePath)
+		cmd := v.Exec.Command(context.WithoutCancel(ctx), localEnginePath)
 		cmd.SetEnv([]string{fmt.Sprintf("%s=%s", engineLogLevelEnv, engineLogLevel)})
 		cmd.SetCancel(func() error {
 			sig := signal.SignalFromContext(ctx)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -77,7 +77,9 @@ func TestRun_NonOSBackedExecReturnsSentinel(t *testing.T) {
 		CacheDir: t.TempDir(),
 	}
 
-	v := venvtest.New().WithHandler(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+	// The engine source is a real file on disk, so the venv must see the real
+	// filesystem for Run to treat it as a local engine instead of a download.
+	v := venvtest.NewWithOSFS().WithHandler(func(_ context.Context, _ vexec.Invocation) vexec.Result {
 		return vexec.Result{}
 	})
 

--- a/internal/engine/verification.go
+++ b/internal/engine/verification.go
@@ -11,10 +11,11 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 )
 
 // verifyFile verifies the checksums file and the signature file of the passed file
-func verifyFile(checkedFile, checksumsFile, signatureFile string) error {
+func verifyFile(fsys vfs.FS, checkedFile, checksumsFile, signatureFile string) error {
 	checksums, err := os.ReadFile(checksumsFile)
 	if err != nil {
 		return err
@@ -43,7 +44,7 @@ func verifyFile(checkedFile, checksumsFile, signatureFile string) error {
 
 	// verify checksums
 	// calculate checksum of package file
-	packageChecksum, err := util.FileSHA256(checkedFile)
+	packageChecksum, err := vfs.FileSHA256(fsys, checkedFile)
 	if err != nil {
 		return err
 	}

--- a/internal/gcphelper/config.go
+++ b/internal/gcphelper/config.go
@@ -158,7 +158,7 @@ func (b *GCPConfigBuilder) Build(
 		clientOpts = append(clientOpts, option.WithTokenSource(tokenSource))
 	} else if env["GOOGLE_CREDENTIALS"] != "" {
 		// Use GOOGLE_CREDENTIALS from environment (can be file path or JSON content)
-		clientOpt, err := createGCPCredentialsFromGoogleCredentialsEnv(ctx, env)
+		clientOpt, err := createGCPCredentialsFromGoogleCredentialsEnv(ctx, v)
 		if err != nil {
 			return nil, err
 		}
@@ -237,7 +237,7 @@ func credentialsJSONOption(v *venv.Venv, data []byte) (option.ClientOption, erro
 // This can be either a file path or the JSON content directly (to mirror how Terraform works).
 func createGCPCredentialsFromGoogleCredentialsEnv(
 	ctx context.Context,
-	env map[string]string,
+	v *venv.Venv,
 ) (option.ClientOption, error) {
 	var account = struct {
 		PrivateKeyID string `json:"private_key_id"`
@@ -247,9 +247,9 @@ func createGCPCredentialsFromGoogleCredentialsEnv(
 	}{}
 
 	// to mirror how Terraform works, we have to accept either the file path or the contents
-	creds := env["GOOGLE_CREDENTIALS"]
+	creds := v.Env["GOOGLE_CREDENTIALS"]
 
-	contents, err := util.FileOrData(creds)
+	contents, err := util.FileOrData(v, creds)
 	if err != nil {
 		return nil, fmt.Errorf("error loading credentials: %w", err)
 	}

--- a/internal/getter/casgetter_detect_test.go
+++ b/internal/getter/casgetter_detect_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestCASGetterDetect_GitForcedPrefix(t *testing.T) {
@@ -348,7 +349,7 @@ func TestCASGetterDetect_SchemeNotInRegistryFallsThrough(t *testing.T) {
 	// matcher. (A higher-priority getter, TFR for instance, wins the
 	// outer registry race in this case.)
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -374,7 +375,7 @@ func TestNewCASGetter_PanicsOnNilVenvFS(t *testing.T) {
 	t.Parallel()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	require.PanicsWithValue(t, venv.ErrVenvFSUnset, func() {
@@ -390,7 +391,7 @@ func TestNewCASGetter_PanicsOnNilVenvExec(t *testing.T) {
 	t.Parallel()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := &venv.Venv{FS: vfs.NewOSFS()}
@@ -409,7 +410,7 @@ func TestNewCASGetter_PanicsOnNilVenvHTTPWithDispatch(t *testing.T) {
 	t.Parallel()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -428,7 +429,7 @@ func TestCASGetterDetect_PanicsOnNilVenvFS(t *testing.T) {
 	t.Parallel()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	g := &getter.CASGetter{
@@ -492,7 +493,7 @@ func newCASGetterForDetect(t *testing.T) *getter.CASGetter {
 	t.Helper()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/getter/casgetter_forced_test.go
+++ b/internal/getter/casgetter_forced_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // TestCASGetter_ForcedThreadedToInnerClient pins the wiring fix that
@@ -38,7 +39,7 @@ func TestCASGetter_ForcedThreadedToInnerClient(t *testing.T) {
 	stub := &forcedRequiredGetter{scheme: scheme}
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -92,7 +93,7 @@ func TestCASGetter_GetCanonicalizesForcedAlias(t *testing.T) {
 	stub := &forcedRequiredGetter{scheme: getter.SchemeGCS}
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/getter/casgetter_generic_test.go
+++ b/internal/getter/casgetter_generic_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // tarballHandler serves the supplied tar.gz bytes with a stable ETag and
@@ -94,7 +95,7 @@ func TestCASGetter_HTTPArchiveCachesSecondRun(t *testing.T) {
 	defer srv.Close()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -162,7 +163,7 @@ func TestCASGetter_HTTPArchiveFalseSkipsExtraction(t *testing.T) {
 	defer srv.Close()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -217,7 +218,7 @@ func TestCASGetter_HTTPMissingETagFallsBackToContentHash(t *testing.T) {
 	defer srv.Close()
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/getter/casgetter_oci_test.go
+++ b/internal/getter/casgetter_oci_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	gogetter "github.com/hashicorp/go-getter/v2"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
@@ -145,7 +146,7 @@ func TestCASGetterDoesNotClaimOCIWithoutFetcher(t *testing.T) {
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
 
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -265,7 +266,7 @@ func newOCICASHarness(
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
 
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/getter/casgetter_tfr_test.go
+++ b/internal/getter/casgetter_tfr_test.go
@@ -48,7 +48,7 @@ func TestCASGetter_TFRRoutesThroughCAS(t *testing.T) {
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
 
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -128,7 +128,7 @@ func TestCASGetter_TFRBareSchemeIsClaimed(t *testing.T) {
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
 
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/getter/options_test.go
+++ b/internal/getter/options_test.go
@@ -29,7 +29,7 @@ import (
 func TestWithCASRegistersCASGetter(t *testing.T) {
 	t.Parallel()
 
-	c, err := cas.New(cas.WithStorePath(filepath.Join(helpers.TmpDirWOSymlinks(t), "store")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(helpers.TmpDirWOSymlinks(t), "store")))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()
@@ -54,7 +54,7 @@ func TestWithCASRegistersCASGetter(t *testing.T) {
 func TestWithCASRoutesCASProtocolURLs(t *testing.T) {
 	t.Parallel()
 
-	c, err := cas.New(cas.WithStorePath(filepath.Join(helpers.TmpDirWOSymlinks(t), "store")))
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(helpers.TmpDirWOSymlinks(t), "store")))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/internal/getter/tfr_test.go
+++ b/internal/getter/tfr_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -27,7 +26,7 @@ func TestRegistryGetterRootDir(t *testing.T) {
 
 	dstPath := helpers.TmpDirWOSymlinks(t)
 	moduleDestPath := filepath.Join(dstPath, "terraform-aws-vpc")
-	require.False(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+	require.NoFileExists(t, filepath.Join(moduleDestPath, "main.tf"))
 
 	src := "tfr://" + server.Listener.Addr().
 		String() +
@@ -40,7 +39,7 @@ func TestRegistryGetterRootDir(t *testing.T) {
 		GetMode: getter.ModeDir,
 	})
 	require.NoError(t, err)
-	assert.True(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+	assert.FileExists(t, filepath.Join(moduleDestPath, "main.tf"))
 }
 
 func TestRegistryGetterSubModule(t *testing.T) {
@@ -50,7 +49,7 @@ func TestRegistryGetterSubModule(t *testing.T) {
 
 	dstPath := helpers.TmpDirWOSymlinks(t)
 	moduleDestPath := filepath.Join(dstPath, "terraform-aws-vpc")
-	require.False(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+	require.NoFileExists(t, filepath.Join(moduleDestPath, "main.tf"))
 
 	src := "tfr://" + server.Listener.Addr().
 		String() +
@@ -63,7 +62,7 @@ func TestRegistryGetterSubModule(t *testing.T) {
 		GetMode: getter.ModeDir,
 	})
 	require.NoError(t, err)
-	assert.True(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+	assert.FileExists(t, filepath.Join(moduleDestPath, "main.tf"))
 }
 
 // TestRegistryGetterSubdirInTerraformGetHeader pins the path where the
@@ -151,7 +150,7 @@ func TestRegistryGetterWithoutVersion(t *testing.T) {
 
 	dstPath := helpers.TmpDirWOSymlinks(t)
 	moduleDestPath := filepath.Join(dstPath, "terraform-aws-vpc")
-	require.False(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+	require.NoFileExists(t, filepath.Join(moduleDestPath, "main.tf"))
 
 	// With no ?version= query, the getter resolves the latest version (4.0.0)
 	// via the versions endpoint.
@@ -164,7 +163,7 @@ func TestRegistryGetterWithoutVersion(t *testing.T) {
 		GetMode: getter.ModeDir,
 	})
 	require.NoError(t, err)
-	assert.True(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+	assert.FileExists(t, filepath.Join(moduleDestPath, "main.tf"))
 }
 
 // TestRegistryGetterBuildMetadataVersion pins the download path for a version
@@ -180,7 +179,7 @@ func TestRegistryGetterBuildMetadataVersion(t *testing.T) {
 
 	dstPath := helpers.TmpDirWOSymlinks(t)
 	moduleDestPath := filepath.Join(dstPath, "terraform-aws-vpc")
-	require.False(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+	require.NoFileExists(t, filepath.Join(moduleDestPath, "main.tf"))
 
 	src := "tfr://" + server.Listener.Addr().
 		String() +
@@ -193,7 +192,7 @@ func TestRegistryGetterBuildMetadataVersion(t *testing.T) {
 		GetMode: getter.ModeDir,
 	})
 	require.NoError(t, err)
-	assert.True(t, util.FileExists(filepath.Join(moduleDestPath, "main.tf")))
+	assert.FileExists(t, filepath.Join(moduleDestPath, "main.tf"))
 	assert.Equal(t, "1.8.26+css9.10.001", requestedVersion)
 }
 

--- a/internal/prepare/prepare.go
+++ b/internal/prepare/prepare.go
@@ -98,7 +98,7 @@ func PrepareSource(
 		opts.Errors = errConfig
 	}
 
-	runCfg := cfg.ToRunConfig(l)
+	runCfg := cfg.ToRunConfig(l, v.FS)
 
 	l, optsClone, err := opts.CloneWithConfigPath(l, opts.TerragruntConfigPath)
 	if err != nil {

--- a/internal/providercache/archive_staging_test.go
+++ b/internal/providercache/archive_staging_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -135,8 +135,7 @@ func startProviderCacheRun(t *testing.T, registryName, upstreamURL string) *prov
 		helpers.TmpDirWOSymlinks(t),
 		nil,
 		l,
-		vfs.NewOSFS(),
-		vhttp.NewOSClient(),
+		venv.OSVenv(),
 	)
 
 	// The pre-populated discovery cache points version and platform lookups at

--- a/internal/providercache/concurrent_warmup_test.go
+++ b/internal/providercache/concurrent_warmup_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -121,7 +121,7 @@ func TestProviderCacheConcurrentWarmupWithRacing(t *testing.T) {
 	providerCacheDir := helpers.TmpDirWOSymlinks(t)
 	pluginCacheDir := helpers.TmpDirWOSymlinks(t)
 
-	providerService := services.NewProviderService(providerCacheDir, pluginCacheDir, nil, l, vfs.NewOSFS(), vhttp.NewOSClient())
+	providerService := services.NewProviderService(providerCacheDir, pluginCacheDir, nil, l, venv.OSVenv())
 
 	// The pre-populated discovery cache points version and platform lookups at
 	// the fake upstream over plain HTTP, without DNS lookups.

--- a/internal/providercache/nested_modules_credentials_test.go
+++ b/internal/providercache/nested_modules_credentials_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -103,7 +103,7 @@ func TestNestedModuleCredentials(t *testing.T) {
 	pluginCacheDir := helpers.TmpDirWOSymlinks(t)
 
 	l := logger.CreateLogger()
-	providerService := services.NewProviderService(providerCacheDir, pluginCacheDir, nil, l, vfs.NewOSFS(), vhttp.NewOSClient())
+	providerService := services.NewProviderService(providerCacheDir, pluginCacheDir, nil, l, venv.OSVenv())
 	proxyProviderHandler := handlers.NewProxyProviderHandler(
 		l,
 		vhttp.NewNoNetworkClient(),

--- a/internal/providercache/providercache.go
+++ b/internal/providercache/providercache.go
@@ -116,7 +116,7 @@ func (pc *ProviderCache) Init(
 	// ProviderCacheDir has the same file structure as terraform plugin_cache_dir.
 	// https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache
 	if pcOpts.Dir == "" {
-		cacheDir, err := util.EnsureCacheDir()
+		cacheDir, err := util.EnsureCacheDir(v)
 		if err != nil {
 			return fmt.Errorf("failed to get cache directory: %w", err)
 		}
@@ -156,8 +156,7 @@ func (pc *ProviderCache) Init(
 		userProviderDir,
 		cliCfg.CredentialsSource(),
 		l,
-		v.FS,
-		v.HTTP,
+		v,
 	)
 	proxyProviderHandler := handlers.NewProxyProviderHandler(l, v.HTTP, cliCfg.CredentialsSource())
 
@@ -242,7 +241,7 @@ func (pc *ProviderCache) TerraformCommandHook(
 	var skipRunTargetCommand bool
 
 	lockfilePath := filepath.Join(tfOpts.ShellOptions.WorkingDir, tf.TerraformLockFile)
-	lockfileExists := util.FileExists(lockfilePath)
+	lockfileExists := vfs.Exists(v.FS, lockfilePath)
 
 	// Use Hook only for the `terraform init` command, which can be run explicitly by the user or Terragrunt's `auto-init` feature.
 	switch {

--- a/internal/providercache/providercache_test.go
+++ b/internal/providercache/providercache_test.go
@@ -157,8 +157,7 @@ func testProviderCache(t *testing.T, c vhttp.Client) {
 				pluginCacheDir,
 				nil,
 				l,
-				vfs.NewOSFS(),
-				c,
+				venv.OSVenv().WithHTTP(c),
 			)
 			providerHandler := handlers.NewDirectProviderHandler(
 				l,

--- a/internal/remotestate/terraform_state_file.go
+++ b/internal/remotestate/terraform_state_file.go
@@ -3,11 +3,10 @@ package remotestate
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend"
-	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 )
 
 // TODO: this file could be changed to use the Terraform Go code to read state files, but that code is relatively
@@ -52,29 +51,30 @@ func (state *TerraformState) IsRemote() bool {
 // file from the location specified by workingDir. If no location is specified, search the current
 // directory. If the file doesn't exist at any of the default locations, return nil.
 func ParseTerraformStateFileFromLocation(
+	fsys vfs.FS,
 	backend string,
 	config backend.Config,
 	workingDir, dataDir string,
 ) (*TerraformState, error) {
 	if stateFile := config.Path(); backend == "local" && stateFile != "" &&
-		util.FileExists(stateFile) {
-		return ParseTerraformStateFile(stateFile)
+		vfs.Exists(fsys, stateFile) {
+		return ParseTerraformStateFile(fsys, stateFile)
 	}
 
-	if util.FileExists(filepath.Join(dataDir, DefaultPathToRemoteStateFile)) {
-		return ParseTerraformStateFile(filepath.Join(dataDir, DefaultPathToRemoteStateFile))
+	if remoteStateFile := filepath.Join(dataDir, DefaultPathToRemoteStateFile); vfs.Exists(fsys, remoteStateFile) {
+		return ParseTerraformStateFile(fsys, remoteStateFile)
 	}
 
-	if util.FileExists(filepath.Join(workingDir, DefaultPathToLocalStateFile)) {
-		return ParseTerraformStateFile(filepath.Join(workingDir, DefaultPathToLocalStateFile))
+	if localStateFile := filepath.Join(workingDir, DefaultPathToLocalStateFile); vfs.Exists(fsys, localStateFile) {
+		return ParseTerraformStateFile(fsys, localStateFile)
 	}
 
 	return nil, nil
 }
 
 // ParseTerraformStateFile parses the Terraform .tfstate file located at the specified path.
-func ParseTerraformStateFile(path string) (*TerraformState, error) {
-	bytes, err := os.ReadFile(path)
+func ParseTerraformStateFile(fsys vfs.FS, path string) (*TerraformState, error) {
+	bytes, err := vfs.ReadFile(fsys, path)
 	if err != nil {
 		return nil, CantParseTerraformStateFileError{Path: path, UnderlyingErr: err}
 	}

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -607,7 +607,7 @@ func tryCASDownload(
 		return false, err
 	}
 
-	c, err := cas.New(cas.WithCloneDepth(opts.CASCloneDepth))
+	c, err := cas.New(v, cas.WithCloneDepth(opts.CASCloneDepth))
 	if err != nil {
 		l.Warnf("Failed to initialize CAS: %v. Falling back to standard getter.", err)
 		cas.RecordFallback(

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -378,9 +378,9 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirSameVe
 	require.NoError(t, err, "For terraform source %v: %v", terraformSource, err)
 
 	expectedFilePath := filepath.Join(downloadDir, "main.tf")
-	if assert.True(
+	if assert.FileExists(
 		t,
-		util.FileExists(expectedFilePath),
+		expectedFilePath,
 		"For terraform source %v",
 		terraformSource,
 	) {
@@ -527,42 +527,42 @@ func TestDownloadTerraformSourceFromLocalFolderWithManifest(t *testing.T) {
 			name:      "test-stale-file-exists",
 			sourceURL: "../../../test/fixtures/manifest/version-1",
 			comp: func() bool {
-				return util.FileExists(filepath.Join(downloadDir, "stale.tf"))
+				return vfs.Exists(vfs.NewOSFS(), filepath.Join(downloadDir, "stale.tf"))
 			},
 		},
 		{
 			name:      "test-stale-file-doesnt-exist-after-source-update",
 			sourceURL: "../../../test/fixtures/manifest/version-2",
 			comp: func() bool {
-				return !util.FileExists(filepath.Join(downloadDir, "stale.tf"))
+				return !vfs.Exists(vfs.NewOSFS(), filepath.Join(downloadDir, "stale.tf"))
 			},
 		},
 		{
 			name:      "test-tffile-exists-in-subfolder",
 			sourceURL: "../../../test/fixtures/manifest/version-3-subfolder",
 			comp: func() bool {
-				return util.FileExists(filepath.Join(downloadDir, "sub", "main.tf"))
+				return vfs.Exists(vfs.NewOSFS(), filepath.Join(downloadDir, "sub", "main.tf"))
 			},
 		},
 		{
 			name:      "test-tffile-doesnt-exist-in-subfolder",
 			sourceURL: "../../../test/fixtures/manifest/version-4-subfolder-empty",
 			comp: func() bool {
-				return !util.FileExists(filepath.Join(downloadDir, "sub", "main.tf"))
+				return !vfs.Exists(vfs.NewOSFS(), filepath.Join(downloadDir, "sub", "main.tf"))
 			},
 		},
 		{
 			name:      "test-empty-folder-gets-copied",
 			sourceURL: testDir,
 			comp: func() bool {
-				return util.FileExists(filepath.Join(downloadDir, "sub2"))
+				return vfs.Exists(vfs.NewOSFS(), filepath.Join(downloadDir, "sub2"))
 			},
 		},
 		{
 			name:      "test-empty-folder-gets-populated",
 			sourceURL: "../../../test/fixtures/manifest/version-5-not-empty-subfolder",
 			comp: func() bool {
-				return util.FileExists(filepath.Join(downloadDir, "sub2", "main.tf"))
+				return vfs.Exists(vfs.NewOSFS(), filepath.Join(downloadDir, "sub2", "main.tf"))
 			},
 		},
 	}
@@ -609,9 +609,9 @@ func testDownloadTerraformSourceIfNecessary(
 	require.NoError(t, err, "For terraform source %v: %v", terraformSource, err)
 
 	expectedFilePath := filepath.Join(downloadDir, "main.tf")
-	if assert.True(
+	if assert.FileExists(
 		t,
-		util.FileExists(expectedFilePath),
+		expectedFilePath,
 		"For terraform source %v",
 		terraformSource,
 	) {
@@ -626,10 +626,10 @@ func testDownloadTerraformSourceIfNecessary(
 	}
 
 	if requireInitFile {
-		existsInitFile := util.FileExists(
+		require.FileExists(
+			t,
 			filepath.Join(terraformSource.WorkingDir, run.ModuleInitRequiredFile),
 		)
-		require.True(t, existsInitFile)
 	}
 }
 
@@ -764,7 +764,7 @@ func parseURL(t *testing.T, str string) *url.URL {
 func readFile(t *testing.T, path string) string {
 	t.Helper()
 
-	contents, err := util.ReadFileAsString(path)
+	contents, err := vfs.ReadFileAsString(vfs.NewOSFS(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -224,7 +224,7 @@ func GenerateConfig(
 	actualLock.Lock()
 	defer actualLock.Unlock()
 
-	writeOpts := generateWriteOptions(l, opts)
+	writeOpts := generateWriteOptions(l, v, opts)
 
 	for _, genCfg := range cfg.GenerateConfigs {
 		if err := codegen.WriteToFile(ctx, l, v, opts.CacheDir, &genCfg, writeOpts...); err != nil {
@@ -256,12 +256,12 @@ func GenerateConfig(
 //
 // A CAS that cannot be initialized is not fatal: generation falls back to direct
 // writes, matching how source downloads degrade.
-func generateWriteOptions(l log.Logger, opts *Options) []codegen.WriteOption {
+func generateWriteOptions(l log.Logger, v *venv.Venv, opts *Options) []codegen.WriteOption {
 	if opts.NoCAS || !opts.Experiments.Evaluate(experiment.MutableGenerate) {
 		return nil
 	}
 
-	c, err := cas.New()
+	c, err := cas.New(v)
 	if err != nil {
 		l.Warnf("Failed to initialize CAS: %v. Generated files will not be deduplicated.", err)
 
@@ -297,7 +297,7 @@ func runTerragruntWithConfig(
 	}
 
 	if len(cfg.Terraform.ExtraArgs) > 0 {
-		args := FilterTerraformExtraArgs(l, opts, cfg)
+		args := FilterTerraformExtraArgs(l, v.FS, opts, cfg)
 
 		opts.InsertTerraformCliArgs(args...)
 
@@ -541,7 +541,7 @@ func checkTerraformCodeDefinesBackend(fs vfs.FS, opts *Options, backendType stri
 	}
 
 	// Check for backend definitions in .tf and .tofu files using WalkDir
-	definesBackend, err := util.RegexFoundInTFFiles(opts.CacheDir, terraformBackendRegexp)
+	definesBackend, err := util.RegexFoundInTFFiles(fs, opts.CacheDir, terraformBackendRegexp)
 	if err != nil {
 		return err
 	}
@@ -579,13 +579,13 @@ func checkTerraformCodeDefinesBackend(fs vfs.FS, opts *Options, backendType stri
 }
 
 // Returns true if we need to run `terraform init` to download providers
-func providersNeedInit(opts *Options, env map[string]string) bool {
+func providersNeedInit(fsys vfs.FS, opts *Options, env map[string]string) bool {
 	pluginsPath := filepath.Join(opts.DataDir(env), "plugins")
 	providersPath := filepath.Join(opts.DataDir(env), "providers")
 	terraformLockPath := filepath.Join(opts.CacheDir, tf.TerraformLockFile)
 
-	return (!util.FileExists(pluginsPath) && !util.FileExists(providersPath)) ||
-		!util.FileExists(terraformLockPath)
+	return (!vfs.Exists(fsys, pluginsPath) && !vfs.Exists(fsys, providersPath)) ||
+		!vfs.Exists(fsys, terraformLockPath)
 }
 
 // prepareInitOptions clones opts for a `terraform init` invocation. The
@@ -620,14 +620,14 @@ func prepareInitOptions(l log.Logger, opts *Options) (log.Logger, *Options, bool
 // Note that to keep the logic in this code very simple, this code ONLY detects the case where you haven't downloaded
 // modules at all. Detecting if your downloaded modules are out of date (as opposed to missing entirely) is more
 // complicated and not something we handle at the moment.
-func modulesNeedInit(opts *Options, env map[string]string) (bool, error) {
+func modulesNeedInit(fsys vfs.FS, opts *Options, env map[string]string) (bool, error) {
 	modulesPath := filepath.Join(opts.DataDir(env), "modules")
-	if util.FileExists(modulesPath) {
+	if vfs.Exists(fsys, modulesPath) {
 		return false, nil
 	}
 
 	// Check for module definitions in .tf and .tofu files using WalkDir
-	hasModuleDefinition, err := util.RegexFoundInTFFiles(opts.CacheDir, ModuleRegex)
+	hasModuleDefinition, err := util.RegexFoundInTFFiles(fsys, opts.CacheDir, ModuleRegex)
 	if err != nil {
 		return false, err
 	}
@@ -669,7 +669,7 @@ func remoteStateNeedsInit(
 }
 
 // FilterTerraformExtraArgs extracts terraform extra arguments using runcfg types.
-func FilterTerraformExtraArgs(l log.Logger, opts *Options, cfg *runcfg.RunConfig) []string {
+func FilterTerraformExtraArgs(l log.Logger, fsys vfs.FS, opts *Options, cfg *runcfg.RunConfig) []string {
 	out := []string{}
 	cmd := opts.TerraformCliArgs.First()
 
@@ -679,7 +679,7 @@ func FilterTerraformExtraArgs(l log.Logger, opts *Options, cfg *runcfg.RunConfig
 			if cmd == argCmd {
 				lastArg := opts.TerraformCliArgs.Last()
 				skipVars := (cmd == tf.CommandNameApply || cmd == tf.CommandNameDestroy) &&
-					util.IsFile(lastArg)
+					vfs.IsFile(fsys, lastArg)
 
 				if len(arg.Arguments) > 0 {
 					if skipVars {
@@ -819,15 +819,15 @@ func needsInitRunCfg(
 
 	// Marker check lives here, not in modulesNeedInit, so a populated .terraform/modules/
 	// can't short-circuit past it. Refs: #1921, #6058.
-	if util.FileExists(filepath.Join(opts.CacheDir, ModuleInitRequiredFile)) {
+	if vfs.Exists(v.FS, filepath.Join(opts.CacheDir, ModuleInitRequiredFile)) {
 		return true, nil
 	}
 
-	if providersNeedInit(opts, v.Env) {
+	if providersNeedInit(v.FS, opts, v.Env) {
 		return true, nil
 	}
 
-	modulesNeedsInit, err := modulesNeedInit(opts, v.Env)
+	modulesNeedsInit, err := modulesNeedInit(v.FS, opts, v.Env)
 	if err != nil {
 		return false, err
 	}
@@ -884,8 +884,8 @@ func runTerraformInitRunCfg(
 	}
 
 	moduleNeedInit := filepath.Join(opts.CacheDir, ModuleInitRequiredFile)
-	if util.FileExists(moduleNeedInit) {
-		return os.Remove(moduleNeedInit)
+	if vfs.Exists(v.FS, moduleNeedInit) {
+		return v.FS.Remove(moduleNeedInit)
 	}
 
 	return nil

--- a/internal/runner/run/run_test.go
+++ b/internal/runner/run/run_test.go
@@ -514,7 +514,7 @@ func TestFilterTerraformExtraArgs(t *testing.T) {
 			},
 		}
 		l := logger.CreateLogger()
-		out := run.FilterTerraformExtraArgs(l, configbridge.NewRunOptions(tc.options), &config)
+		out := run.FilterTerraformExtraArgs(l, vfs.NewOSFS(), configbridge.NewRunOptions(tc.options), &config)
 		assert.Equal(t, tc.expectedArgs, out)
 	}
 }
@@ -562,7 +562,7 @@ func mockExtraArgs(
 	// Include OptionalVarFiles only if they exist
 	if len(optionalVarFiles) > 0 {
 		for _, file := range util.RemoveDuplicatesKeepLast(optionalVarFiles) {
-			if !util.FileExists(file) {
+			if !vfs.Exists(vfs.NewOSFS(), file) {
 				continue
 			}
 

--- a/internal/runner/run/tofu_extensions_test.go
+++ b/internal/runner/run/tofu_extensions_test.go
@@ -112,7 +112,7 @@ terraform {
 				fmt.Sprintf(`backend[[:blank:]]+"%s"`, tc.backendType),
 			)
 
-			hasBackend, err := util.RegexFoundInTFFiles(tmpDir, terraformBackendRegexp)
+			hasBackend, err := util.RegexFoundInTFFiles(vfs.NewOSFS(), tmpDir, terraformBackendRegexp)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectBackend, hasBackend, "For test case: %s", tc.description)
@@ -212,7 +212,7 @@ resource "aws_instance" "example" {
 
 			moduleRegex := regexp.MustCompile(`module[[:blank:]]+".+"`)
 
-			hasModules, err := util.RegexFoundInTFFiles(tmpDir, moduleRegex)
+			hasModules, err := util.RegexFoundInTFFiles(vfs.NewOSFS(), tmpDir, moduleRegex)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectModules, hasModules, "For test case: %s", tc.description)

--- a/internal/runner/run/version_check.go
+++ b/internal/runner/run/version_check.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/go-version"
 )
@@ -56,6 +57,7 @@ func PopulateTFVersion(
 ) (log.Logger, *version.Version, tfimpl.Type, error) {
 	versionCache := GetRunVersionCache(ctx)
 	cacheKey := computeVersionFilesCacheKey(
+		v.FS,
 		in.WorkingDir,
 		in.VersionFiles,
 		in.TFOpts.ShellOptions.TFPath,
@@ -273,13 +275,18 @@ func parseTerraformImplementationType(versionCommandOutput string) (tfimpl.Type,
 // the key because the same working directory can legitimately resolve to
 // different binaries within a single run (e.g. when terraform_binary overrides
 // the default), and conflating those produces the wrong version string.
-func computeVersionFilesCacheKey(workingDir string, versionFiles []string, tfPath string) string {
+func computeVersionFilesCacheKey(
+	fsys vfs.FS,
+	workingDir string,
+	versionFiles []string,
+	tfPath string,
+) string {
 	var hashes []string
 
 	for _, file := range versionFiles {
 		path := filepath.Join(workingDir, file)
 
-		if !util.FileExists(path) {
+		if !vfs.Exists(fsys, path) {
 			continue
 		}
 
@@ -288,7 +295,7 @@ func computeVersionFilesCacheKey(workingDir string, versionFiles []string, tfPat
 			sanitizedPath = path
 		}
 
-		hash, err := util.FileSHA256(sanitizedPath)
+		hash, err := vfs.FileSHA256(fsys, sanitizedPath)
 		if err == nil {
 			hashes = append(hashes, file+":"+hex.EncodeToString(hash))
 		}

--- a/internal/runner/run/version_check_internal_test.go
+++ b/internal/runner/run/version_check_internal_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -63,7 +64,7 @@ func Test_computeVersionFilesCacheKey(t *testing.T) {
 			assert.Equalf(
 				t,
 				tt.want,
-				computeVersionFilesCacheKey(tt.workingDir, tt.versionFiles, tt.tfPath),
+				computeVersionFilesCacheKey(vfs.NewOSFS(), tt.workingDir, tt.versionFiles, tt.tfPath),
 				"computeVersionFilesCacheKey(%v, %v, %v)",
 				tt.workingDir,
 				tt.versionFiles,

--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -574,7 +574,7 @@ func (rnr *Runner) Run(
 					unitOpts.TFPath = cfg.TerraformBinary
 				}
 
-				runCfg := cfg.ToRunConfig(unitLogger)
+				runCfg := cfg.ToRunConfig(unitLogger, unitV.FS)
 
 				err = telemetry.TelemeterFromContext(childCtx).
 					Collect(childCtx, unitLogger, "unit_run", map[string]any{

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -499,7 +499,7 @@ func (repo *Repo) performClone(
 			return err
 		}
 
-		casStore, err := cas.New(cas.WithCloneDepth(cloneDepth))
+		casStore, err := cas.New(v, cas.WithCloneDepth(cloneDepth))
 		if err != nil {
 			return err
 		}

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/worker"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
@@ -242,7 +243,7 @@ func generateLevel(
 		generatedFiles[node.FilePath] = true
 
 		// Best-effort skip; GenerateStackFile surfaces ENOENT if the file is removed in the TOCTOU window.
-		if !util.FileExists(node.FilePath) {
+		if !vfs.Exists(v.FS, node.FilePath) {
 			continue
 		}
 

--- a/internal/tf/cache/download_auth_test.go
+++ b/internal/tf/cache/download_auth_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
@@ -39,7 +39,7 @@ func TestDownloadRouteRequiresSecretSegment(t *testing.T) {
 		cache.WithHostname("127.0.0.1"),
 		cache.WithToken(token),
 		cache.WithLogger(l),
-		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, vfs.NewOSFS(), vhttp.NewOSClient())),
+		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, venv.OSVenv())),
 		cache.WithProxyProviderHandler(
 			handlers.NewProxyProviderHandler(l, vhttp.NewNoNetworkClient(), nil),
 		),
@@ -109,7 +109,7 @@ func TestDownloadSegmentIsRedactedFromLogs(t *testing.T) {
 	server := cache.NewServer(
 		cache.WithHostname("127.0.0.1"),
 		cache.WithLogger(l),
-		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, vfs.NewOSFS(), vhttp.NewOSClient())),
+		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, venv.OSVenv())),
 		cache.WithProxyProviderHandler(
 			handlers.NewProxyProviderHandler(l, vhttp.NewNoNetworkClient(), nil),
 		),

--- a/internal/tf/cache/handlers/filesystem_mirror_provider.go
+++ b/internal/tf/cache/handlers/filesystem_mirror_provider.go
@@ -3,13 +3,13 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/models"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -116,12 +116,14 @@ func (handler *FilesystemMirrorProviderHandler) GetPlatform(
 func (handler *FilesystemMirrorProviderHandler) readMirrorData(filename string, value any) error {
 	filename = filepath.Join(handler.filesystemMirrorPath, filename)
 
-	if !util.FileExists(filename) {
-		return nil
-	}
-
 	data, err := os.ReadFile(filename)
 	if err != nil {
+		// A mirror that carries no data for this provider is not an error; the
+		// caller reports an empty result and moves on to the next handler.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
 		return err
 	}
 

--- a/internal/tf/cache/server_init_test.go
+++ b/internal/tf/cache/server_init_test.go
@@ -8,8 +8,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
-	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
 
@@ -36,7 +35,7 @@ func TestServerRunInitializesServicesBeforeServing(t *testing.T) {
 	server := cache.NewServer(
 		cache.WithHostname("127.0.0.1"),
 		cache.WithLogger(l),
-		cache.WithProviderService(services.NewProviderService("", t.TempDir(), nil, l, vfs.NewOSFS(), vhttp.NewOSClient())),
+		cache.WithProviderService(services.NewProviderService("", t.TempDir(), nil, l, venv.OSVenv())),
 	)
 
 	ln, err := server.Listen(t.Context())

--- a/internal/tf/cache/server_test.go
+++ b/internal/tf/cache/server_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/models"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
@@ -221,7 +221,7 @@ func TestServerRunReportsServeFailure(t *testing.T) {
 	server := cache.NewServer(
 		cache.WithHostname("127.0.0.1"),
 		cache.WithLogger(l),
-		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, vfs.NewOSFS(), vhttp.NewNoNetworkClient())),
+		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, venv.OSVenv())),
 	)
 
 	ln, err := server.Listen(t.Context())

--- a/internal/tf/cache/services/provider_cache.go
+++ b/internal/tf/cache/services/provider_cache.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
 	"github.com/gruntwork-io/terragrunt/internal/tf/getproviders"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -526,13 +527,13 @@ type ProviderServiceOption func(*ProviderService)
 type ProviderService struct {
 	logger log.Logger
 
-	// fs is the filesystem for file operations.
-	fs vfs.FS
+	// venv supplies the filesystem, outbound HTTP client, and temp-directory
+	// handle every cached provider is fetched and unpacked through.
+	venv *venv.Venv
 
 	initErr               error
 	providerCacheWarmUpCh chan *ProviderCache
 	credsSource           *cliconfig.CredentialsSource
-	httpClient            vhttp.Client
 
 	// tempDir is a predictable temporary directory for provider lock files.
 	tempDir string
@@ -556,12 +557,12 @@ type ProviderService struct {
 
 // FS returns the configured filesystem.
 func (service *ProviderService) FS() vfs.FS {
-	return service.fs
+	return service.venv.FS
 }
 
 // HTTPClient returns the configured HTTP client.
 func (service *ProviderService) HTTPClient() vhttp.Client {
-	return service.httpClient
+	return service.venv.HTTP
 }
 
 func NewProviderService(
@@ -569,8 +570,7 @@ func NewProviderService(
 	userCacheDir string,
 	credsSource *cliconfig.CredentialsSource,
 	l log.Logger,
-	fsys vfs.FS,
-	c vhttp.Client,
+	v *venv.Venv,
 	opts ...ProviderServiceOption,
 ) *ProviderService {
 	service := &ProviderService{
@@ -579,8 +579,7 @@ func NewProviderService(
 		providerCacheWarmUpCh: make(chan *ProviderCache, providerCacheWarmUpChBufferSize),
 		credsSource:           credsSource,
 		logger:                l,
-		fs:                    fsys,
-		httpClient:            c,
+		venv:                  v,
 	}
 
 	for _, opt := range opts {
@@ -759,7 +758,7 @@ func (service *ProviderService) init() error {
 		return err
 	}
 
-	tempDir, err := util.EnsureTempDir()
+	tempDir, err := util.EnsureTempDir(service.venv)
 	if err != nil {
 		return err
 	}

--- a/internal/tf/cache/services/provider_cache_test.go
+++ b/internal/tf/cache/services/provider_cache_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
-	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
 
@@ -156,7 +156,7 @@ func TestProviderServiceInitIsIdempotent(t *testing.T) {
 	t.Parallel()
 
 	service := services.NewProviderService(
-		t.TempDir(), t.TempDir(), nil, logger.CreateLogger(), vfs.NewOSFS(), vhttp.NewOSClient(),
+		t.TempDir(), t.TempDir(), nil, logger.CreateLogger(), venv.OSVenv(),
 	)
 
 	require.NoError(t, service.Init())
@@ -167,7 +167,7 @@ func TestProviderServiceInitWithoutCacheDir(t *testing.T) {
 	t.Parallel()
 
 	service := services.NewProviderService(
-		"", t.TempDir(), nil, logger.CreateLogger(), vfs.NewOSFS(), vhttp.NewOSClient(),
+		"", t.TempDir(), nil, logger.CreateLogger(), venv.OSVenv(),
 	)
 
 	require.ErrorIs(t, service.Init(), services.ErrCacheDirNotSpecified)

--- a/internal/tf/getproviders/lock.go
+++ b/internal/tf/getproviders/lock.go
@@ -17,7 +17,6 @@ import (
 	"unicode"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -32,12 +31,14 @@ func UpdateLockfile(ctx context.Context, workingDir string, providers []Provider
 		file     = hclwrite.NewFile()
 	)
 
-	if util.FileExists(filename) {
-		content, err := os.ReadFile(filename)
-		if err != nil {
-			return err
-		}
+	// A missing lock file is the first-run case: the empty file built above is
+	// written out as-is.
+	content, err := os.ReadFile(filename)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
 
+	if err == nil {
 		var diags hcl.Diagnostics
 
 		file, diags = hclwrite.ParseConfig(content, filename, hcl.Pos{Line: 1, Column: 1})
@@ -324,12 +325,13 @@ func UpdateLockfileConstraints(
 ) error {
 	filename := filepath.Join(workingDir, tf.TerraformLockFile)
 
-	if !util.FileExists(filename) {
-		return nil
-	}
-
 	content, err := os.ReadFile(filename)
 	if err != nil {
+		// Nothing to update when no lock file has been written yet.
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+
 		return err
 	}
 

--- a/internal/tf/source.go
+++ b/internal/tf/source.go
@@ -139,7 +139,7 @@ func (src Source) encodeLocalSourceVersion(
 	sourceHash := sha256.New()
 	sourceDir := filepath.Clean(src.CanonicalSourceURL.Path)
 
-	copied, err := util.NewCopyFilter(l, sourceDir, copyOpts...)
+	copied, err := util.NewCopyFilter(l, fsys, sourceDir, copyOpts...)
 	if err != nil {
 		return "", err
 	}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -3,7 +3,6 @@ package util
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/gob"
 	"fmt"
 	"io"
@@ -23,6 +22,7 @@ import (
 	"errors"
 
 	"github.com/gruntwork-io/terragrunt/internal/glob"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -38,51 +38,30 @@ const (
 
 // FileOrData will read the contents of the data of the given arg if it is a file, and otherwise return the contents by
 // itself. This will return an error if the given path is a directory.
-func FileOrData(maybePath string) (string, error) {
+func FileOrData(v *venv.Venv, maybePath string) (string, error) {
+	v.RequireFS()
+
 	// Blindly call expandHome: it's a no-op for anything that doesn't start with `~`,
 	// and a leading `~` is far more likely to be a path than literal data.
-	expandedMaybePath, err := expandHome(maybePath)
+	expandedMaybePath, err := expandHome(v, maybePath)
 	if err != nil {
 		return "", err
 	}
 
-	if IsFile(expandedMaybePath) {
-		contents, err := os.ReadFile(expandedMaybePath)
+	if vfs.IsFile(v.FS, expandedMaybePath) {
+		contents, err := vfs.ReadFile(v.FS, expandedMaybePath)
 		if err != nil {
 			return "", err
 		}
 
 		return string(contents), nil
-	} else if IsDir(expandedMaybePath) {
+	}
+
+	if vfs.IsDir(v.FS, expandedMaybePath) {
 		return "", PathIsNotFile{path: expandedMaybePath}
 	}
 
 	return expandedMaybePath, nil
-}
-
-// FileExists returns true if the given file exists.
-func FileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
-
-// FileNotExists returns true if the given file does not exist.
-func FileNotExists(path string) bool {
-	_, err := os.Stat(path)
-	return errors.Is(err, fs.ErrNotExist)
-}
-
-// EnsureDirectory creates a directory at this path if it does not exist, or error if the path exists and is a file.
-func EnsureDirectory(path string) error {
-	if FileExists(path) && IsFile(path) {
-		return PathIsNotDirectory{path}
-	} else if !FileExists(path) {
-		const ownerReadWriteExecutePerms = 0o700
-
-		return os.MkdirAll(path, ownerReadWriteExecutePerms)
-	}
-
-	return nil
 }
 
 // CanonicalPath returns the canonical version of the given path, relative to the given base path. That is, if the given
@@ -179,10 +158,10 @@ func FindTFFiles(fsys vfs.FS, rootPath string) ([]string, error) {
 // RegexFoundInTFFiles walks through the directory and checks if any
 // OpenTofu/Terraform files (.tf, .tofu, .tf.json, .tofu.json) contain the given
 // regex pattern
-func RegexFoundInTFFiles(workingDir string, pattern *regexp.Regexp) (bool, error) {
+func RegexFoundInTFFiles(fsys vfs.FS, workingDir string, pattern *regexp.Regexp) (bool, error) {
 	var found bool
 
-	err := filepath.WalkDir(workingDir, func(path string, d fs.DirEntry, err error) error {
+	err := vfs.WalkDir(fsys, workingDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -195,7 +174,7 @@ func RegexFoundInTFFiles(workingDir string, pattern *regexp.Regexp) (bool, error
 			return nil
 		}
 
-		content, err := os.ReadFile(path)
+		content, err := vfs.ReadFile(fsys, path)
 		if err != nil {
 			return err
 		}
@@ -254,28 +233,6 @@ func IsTFFile(path string) bool {
 	return false
 }
 
-// IsDir returns true if the path points to a directory.
-func IsDir(path string) bool {
-	fileInfo, err := os.Stat(path)
-	return err == nil && fileInfo.IsDir()
-}
-
-// IsFile returns true if the path points to a file.
-func IsFile(path string) bool {
-	fileInfo, err := os.Stat(path)
-	return err == nil && !fileInfo.IsDir()
-}
-
-// ReadFileAsString returns the contents of the file at the given path as a string.
-func ReadFileAsString(path string) (string, error) {
-	bytes, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("error reading file at path %s: %w", path, err)
-	}
-
-	return string(bytes), nil
-}
-
 func listContainsElementWithPrefix(list []string, elementPrefix string) bool {
 	for _, element := range list {
 		if strings.HasPrefix(element, elementPrefix) {
@@ -297,7 +254,7 @@ func pathContainsPrefix(path string, prefixes []string) bool {
 }
 
 // Takes apbsolute glob path and returns an array of expanded relative paths
-func expandGlobPath(source, absoluteGlobPath string) ([]string, error) {
+func expandGlobPath(fsys vfs.FS, source, absoluteGlobPath string) ([]string, error) {
 	includeExpandedGlobs := []string{}
 
 	absoluteExpandGlob, err := glob.LegacyExpand(absoluteGlobPath)
@@ -326,8 +283,8 @@ func expandGlobPath(source, absoluteGlobPath string) ([]string, error) {
 			filepath.ToSlash(relativeExpandGlobPath),
 		)
 
-		if IsDir(absoluteExpandGlobPath) {
-			dirExpandGlob, err := expandGlobPath(source, absoluteExpandGlobPath+"/*")
+		if vfs.IsDir(fsys, absoluteExpandGlobPath) {
+			dirExpandGlob, err := expandGlobPath(fsys, source, absoluteExpandGlobPath+"/*")
 			if err != nil {
 				return nil, err
 			}
@@ -422,7 +379,7 @@ func CopyFolderContents(
 		)
 	}
 
-	filter, err := newLegacyCopyFilter(l, source, cfg.includeInCopy, cfg.excludeFromCopy)
+	filter, err := newLegacyCopyFilter(l, fsys, source, cfg.includeInCopy, cfg.excludeFromCopy)
 	if err != nil {
 		return err
 	}
@@ -440,7 +397,7 @@ type CopyFilter func(absolutePath string, isDir bool) bool
 // applies with the same options, without performing a copy. It lets callers
 // reason about which files a copy would deliver — for example, hashing only
 // those files when computing a source version.
-func NewCopyFilter(l log.Logger, source string, opts ...CopyOption) (CopyFilter, error) {
+func NewCopyFilter(l log.Logger, fsys vfs.FS, source string, opts ...CopyOption) (CopyFilter, error) {
 	var cfg copyConfig
 	for _, opt := range opts {
 		opt(&cfg)
@@ -452,7 +409,7 @@ func NewCopyFilter(l log.Logger, source string, opts ...CopyOption) (CopyFilter,
 		return newFastCopyFilter(l, source, cfg.includeInCopy, cfg.excludeFromCopy)
 	}
 
-	filter, err := newLegacyCopyFilter(l, source, cfg.includeInCopy, cfg.excludeFromCopy)
+	filter, err := newLegacyCopyFilter(l, fsys, source, cfg.includeInCopy, cfg.excludeFromCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -468,6 +425,7 @@ func NewCopyFilter(l log.Logger, source string, opts ...CopyOption) (CopyFilter,
 // [CopyFolderContents] and the filter passed to the slow-path implementation.
 func newLegacyCopyFilter(
 	l log.Logger,
+	fsys vfs.FS,
 	source string,
 	includeInCopy, excludeFromCopy []string,
 ) (func(absolutePath string) bool, error) {
@@ -478,7 +436,7 @@ func newLegacyCopyFilter(
 	for _, includeGlob := range includeInCopy {
 		globPath := filepath.Join(source, includeGlob)
 
-		expandGlob, err := expandGlobPath(source, globPath)
+		expandGlob, err := expandGlobPath(fsys, source, globPath)
 		if err != nil {
 			return nil, err
 		}
@@ -491,7 +449,7 @@ func newLegacyCopyFilter(
 	for _, excludeGlob := range excludeFromCopy {
 		globPath := filepath.Join(source, excludeGlob)
 
-		expandGlob, err := expandGlobPath(source, globPath)
+		expandGlob, err := expandGlobPath(fsys, source, globPath)
 		if err != nil {
 			return nil, err
 		}
@@ -1143,13 +1101,6 @@ func assertCopyPathsSafe(source, destination string, filter func(absolutePath st
 	}
 }
 
-// IsSymLink returns true if the given file is a symbolic link
-// Per https://stackoverflow.com/a/18062079/2308858
-func IsSymLink(path string) bool {
-	fileInfo, err := os.Lstat(path)
-	return err == nil && fileInfo.Mode()&os.ModeSymlink != 0
-}
-
 func TerragruntExcludes(path string) bool {
 	if filepath.Base(path) == TerraformLockFile {
 		return false
@@ -1720,35 +1671,19 @@ func ListTfFiles(fsys vfs.FS, directoryPath string) ([]string, error) {
 	return tfFiles, nil
 }
 
-// IsDirectoryEmpty - returns true if the given path exists and is a empty directory.
-func IsDirectoryEmpty(dirPath string) (bool, error) {
-	dir, err := os.Open(dirPath)
-	if err != nil {
-		return false, err
-	}
-
-	defer func() {
-		_ = dir.Close()
-	}()
-
-	_, err = dir.Readdir(1)
-	if err == nil {
-		return false, nil
-	}
-
-	return true, nil
-}
-
 // EnsureCacheDir returns the global terragrunt cache directory for the current user.
-func EnsureCacheDir() (string, error) {
-	cacheDir, err := os.UserCacheDir()
+func EnsureCacheDir(v *venv.Venv) (string, error) {
+	v.RequireFS()
+	v.RequireUserCacheDir()
+
+	cacheDir, err := v.Platform.UserCacheDir()
 	if err != nil {
 		return "", err
 	}
 
 	cacheDir = filepath.Join(cacheDir, "terragrunt")
 
-	if err := os.MkdirAll(cacheDir, os.ModePerm); err != nil {
+	if err := v.FS.MkdirAll(cacheDir, os.ModePerm); err != nil {
 		return "", err
 	}
 
@@ -1756,10 +1691,13 @@ func EnsureCacheDir() (string, error) {
 }
 
 // EnsureTempDir returns the global terragrunt temp directory.
-func EnsureTempDir() (string, error) {
-	tempDir := filepath.Join(os.TempDir(), "terragrunt")
+func EnsureTempDir(v *venv.Venv) (string, error) {
+	v.RequireFS()
+	v.RequireTempDir()
 
-	if err := os.MkdirAll(tempDir, os.ModePerm); err != nil {
+	tempDir := filepath.Join(v.Platform.TempDir(), "terragrunt")
+
+	if err := v.FS.MkdirAll(tempDir, os.ModePerm); err != nil {
 		return "", err
 	}
 
@@ -1770,17 +1708,17 @@ func EnsureTempDir() (string, error) {
 //
 // Note that this is a backwards compatibility implementation for the `--queue-excludes-file` flag, so it's going to
 // append the ! prefix to each filter to negate it.
-func ExcludeFiltersFromFile(baseDir, filename string) ([]string, error) {
+func ExcludeFiltersFromFile(fsys vfs.FS, baseDir, filename string) ([]string, error) {
 	filename, err := CanonicalPath(filename, baseDir)
 	if err != nil {
 		return nil, err
 	}
 
-	if !FileExists(filename) || !IsFile(filename) {
+	if !vfs.IsFile(fsys, filename) {
 		return nil, nil
 	}
 
-	content, err := ReadFileAsString(filename)
+	content, err := vfs.ReadFileAsString(fsys, filename)
 	if err != nil {
 		return nil, err
 	}
@@ -1804,17 +1742,17 @@ func ExcludeFiltersFromFile(baseDir, filename string) ([]string, error) {
 
 // GetFiltersFromFile returns a list of filter queries from the given filename,
 // where each filter query starts on a new line.
-func GetFiltersFromFile(baseDir, filename string) ([]string, error) {
+func GetFiltersFromFile(fsys vfs.FS, baseDir, filename string) ([]string, error) {
 	filename, err := CanonicalPath(filename, baseDir)
 	if err != nil {
 		return nil, err
 	}
 
-	if !FileExists(filename) || !IsFile(filename) {
+	if !vfs.IsFile(fsys, filename) {
 		return nil, nil
 	}
 
-	content, err := ReadFileAsString(filename)
+	content, err := vfs.ReadFileAsString(fsys, filename)
 	if err != nil {
 		return nil, err
 	}
@@ -1853,35 +1791,6 @@ func MatchSha256Checksum(file, filename []byte) []byte {
 	}
 
 	return checksum
-}
-
-// FileSHA256 calculates the SHA256 hash of the file at the given path.
-func FileSHA256(filePath string) ([]byte, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close() //nolint:errcheck
-
-	hash := sha256.New()
-	buffer := make([]byte, ChecksumReadBlock)
-
-	for {
-		n, err := file.Read(buffer)
-		if err != nil && err != io.EOF {
-			return nil, err
-		}
-
-		if n == 0 {
-			break
-		}
-
-		if _, err := hash.Write(buffer[:n]); err != nil {
-			return nil, err
-		}
-	}
-
-	return hash.Sum(nil), nil
 }
 
 // readerFunc is syntactic sugar for read interface.
@@ -2035,7 +1944,7 @@ func SkipDirIfIgnorable(dir string) error {
 // expandHome resolves a leading `~` (with no user qualifier) to the current
 // user's home directory. Anything else is returned unchanged. `~user/...` is
 // rejected because per-user lookup is platform-specific and not needed here.
-func expandHome(path string) (string, error) {
+func expandHome(v *venv.Venv, path string) (string, error) {
 	if path == "" || path[0] != '~' {
 		return path, nil
 	}
@@ -2044,7 +1953,9 @@ func expandHome(path string) (string, error) {
 		return "", errors.New("cannot expand user-specific home dir")
 	}
 
-	home, err := os.UserHomeDir()
+	v.RequireUserHomeDir()
+
+	home, err := v.Platform.UserHomeDir()
 	if err != nil {
 		return "", err
 	}

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -182,7 +182,7 @@ func TestFileManifest(t *testing.T) {
 	assert.NoError(t, manifest.Clean(l))
 	// test if the files have been deleted
 	for _, file := range testfiles {
-		assert.False(t, util.FileExists(file))
+		assert.NoFileExists(t, file)
 	}
 }
 
@@ -1072,7 +1072,7 @@ func TestEmptyDir(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
-			emptyValue, err := util.IsDirectoryEmpty(tc.path)
+			emptyValue, err := vfs.IsDirectoryEmpty(vfs.NewOSFS(), tc.path)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectEmpty, emptyValue, "For path %s", tc.path)
 		})

--- a/internal/util/file_tofu_test.go
+++ b/internal/util/file_tofu_test.go
@@ -465,7 +465,7 @@ module "database" {
 			regex, err := regexp.Compile(tc.pattern)
 			require.NoError(t, err)
 
-			actual, err := util.RegexFoundInTFFiles(tmpDir, regex)
+			actual, err := util.RegexFoundInTFFiles(vfs.NewOSFS(), tmpDir, regex)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expected, actual, "For test case: %s", tc.description)
@@ -481,7 +481,7 @@ func TestRegexFoundInTFFilesErrorHandling(t *testing.T) {
 		t.Parallel()
 
 		regex := regexp.MustCompile("test")
-		_, err := util.RegexFoundInTFFiles("/non/existent/directory", regex)
+		_, err := util.RegexFoundInTFFiles(vfs.NewOSFS(), "/non/existent/directory", regex)
 		assert.Error(t, err)
 	})
 
@@ -505,7 +505,7 @@ func TestRegexFoundInTFFilesErrorHandling(t *testing.T) {
 		}()
 
 		regex := regexp.MustCompile("test")
-		_, err = util.RegexFoundInTFFiles(tmpDir, regex)
+		_, err = util.RegexFoundInTFFiles(vfs.NewOSFS(), tmpDir, regex)
 		// We expect an error due to permission denied, but don't fail the test
 		// if the OS doesn't enforce permission restrictions in the test environment
 		if err == nil {

--- a/internal/util/lockfile.go
+++ b/internal/util/lockfile.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -26,10 +27,8 @@ func (lockfile *Lockfile) Unlock() error {
 		return err
 	}
 
-	if FileExists(lockfile.Path()) {
-		if err := os.Remove(lockfile.Path()); err != nil {
-			return err
-		}
+	if err := os.Remove(lockfile.Path()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
 	}
 
 	return nil

--- a/internal/venv/venv.go
+++ b/internal/venv/venv.go
@@ -68,10 +68,20 @@ var ErrVenvGOOSUnset = errors.New("venv.Venv.Platform.GOOS is required but unset
 // when UserHomeDir is nil.
 var ErrVenvUserHomeDirUnset = errors.New("venv.Venv.Platform.UserHomeDir is required but unset")
 
+// ErrVenvUserCacheDirUnset is the panic value [Venv.RequireUserCacheDir] raises
+// when UserCacheDir is nil.
+var ErrVenvUserCacheDirUnset = errors.New("venv.Venv.Platform.UserCacheDir is required but unset")
+
+// ErrVenvTempDirUnset is the panic value [Venv.RequireTempDir] raises when
+// TempDir is nil.
+var ErrVenvTempDirUnset = errors.New("venv.Venv.Platform.TempDir is required but unset")
+
 // Platform carries the operating-system handles used below the CLI boundary.
 type Platform struct {
-	UserHomeDir func() (string, error)
-	GOOS        string
+	UserHomeDir  func() (string, error)
+	UserCacheDir func() (string, error)
+	TempDir      func() string
+	GOOS         string
 }
 
 // Venv is the root virtualized environment. It carries the filesystem,
@@ -283,6 +293,20 @@ func (v *Venv) RequireUserHomeDir() {
 	}
 }
 
+// RequireUserCacheDir panics with [ErrVenvUserCacheDirUnset] when UserCacheDir is nil.
+func (v *Venv) RequireUserCacheDir() {
+	if v.Platform == nil || v.Platform.UserCacheDir == nil {
+		panic(ErrVenvUserCacheDirUnset)
+	}
+}
+
+// RequireTempDir panics with [ErrVenvTempDirUnset] when TempDir is nil.
+func (v *Venv) RequireTempDir() {
+	if v.Platform == nil || v.Platform.TempDir == nil {
+		panic(ErrVenvTempDirUnset)
+	}
+}
+
 // OSVenv builds the production [Venv]: the real OS filesystem, the real OS
 // process executor, the real outbound HTTP client, platform handles, a
 // snapshot of the OS environment, and stdin/stdout/stderr wired to the real
@@ -303,8 +327,10 @@ func OSVenv() *Venv {
 		Reader: bufio.NewReader(os.Stdin),
 		Env:    ParseEnviron(os.Environ()),
 		Platform: &Platform{
-			UserHomeDir: os.UserHomeDir,
-			GOOS:        runtime.GOOS,
+			UserHomeDir:  os.UserHomeDir,
+			UserCacheDir: os.UserCacheDir,
+			TempDir:      os.TempDir,
+			GOOS:         runtime.GOOS,
 		},
 		Writers: &writer.Writers{Writer: os.Stdout, ErrWriter: os.Stderr},
 	}

--- a/internal/vfs/errors.go
+++ b/internal/vfs/errors.go
@@ -18,6 +18,15 @@ var ErrNoLock = errors.New("locking not supported")
 // cannot be followed at all.
 var ErrSymlinkEscapes = errors.New("symlink target escapes destination")
 
+// PathIsNotDirectory is returned when the given path is unexpectedly not a directory.
+type PathIsNotDirectory struct {
+	path string
+}
+
+func (err PathIsNotDirectory) Error() string {
+	return err.path + " is not a directory"
+}
+
 // ZipDecompressedSizeLimitError reports an extraction exceeding its configured decompressed size limit.
 type ZipDecompressedSizeLimitError struct {
 	// Name is the archive entry whose extraction breached the limit.

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -6,6 +6,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -108,11 +109,91 @@ func FileExists(vfs FS, path string) (bool, error) {
 	return false, err
 }
 
+// Exists reports whether path is present on the given filesystem. A path that
+// cannot be stat'd counts as absent, so an entry the caller may not read reads
+// the same as one that is not there. Use [FileExists] to tell those apart.
+func Exists(fsys FS, path string) bool {
+	_, err := fsys.Stat(path)
+	return err == nil
+}
+
 // IsDir reports whether path is a directory on the given filesystem,
 // following symlinks. A path that cannot be stat'd is not a directory.
 func IsDir(fsys FS, path string) bool {
 	info, err := fsys.Stat(path)
 	return err == nil && info.IsDir()
+}
+
+// checksumReadBlock is the block size FileSHA256 hashes with.
+const checksumReadBlock = 8192
+
+// IsFile reports whether path points to a regular file. A path that cannot be
+// stat'd is not a file.
+func IsFile(fsys FS, path string) bool {
+	info, err := fsys.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// EnsureDirectory creates the directory at path, and any missing parents, when
+// nothing is there yet. A path already occupied by a file yields
+// [PathIsNotDirectory].
+func EnsureDirectory(fsys FS, path string) error {
+	if IsFile(fsys, path) {
+		return PathIsNotDirectory{path: path}
+	}
+
+	if Exists(fsys, path) {
+		return nil
+	}
+
+	const ownerReadWriteExecutePerms = 0o700
+
+	return fsys.MkdirAll(path, ownerReadWriteExecutePerms)
+}
+
+// IsDirectoryEmpty reports whether path is a directory holding no entries.
+func IsDirectoryEmpty(fsys FS, path string) (retEmpty bool, retErr error) {
+	dir, err := fsys.Open(path)
+	if err != nil {
+		return false, err
+	}
+
+	defer func() {
+		if err := dir.Close(); err != nil && retErr == nil {
+			retEmpty, retErr = false, err
+		}
+	}()
+
+	// Reading a single entry is enough to answer the question, so a directory
+	// holding a million files costs the same as one holding one.
+	if _, err := dir.Readdir(1); err == nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// FileSHA256 returns the SHA256 of the file at path, read in fixed-size blocks
+// so hashing a large archive does not pull it entirely into memory.
+func FileSHA256(fsys FS, path string) (_ []byte, retErr error) {
+	file, err := fsys.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err := file.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
+
+	hash := sha256.New()
+
+	if _, err := io.CopyBuffer(hash, file, make([]byte, checksumReadBlock)); err != nil {
+		return nil, err
+	}
+
+	return hash.Sum(nil), nil
 }
 
 // CopyFile copies a file from source to destination on the given filesystem,
@@ -175,6 +256,18 @@ func WriteFile(fs FS, filename string, data []byte, perm os.FileMode) error {
 // ReadFile reads the contents of a file from the given filesystem.
 func ReadFile(fs FS, filename string) ([]byte, error) {
 	return afero.ReadFile(fs, filename)
+}
+
+// ReadFileAsString reads the contents of a file from the given filesystem as a
+// string, annotating the failure with the path so a caller reading several
+// files can tell which one failed.
+func ReadFileAsString(fsys FS, filename string) (string, error) {
+	contents, err := ReadFile(fsys, filename)
+	if err != nil {
+		return "", fmt.Errorf("error reading file at path %s: %w", filename, err)
+	}
+
+	return string(contents), nil
 }
 
 // ReadFileLimit reads up to limit bytes from the start of a file on the given

--- a/pkg/config/catalog.go
+++ b/pkg/config/catalog.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/zclconf/go-cty/cty"
@@ -152,7 +153,7 @@ func findCatalogConfig(
 			return "", "", err
 		}
 
-		configString, err := util.ReadFileAsString(newConfigPath)
+		configString, err := vfs.ReadFileAsString(pctx.Venv.FS, newConfigPath)
 		if err != nil {
 			return "", "", err
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1091,7 +1091,7 @@ func (args *TerraformExtraArguments) String() string {
 		args.EnvVars)
 }
 
-func (args *TerraformExtraArguments) GetVarFiles(l log.Logger) []string {
+func (args *TerraformExtraArguments) GetVarFiles(l log.Logger, fsys vfs.FS) []string {
 	var varFiles []string
 
 	// Include all specified RequiredVarFiles.
@@ -1104,7 +1104,7 @@ func (args *TerraformExtraArguments) GetVarFiles(l log.Logger) []string {
 	// duplicates.
 	if args.OptionalVarFiles != nil {
 		for _, file := range util.RemoveDuplicatesKeepLast(*args.OptionalVarFiles) {
-			if util.FileExists(file) {
+			if vfs.Exists(fsys, file) {
 				varFiles = append(varFiles, file)
 			} else {
 				l.Debugf("Skipping var-file %s as it does not exist", file)
@@ -2270,7 +2270,7 @@ func validateDependencies(ctx *ParsingContext, dependencies *ModuleDependencies)
 			fullPath = path.Join(ctx.WorkingDir, fullPath)
 		}
 
-		if !util.IsDir(fullPath) {
+		if !vfs.IsDir(ctx.Venv.FS, fullPath) {
 			missingDependencies = append(
 				missingDependencies,
 				fmt.Sprintf("%s (%s)", dependencyPath, fullPath),

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	tflang "github.com/hashicorp/terraform/lang"
@@ -794,7 +795,7 @@ func findInParentFoldersImpl(
 
 		fileToFind := parentFileCandidate(currentDir, fileToFindParam)
 
-		if parentFileExists(ctx, probes, fileToFind) {
+		if parentFileExists(ctx, pctx.Venv.FS, probes, fileToFind) {
 			return fileToFind, nil
 		}
 
@@ -829,12 +830,17 @@ func parentFileCandidate(dir, fileName string) string {
 // created in an already-probed ancestor part-way through a run is therefore not
 // observed. Nothing Terragrunt generates lands in an ancestor it has already
 // walked past, and the cache lives only as long as one run.
-func parentFileExists(ctx context.Context, probes *cache.Cache[bool], path string) bool {
+func parentFileExists(
+	ctx context.Context,
+	fsys vfs.FS,
+	probes *cache.Cache[bool],
+	path string,
+) bool {
 	if exists, found := probes.Get(ctx, path); found {
 		return exists
 	}
 
-	exists := util.FileExists(path)
+	exists := vfs.Exists(fsys, path)
 	probes.Put(ctx, path, exists)
 
 	return exists
@@ -1058,9 +1064,9 @@ func ParseTerragruntConfig(
 	// target config check: make sure the target config exists. If the file does not exist, and there is no default val,
 	// return an error. If the file does not exist but there is a default val, return the default val. Otherwise,
 	// proceed to parse the file as a terragrunt config file.
-	targetConfig := getCleanedTargetConfigPath(configPath, pctx.TerragruntConfigPath)
+	targetConfig := getCleanedTargetConfigPath(pctx.Venv.FS, configPath, pctx.TerragruntConfigPath)
 
-	targetConfigFileExists := util.FileExists(targetConfig)
+	targetConfigFileExists := vfs.Exists(pctx.Venv.FS, targetConfig)
 
 	if !targetConfigFileExists && defaultVal == nil {
 		return cty.NilVal, TerragruntConfigNotFoundError{Path: targetConfig}
@@ -1197,7 +1203,7 @@ func readTerragruntConfigAsFuncImpl(
 // Returns a cleaned path to the target config (the `terragrunt.hcl` or `terragrunt.hcl.json` file), handling relative
 // paths correctly. This will automatically append `terragrunt.hcl` or `terragrunt.hcl.json` to the path if the target
 // path is a directory.
-func getCleanedTargetConfigPath(configPath string, workingPath string) string {
+func getCleanedTargetConfigPath(fsys vfs.FS, configPath string, workingPath string) string {
 	cwd := filepath.Dir(workingPath)
 
 	targetConfig := configPath
@@ -1205,7 +1211,7 @@ func getCleanedTargetConfigPath(configPath string, workingPath string) string {
 		targetConfig = filepath.Join(cwd, targetConfig)
 	}
 
-	if util.IsDir(targetConfig) {
+	if vfs.IsDir(fsys, targetConfig) {
 		targetConfig = GetDefaultConfigPath(targetConfig)
 	}
 
@@ -1562,7 +1568,7 @@ func readTFVarsFileImpl(pctx *ParsingContext, l log.Logger, args []string) (stri
 		varFile = filepath.Clean(varFile)
 	}
 
-	if !util.FileExists(varFile) {
+	if !vfs.Exists(pctx.Venv.FS, varFile) {
 		return "", TFVarFileNotFoundError{File: varFile}
 	}
 

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
-	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/huandu/go-clone"
 
@@ -1013,7 +1013,7 @@ func registerSiblingAutoInclude(
 		return
 	}
 
-	if !util.FileExists(autoIncludePath) {
+	if !vfs.Exists(pctx.Venv.FS, autoIncludePath) {
 		return
 	}
 
@@ -1157,19 +1157,19 @@ func autoIncludeCacheKeySuffix(
 		return suffix
 	}
 
-	suffix := autoIncludeContentSuffix(autoIncludePath)
+	suffix := autoIncludeContentSuffix(pctx.Venv.FS, autoIncludePath)
 	memo.Put(ctx, fingerprint, suffix)
 
 	return suffix
 }
 
 // autoIncludeContentSuffix folds the sibling autoinclude existence and content into the cache key, with distinct sentinels for absent and unreadable.
-func autoIncludeContentSuffix(autoIncludePath string) string {
-	if !util.FileExists(autoIncludePath) {
+func autoIncludeContentSuffix(fsys vfs.FS, autoIncludePath string) string {
+	if !vfs.Exists(fsys, autoIncludePath) {
 		return fmt.Sprintf("-autoinclude:%#v", false)
 	}
 
-	content, err := util.ReadFileAsString(autoIncludePath)
+	content, err := vfs.ReadFileAsString(fsys, autoIncludePath)
 	if err != nil {
 		// An unreadable autoinclude must not collide with the absent sentinel; key on the error text.
 		return fmt.Sprintf("-autoinclude:%#v-err:%#v", true, err.Error())

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1066,7 +1066,7 @@ func TestParseTerragruntConfigTwoLevels(t *testing.T) {
 	configPathRel := "../../test/fixtures/parent-folders/multiple-terragrunt-in-parents/child/sub-child/" + config.RecommendedParentConfigName
 	configPath := absPath(t, configPathRel)
 
-	cfg, err := util.ReadFileAsString(configPathRel)
+	cfg, err := vfs.ReadFileAsString(vfs.NewOSFS(), configPathRel)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1099,7 +1099,7 @@ func TestParseTerragruntConfigThreeLevels(t *testing.T) {
 	configPathRel := "../../test/fixtures/parent-folders/multiple-terragrunt-in-parents/child/sub-child/sub-sub-child/" + config.DefaultTerragruntConfigPath
 	configPath := absPath(t, configPathRel)
 
-	cfg, err := util.ReadFileAsString(configPathRel)
+	cfg, err := vfs.ReadFileAsString(vfs.NewOSFS(), configPathRel)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -383,9 +383,13 @@ func decodeDependencies(
 			return &updatedDependencies, DependencyInvalidConfigPathError{DependencyName: dep.Name}
 		}
 
-		depPath := getCleanedTargetConfigPath(dep.ConfigPath.AsString(), pctx.TerragruntConfigPath)
+		depPath := getCleanedTargetConfigPath(
+			pctx.Venv.FS,
+			dep.ConfigPath.AsString(),
+			pctx.TerragruntConfigPath,
+		)
 
-		if !util.FileExists(depPath) {
+		if !vfs.Exists(pctx.Venv.FS, depPath) {
 			updatedDependencies.Dependencies = append(updatedDependencies.Dependencies, dep)
 
 			continue
@@ -515,10 +519,14 @@ func checkForDependencyBlockCycles(
 			return DependencyInvalidConfigPathError{DependencyName: dependency.Name}
 		}
 
-		dependencyPath := getCleanedTargetConfigPath(dependency.ConfigPath.AsString(), configPath)
+		dependencyPath := getCleanedTargetConfigPath(
+			pctx.Venv.FS,
+			dependency.ConfigPath.AsString(),
+			configPath,
+		)
 
 		// Skip cycle checking for nonexistent dependency targets — there is nothing to traverse.
-		if !util.FileExists(dependencyPath) {
+		if !vfs.Exists(pctx.Venv.FS, dependencyPath) {
 			continue
 		}
 
@@ -570,10 +578,10 @@ func checkForDependencyBlockCyclesUsingDFS(
 	}
 
 	for _, dependency := range dependencyPaths {
-		dependencyPath := getCleanedTargetConfigPath(dependency, dependencyPath)
+		dependencyPath := getCleanedTargetConfigPath(pctx.Venv.FS, dependency, dependencyPath)
 
 		// Skip cycle checking for nonexistent dependency targets such as stack directories.
-		if !util.FileExists(dependencyPath) {
+		if !vfs.Exists(pctx.Venv.FS, dependencyPath) {
 			continue
 		}
 
@@ -785,6 +793,7 @@ func getTerragruntOutputIfAppliedElseConfiguredDefault(
 	// applied. In either case, check if there are default output values to return. If yes, return that. Else,
 	// return error.
 	targetConfig := getCleanedTargetConfigPath(
+		pctx.Venv.FS,
 		dependencyConfig.ConfigPath.AsString(),
 		pctx.TerragruntConfigPath,
 	)
@@ -840,6 +849,7 @@ func getTerragruntOutput(
 ) (*cty.Value, bool, error) {
 	// target config check: make sure the target config exists
 	targetConfigPath := getCleanedTargetConfigPath(
+		pctx.Venv.FS,
 		dependencyConfig.ConfigPath.AsString(),
 		pctx.TerragruntConfigPath,
 	)
@@ -851,7 +861,7 @@ func getTerragruntOutput(
 		return stackOutput, stackOutput == nil, err
 	}
 
-	if !util.FileExists(targetConfigPath) {
+	if !vfs.Exists(pctx.Venv.FS, targetConfigPath) {
 		return nil, true, DependencyConfigNotFound{Path: targetConfigPath}
 	}
 
@@ -906,7 +916,7 @@ func collectStackUnitOutputs(
 		unitDir := unit.GeneratedPath(stackDir)
 		unitConfigPath := filepath.Join(unitDir, DefaultTerragruntConfigPath)
 
-		if !util.FileExists(unitConfigPath) {
+		if !vfs.Exists(pctx.Venv.FS, unitConfigPath) {
 			l.Warnf("Stack unit %s config not found at %s, skipping", unit.Name, unitConfigPath)
 
 			continue
@@ -1009,7 +1019,7 @@ func tryGetStackOutput(
 		return nil, false, nil
 	}
 
-	if !util.FileExists(stackFilePath) {
+	if !vfs.Exists(pctx.Venv.FS, stackFilePath) {
 		return nil, false, nil
 	}
 
@@ -1529,7 +1539,7 @@ func terragruntAlreadyInit(
 	// NOTE: if the ref changes, the workingDir would be different as the download dir includes a base64 encoded hash of
 	// the source URL with ref. This would ensure that this routine would not return true if the new ref is not already
 	// init-ed.
-	return util.FileExists(filepath.Join(workingDir, ".terraform")), workingDir, nil
+	return vfs.Exists(pctx.Venv.FS, filepath.Join(workingDir, ".terraform")), workingDir, nil
 }
 
 // getTerragruntOutputJSONFromInitFolder will retrieve the outputs directly from the module's working directory without
@@ -1875,7 +1885,7 @@ func runTerragruntOutputJSON(
 		return nil, err
 	}
 
-	runCfg := cfg.ToRunConfig(l)
+	runCfg := cfg.ToRunConfig(l, pctx.Venv.FS)
 
 	credsGetter := creds.NewGetter()
 	if err = credsGetter.ObtainAndUpdateEnvIfNecessary(

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -416,7 +416,7 @@ func setupCAS(l log.Logger, v *venv.Venv, enabled bool, cloneDepth int) (casSetu
 		return casSetup{}, err
 	}
 
-	c, err := cas.New(cas.WithCloneDepth(cloneDepth))
+	c, err := cas.New(v, cas.WithCloneDepth(cloneDepth))
 	if err != nil {
 		l.Warnf("Failed to initialize CAS for stack generation: %v. CAS features disabled.", err)
 		return casSetup{}, nil
@@ -739,7 +739,7 @@ func generateComponent(
 		return err
 	}
 
-	if err := writeValues(l, cmp.values, dest); err != nil {
+	if err := writeValues(l, v.FS, cmp.values, dest); err != nil {
 		return fmt.Errorf("failed to write values %v %w", cmp.name, err)
 	}
 
@@ -1664,7 +1664,7 @@ func stackName(s *Stack) string {
 }
 
 // writeValues generates and writes values to a terragrunt.values.hcl file in the specified directory.
-func writeValues(l log.Logger, values *cty.Value, directory string) error {
+func writeValues(l log.Logger, fsys vfs.FS, values *cty.Value, directory string) error {
 	if values == nil {
 		l.Debugf("No values to write in %s", directory)
 		return nil
@@ -1690,7 +1690,7 @@ func writeValues(l log.Logger, values *cty.Value, directory string) error {
 		return errors.New("writeValues: unit directory path cannot be empty")
 	}
 
-	if err := os.MkdirAll(directory, unitDirPerm); err != nil {
+	if err := fsys.MkdirAll(directory, unitDirPerm); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", directory, err)
 	}
 
@@ -1724,13 +1724,13 @@ func writeValues(l log.Logger, values *cty.Value, directory string) error {
 	}
 
 	// CAS may materialize the target as a read-only hard link, so remove it before writing
-	if util.IsFile(filePath) {
-		if err := os.Remove(filePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if vfs.IsFile(fsys, filePath) {
+		if err := fsys.Remove(filePath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("failed to remove values file %s before writing: %w", filePath, err)
 		}
 	}
 
-	if err := os.WriteFile(filePath, file.Bytes(), valueFilePerm); err != nil {
+	if err := vfs.WriteFile(fsys, filePath, file.Bytes(), valueFilePerm); err != nil {
 		return fmt.Errorf("failed to write values file %s: %w", filePath, err)
 	}
 

--- a/pkg/config/terraform_version_test.go
+++ b/pkg/config/terraform_version_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -43,7 +44,7 @@ terraform {
 	require.NotNil(t, terragruntConfig.Terraform.Version)
 	assert.Equal(t, "~> 3.3", *terragruntConfig.Terraform.Version)
 
-	runConfig := terragruntConfig.ToRunConfig(l)
+	runConfig := terragruntConfig.ToRunConfig(l, vfs.NewOSFS())
 	require.NotNil(t, runConfig)
 	assert.Equal(t, "~> 3.3", runConfig.Terraform.Version)
 }

--- a/pkg/config/translate.go
+++ b/pkg/config/translate.go
@@ -5,18 +5,19 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
 // ToRunConfig translates a TerragruntConfig to a runcfg.RunConfig.
 // This is the primary method for converting config types to runner types.
-func (cfg *TerragruntConfig) ToRunConfig(l log.Logger) *runcfg.RunConfig {
+func (cfg *TerragruntConfig) ToRunConfig(l log.Logger, fsys vfs.FS) *runcfg.RunConfig {
 	if cfg == nil {
 		return nil
 	}
 
 	runCfg := &runcfg.RunConfig{
-		Terraform:                   translateTerraformConfig(cfg.Terraform, l),
+		Terraform:                   translateTerraformConfig(cfg.Terraform, l, fsys),
 		RemoteState:                 translateRemoteState(cfg.RemoteState),
 		Exclude:                     translateExcludeConfig(cfg.Exclude),
 		GenerateConfigs:             translateGenerateConfigs(cfg.GenerateConfigs),
@@ -37,7 +38,7 @@ func (cfg *TerragruntConfig) ToRunConfig(l log.Logger) *runcfg.RunConfig {
 }
 
 // translateTerraformConfig converts config.TerraformConfig to runcfg.TerraformConfig.
-func translateTerraformConfig(tf *TerraformConfig, l log.Logger) runcfg.TerraformConfig {
+func translateTerraformConfig(tf *TerraformConfig, l log.Logger, fsys vfs.FS) runcfg.TerraformConfig {
 	if tf == nil {
 		return runcfg.TerraformConfig{}
 	}
@@ -85,7 +86,7 @@ func translateTerraformConfig(tf *TerraformConfig, l log.Logger) runcfg.Terrafor
 		NoCopyTerraformLockFile: noCopyTerraformLockFile,
 		UpdateSourceWithCAS:     updateSourceWithCAS,
 		Mutable:                 mutable,
-		ExtraArgs:               translateExtraArgs(tf.ExtraArgs, l),
+		ExtraArgs:               translateExtraArgs(tf.ExtraArgs, l, fsys),
 		BeforeHooks:             translateHooks(tf.BeforeHooks),
 		AfterHooks:              translateHooks(tf.AfterHooks),
 		ErrorHooks:              translateErrorHooks(tf.ErrorHooks),
@@ -96,6 +97,7 @@ func translateTerraformConfig(tf *TerraformConfig, l log.Logger) runcfg.Terrafor
 func translateExtraArgs(
 	args []TerraformExtraArguments,
 	l log.Logger,
+	fsys vfs.FS,
 ) []runcfg.TerraformExtraArguments {
 	if args == nil {
 		return nil
@@ -103,7 +105,7 @@ func translateExtraArgs(
 
 	result := make([]runcfg.TerraformExtraArguments, len(args))
 	for i, arg := range args {
-		varFiles := computeVarFiles(arg.RequiredVarFiles, arg.OptionalVarFiles, l)
+		varFiles := computeVarFiles(arg.RequiredVarFiles, arg.OptionalVarFiles, l, fsys)
 
 		var arguments []string
 		if arg.Arguments != nil {
@@ -144,6 +146,7 @@ func computeVarFiles(
 	requiredVarFiles *[]string,
 	optionalVarFiles *[]string,
 	l log.Logger,
+	fsys vfs.FS,
 ) []string {
 	var varFiles []string
 
@@ -157,7 +160,7 @@ func computeVarFiles(
 	// duplicates.
 	if optionalVarFiles != nil {
 		for _, file := range util.RemoveDuplicatesKeepLast(*optionalVarFiles) {
-			if util.FileExists(file) {
+			if vfs.Exists(fsys, file) {
 				varFiles = append(varFiles, file)
 			} else {
 				l.Debugf("Skipping var-file %s as it does not exist", file)

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -211,7 +211,7 @@ func CopyAndFillMapPlaceholders(
 ) {
 	t.Helper()
 
-	contents, err := util.ReadFileAsString(srcPath)
+	contents, err := vfs.ReadFileAsString(vfs.NewOSFS(), srcPath)
 	require.NoError(t, err, "Error reading file at %s: %v", srcPath, err)
 
 	// iterate over placeholders and replace placeholders
@@ -784,11 +784,11 @@ func (provider *FakeProvider) createZipArchive(t *testing.T, providerDir string)
 func unmarshalFile(t *testing.T, filename string, dest any) {
 	t.Helper()
 
-	if !util.FileExists(filename) {
+	data, err := os.ReadFile(filename)
+	if errors.Is(err, os.ErrNotExist) {
 		return
 	}
 
-	data, err := os.ReadFile(filename)
 	require.NoError(t, err)
 	err = json.Unmarshal(data, dest)
 	require.NoError(t, err)
@@ -1321,7 +1321,7 @@ func RunTerragruntValidateInputs(
 	t.Helper()
 
 	maybeNested := filepath.Join(moduleDir, "module")
-	if util.FileExists(maybeNested) {
+	if vfs.Exists(vfs.NewOSFS(), maybeNested) {
 		// Nested module test case with included file, so run terragrunt from the nested module.
 		moduleDir = maybeNested
 	}

--- a/test/helpers/venvtest/venvtest.go
+++ b/test/helpers/venvtest/venvtest.go
@@ -18,6 +18,14 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/writer"
 )
 
+// Cache and temp roots for the in-memory bundle. They sit under a name no real
+// machine uses, so a test that accidentally runs them against the OS filesystem
+// fails loudly instead of writing into the invoking user's directories.
+const (
+	memCacheDir = "/venvtest/cache"
+	memTempDir  = "/venvtest/tmp"
+)
+
 // New returns an in-memory venv: a fail-closed exec, an in-memory filesystem,
 // a fail-closed no-network HTTP client, a mem SOPS decrypter yielding empty
 // cleartext, an empty (non-nil) environment, deterministic platform handles,
@@ -39,6 +47,12 @@ func New() *venv.Venv {
 		Platform: &venv.Platform{
 			UserHomeDir: func() (string, error) {
 				return "", nil
+			},
+			UserCacheDir: func() (string, error) {
+				return memCacheDir, nil
+			},
+			TempDir: func() string {
+				return memTempDir
 			},
 			GOOS: runtime.GOOS,
 		},

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -520,7 +520,7 @@ func TestAwsBootstrapBackendWithoutVersioning(t *testing.T) {
 		helpers.TerraformRemoteStateS3Region,
 	)
 	// Add skip_bucket_versioning to disable_versioning feature
-	contents, err := util.ReadFileAsString(dualLockingConfigPath)
+	contents, err := vfs.ReadFileAsString(vfs.NewOSFS(), dualLockingConfigPath)
 	require.NoError(t, err)
 
 	anchorText := "    enable_lock_table_ssencryption = feature.enable_lock_table_ssencryption.value"
@@ -558,7 +558,7 @@ func TestAwsBootstrapBackendWithoutVersioning(t *testing.T) {
 		helpers.TerraformRemoteStateS3Region,
 	)
 	// Add skip_bucket_versioning for disable_versioning feature
-	contents, err = util.ReadFileAsString(useLockfileConfigPath)
+	contents, err = vfs.ReadFileAsString(vfs.NewOSFS(), useLockfileConfigPath)
 	require.NoError(t, err)
 
 	// Use regex to match use_lockfile with any amount of whitespace before the equals sign
@@ -1972,7 +1972,7 @@ func TestAwsProviderPatch(t *testing.T) {
 	mainTFFile := filepath.Join(modulePath, "main.tf")
 
 	// fill in branch so we can test against updates to the test case file
-	mainContents, err := util.ReadFileAsString(mainTFFile)
+	mainContents, err := vfs.ReadFileAsString(vfs.NewOSFS(), mainTFFile)
 	require.NoError(t, err)
 	gitRunner, err := git.NewGitRunner(vexec.NewOSExec())
 	require.NoError(t, err)
@@ -3115,7 +3115,7 @@ func TestAwsReadTerragruntConfigIamRole(t *testing.T) {
 	// Check that output contains value defined in IAM role
 	assert.Contains(t, output, "666666666666")
 	// Ensure that state file wasn't created with default IAM value
-	assert.True(t, util.FileNotExists(filepath.Join(rootPath, identityArn+".txt")))
+	assert.NoFileExists(t, filepath.Join(rootPath, identityArn+".txt"))
 }
 
 func TestAwsTerragruntWorksWithIncludeShallowMerge(t *testing.T) {

--- a/test/integration_cas_gcs_test.go
+++ b/test/integration_cas_gcs_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // TestGcpCASGCSMD5Probe exercises CASGetter end-to-end against a
@@ -40,7 +41,7 @@ func TestGcpCASGCSMD5Probe(t *testing.T) {
 	uploadGCSObjectForCAS(t, bucket, object, makeModuleArchive(t))
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/test/integration_cas_rustfs_test.go
+++ b/test/integration_cas_rustfs_test.go
@@ -49,7 +49,7 @@ func TestCAS_S3_RustFS_ProbeAvoidsRedownload(t *testing.T) { //nolint: parallelt
 	// path-style URLs, so we set the resolver's NewClient hook to
 	// match.
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/test/integration_cas_s3_test.go
+++ b/test/integration_cas_s3_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // TestAwsCASS3ChecksumProbe exercises CASGetter end-to-end against a
@@ -28,7 +29,7 @@ func TestAwsCASS3ChecksumProbe(t *testing.T) {
 	bucket := provisionS3ModuleArchive(t, region, key)
 
 	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-	c, err := tgcas.New(tgcas.WithStorePath(storePath))
+	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
 	v := venv.OSVenv()

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/component"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	viewtui "github.com/gruntwork-io/terragrunt/internal/view/tui"
@@ -186,7 +185,7 @@ func TestCatalogWithLocalDefaultTemplate(t *testing.T) {
 	assert.FileExists(t, filepath.Join(targetPath, "terragrunt.hcl"))
 	assert.FileExists(t, filepath.Join(targetPath, "custom-template.txt"))
 
-	content, err := util.ReadFileAsString(filepath.Join(targetPath, "terragrunt.hcl"))
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(targetPath, "terragrunt.hcl"))
 	require.NoError(t, err)
 	assert.Contains(t, content, "# Custom local template")
 }

--- a/test/integration_common_test.go
+++ b/test/integration_common_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -293,7 +294,7 @@ func (provider *FakeProvider) createZipArchive(t *testing.T, providerDir string)
 func unmarshalFile(t *testing.T, filename string, dest any) {
 	t.Helper()
 
-	if !util.FileExists(filename) {
+	if !vfs.Exists(vfs.NewOSFS(), filename) {
 		return
 	}
 

--- a/test/integration_debug_tf_test.go
+++ b/test/integration_debug_tf_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -36,7 +35,7 @@ func TestTFDebugGeneratedInputs(t *testing.T) {
 
 	// Debug file is created in the original config directory
 	debugFile := filepath.Join(rootPath, helpers.TerragruntDebugFile)
-	assert.True(t, util.FileExists(debugFile))
+	assert.FileExists(t, debugFile)
 
 	// Find cache directory for running terraform
 	cacheWorkingDir := helpers.FindCacheWorkingDir(t, rootPath)

--- a/test/integration_docs_aws_tofu_test.go
+++ b/test/integration_docs_aws_tofu_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1659,7 +1659,7 @@ EOF
 		for _, env := range environments {
 			for _, component := range components {
 				componentDir := filepath.Join(liveDir, env, component)
-				if util.FileExists(componentDir) {
+				if vfs.Exists(vfs.NewOSFS(), componentDir) {
 					require.NoError(t, os.RemoveAll(componentDir))
 				}
 			}

--- a/test/integration_docs_tf_test.go
+++ b/test/integration_docs_tf_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -260,11 +260,11 @@ func TestTFStacksWithLocalState(t *testing.T) {
 	require.FileExists(t, bazStatePath)
 
 	// Verify state files contain actual state (not empty)
-	fooStateContent, err := util.ReadFileAsString(fooStatePath)
+	fooStateContent, err := vfs.ReadFileAsString(vfs.NewOSFS(), fooStatePath)
 	require.NoError(t, err)
-	barStateContent, err := util.ReadFileAsString(barStatePath)
+	barStateContent, err := vfs.ReadFileAsString(vfs.NewOSFS(), barStatePath)
 	require.NoError(t, err)
-	bazStateContent, err := util.ReadFileAsString(bazStatePath)
+	bazStateContent, err := vfs.ReadFileAsString(vfs.NewOSFS(), bazStatePath)
 	require.NoError(t, err)
 
 	assert.Contains(t, fooStateContent, "null_resource")

--- a/test/integration_provider_cache_constraint_test.go
+++ b/test/integration_provider_cache_constraint_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -139,7 +139,7 @@ func TestTFTerragruntProviderCacheWeakConstraint(t *testing.T) {
 
 		// Also clean up .terraform directory to ensure fresh start
 		terraformDir := filepath.Join(appPath, ".terraform")
-		if util.FileExists(terraformDir) {
+		if vfs.Exists(vfs.NewOSFS(), terraformDir) {
 			err = os.RemoveAll(terraformDir)
 			require.NoError(t, err)
 		}
@@ -170,7 +170,7 @@ func extractConstraintsFromLockFile(t *testing.T, appPath string, providerName s
 	t.Helper()
 
 	lockfilePath := filepath.Join(appPath, ".terraform.lock.hcl")
-	require.True(t, util.FileExists(lockfilePath), "Lock file should exist")
+	require.FileExists(t, lockfilePath, "Lock file should exist")
 
 	// Read and parse the lock file
 	lockfileContent, err := os.ReadFile(lockfilePath)

--- a/test/integration_provider_cache_lockfile_readonly_test.go
+++ b/test/integration_provider_cache_lockfile_readonly_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,7 +42,7 @@ func TestTFTerragruntProviderCacheLockfileReadonly(t *testing.T) {
 			appPath,
 		))
 
-		assert.True(t, util.FileExists(filepath.Join(appPath, lockfileName)),
+		assert.FileExists(t, filepath.Join(appPath, lockfileName),
 			"provider cache should generate the lock file when -lockfile=readonly is not set")
 	})
 
@@ -58,7 +57,7 @@ func TestTFTerragruntProviderCacheLockfileReadonly(t *testing.T) {
 		))
 
 		require.Error(t, err, "init must fail because the lock file is missing and read-only")
-		assert.False(t, util.FileExists(filepath.Join(appPath, lockfileName)),
+		assert.NoFileExists(t, filepath.Join(appPath, lockfileName),
 			"provider cache must not generate the lock file when -lockfile=readonly is set")
 		assert.NotContains(t, stderr, lockfileReadonlyLogMessage,
 			"skipping the lock file is the requested behaviour, so it must not be logged above debug level")
@@ -95,9 +94,9 @@ func TestTFTerragruntProviderCacheLockfileReadonly(t *testing.T) {
 		))
 
 		require.Error(t, err, "init must fail because the lock file is missing and read-only")
-		assert.False(
+		assert.NoFileExists(
 			t,
-			util.FileExists(filepath.Join(appPath, lockfileName)),
+			filepath.Join(appPath, lockfileName),
 			"provider cache must not generate the lock file when TF_CLI_ARGS_init requests -lockfile=readonly",
 		)
 	})

--- a/test/integration_registry_test.go
+++ b/test/integration_registry_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -104,7 +103,7 @@ func TestTFTerraformRegistryVersionConstraintPinsResolvedVersion(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	assert.True(t, util.FileExists(filepath.Join(pinned.WorkingDir, "main.tf")))
+	assert.FileExists(t, filepath.Join(pinned.WorkingDir, "main.tf"))
 
 	wantVersion, err := pinned.EncodeSourceVersion(l, vfs.NewOSFS())
 	require.NoError(t, err)
@@ -125,7 +124,7 @@ func TestTFTerraformRegistryVersionConstraintPinsResolvedVersion(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, wantVersion, otherVersion)
 
-	gotVersion, err := util.ReadFileAsString(pinned.VersionFile)
+	gotVersion, err := vfs.ReadFileAsString(vfs.NewOSFS(), pinned.VersionFile)
 	require.NoError(t, err)
 	assert.Equal(t, wantVersion, gotVersion)
 }
@@ -165,7 +164,7 @@ func TestTFTerraformRegistryVersionConstraintSharedAcrossUnitsWithRacing(t *test
 		wantVersion, err := pinned.EncodeSourceVersion(l, vfs.NewOSFS())
 		require.NoError(t, err)
 
-		gotVersion, err := util.ReadFileAsString(pinned.VersionFile)
+		gotVersion, err := vfs.ReadFileAsString(vfs.NewOSFS(), pinned.VersionFile)
 		require.NoError(t, err)
 		assert.Equal(t, wantVersion, gotVersion, unit)
 	}

--- a/test/integration_s3_encryption_test.go
+++ b/test/integration_s3_encryption_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -109,7 +109,7 @@ func TestAwsS3SSECustomKey(t *testing.T) {
 	// Replace the custom key with a new one, and check that the key is updated in s3
 	helpers.CleanupTerraformFolder(t, testPath)
 
-	contents, err := util.ReadFileAsString(tmpTerragruntConfigPath)
+	contents, err := vfs.ReadFileAsString(vfs.NewOSFS(), tmpTerragruntConfigPath)
 	require.NoError(t, err)
 
 	err = os.Remove(tmpTerragruntConfigPath)
@@ -309,9 +309,9 @@ func TestAwsSkipBackend(t *testing.T) {
 	require.Error(t, err)
 
 	dotTerraformDir := filepath.Join(testPath, ".terraform")
-	assert.False(
+	assert.NoDirExists(
 		t,
-		util.FileExists(dotTerraformDir),
+		dotTerraformDir,
 		".terraform directory %s exists",
 		dotTerraformDir,
 	)
@@ -325,9 +325,9 @@ func TestAwsSkipBackend(t *testing.T) {
 	// .terraform is created in the cache directory, not the original config directory
 	cacheDir := helpers.FindCacheWorkingDir(t, testPath)
 	cacheDotTerraformDir := filepath.Join(cacheDir, ".terraform")
-	assert.True(
+	assert.DirExists(
 		t,
-		util.FileExists(cacheDotTerraformDir),
+		cacheDotTerraformDir,
 		".terraform directory %s does not exist",
 		cacheDotTerraformDir,
 	)

--- a/test/integration_scaffold_ssh_test.go
+++ b/test/integration_scaffold_ssh_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 
 	"github.com/stretchr/testify/assert"
@@ -169,7 +169,7 @@ EnableRootInclude: false
 	))
 	require.NoError(t, err)
 
-	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), tmpEnvPath+"/terragrunt.hcl")
 	require.NoError(t, err)
 	assert.NotContains(t, content, "find_in_parent_folders")
 }

--- a/test/integration_scaffold_test.go
+++ b/test/integration_scaffold_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 
 	"github.com/stretchr/testify/assert"
@@ -74,7 +74,7 @@ func TestScaffoldModuleShortUrl(t *testing.T) {
 
 	require.NoError(t, err)
 	// check that find_in_parent_folders is generated in terragrunt.hcl
-	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), tmpEnvPath+"/terragrunt.hcl")
 	require.NoError(t, err)
 	assert.Contains(t, content, "find_in_parent_folders")
 }
@@ -95,7 +95,7 @@ func TestScaffoldModuleShortUrlNoRootInclude(t *testing.T) {
 	)
 	require.NoError(t, err)
 	// check that find_in_parent_folders is NOT generated in  terragrunt.hcl
-	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), tmpEnvPath+"/terragrunt.hcl")
 	require.NoError(t, err)
 	assert.NotContains(t, content, "find_in_parent_folders")
 }
@@ -117,7 +117,7 @@ func TestScaffoldModuleDifferentRevision(t *testing.T) {
 
 	require.NoError(t, err)
 
-	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), tmpEnvPath+"/terragrunt.hcl")
 	require.NoError(t, err)
 	assert.Contains(t, content, mirror.URL+"//test/fixtures/inputs?ref=v0.67.4")
 }
@@ -155,7 +155,7 @@ func TestScaffoldLocalTofuModule(t *testing.T) {
 	assert.FileExists(t, tmpEnvPath+"/terragrunt.hcl")
 
 	// Verify variables from .tofu files were parsed and included in generated config
-	content, err := util.ReadFileAsString(tmpEnvPath + "/terragrunt.hcl")
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), tmpEnvPath+"/terragrunt.hcl")
 	require.NoError(t, err)
 	assert.Contains(
 		t,
@@ -227,16 +227,16 @@ func TestScaffoldCopiesUnit(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	got, err := util.ReadFileAsString(filepath.Join(tmpEnvPath, "terragrunt.hcl"))
+	got, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(tmpEnvPath, "terragrunt.hcl"))
 	require.NoError(t, err)
 
-	want, err := util.ReadFileAsString(filepath.Join(testScaffoldCopyableUnitPath, "terragrunt.hcl"))
+	want, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(testScaffoldCopyableUnitPath, "terragrunt.hcl"))
 	require.NoError(t, err)
 	assert.Equal(t, want, got, "the unit's own configuration is scaffolded as written")
 
 	assert.FileExists(t, filepath.Join(tmpEnvPath, "extra.hcl"))
 
-	values, err := util.ReadFileAsString(filepath.Join(tmpEnvPath, "terragrunt.values.hcl"))
+	values, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(tmpEnvPath, "terragrunt.values.hcl"))
 	require.NoError(t, err)
 	assert.Contains(t, values, `# === Required ===
 base_url = "TODO"
@@ -293,7 +293,7 @@ func TestScaffoldCopyRefusesToOverwrite(t *testing.T) {
 
 	assert.NoFileExists(t, filepath.Join(tmpEnvPath, "terragrunt.hcl"))
 
-	got, err := util.ReadFileAsString(existing)
+	got, err := vfs.ReadFileAsString(vfs.NewOSFS(), existing)
 	require.NoError(t, err)
 	assert.Equal(t, "# mine\n", got)
 }
@@ -379,7 +379,7 @@ func TestScaffoldWithRootHCL(t *testing.T) {
 	assert.FileExists(t, filepath.Join(testPath, "unit", "terragrunt.hcl"))
 
 	// Read the file
-	content, err := util.ReadFileAsString(filepath.Join(testPath, "unit", "terragrunt.hcl"))
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(testPath, "unit", "terragrunt.hcl"))
 	require.NoError(t, err)
 	assert.Contains(t, content, `path = find_in_parent_folders("root.hcl")`)
 }
@@ -430,7 +430,7 @@ func TestScaffoldWithShellCommandsEnabled(t *testing.T) {
 
 	require.NoError(t, err)
 
-	content, err := util.ReadFileAsString(filepath.Join(tmpEnvPath, "terragrunt.hcl"))
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(tmpEnvPath, "terragrunt.hcl"))
 	require.NoError(t, err)
 
 	assert.NotContains(t, content, "{{ shell", "Shell template should be processed")
@@ -458,7 +458,7 @@ func TestScaffoldWithShellCommandsDisabled(t *testing.T) {
 
 	require.NoError(t, err)
 
-	content, err := util.ReadFileAsString(filepath.Join(tmpEnvPath, "terragrunt.hcl"))
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(tmpEnvPath, "terragrunt.hcl"))
 	require.NoError(t, err)
 
 	assert.NotContains(
@@ -495,7 +495,7 @@ func TestScaffoldWithHooksEnabled(t *testing.T) {
 
 	require.NoError(t, err)
 
-	content, err := util.ReadFileAsString(filepath.Join(tmpEnvPath, "terragrunt.hcl"))
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(tmpEnvPath, "terragrunt.hcl"))
 	require.NoError(t, err)
 	assert.Contains(t, content, "terraform {", "Generated file should be valid")
 }
@@ -520,7 +520,7 @@ func TestScaffoldWithHooksDisabled(t *testing.T) {
 
 	require.NoError(t, err)
 
-	content, err := util.ReadFileAsString(filepath.Join(tmpEnvPath, "terragrunt.hcl"))
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(tmpEnvPath, "terragrunt.hcl"))
 	require.NoError(t, err)
 	assert.Contains(t, content, "terraform {", "Generated file should be valid")
 }
@@ -545,7 +545,7 @@ func TestScaffoldWithBothFlagsDisabled(t *testing.T) {
 
 	require.NoError(t, err)
 
-	content, err := util.ReadFileAsString(filepath.Join(tmpEnvPath, "terragrunt.hcl"))
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(tmpEnvPath, "terragrunt.hcl"))
 	require.NoError(t, err)
 
 	assert.NotContains(t, content, "SHELL_OUTPUT_1", "Shell command should not have executed")
@@ -583,7 +583,7 @@ baz="qux"
 	assert.FileExists(t, filepath.Join(tmpEnvPath, "terragrunt.hcl"))
 
 	// Verify the pre-existing file was not modified by scaffold's formatting step.
-	content, err := util.ReadFileAsString(preExistingFile)
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), preExistingFile)
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -606,7 +606,7 @@ func TestScaffoldCatalogConfigIntegration(t *testing.T) {
 	templatePath := workingDir + "//fixtures/scaffold/with-shell-and-hooks"
 	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 
-	catalogContent, err := util.ReadFileAsString(catalogConfigPath)
+	catalogContent, err := vfs.ReadFileAsString(vfs.NewOSFS(), catalogConfigPath)
 	require.NoError(t, err)
 
 	err = os.WriteFile(filepath.Join(tmpEnvPath, "terragrunt.hcl"), []byte(catalogContent), 0644)
@@ -628,7 +628,7 @@ func TestScaffoldCatalogConfigIntegration(t *testing.T) {
 
 	require.NoError(t, err)
 
-	content, err := util.ReadFileAsString(filepath.Join(outputDir, "terragrunt.hcl"))
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(outputDir, "terragrunt.hcl"))
 	require.NoError(t, err)
 
 	assert.NotContains(t, content, "SHELL_OUTPUT_1", "Shell should be disabled by catalog config")

--- a/test/integration_serial_tf_test.go
+++ b/test/integration_serial_tf_test.go
@@ -31,6 +31,8 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 )
 
 func TestTFTerragruntProviderCacheWithFilesystemMirror(t *testing.T) {
@@ -652,7 +654,7 @@ func TestTFTerragruntProviderCache(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureProviderCacheDirect)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureProviderCacheDirect)
 
-	cacheDir, err := util.EnsureCacheDir()
+	cacheDir, err := util.EnsureCacheDir(venv.OSVenv())
 	require.NoError(t, err)
 
 	providerCacheDir := filepath.Join(cacheDir, "provider-cache-test-direct")
@@ -735,7 +737,7 @@ func TestTFTerragruntProviderCache(t *testing.T) {
 				assert.NotNil(t, providerBlock)
 
 				providerPath := filepath.Join(cacheWorkingDir, ".terraform/providers", provider)
-				assert.True(t, util.FileExists(providerPath))
+				assert.True(t, vfs.Exists(vfs.NewOSFS(), providerPath))
 
 				entries, err := os.ReadDir(providerPath)
 				require.NoError(t, err)

--- a/test/integration_stacks_tf_test.go
+++ b/test/integration_stacks_tf_test.go
@@ -856,7 +856,7 @@ func TestTFStackApplyDestroyWithDependency(t *testing.T) {
 
 	// check that the data.txt file was deleted
 	dataPath := filepath.Join(rootPath, ".terragrunt-stack", "app-with-dependency", "data.txt")
-	assert.True(t, util.FileNotExists(dataPath))
+	assert.NoFileExists(t, dataPath)
 }
 
 func TestTFStackOutputWithDependency(t *testing.T) {
@@ -919,7 +919,7 @@ func TestTFStackApplyStrictInclude(t *testing.T) {
 
 	// check that test file wasn't created
 	dataPath := filepath.Join(rootPath, ".terragrunt-stack", "app-with-dependency", "data.txt")
-	assert.True(t, util.FileNotExists(dataPath))
+	assert.NoFileExists(t, dataPath)
 }
 
 func TestTFStackApplyStrictIncludeWithFilter(t *testing.T) {
@@ -948,7 +948,7 @@ func TestTFStackApplyStrictIncludeWithFilter(t *testing.T) {
 
 	// check that test file wasn't created
 	dataPath := filepath.Join(rootPath, ".terragrunt-stack", "app-with-dependency", "data.txt")
-	assert.True(t, util.FileNotExists(dataPath))
+	assert.NoFileExists(t, dataPath)
 }
 
 func TestTFStacksSourceMap(t *testing.T) {
@@ -1565,22 +1565,25 @@ func TestTFStackRunAllNoStackDir(t *testing.T) {
 
 	// Verify that no .terragrunt-stack directory was created since all units have no_dot_terragrunt_stack = true
 	stackDir := filepath.Join(rootPath, ".terragrunt-stack")
-	stackDirExists := util.FileExists(stackDir)
+	stackDirExists := vfs.Exists(vfs.NewOSFS(), stackDir)
 	t.Logf("Stack directory exists: %v", stackDirExists)
 
 	// Verify that units were generated in the same directory as terragrunt.stack.hcl
 	expectedUnits := []string{"foo", "bar"}
 	for _, unit := range expectedUnits {
 		unitPath := filepath.Join(rootPath, unit)
-		assert.True(
+		assert.DirExists(
 			t,
-			util.FileExists(unitPath),
+			unitPath,
 			"Expected unit %s to exist in root directory",
 			unit,
 		)
-		assert.True(t, util.FileExists(
+		assert.FileExists(
+			t,
 			filepath.Join(unitPath, "terragrunt.hcl"),
-		), "Expected terragrunt.hcl to exist in unit %s", unit)
+			"Expected terragrunt.hcl to exist in unit %s",
+			unit,
+		)
 	}
 
 	stdout, _, err := helpers.RunTerragruntCommandWithOutput(
@@ -1721,7 +1724,7 @@ func TestTFStackOutputWithExclude(t *testing.T) {
 	// Verify no terraform was attempted for excluded units
 	for _, excluded := range []string{"excluded-app", "excluded-all"} {
 		tfDir := filepath.Join(rootPath, ".terragrunt-stack", excluded, ".terraform")
-		assert.True(t, util.FileNotExists(tfDir),
+		assert.NoDirExists(t, tfDir,
 			"excluded unit %s should not have .terraform directory", excluded)
 	}
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -442,9 +442,9 @@ func TestTerragruntFullLockfile(t *testing.T) {
 			helpers.RunTerragrunt(t, cmd)
 
 			lockfilePath := filepath.Join(rootPath, ".terraform.lock.hcl")
-			require.True(
+			require.FileExists(
 				t,
-				util.FileExists(lockfilePath),
+				lockfilePath,
 				"expected lock file to exist at %s",
 				lockfilePath,
 			)

--- a/test/integration_tf_test.go
+++ b/test/integration_tf_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
@@ -859,7 +860,7 @@ func TestTFTerragruntProviderCacheMultiplePlatforms(t *testing.T) {
 
 			for _, appName := range []string{"app1", "app2", "app3"} {
 				appPath := filepath.Join(rootPath, appName)
-				assert.True(t, util.FileExists(appPath))
+				assert.DirExists(t, appPath)
 
 				lockfilePath := filepath.Join(appPath, ".terraform.lock.hcl")
 				lockfileContent, err := os.ReadFile(lockfilePath)
@@ -881,11 +882,11 @@ func TestTFTerragruntProviderCacheMultiplePlatforms(t *testing.T) {
 					assert.NotNil(t, providerBlock)
 
 					providerPath := filepath.Join(providerCacheDir, provider)
-					assert.True(t, util.FileExists(providerPath))
+					assert.True(t, vfs.Exists(vfs.NewOSFS(), providerPath))
 
 					for _, platform := range platforms {
 						platformPath := filepath.Join(providerPath, platform)
-						assert.True(t, util.FileExists(platformPath))
+						assert.True(t, vfs.Exists(vfs.NewOSFS(), platformPath))
 					}
 				}
 			}
@@ -4195,7 +4196,7 @@ func TestTFAutoInitWhenSourceIsChanged(t *testing.T) {
 
 	terragruntHcl := filepath.Join(testPath, "terragrunt.hcl")
 
-	contents, err := util.ReadFileAsString(terragruntHcl)
+	contents, err := vfs.ReadFileAsString(vfs.NewOSFS(), terragruntHcl)
 	if err != nil {
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Replaces `util/file.go` utilities with `vfs` utilities and further expands venv usage throughout the codebase as a consequence.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized file, directory, cache, and temporary-file operations through the virtual filesystem environment.
  * Improved consistency when running commands, rendering configurations, handling credentials, managing provider caches, and processing Terraform state.
  * Added filesystem helpers for existence checks, directory management, hashing, and file reading.
  * Updated cache and temporary-directory handling across supported environments.

* **Tests**
  * Updated unit, integration, and benchmark coverage to use the new filesystem environment and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->