### PR TITLE
docs: mention MegaLinter for running hcl fmt --check in CI

### DIFF
--- a/docs/src/content/docs/04-reference/01-hcl/01-overview.mdx
+++ b/docs/src/content/docs/04-reference/01-hcl/01-overview.mdx
@@ -283,3 +283,5 @@ Additionally, there's a flag `--check`. `terragrunt hcl fmt --check` will only v
 You can exclude directories from the formatting process by using the `--exclude-dir` flag. For example, `terragrunt hcl fmt --exclude-dir=qa/services`.
 
 If you want to format a single file, you can use the `--file` flag. For example, `terragrunt hcl fmt --file qa/services/services.hcl`.
+
+If you want to enforce formatting in CI alongside other linters, [MegaLinter](https://megalinter.io) runs `terragrunt hcl fmt --check` on your HCL files out of the box. See its [Terragrunt descriptor](https://megalinter.io/latest/descriptors/terraform_terragrunt/) for configuration details.


### PR DESCRIPTION
## Description

Small docs addition: at the end of the "Formatting HCL files" section of the HCL overview, I added a line pointing to [MegaLinter](https://megalinter.io), which ships with `terragrunt hcl fmt --check` support out of the box ([descriptor page](https://megalinter.io/latest/descriptors/terraform_terragrunt/)).

I maintain MegaLinter, and quite a few users discover the `--check` flag through it, so I figured a pointer from the docs could help folks wanting to enforce formatting in CI without wiring it up themselves.

## TODOs

- [x] I authored this code entirely myself
- [x] Update the docs.
- [x] This change is backwards compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that MegaLinter checks HCL file formatting with Terragrunt by default.
  * Added a link to configuration details for the Terragrunt descriptor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->