### PR TITLE
chore: Adding unit tests for internal packages

### DIFF
--- a/internal/cli/commands/catalog/catalog_test.go
+++ b/internal/cli/commands/catalog/catalog_test.go
@@ -1,0 +1,298 @@
+package catalog_test
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog"
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/format"
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+)
+
+// TestRunOnEmptyWorkspaceWritesNothing pins that a workspace with no
+// configuration yields an empty catalog rather than an error: every line of a
+// non-interactive run is a component, so nothing at all may be written when
+// discovery finds no source.
+func TestRunOnEmptyWorkspaceWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	var buf strings.Builder
+
+	v := venvtest.New().WithWriter(&buf)
+	workDir := "/catalog-empty"
+
+	require.NoError(t, v.FS.MkdirAll(workDir, 0o755))
+
+	err := catalog.Run(
+		t.Context(), logger.CreateLogger(), v, newOptions(t, workDir, catalog.FormatJSONL), "",
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, buf.String(), "an empty workspace must not write a header or a summary")
+}
+
+// TestRunReportsEveryUnreachableSource pins that a run whose sources all fail
+// to load reports each of them once. Discovery feeds every terraform.source it
+// finds to the loader, and a repo named by two units is a clone the user would
+// pay for twice.
+func TestRunReportsEveryUnreachableSource(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		sources       map[string]string
+		wantURLs      []string
+		wantAttempted int
+	}{
+		{
+			name: "one source per unit",
+			sources: map[string]string{
+				"vpc": "github.com/acme/vpc//modules/x",
+				"ecs": "github.com/acme/ecs//modules/x",
+			},
+			wantURLs:      []string{"github.com/acme/ecs", "github.com/acme/vpc"},
+			wantAttempted: 2,
+		},
+		{
+			name: "two units of the same repo",
+			sources: map[string]string{
+				"vpc-app": "github.com/acme/vpc//modules/app",
+				"vpc-net": "github.com/acme/vpc//modules/net",
+			},
+			wantURLs:      []string{"github.com/acme/vpc"},
+			wantAttempted: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf strings.Builder
+
+			v := venvtest.New().WithWriter(&buf)
+			workDir := "/catalog-sources"
+
+			for unit, source := range tc.sources {
+				writeUnit(t, v, filepath.Join(workDir, unit), source)
+			}
+
+			err := catalog.Run(
+				t.Context(), logger.CreateLogger(), v, newOptions(t, workDir, catalog.FormatJSONL), "",
+			)
+
+			var loadErr *tui.SourceLoadError
+
+			require.ErrorAs(t, err, &loadErr)
+			require.ErrorIs(t, err, module.ErrRemoteCloneFSNotOS,
+				"the per-source cause must stay reachable through the aggregate error")
+			assert.Equal(t, tc.wantAttempted, loadErr.Attempted)
+			assert.Equal(t, tc.wantURLs, failedURLs(loadErr))
+			assert.True(t, loadErr.AllFailed())
+			assert.Empty(t, buf.String())
+		})
+	}
+}
+
+// TestRunLoadsARepoNamedByBothDiscoverersOnce pins the deduplication across
+// the two concurrent discoverers: a repo named by the catalog block and by a
+// unit's source reaches the loader twice, and cloning it twice is work the
+// user pays for.
+func TestRunLoadsARepoNamedByBothDiscoverersOnce(t *testing.T) {
+	t.Parallel()
+
+	const repoURL = "github.com/acme/vpc"
+
+	// The root config holding the catalog block is found by walking the real filesystem.
+	rootDir := t.TempDir()
+
+	v := venvtest.NewWithOSFS()
+
+	writeUnit(t, v, filepath.Join(rootDir, "vpc"), repoURL+"//modules/x")
+	require.NoError(t, vfs.WriteFile(
+		v.FS,
+		filepath.Join(rootDir, "root.hcl"),
+		[]byte("catalog {\n  urls = [\""+repoURL+"\"]\n}\n"),
+		0o644,
+	))
+
+	opts := newOptions(t, rootDir, catalog.FormatJSONL)
+	// CAS is bypassed so the load fails in the getter, keeping this test off the content store.
+	opts.NoCAS = true
+
+	err := catalog.Run(t.Context(), logger.CreateLogger(), v, opts, "")
+
+	var loadErr *tui.SourceLoadError
+
+	require.ErrorAs(t, err, &loadErr)
+	assert.Equal(t, []string{repoURL}, failedURLs(loadErr), "the repo must be loaded once, not once per discoverer")
+	assert.Equal(t, 1, loadErr.Attempted)
+}
+
+// TestRunWritesComponentsFromTheCatalogBlock pins that the catalog block of
+// the root config is honored by the non-interactive formats, and that each
+// component of the source it names is written.
+func TestRunWritesComponentsFromTheCatalogBlock(t *testing.T) {
+	t.Parallel()
+
+	// The root config is found by walking the real filesystem.
+	rootDir := t.TempDir()
+	repoDir := filepath.Join(rootDir, "repo")
+
+	var buf strings.Builder
+
+	v := venvtest.NewWithOSFS().WithWriter(&buf)
+
+	writeLocalRepo(t, v, repoDir)
+	require.NoError(t, vfs.WriteFile(
+		v.FS,
+		filepath.Join(rootDir, "root.hcl"),
+		[]byte("catalog {\n  urls = [\""+repoDir+"\"]\n}\n"),
+		0o644,
+	))
+
+	err := catalog.Run(
+		t.Context(), logger.CreateLogger(), v, newOptions(t, rootDir, catalog.FormatJSONL), "",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha", "bravo"}, sortedDirs(t, buf.String()))
+}
+
+// TestRunToleratesAnUnparseableCatalogConfig pins that a root config the
+// parser chokes on ends the run cleanly with no components instead of failing
+// it: a config a user is midway through editing must not break the command.
+func TestRunToleratesAnUnparseableCatalogConfig(t *testing.T) {
+	t.Parallel()
+
+	// The root config is found by walking the real filesystem.
+	rootDir := t.TempDir()
+
+	var buf strings.Builder
+
+	v := venvtest.NewWithOSFS().WithWriter(&buf)
+
+	require.NoError(t, vfs.WriteFile(
+		v.FS, filepath.Join(rootDir, "root.hcl"), []byte("catalog {\n  urls = [\n}\n"), 0o644,
+	))
+
+	err := catalog.Run(
+		t.Context(), logger.CreateLogger(), v, newOptions(t, rootDir, catalog.FormatJSONL), "",
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+// TestRunWithAnExplicitRepoURLSkipsDiscovery pins that a URL given on the
+// command line is the only source loaded: the failure comes back as it is,
+// rather than as the aggregate discovery reports.
+func TestRunWithAnExplicitRepoURLSkipsDiscovery(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+	workDir := "/catalog-explicit"
+
+	writeUnit(t, v, filepath.Join(workDir, "vpc"), "github.com/acme/discovered//modules/x")
+
+	err := catalog.Run(
+		t.Context(), logger.CreateLogger(), v,
+		newOptions(t, workDir, catalog.FormatJSONL), "github.com/acme/explicit",
+	)
+
+	require.ErrorIs(t, err, module.ErrRemoteCloneFSNotOS)
+	require.NotErrorAs(t, err, new(*tui.SourceLoadError),
+		"an explicit repo URL must not run discovery")
+}
+
+// TestRunRejectsAnUnknownFormat pins that an unsupported format is rejected
+// before anything is cloned, so a typo cannot cost the user a repository fetch.
+func TestRunRejectsAnUnknownFormat(t *testing.T) {
+	t.Parallel()
+
+	err := catalog.Run(
+		t.Context(), logger.CreateLogger(), venvtest.New(),
+		newOptions(t, "/catalog-unknown-format", "yaml"), "github.com/acme/vpc",
+	)
+
+	require.ErrorIs(t, err, format.ErrUnsupportedFormat)
+}
+
+// newOptions returns catalog options for a run rooted at workDir, reading its
+// root configuration from a root.hcl.
+func newOptions(t *testing.T, workDir, outputFormat string) *catalog.Options {
+	t.Helper()
+
+	tgOpts := options.NewTerragruntOptions()
+	tgOpts.WorkingDir = workDir
+	tgOpts.RootWorkingDir = workDir
+	tgOpts.TerragruntConfigPath = filepath.Join(workDir, "terragrunt.hcl")
+	tgOpts.ScaffoldRootFileName = "root.hcl"
+
+	opts := catalog.NewOptions(tgOpts)
+	opts.Format = outputFormat
+
+	return opts
+}
+
+// writeUnit writes a unit that runs the given OpenTofu/Terraform source.
+func writeUnit(t *testing.T, v *venv.Venv, dir, source string) {
+	t.Helper()
+
+	require.NoError(t, v.FS.MkdirAll(dir, 0o755))
+	require.NoError(t, vfs.WriteFile(
+		v.FS,
+		filepath.Join(dir, "terragrunt.hcl"),
+		[]byte("terraform {\n  source = \""+source+"\"\n}\n"),
+		0o644,
+	))
+}
+
+// writeLocalRepo writes a checked-out repository holding two components.
+func writeLocalRepo(t *testing.T, v *venv.Venv, repoDir string) {
+	t.Helper()
+
+	require.NoError(t, v.FS.MkdirAll(filepath.Join(repoDir, ".git"), 0o755))
+	require.NoError(t, vfs.WriteFile(
+		v.FS, filepath.Join(repoDir, ".git", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644,
+	))
+	require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(repoDir, ".git", "config"), []byte(`[core]
+	repositoryformatversion = 0
+[remote "origin"]
+	url = github.com/acme/repo
+`), 0o644))
+
+	for _, name := range []string{"alpha", "bravo"} {
+		dir := filepath.Join(repoDir, name)
+
+		require.NoError(t, v.FS.MkdirAll(dir, 0o755))
+		require.NoError(t, vfs.WriteFile(
+			v.FS, filepath.Join(dir, "main.tf"), []byte("# "+name+"\n"), 0o644,
+		))
+	}
+}
+
+// failedURLs returns the reported source URLs, sorted: loads run concurrently,
+// so no test may depend on the order they fail in.
+func failedURLs(err *tui.SourceLoadError) []string {
+	urls := make([]string, 0, len(err.Failures))
+
+	for _, failure := range err.Failures {
+		urls = append(urls, failure.URL)
+	}
+
+	slices.Sort(urls)
+
+	return urls
+}

--- a/internal/cli/commands/catalog/catalog_test.go
+++ b/internal/cli/commands/catalog/catalog_test.go
@@ -105,33 +105,30 @@ func TestRunReportsEveryUnreachableSource(t *testing.T) {
 	}
 }
 
-// TestRunLoadsARepoNamedByBothDiscoverersOnce pins the deduplication across
-// the two concurrent discoverers: a repo named by the catalog block and by a
-// unit's source reaches the loader twice, and cloning it twice is work the
-// user pays for.
-func TestRunLoadsARepoNamedByBothDiscoverersOnce(t *testing.T) {
+// TestRunLoadsARepoNamedTwiceOnce pins that a repo reaching the loader twice
+// is loaded once. The catalog block forwards its URLs unfiltered, so a repo
+// listed twice is a clone the user would pay for twice.
+func TestRunLoadsARepoNamedTwiceOnce(t *testing.T) {
 	t.Parallel()
-
-	const repoURL = "github.com/acme/vpc"
 
 	// The root config holding the catalog block is found by walking the real filesystem.
 	rootDir := t.TempDir()
 
+	// A local path that does not exist fails in the getter without reaching the network.
+	repoURL := filepath.Join(rootDir, "missing-repo")
+
 	v := venvtest.NewWithOSFS()
 
-	writeUnit(t, v, filepath.Join(rootDir, "vpc"), repoURL+"//modules/x")
 	require.NoError(t, vfs.WriteFile(
 		v.FS,
 		filepath.Join(rootDir, "root.hcl"),
-		[]byte("catalog {\n  urls = [\""+repoURL+"\"]\n}\n"),
+		[]byte("catalog {\n  urls = [\""+repoURL+"\", \""+repoURL+"\"]\n}\n"),
 		0o644,
 	))
 
-	opts := newOptions(t, rootDir, catalog.FormatJSONL)
-	// CAS is bypassed so the load fails in the getter, keeping this test off the content store.
-	opts.NoCAS = true
-
-	err := catalog.Run(t.Context(), logger.CreateLogger(), v, opts, "")
+	err := catalog.Run(
+		t.Context(), logger.CreateLogger(), v, newOptions(t, rootDir, catalog.FormatJSONL), "",
+	)
 
 	var loadErr *tui.SourceLoadError
 

--- a/internal/cli/commands/catalog/cli_test.go
+++ b/internal/cli/commands/catalog/cli_test.go
@@ -1,0 +1,228 @@
+package catalog_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog"
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+)
+
+// ignoreFileName is the fixture written for the ignore-file flag cases.
+const ignoreFileName = ".terragrunt-catalog-ignore"
+
+// TestNewCommandExposesTheCatalogFlags pins the command name and the flags
+// users invoke it with, both of which are part of the CLI contract.
+func TestNewCommandExposesTheCatalogFlags(t *testing.T) {
+	t.Parallel()
+
+	cmd := catalog.NewCommand(
+		logger.CreateLogger(), options.NewTerragruntOptions(), venvtest.New(),
+	)
+
+	assert.Equal(t, catalog.CommandName, cmd.Name)
+	assert.NotNil(t, cmd.Flags.Get(catalog.FormatFlagName))
+	assert.NotNil(t, cmd.Flags.Get(catalog.IgnoreFileFlagName))
+}
+
+// TestNewCommandBeforeGatesNonInteractiveFormats pins the experiment gate on
+// the non-interactive formats: their output is a compatibility promise, so it
+// stays behind the experiment until the shape of it is settled.
+func TestNewCommandBeforeGatesNonInteractiveFormats(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		wantErr        error
+		name           string
+		format         string
+		withExperiment bool
+		wantInvalid    bool
+	}{
+		{name: "tui needs no experiment", format: catalog.FormatTUI},
+		{
+			name:    "jsonl without the experiment",
+			format:  catalog.FormatJSONL,
+			wantErr: catalog.ErrFormatRequiresExperiment,
+		},
+		{
+			name:    "md without the experiment",
+			format:  catalog.FormatMD,
+			wantErr: catalog.ErrFormatRequiresExperiment,
+		},
+		{name: "jsonl with the experiment", format: catalog.FormatJSONL, withExperiment: true},
+		{name: "md with the experiment", format: catalog.FormatMD, withExperiment: true},
+		{name: "unknown format", format: "yaml", wantInvalid: true},
+		{
+			name:           "unknown format with the experiment",
+			format:         "yaml",
+			withExperiment: true,
+			wantInvalid:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := options.NewTerragruntOptions()
+
+			if tc.withExperiment {
+				require.NoError(t, opts.Experiments.EnableExperiment(experiment.CatalogFormat))
+			}
+
+			cmd := catalog.NewCommand(logger.CreateLogger(), opts, venvtest.New())
+			require.NoError(t, cmd.Flags.Parse(clihelper.Args{"--" + catalog.FormatFlagName, tc.format}))
+
+			err := cmd.Before(t.Context(), &clihelper.Context{})
+
+			switch {
+			case tc.wantErr != nil:
+				require.ErrorIs(t, err, tc.wantErr)
+			case tc.wantInvalid:
+				require.Error(t, err)
+				require.NotErrorIs(t, err, catalog.ErrFormatRequiresExperiment,
+					"an unusable format must fail validation rather than the experiment gate")
+				assertGeneralError(t, err)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestNewCommandActionLoadsThePositionalSource pins that the first argument of
+// `terragrunt catalog <source>` is the source that gets browsed.
+func TestNewCommandActionLoadsThePositionalSource(t *testing.T) {
+	t.Parallel()
+
+	var buf strings.Builder
+
+	v := venvtest.New().WithWriter(&buf)
+	repoDir := "/catalog-positional/repo"
+
+	writeLocalRepo(t, v, repoDir)
+
+	opts := options.NewTerragruntOptions()
+	require.NoError(t, opts.Experiments.EnableExperiment(experiment.CatalogFormat))
+
+	cmd := catalog.NewCommand(logger.CreateLogger(), opts, v)
+
+	require.NoError(t, cmd.Flags.Parse(
+		clihelper.Args{"--" + catalog.FormatFlagName, catalog.FormatJSONL},
+	))
+	require.NoError(t, cmd.Before(t.Context(), &clihelper.Context{}))
+	require.NoError(t, cmd.Action(
+		t.Context(), clihelper.NewAppContext(nil, clihelper.Args{repoDir}),
+	))
+
+	assert.Equal(t, []string{"alpha", "bravo"}, sortedDirs(t, buf.String()))
+}
+
+// TestNewFlagsIgnoreFileAction pins how the ignore-file path is resolved and
+// rejected: the flag names a file the user expects to be read, so a path that
+// cannot be read has to fail the run rather than be silently ignored.
+func TestNewFlagsIgnoreFileAction(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		wantErr      error
+		value        func(dir string) string
+		name         string
+		noWorkingDir bool
+		wantRejected bool
+		wantNoop     bool
+	}{
+		{
+			name:  "absolute path to a file",
+			value: func(dir string) string { return filepath.Join(dir, ignoreFileName) },
+		},
+		{
+			name:  "relative path resolved against the working dir",
+			value: func(string) string { return ignoreFileName },
+		},
+		{
+			name:         "relative path falling back to the root working dir",
+			value:        func(string) string { return ignoreFileName },
+			noWorkingDir: true,
+		},
+		{
+			name:     "no value",
+			value:    func(string) string { return "" },
+			wantNoop: true,
+		},
+		{
+			name:    "missing file",
+			value:   func(dir string) string { return filepath.Join(dir, "absent") },
+			wantErr: fs.ErrNotExist,
+		},
+		{
+			name:         "directory",
+			value:        func(dir string) string { return dir },
+			wantRejected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// The action stats the path on the real filesystem.
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, ignoreFileName), []byte("vendor\n"), 0o644))
+
+			opts := catalog.NewOptions(options.NewTerragruntOptions())
+			opts.RootWorkingDir = dir
+
+			if !tc.noWorkingDir {
+				opts.WorkingDir = dir
+			}
+
+			flags := catalog.NewFlags(opts, nil)
+			require.NoError(t, flags.Parse(
+				clihelper.Args{"--" + catalog.IgnoreFileFlagName, tc.value(dir)},
+			))
+
+			err := flags.RunActions(t.Context(), &clihelper.Context{})
+
+			switch {
+			case tc.wantErr != nil:
+				require.ErrorIs(t, err, tc.wantErr)
+				assertGeneralError(t, err)
+			case tc.wantRejected:
+				require.Error(t, err)
+				require.NotErrorIs(t, err, fs.ErrNotExist,
+					"a directory must be rejected on its own, not for failing to resolve")
+				assertGeneralError(t, err)
+			case tc.wantNoop:
+				require.NoError(t, err)
+				assert.Empty(t, opts.CatalogIgnoreFile,
+					"an empty flag value must not resolve to the working dir")
+			default:
+				require.NoError(t, err)
+				assert.Equal(t, filepath.Join(dir, ignoreFileName), opts.CatalogIgnoreFile,
+					"the flag value must reach the run as an absolute path")
+			}
+		})
+	}
+}
+
+// assertGeneralError reports that err exits the process with the general
+// error status, which is what the shell sees.
+func assertGeneralError(t *testing.T, err error) {
+	t.Helper()
+
+	var exitErr clihelper.ExitCoder
+
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, int(clihelper.ExitCodeGeneralError), exitErr.ExitCode())
+}

--- a/internal/configbridge/copy_test.go
+++ b/internal/configbridge/copy_test.go
@@ -93,7 +93,6 @@ func TestNewParsingContextPropagatesStrictControls(t *testing.T) {
 	ctrl := pctx.StrictControls.Find(controls.BareInclude)
 	require.NotNil(t, ctrl, "strict controls must reach the parsing context")
 	assert.True(t, ctrl.GetEnabled(), "a control enabled on the options must arrive enabled")
-	assert.NotEmpty(t, pctx.ParserOptions, "parser options are built from the strict controls at construction")
 }
 
 // TestNewRunOptionsCopiesEveryOption pins every bridged option onto the run options so no flag is dropped.

--- a/internal/configbridge/copy_test.go
+++ b/internal/configbridge/copy_test.go
@@ -1,0 +1,343 @@
+package configbridge_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/configbridge"
+	"github.com/gruntwork-io/terragrunt/internal/engine"
+	"github.com/gruntwork-io/terragrunt/internal/errorconfig"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/iacargs"
+	"github.com/gruntwork-io/terragrunt/internal/iam"
+	pcoptions "github.com/gruntwork-io/terragrunt/internal/providercache/options"
+	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
+	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewParsingContextCopiesEveryOption pins every bridged option onto the ParsingContext so no flag is dropped.
+func TestNewParsingContextCopiesEveryOption(t *testing.T) {
+	t.Parallel()
+
+	opts := optionsWithDistinctValues(t)
+	v := venvtest.New()
+
+	_, pctx := configbridge.NewParsingContext(t.Context(), logger.CreateLogger(), v, opts)
+	require.NotNil(t, pctx)
+
+	assert.Same(t, v, pctx.Venv, "HCL helpers shell out and read files through the venv handed to the bridge")
+	assert.Equal(t, opts.TerragruntConfigPath, pctx.TerragruntConfigPath)
+	assert.Equal(t, opts.OriginalTerragruntConfigPath, pctx.OriginalTerragruntConfigPath)
+	assert.Equal(t, opts.WorkingDir, pctx.WorkingDir)
+	assert.Equal(t, opts.RootWorkingDir, pctx.RootWorkingDir)
+	assert.Equal(t, opts.DownloadDir, pctx.DownloadDir)
+	assert.Equal(t, opts.TerraformCommand, pctx.TerraformCommand)
+	assert.Equal(t, opts.OriginalTerraformCommand, pctx.OriginalTerraformCommand)
+	assert.Same(t, opts.TerraformCliArgs, pctx.TerraformCliArgs, "the copy must replace the args the constructor seeds")
+	assert.Equal(t, opts.Source, pctx.Source)
+	assert.Equal(t, opts.SourceMap, pctx.SourceMap)
+	assert.True(t, pctx.Experiments.Evaluate(experiment.Stacks), "enabled experiments must reach config parsing")
+	assert.Equal(t, opts.StrictControls, pctx.StrictControls)
+	assert.True(t, pctx.LogShowAbsPaths)
+	assert.True(t, pctx.LogDisableErrorSummary)
+	assert.Equal(t, opts.IAMRoleOptions, pctx.IAMRoleOptions)
+	assert.Equal(t, opts.OriginalIAMRoleOptions, pctx.OriginalIAMRoleOptions)
+	assert.True(t, pctx.UsePartialParseConfigCache)
+	assert.Equal(t, opts.MaxFoldersToCheck, pctx.MaxFoldersToCheck)
+	assert.True(t, pctx.NoDependencyFetchOutputFromState)
+	assert.True(t, pctx.SkipOutput)
+	assert.True(t, pctx.TFPathExplicitlySet)
+	assert.Equal(t, opts.AuthProviderCmd, pctx.AuthProviderCmd)
+	assert.Same(t, opts.EngineConfig, pctx.EngineConfig)
+	assert.Same(t, opts.EngineOptions, pctx.EngineOptions)
+	assert.Equal(t, opts.TFPath, pctx.TFPath)
+	assert.Equal(t, opts.TofuImplementation, pctx.TofuImplementation)
+	assert.True(t, pctx.ForwardTFStdout)
+	assert.True(t, pctx.JSONLogFormat)
+	assert.True(t, pctx.Debug)
+	assert.True(t, pctx.AutoInit)
+	assert.True(t, pctx.Headless)
+	assert.True(t, pctx.BackendBootstrap)
+	assert.True(t, pctx.CheckDependentUnits)
+	assert.Same(t, opts.Telemetry, pctx.Telemetry)
+	assert.True(t, pctx.NoStackValidate)
+	assert.True(t, pctx.NoCAS)
+	assert.Equal(t, opts.CASCloneDepth, pctx.CASCloneDepth)
+	assert.Equal(t, opts.ScaffoldRootFileName, pctx.ScaffoldRootFileName)
+	assert.Equal(t, opts.TerragruntStackConfigPath, pctx.TerragruntStackConfigPath)
+	assert.Equal(t, opts.ProviderCacheOptions, pctx.ProviderCacheOptions)
+
+	require.NotNil(t, pctx.FeatureFlags)
+
+	flag, ok := pctx.FeatureFlags.Load("region")
+	require.True(t, ok, "feature flags supplied on the CLI must reach config parsing")
+	assert.Equal(t, "us-east-1", flag)
+}
+
+// TestNewParsingContextPropagatesStrictControls pins that a control enabled on the options arrives enabled.
+func TestNewParsingContextPropagatesStrictControls(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("terragrunt.hcl")
+	require.NoError(t, err)
+	require.NoError(t, opts.StrictControls.EnableControl(controls.BareInclude))
+
+	_, pctx := configbridge.NewParsingContext(t.Context(), logger.CreateLogger(), venvtest.New(), opts)
+
+	ctrl := pctx.StrictControls.Find(controls.BareInclude)
+	require.NotNil(t, ctrl, "strict controls must reach the parsing context")
+	assert.True(t, ctrl.GetEnabled(), "a control enabled on the options must arrive enabled")
+	assert.NotEmpty(t, pctx.ParserOptions, "parser options are built from the strict controls at construction")
+}
+
+// TestNewRunOptionsCopiesEveryOption pins every bridged option onto the run options so no flag is dropped.
+func TestNewRunOptionsCopiesEveryOption(t *testing.T) {
+	t.Parallel()
+
+	opts := optionsWithDistinctValues(t)
+
+	opts.ProfileDir = "/run/profiles"
+	opts.NonInteractive = true
+	opts.AutoRetry = true
+	opts.FailIfBucketCreationRequired = true
+	opts.DisableBucketUpdate = true
+	opts.SourceUpdate = true
+	opts.NoRunHooks = true
+	opts.Errors = &errorconfig.Config{
+		Retry: map[string]*errorconfig.RetryConfig{
+			"transient": {Name: "transient", MaxAttempts: 3},
+		},
+	}
+
+	runOpts := configbridge.NewRunOptions(opts)
+	require.NotNil(t, runOpts)
+
+	assert.True(t, runOpts.LogShowAbsPaths)
+	assert.True(t, runOpts.LogDisableErrorSummary)
+	assert.Equal(t, opts.TerragruntConfigPath, runOpts.TerragruntConfigPath)
+	assert.Equal(t, opts.OriginalTerragruntConfigPath, runOpts.OriginalTerragruntConfigPath)
+	assert.Equal(t, opts.WorkingDir, runOpts.UnitDir, "the unit dir is the working dir, not a separate option")
+	assert.Equal(t, opts.WorkingDir, runOpts.CacheDir, "the cache dir is the working dir, not the download dir")
+	assert.Equal(t, opts.RootWorkingDir, runOpts.RootWorkingDir)
+	assert.Equal(t, opts.ProfileDir, runOpts.ProfileDir)
+	assert.Equal(t, opts.DownloadDir, runOpts.DownloadDir)
+	assert.Equal(t, opts.TerraformCommand, runOpts.TerraformCommand)
+	assert.Equal(t, opts.OriginalTerraformCommand, runOpts.OriginalTerraformCommand)
+	assert.Same(t, opts.TerraformCliArgs, runOpts.TerraformCliArgs)
+	assert.Equal(t, opts.Source, runOpts.Source)
+	assert.Equal(t, opts.SourceMap, runOpts.SourceMap)
+	assert.Equal(t, opts.IAMRoleOptions, runOpts.IAMRoleOptions)
+	assert.Equal(t, opts.OriginalIAMRoleOptions, runOpts.OriginalIAMRoleOptions)
+	assert.Same(t, opts.EngineConfig, runOpts.EngineConfig)
+	assert.Same(t, opts.EngineOptions, runOpts.EngineOptions)
+	assert.Same(t, opts.Errors, runOpts.Errors)
+	assert.True(t, runOpts.Experiments.Evaluate(experiment.Stacks), "enabled experiments must reach the runner")
+	assert.Equal(t, opts.StrictControls, runOpts.StrictControls)
+	assert.Equal(t, opts.TFPath, runOpts.TFPath)
+	assert.Equal(t, opts.TofuImplementation, runOpts.TofuImplementation)
+	assert.True(t, runOpts.ForwardTFStdout)
+	assert.True(t, runOpts.JSONLogFormat)
+	assert.True(t, runOpts.Headless)
+	assert.True(t, runOpts.NonInteractive)
+	assert.True(t, runOpts.Debug)
+	assert.True(t, runOpts.AutoInit)
+	assert.True(t, runOpts.AutoRetry)
+	assert.True(t, runOpts.BackendBootstrap)
+	assert.Same(t, opts.Telemetry, runOpts.Telemetry)
+	assert.Equal(t, opts.AuthProviderCmd, runOpts.AuthProviderCmd)
+	assert.Equal(t, opts.MaxFoldersToCheck, runOpts.MaxFoldersToCheck)
+	assert.True(t, runOpts.FailIfBucketCreationRequired)
+	assert.True(t, runOpts.DisableBucketUpdate)
+	assert.True(t, runOpts.SourceUpdate)
+	assert.Equal(t, opts.CASCloneDepth, runOpts.CASCloneDepth)
+	assert.True(t, runOpts.NoCAS)
+	assert.True(t, runOpts.NoHooks, "NoHooks is fed by NoRunHooks, so before/after hooks stay disabled when asked")
+
+	require.NotNil(t, runOpts.FeatureFlags)
+
+	flag, ok := runOpts.FeatureFlags.Load("region")
+	require.True(t, ok, "feature flags supplied on the CLI must reach the runner")
+	assert.Equal(t, "us-east-1", flag)
+}
+
+// TestNewRunOptionsLeavesHooksEnabledByDefault pins that hooks stay enabled unless the user asks otherwise.
+func TestNewRunOptionsLeavesHooksEnabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("terragrunt.hcl")
+	require.NoError(t, err)
+
+	runOpts := configbridge.NewRunOptions(opts)
+
+	assert.False(t, runOpts.NoHooks, "hooks run unless the user asks for --no-run-hooks")
+}
+
+// TestShellRunOptsFromOptsCopiesEveryOption pins every option the shell needs to run OpenTofu/Terraform.
+func TestShellRunOptsFromOptsCopiesEveryOption(t *testing.T) {
+	t.Parallel()
+
+	opts := optionsWithDistinctValues(t)
+
+	shellOpts := configbridge.ShellRunOptsFromOpts(opts)
+	require.NotNil(t, shellOpts)
+
+	assert.Equal(t, opts.WorkingDir, shellOpts.WorkingDir, "commands run in the working dir of the unit")
+	assert.Equal(t, opts.RootWorkingDir, shellOpts.RootWorkingDir)
+	assert.Equal(t, opts.TFPath, shellOpts.TFPath)
+	assert.Same(t, opts.Telemetry, shellOpts.Telemetry, "the copy must replace the telemetry the constructor seeds")
+	assert.Same(t, opts.EngineConfig, shellOpts.EngineConfig)
+	assert.Same(t, opts.EngineOptions, shellOpts.EngineOptions)
+	assert.True(t, shellOpts.Experiments.Evaluate(experiment.Stacks), "enabled experiments must reach the shell")
+	assert.True(t, shellOpts.Headless)
+	assert.True(t, shellOpts.ForwardTFStdout)
+	assert.True(t, shellOpts.LogShowAbsPaths)
+	assert.True(t, shellOpts.LogDisableErrorSummary)
+}
+
+// TestTFRunOptsFromOptsCopiesEveryOption pins the options that state migration pull and push run with.
+func TestTFRunOptsFromOptsCopiesEveryOption(t *testing.T) {
+	t.Parallel()
+
+	opts := optionsWithDistinctValues(t)
+
+	tfOpts := configbridge.TFRunOptsFromOpts(opts)
+	require.NotNil(t, tfOpts)
+
+	assert.True(t, tfOpts.JSONLogFormat)
+	assert.Equal(t, opts.TerragruntConfigPath, tfOpts.TerragruntConfigPath)
+	assert.Equal(t, opts.OriginalTerragruntConfigPath, tfOpts.OriginalTerragruntConfigPath)
+	assert.Equal(t, opts.TofuImplementation, tfOpts.TofuImplementation)
+	assert.Same(t, opts.TerraformCliArgs, tfOpts.TerraformCliArgs)
+
+	require.NotNil(t, tfOpts.ShellOptions, "tf commands shell out, so the shell options must be threaded through")
+	assert.Equal(t, opts.WorkingDir, tfOpts.ShellOptions.WorkingDir)
+}
+
+// TestStackFuncFactoryScopesFunctionsToStackDir pins that get_working_dir resolves to the stack dir, not the unit.
+func TestStackFuncFactoryScopesFunctionsToStackDir(t *testing.T) {
+	t.Parallel()
+
+	opts, err := options.NewTerragruntOptionsForTest("/mem/root/live/terragrunt.hcl")
+	require.NoError(t, err)
+
+	opts.WorkingDir = "/mem/root/live"
+	opts.RootWorkingDir = "/mem/root"
+
+	funcsFor := configbridge.StackFuncFactory(t.Context(), logger.CreateLogger(), venvtest.New(), opts)
+
+	testCases := []struct {
+		name     string
+		stackDir string
+	}{
+		{
+			name:     "first stack dir",
+			stackDir: "/mem/root/live/stack-a",
+		},
+		{
+			name:     "second stack dir",
+			stackDir: "/mem/root/live/stack-b",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			funcs, err := funcsFor(tc.stackDir)
+			require.NoError(t, err)
+			assert.NotEmpty(t, funcs, "stack files are evaluated with this map, so an empty one breaks every function")
+
+			workingDir, ok := funcs[config.FuncNameGetWorkingDir]
+			require.True(t, ok, "the factory must inject the dir-sensitive get_working_dir override")
+
+			got, err := workingDir.Call(nil)
+			require.NoError(t, err)
+			assert.NotEqual(t, opts.WorkingDir, got.AsString(), "the unit working dir must not leak into a stack file")
+			assert.Equal(t, tc.stackDir, got.AsString(), "each call is scoped to the stack dir it was given")
+		})
+	}
+}
+
+// optionsWithDistinctValues returns options whose every bridged field holds a recognizable non-zero value.
+func optionsWithDistinctValues(t *testing.T) *options.TerragruntOptions {
+	t.Helper()
+
+	opts, err := options.NewTerragruntOptionsForTest("terragrunt.hcl")
+	require.NoError(t, err)
+	require.NoError(t, opts.Experiments.EnableExperiment(experiment.Stacks))
+
+	opts.FeatureFlags.Store("region", "us-east-1")
+
+	opts.TerragruntConfigPath = "/copy/unit/terragrunt.hcl"
+	opts.OriginalTerragruntConfigPath = "/copy/original/terragrunt.hcl"
+	opts.WorkingDir = "/copy/working"
+	opts.RootWorkingDir = "/copy/root"
+	opts.DownloadDir = "/copy/download"
+	opts.TerraformCommand = "apply"
+	opts.OriginalTerraformCommand = "plan"
+	opts.TerraformCliArgs = iacargs.New("plan", "-input=false")
+	opts.Source = "github.com/acme/units//vpc"
+	opts.SourceMap = map[string]string{"github.com/acme/units": "/copy/local/units"}
+	opts.AuthProviderCmd = "/copy/bin/auth-provider"
+	opts.TFPath = "/copy/bin/tofu"
+	opts.TofuImplementation = tfimpl.OpenTofu
+	opts.ScaffoldRootFileName = "copy-root.hcl"
+	opts.TerragruntStackConfigPath = "/copy/unit/terragrunt.stack.hcl"
+	opts.MaxFoldersToCheck = 42
+	opts.CASCloneDepth = 7
+	opts.IAMRoleOptions = iam.RoleOptions{
+		RoleARN:               "arn:aws:iam::111111111111:role/resolved",
+		AssumeRoleSessionName: "resolved-session",
+		AssumeRoleDuration:    3600,
+	}
+	opts.OriginalIAMRoleOptions = iam.RoleOptions{
+		RoleARN:               "arn:aws:iam::222222222222:role/original",
+		AssumeRoleSessionName: "original-session",
+		AssumeRoleDuration:    900,
+	}
+	opts.EngineConfig = &engine.EngineConfig{
+		Source:  "github.com/acme/engine",
+		Version: "0.1.2",
+		Type:    "rpc",
+	}
+	opts.EngineOptions = &engine.EngineOptions{
+		CachePath: "/copy/engine-cache",
+		LogLevel:  "debug",
+	}
+	opts.Telemetry = &telemetry.Options{
+		TraceExporter:             "otlpHttp",
+		TraceExporterHTTPEndpoint: "http://127.0.0.1:4318",
+	}
+	opts.ProviderCacheOptions = pcoptions.ProviderCacheOptions{
+		Dir:           "/copy/provider-cache",
+		Hostname:      "127.0.0.1",
+		Token:         "copy-token",
+		RegistryNames: []string{"registry.opentofu.org"},
+		Port:          8899,
+		Enabled:       true,
+	}
+
+	opts.LogShowAbsPaths = true
+	opts.LogDisableErrorSummary = true
+	opts.UsePartialParseConfigCache = true
+	opts.NoDependencyFetchOutputFromState = true
+	opts.SkipOutput = true
+	opts.TFPathExplicitlySet = true
+	opts.ForwardTFStdout = true
+	opts.JSONLogFormat = true
+	opts.Debug = true
+	opts.AutoInit = true
+	opts.Headless = true
+	opts.BackendBootstrap = true
+	opts.CheckDependentUnits = true
+	opts.NoStackValidate = true
+	opts.NoCAS = true
+
+	return opts
+}

--- a/internal/iam/iam_test.go
+++ b/internal/iam/iam_test.go
@@ -1,11 +1,42 @@
 package iam_test
 
 import (
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/iam"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+const (
+	sessionNamePrefix          = "terragrunt-"
+	sessionNameFreshnessWindow = time.Hour
+)
+
+// TestGetDefaultAssumeRoleSessionName pins the generated STS RoleSessionName format: the "terragrunt-" prefix CloudTrail attributes sessions by, followed by a bare current-time nanosecond suffix.
+func TestGetDefaultAssumeRoleSessionName(t *testing.T) {
+	t.Parallel()
+
+	name := iam.GetDefaultAssumeRoleSessionName()
+
+	suffix, hasPrefix := strings.CutPrefix(name, sessionNamePrefix)
+	require.True(t, hasPrefix, "CloudTrail identifies terragrunt sessions by the %q prefix", sessionNamePrefix)
+
+	nanos, err := strconv.ParseInt(suffix, 10, 64)
+	require.NoError(t, err, "the suffix has to stay a bare integer, which also keeps the name inside the character set STS accepts")
+
+	assert.Less(t, time.Since(time.Unix(0, nanos)).Abs(), sessionNameFreshnessWindow, "the suffix encodes the current time in nanoseconds so separate runs get separate STS sessions")
+}
+
+// TestDefaultAssumeRoleDuration pins the default STS DurationSeconds at the one hour callers get when they multiply the constant by time.Second.
+func TestDefaultAssumeRoleDuration(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, time.Hour, time.Duration(iam.DefaultAssumeRoleDuration)*time.Second, "callers convert the constant with time.Second, so it has to stay a count of seconds inside the 15 minute to 12 hour range STS accepts")
+}
 
 // TestMergeRoleOptions pins the precedence rule callers rely on when combining
 // the iam_role config attribute (target) with the --iam-assume-role CLI flag or
@@ -67,6 +98,45 @@ func TestMergeRoleOptions(t *testing.T) {
 				AssumeRoleDuration:    900,
 				WebIdentityToken:      "attribute-token",
 			},
+		},
+		{
+			name:   "flag-role-arn-only",
+			target: attr,
+			source: iam.RoleOptions{RoleARN: "arn:aws:iam::111111111111:role/from-flag"},
+			want: iam.RoleOptions{
+				RoleARN:               "arn:aws:iam::111111111111:role/from-flag",
+				AssumeRoleSessionName: "attribute-session",
+				AssumeRoleDuration:    1800,
+				WebIdentityToken:      "attribute-token",
+			},
+		},
+		{
+			name:   "flag-session-name-only",
+			target: attr,
+			source: iam.RoleOptions{AssumeRoleSessionName: "flag-session"},
+			want: iam.RoleOptions{
+				RoleARN:               "arn:aws:iam::111111111111:role/from-attribute",
+				AssumeRoleSessionName: "flag-session",
+				AssumeRoleDuration:    1800,
+				WebIdentityToken:      "attribute-token",
+			},
+		},
+		{
+			name:   "flag-web-identity-token-only",
+			target: attr,
+			source: iam.RoleOptions{WebIdentityToken: "flag-token"},
+			want: iam.RoleOptions{
+				RoleARN:               "arn:aws:iam::111111111111:role/from-attribute",
+				AssumeRoleSessionName: "attribute-session",
+				AssumeRoleDuration:    1800,
+				WebIdentityToken:      "flag-token",
+			},
+		},
+		{
+			name:   "empty-target-takes-single-flag-field",
+			target: iam.RoleOptions{},
+			source: iam.RoleOptions{RoleARN: "arn:aws:iam::111111111111:role/from-flag"},
+			want:   iam.RoleOptions{RoleARN: "arn:aws:iam::111111111111:role/from-flag"},
 		},
 	}
 

--- a/internal/runner/run/creds/getter_test.go
+++ b/internal/runner/run/creds/getter_test.go
@@ -2,11 +2,15 @@ package creds_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds/providers"
+	"github.com/gruntwork-io/terragrunt/internal/shell"
+	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -14,8 +18,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var errProviderUnavailable = errors.New("auth provider unavailable")
+
 type stubProvider struct {
 	creds *providers.Credentials
+	err   error
 	name  string
 }
 
@@ -26,7 +33,7 @@ func (p *stubProvider) GetCredentials(
 	_ log.Logger,
 	_ *venv.Venv,
 ) (*providers.Credentials, error) {
-	return p.creds, nil
+	return p.creds, p.err
 }
 
 // TestObtainAndUpdateEnvLaterProviderWins pins the ordering the S3 backend relies on: when an
@@ -99,4 +106,132 @@ func TestObtainAndUpdateEnvNilCredsLeaveEnvUntouched(t *testing.T) {
 	assert.Equal(t, "source-access-key", v.Env["AWS_ACCESS_KEY_ID"])
 	assert.Equal(t, "source-secret-key", v.Env["AWS_SECRET_ACCESS_KEY"])
 	assert.Equal(t, "kept", v.Env["UNRELATED"])
+}
+
+// TestObtainAndUpdateEnvPropagatesProviderFailure pins that the chain fails closed: the first
+// provider error is returned as-is and no later provider runs, so units never run
+// OpenTofu/Terraform with half-populated credentials.
+func TestObtainAndUpdateEnvPropagatesProviderFailure(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	v := venvtest.New()
+
+	failingProvider := &stubProvider{
+		name: "external command",
+		err:  errProviderUnavailable,
+	}
+	stsProvider := &stubProvider{
+		name: "API calls to Amazon STS",
+		creds: &providers.Credentials{
+			Name: providers.AWSCredentials,
+			Envs: map[string]string{
+				"AWS_ACCESS_KEY_ID": "role-session-access-key",
+				"AWS_SESSION_TOKEN": "role-session-token",
+			},
+		},
+	}
+
+	err := creds.NewGetter().ObtainAndUpdateEnvIfNecessary(t.Context(), l, v, failingProvider, stsProvider)
+	require.ErrorIs(t, err, errProviderUnavailable)
+	assert.Empty(t, v.Env, "a provider failure must abort the chain before any later provider runs")
+}
+
+// TestObtainCredsForParsingWithoutAuthProviderCmd pins the path every parse without
+// auth_provider_cmd takes: no subprocess is dispatched and v.Env is left as the caller built it.
+func TestObtainCredsForParsingWithoutAuthProviderCmd(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+
+	l := logger.CreateLogger()
+	v := venvtest.New().WithHandler(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		calls++
+
+		return vexec.Result{}
+	})
+	v.Env["UNRELATED"] = "kept"
+
+	getter, err := creds.ObtainCredsForParsing(t.Context(), l, v, "", shell.NewShellOptions())
+	require.NoError(t, err)
+	assert.NotNil(t, getter)
+	assert.Zero(t, calls, "expected no subprocess invocations for an empty auth-provider command")
+	assert.Equal(t, map[string]string{"UNRELATED": "kept"}, v.Env)
+}
+
+// TestObtainCredsForParsingPopulatesEnvBeforeParsing pins that auth-provider credentials reach
+// v.Env before HCL parsing, which is what makes sops_decrypt_file() and get_aws_account_id() work
+// inside locals.
+func TestObtainCredsForParsingPopulatesEnvBeforeParsing(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		wantEnv map[string]string
+		name    string
+		stdout  string
+	}{
+		{
+			name:   "arbitrary envs",
+			stdout: `{"envs": {"SOPS_AGE_KEY": "age-key", "FOO": "bar"}}`,
+			wantEnv: map[string]string{
+				"SOPS_AGE_KEY": "age-key",
+				"FOO":          "bar",
+			},
+		},
+		{
+			name: "aws credentials",
+			stdout: `{
+                "awsCredentials": {
+                    "ACCESS_KEY_ID": "AKIA111",
+                    "SECRET_ACCESS_KEY": "secret-xyz",
+                    "SESSION_TOKEN": "session-abc"
+                }
+            }`,
+			wantEnv: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "AKIA111",
+				"AWS_SECRET_ACCESS_KEY": "secret-xyz",
+				"AWS_SESSION_TOKEN":     "session-abc",
+				"AWS_SECURITY_TOKEN":    "session-abc",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := logger.CreateLogger()
+			v := venvtest.New().WithHandler(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+				assert.Equal(t, "auth-cmd", inv.Name)
+
+				return vexec.Result{Stdout: []byte(tc.stdout)}
+			})
+
+			getter, err := creds.ObtainCredsForParsing(t.Context(), l, v, "auth-cmd", shell.NewShellOptions())
+			require.NoError(t, err)
+			assert.NotNil(t, getter)
+			assert.Equal(t, tc.wantEnv, v.Env)
+		})
+	}
+}
+
+// TestObtainCredsForParsingReportsCommandFailure pins that a failing auth-provider command aborts
+// parsing with the process execution error rather than continuing with an unauthenticated env.
+func TestObtainCredsForParsingReportsCommandFailure(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	v := venvtest.New().WithHandler(func(_ context.Context, _ vexec.Invocation) vexec.Result {
+		return vexec.Result{ExitCode: 2, Stderr: []byte("permission denied\n")}
+	})
+	v.Env["UNRELATED"] = "kept"
+
+	getter, err := creds.ObtainCredsForParsing(t.Context(), l, v, "auth-cmd", shell.NewShellOptions())
+	require.Error(t, err)
+	assert.Nil(t, getter)
+
+	var procErr util.ProcessExecutionError
+
+	require.ErrorAs(t, err, &procErr)
+	assert.Equal(t, map[string]string{"UNRELATED": "kept"}, v.Env)
 }

--- a/internal/tf/cache/config_test.go
+++ b/internal/tf/cache/config_test.go
@@ -1,0 +1,96 @@
+package cache_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
+)
+
+// TestWithPortSetsListenAddress pins that the configured port reaches the address the server binds to, and that the zero port stays a no-op, since zero means "let the OS choose a free port" and must never undo a port the user asked for.
+func TestWithPortSetsListenAddress(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		wantAddr string
+		opts     []cache.Option
+	}{
+		{
+			name:     "explicit port",
+			opts:     []cache.Option{cache.WithHostname("127.0.0.1"), cache.WithPort(8123)},
+			wantAddr: "127.0.0.1:8123",
+		},
+		{
+			name:     "unset port lets the OS choose",
+			opts:     []cache.Option{cache.WithHostname("127.0.0.1")},
+			wantAddr: "127.0.0.1:0",
+		},
+		{
+			name: "zero port applied after an explicit port",
+			opts: []cache.Option{
+				cache.WithHostname("127.0.0.1"),
+				cache.WithPort(8123),
+				cache.WithPort(0),
+			},
+			wantAddr: "127.0.0.1:8123",
+		},
+		{
+			name: "zero port applied before an explicit port",
+			opts: []cache.Option{
+				cache.WithHostname("127.0.0.1"),
+				cache.WithPort(0),
+				cache.WithPort(8123),
+			},
+			wantAddr: "127.0.0.1:8123",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.wantAddr, cache.NewConfig(tc.opts...).Addr())
+		})
+	}
+}
+
+// TestWithHostnameSetsListenAddress pins that an empty hostname is a no-op, since an empty host would bind the cache server to every interface and expose a per-run token to the rest of the network.
+func TestWithHostnameSetsListenAddress(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		wantAddr string
+		opts     []cache.Option
+	}{
+		{
+			name:     "unset hostname keeps the default",
+			wantAddr: "localhost:0",
+		},
+		{
+			name:     "explicit hostname",
+			opts:     []cache.Option{cache.WithHostname("127.0.0.1")},
+			wantAddr: "127.0.0.1:0",
+		},
+		{
+			name:     "empty hostname keeps the default",
+			opts:     []cache.Option{cache.WithHostname("")},
+			wantAddr: "localhost:0",
+		},
+		{
+			name:     "empty hostname applied after an explicit hostname",
+			opts:     []cache.Option{cache.WithHostname("127.0.0.1"), cache.WithHostname("")},
+			wantAddr: "127.0.0.1:0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.wantAddr, cache.NewConfig(tc.opts...).Addr())
+		})
+	}
+}

--- a/internal/tf/cache/server_test.go
+++ b/internal/tf/cache/server_test.go
@@ -1,0 +1,285 @@
+package cache_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache/models"
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+// TestServerDiscoveryURLUsesTheHandlerThatClaimsTheRegistry pins that discovery is answered by the first handler whose include and exclude settings claim the registry, so the mirror a user configured for a host is the one asked where that host's API lives, and no other handler is contacted.
+func TestServerDiscoveryURLUsesTheHandlerThatClaimsTheRegistry(t *testing.T) {
+	t.Parallel()
+
+	const registryName = "registry.example.com"
+
+	refusing := &stubProviderHandler{
+		registryName: "other.example.com",
+		urls:         &handlers.RegistryURLs{ModulesV1: "/refusing/modules", ProvidersV1: "/refusing/providers"},
+	}
+	claiming := &stubProviderHandler{
+		registryName: registryName,
+		urls:         &handlers.RegistryURLs{ModulesV1: "/claiming/modules", ProvidersV1: "/claiming/providers"},
+	}
+
+	server := cache.NewServer(
+		cache.WithLogger(logger.CreateLogger()),
+		cache.WithProviderHandlers(refusing, claiming),
+	)
+
+	urls, err := server.DiscoveryURL(t.Context(), registryName)
+	require.NoError(t, err)
+
+	assert.Equal(t, claiming.urls, urls)
+	assert.Equal(t, int64(1), claiming.calls.Load())
+	assert.Zero(
+		t,
+		refusing.calls.Load(),
+		"a handler that does not claim the registry must never be asked to discover it",
+	)
+}
+
+// TestServerDiscoveryURLFallsBackToTheDefaultRegistry pins that a registry no handler claims still resolves to the default registry URLs, because returning nothing there breaks provider downloads for every registry the user has not configured a handler for.
+func TestServerDiscoveryURLFallsBackToTheDefaultRegistry(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		handler *stubProviderHandler
+		name    string
+	}{
+		{
+			name: "no handlers configured",
+		},
+		{
+			name: "no handler claims the registry",
+			handler: &stubProviderHandler{
+				registryName: "other.example.com",
+				urls:         &handlers.RegistryURLs{ModulesV1: "/other/modules", ProvidersV1: "/other/providers"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := []cache.Option{cache.WithLogger(logger.CreateLogger())}
+			if tc.handler != nil {
+				opts = append(opts, cache.WithProviderHandlers(tc.handler))
+			}
+
+			urls, err := cache.NewServer(opts...).DiscoveryURL(t.Context(), "registry.example.com")
+			require.NoError(t, err)
+			assert.Equal(t, handlers.DefaultRegistryURLs, urls)
+
+			if tc.handler != nil {
+				assert.Zero(t, tc.handler.calls.Load(), "a refusing handler must not be contacted")
+			}
+		})
+	}
+}
+
+// TestWithCacheProviderHTTPStatusCode pins that the configured status code reaches the provider controller verbatim, since that code is what OpenTofu/Terraform sees while a provider is being cached and is how the client learns to retry rather than fail.
+func TestWithCacheProviderHTTPStatusCode(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		opts     []cache.Option
+		wantCode int
+	}{
+		{
+			name:     "configured status code",
+			opts:     []cache.Option{cache.WithCacheProviderHTTPStatusCode(http.StatusLocked)},
+			wantCode: http.StatusLocked,
+		},
+		{
+			name: "unset status code is not defaulted by the server",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := append([]cache.Option{cache.WithLogger(logger.CreateLogger())}, tc.opts...)
+
+			assert.Equal(
+				t,
+				tc.wantCode,
+				cache.NewServer(opts...).ProviderController.CacheProviderHTTPStatusCode,
+			)
+		})
+	}
+}
+
+// TestWithProxyModuleHandlerRegistersTheModuleEndpoint pins that modules.v1 is advertised in service discovery only when a module proxy is configured, because a client that discovers the endpoint sends module requests the server would otherwise have no handler to answer.
+func TestWithProxyModuleHandlerRegistersTheModuleEndpoint(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name               string
+		wantModulesV1      string
+		proxyModuleHandler bool
+	}{
+		{
+			name: "without a proxy module handler",
+		},
+		{
+			name:               "with a proxy module handler",
+			wantModulesV1:      "/v1/modules/",
+			proxyModuleHandler: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := logger.CreateLogger()
+
+			opts := []cache.Option{cache.WithLogger(l)}
+			if tc.proxyModuleHandler {
+				opts = append(opts, cache.WithProxyModuleHandler(
+					handlers.NewProxyModuleHandler(l, vhttp.NewNoNetworkClient(), nil, nil, nil),
+				))
+			}
+
+			endpoints := discoveryEndpoints(t, cache.NewServer(opts...))
+
+			assert.Equal(
+				t,
+				"/v1/providers",
+				endpoints["providers.v1"],
+				"the provider API is always advertised",
+			)
+
+			if tc.wantModulesV1 == "" {
+				assert.NotContains(
+					t,
+					endpoints,
+					"modules.v1",
+					"the module API must not be advertised without a module proxy",
+				)
+
+				return
+			}
+
+			assert.Equal(t, tc.wantModulesV1, endpoints["modules.v1"])
+		})
+	}
+}
+
+// TestServerListenReportsBindFailure pins that an address the cache server cannot bind is reported to the caller, since a swallowed bind failure leaves units running against a cache server that never accepts a connection.
+func TestServerListenReportsBindFailure(t *testing.T) {
+	t.Parallel()
+
+	lc := &net.ListenConfig{}
+
+	taken, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, taken.Close()) })
+
+	addr, ok := taken.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	server := cache.NewServer(
+		cache.WithHostname("127.0.0.1"),
+		cache.WithPort(addr.Port),
+		cache.WithLogger(logger.CreateLogger()),
+	)
+
+	ln, err := server.Listen(t.Context())
+	assert.Nil(t, ln, "no listener is handed back when the address cannot be bound")
+
+	var opErr *net.OpError
+
+	require.ErrorAs(t, err, &opErr)
+}
+
+// TestServerRunReportsServeFailure pins that a listener the server cannot serve on ends the run with an error, since returning nil there reads as a clean shutdown while no unit can reach the cache.
+func TestServerRunReportsServeFailure(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	tmp := t.TempDir()
+
+	server := cache.NewServer(
+		cache.WithHostname("127.0.0.1"),
+		cache.WithLogger(l),
+		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l)),
+	)
+
+	ln, err := server.Listen(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, ln.Close())
+
+	require.ErrorIs(t, server.Run(t.Context(), ln), net.ErrClosed)
+}
+
+// stubProviderHandler claims a single registry and counts how many times it is asked to discover one.
+type stubProviderHandler struct {
+	urls         *handlers.RegistryURLs
+	registryName string
+	calls        atomic.Int64
+}
+
+func (h *stubProviderHandler) CanHandleProvider(provider *models.Provider) bool {
+	return provider.RegistryName == h.registryName
+}
+
+func (h *stubProviderHandler) GetVersions(
+	_ context.Context,
+	_ *models.Provider,
+) (models.Versions, error) {
+	return nil, nil
+}
+
+func (h *stubProviderHandler) GetPlatform(
+	_ context.Context,
+	_ *models.Provider,
+) (*models.ResponseBody, error) {
+	return nil, nil
+}
+
+func (h *stubProviderHandler) DiscoveryURL(
+	_ context.Context,
+	_ string,
+) (*handlers.RegistryURLs, error) {
+	h.calls.Add(1)
+
+	return h.urls, nil
+}
+
+func discoveryEndpoints(t *testing.T, server *cache.Server) map[string]string {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		"/.well-known/terraform.json",
+		nil,
+	)
+	rec := httptest.NewRecorder()
+
+	server.Router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	endpoints := make(map[string]string)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &endpoints))
+
+	return endpoints
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

- Found: catalog CAS nil-logger panic
- Found: cache Server.Run goroutine leak
- runTUI uncovered, needs TTY

```
  internal/configbridge          7.2% -> 100%
  internal/runner/run/creds     68.4% -> 100%
  internal/iam                  90.9% -> 100%
  internal/tf/cache             75.9% -> 97.6%
  internal/cli/commands/catalog 21.3% -> 90.3%
```

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for catalog commands, including source loading, duplicate handling, configuration tolerance, URL behavior, formats, and error reporting.
  * Added validation for command-line options, ignore-file handling, positional sources, and exit codes.
  * Added tests for configuration propagation, IAM defaults, credential failures, cache settings, provider discovery, HTTP responses, and server startup errors.
  * Improved test fixtures and scenarios to verify consistent behavior across common and failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->