### PR TITLE
test(git): add unit coverage for internal/git command wrappers and parsers

### DIFF
--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -23,12 +23,20 @@ func TestParseDiff(t *testing.T) {
 			name: "classifies paths",
 			output: "A\tadded.txt\n" +
 				"D\tremoved file.txt\n" +
-				"M\tchanged.txt\n" +
-				"T\tignored.txt\n",
+				"M\tchanged.txt\n",
 			want: &git.Diffs{
 				Added:   []string{"added.txt"},
 				Removed: []string{"removed file.txt"},
 				Changed: []string{"changed.txt"},
+			},
+		},
+		{
+			name:   "statuses other than A, D and M are dropped",
+			output: "T\ttypechanged.txt\nU\tunmerged.txt\n",
+			want: &git.Diffs{
+				Added:   []string{},
+				Removed: []string{},
+				Changed: []string{},
 			},
 		},
 		{
@@ -76,8 +84,8 @@ func TestParseDiff_RejectsInvalidOutput(t *testing.T) {
 			wantErr: git.ErrParseDiff,
 		},
 		{
-			name:    "oversized line",
-			output:  strings.Repeat("M path ", 10000),
+			name:    "line longer than the scanner buffer",
+			output:  "M\t" + strings.Repeat("a", bufio.MaxScanTokenSize),
 			wantErr: bufio.ErrTooLong,
 		},
 	}
@@ -87,14 +95,10 @@ func TestParseDiff_RejectsInvalidOutput(t *testing.T) {
 			t.Parallel()
 
 			_, err := git.ParseDiff([]byte(tc.output))
-			require.Error(t, err)
+			require.ErrorIs(t, err, tc.wantErr)
 
 			var wrappedErr *git.WrappedError
 			require.ErrorAs(t, err, &wrappedErr)
-
-			if tc.wantErr != nil {
-				assert.ErrorIs(t, err, tc.wantErr)
-			}
 		})
 	}
 }
@@ -113,7 +117,7 @@ func TestGitRunner_Diff(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{"added.txt"}, diffs.Added)
 		assert.Equal(t, []string{"changed.txt"}, diffs.Changed)
-		assert.Empty(t, diffs.Removed)
+		assert.Equal(t, []string{}, diffs.Removed)
 	})
 
 	t.Run("command failure", func(t *testing.T) {

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"bufio"
 	"strings"
 	"testing"
 
@@ -75,8 +76,9 @@ func TestParseDiff_RejectsInvalidOutput(t *testing.T) {
 			wantErr: git.ErrParseDiff,
 		},
 		{
-			name:   "oversized line",
-			output: strings.Repeat("M path ", 10000),
+			name:    "oversized line",
+			output:  strings.Repeat("M path ", 10000),
+			wantErr: bufio.ErrTooLong,
 		},
 	}
 

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -1,0 +1,145 @@
+package git_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDiff(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		want   *git.Diffs
+		name   string
+		output string
+	}{
+		{
+			name: "classifies paths",
+			output: "A\tadded.txt\n" +
+				"D\tremoved file.txt\n" +
+				"M\tchanged.txt\n" +
+				"T\tignored.txt\n",
+			want: &git.Diffs{
+				Added:   []string{"added.txt"},
+				Removed: []string{"removed file.txt"},
+				Changed: []string{"changed.txt"},
+			},
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want: &git.Diffs{
+				Added:   []string{},
+				Removed: []string{},
+				Changed: []string{},
+			},
+		},
+		{
+			name:   "blank lines",
+			output: "\n\nM\tchanged.txt\n\n",
+			want: &git.Diffs{
+				Added:   []string{},
+				Removed: []string{},
+				Changed: []string{"changed.txt"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := git.ParseDiff([]byte(tc.output))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseDiff_RejectsInvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		wantErr error
+		name    string
+		output  string
+	}{
+		{
+			name:    "missing path",
+			output:  "M\n",
+			wantErr: git.ErrParseDiff,
+		},
+		{
+			name:   "oversized line",
+			output: strings.Repeat("M path ", 10000),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := git.ParseDiff([]byte(tc.output))
+			require.Error(t, err)
+
+			var wrappedErr *git.WrappedError
+			require.ErrorAs(t, err, &wrappedErr)
+
+			if tc.wantErr != nil {
+				assert.ErrorIs(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestGitRunner_Diff(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses command output", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{
+			Stdout: []byte("A\tadded.txt\nM\tchanged.txt\n"),
+		})).WithWorkDir("/repo")
+
+		diffs, err := runner.Diff(t.Context(), "main", "feature")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"added.txt"}, diffs.Added)
+		assert.Equal(t, []string{"changed.txt"}, diffs.Changed)
+		assert.Empty(t, diffs.Removed)
+	})
+
+	t.Run("command failure", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 128})).WithWorkDir("/repo")
+
+		_, err := runner.Diff(t.Context(), "main", "feature")
+		require.ErrorIs(t, err, git.ErrCommandSpawn)
+	})
+
+	t.Run("parse failure", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{
+			Stdout: []byte("M\n"),
+		})).WithWorkDir("/repo")
+
+		_, err := runner.Diff(t.Context(), "main", "feature")
+		require.ErrorIs(t, err, git.ErrParseDiff)
+	})
+
+	t.Run("missing workdir", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+
+		_, err := runner.Diff(t.Context(), "main", "feature")
+		require.ErrorIs(t, err, git.ErrNoWorkDir)
+	})
+}

--- a/internal/git/git_commands_test.go
+++ b/internal/git/git_commands_test.go
@@ -45,6 +45,10 @@ func TestNewGitRunner(t *testing.T) {
 		require.ErrorIs(t, err, git.ErrCommandSpawn)
 		assert.Nil(t, runner)
 	})
+}
+
+func TestGitRunner_WithWorkDir(t *testing.T) {
+	t.Parallel()
 
 	t.Run("nil receiver", func(t *testing.T) {
 		t.Parallel()

--- a/internal/git/git_commands_test.go
+++ b/internal/git/git_commands_test.go
@@ -1,0 +1,847 @@
+package git_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGitRunner(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resolved path", func(t *testing.T) {
+		t.Parallel()
+
+		e := vexec.NewMemExec(
+			staticResult(vexec.Result{}),
+			vexec.WithLookPath(func(string) (string, error) {
+				return "/usr/bin/git", nil
+			}),
+		)
+
+		runner, err := git.NewGitRunner(e)
+		require.NoError(t, err)
+		assert.Equal(t, "/usr/bin/git", runner.GitPath)
+	})
+
+	t.Run("missing binary", func(t *testing.T) {
+		t.Parallel()
+
+		e := vexec.NewMemExec(
+			staticResult(vexec.Result{}),
+			vexec.WithLookPath(func(string) (string, error) {
+				return "", errors.New("not found")
+			}),
+		)
+
+		runner, err := git.NewGitRunner(e)
+		require.ErrorIs(t, err, git.ErrCommandSpawn)
+		assert.Nil(t, runner)
+	})
+
+	t.Run("nil receiver", func(t *testing.T) {
+		t.Parallel()
+
+		var runner *git.GitRunner
+
+		got := runner.WithWorkDir("/repo")
+		assert.Equal(t, "/repo", got.WorkDir)
+	})
+}
+
+func TestGitRunner_GetRepoRoot(t *testing.T) {
+	t.Parallel()
+
+	t.Run("memoizes success", func(t *testing.T) {
+		t.Parallel()
+
+		calls := 0
+		runner := newMemRunner(t, func(context.Context, vexec.Invocation) vexec.Result {
+			calls++
+
+			return vexec.Result{Stdout: []byte("/repo\n")}
+		}).WithWorkDir("/repo/unit")
+
+		for range 2 {
+			root, err := runner.GetRepoRoot(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, "/repo", root)
+		}
+
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("retries failure", func(t *testing.T) {
+		t.Parallel()
+
+		calls := 0
+		runner := newMemRunner(t, func(context.Context, vexec.Invocation) vexec.Result {
+			calls++
+			if calls == 1 {
+				return vexec.Result{ExitCode: 128}
+			}
+
+			return vexec.Result{Stdout: []byte("/repo\n")}
+		}).WithWorkDir("/repo/unit")
+
+		_, err := runner.GetRepoRoot(t.Context())
+		require.ErrorIs(t, err, git.ErrCommandSpawn)
+
+		root, err := runner.GetRepoRoot(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "/repo", root)
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("missing workdir", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+
+		_, err := runner.GetRepoRoot(t.Context())
+		require.ErrorIs(t, err, git.ErrNoWorkDir)
+	})
+}
+
+func TestGitRunner_LatestReleaseTag(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		wantErr error
+		name    string
+		stdout  string
+		want    string
+		exit    int
+	}{
+		{
+			name: "highest stable tag",
+			stdout: "a\trefs/tags/v1.2.0\n" +
+				"b\trefs/tags/v2.0.0-rc1\n" +
+				"c\trefs/tags/not-semver\n" +
+				"d\trefs/tags/v1.10.0\n" +
+				"e\trefs/tags/v1.10.0^{}\n",
+			want: "v1.10.0",
+		},
+		{
+			name:   "no tags",
+			stdout: "",
+			want:   "",
+		},
+		{
+			name:   "no release tags",
+			stdout: "a\trefs/tags/not-semver\nb\trefs/tags/v2.0.0-beta1\n",
+			want:   "",
+		},
+		{
+			name:    "command failure",
+			exit:    128,
+			wantErr: git.ErrCommandSpawn,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, staticResult(vexec.Result{
+				Stdout:   []byte(tc.stdout),
+				ExitCode: tc.exit,
+			}))
+
+			got, err := runner.LatestReleaseTag(t.Context(), "origin")
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGitRunner_InitBare(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, func(_ context.Context, inv vexec.Invocation) vexec.Result {
+			assert.Equal(t, []string{"init", "--bare", "/repo"}, inv.Args)
+
+			return vexec.Result{}
+		}).WithWorkDir("/repo")
+
+		require.NoError(t, runner.InitBare(t.Context()))
+	})
+
+	t.Run("command failure", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 128})).WithWorkDir("/repo")
+
+		err := runner.InitBare(t.Context())
+		require.ErrorIs(t, err, git.ErrGitInitBare)
+	})
+
+	t.Run("missing workdir", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+
+		err := runner.InitBare(t.Context())
+		require.ErrorIs(t, err, git.ErrNoWorkDir)
+	})
+}
+
+func TestGitRunner_Fetch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("full history", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, func(_ context.Context, inv vexec.Invocation) vexec.Result {
+			assert.Equal(t, []string{"fetch", "--", "file:///repo", "main"}, inv.Args)
+
+			return vexec.Result{}
+		}).WithWorkDir("/repo")
+
+		require.NoError(t, runner.Fetch(t.Context(), "file:///repo", "main", 0))
+	})
+
+	t.Run("command failure", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 128})).WithWorkDir("/repo")
+
+		err := runner.Fetch(t.Context(), "file:///repo", "main", 1)
+		require.ErrorIs(t, err, git.ErrGitFetch)
+	})
+
+	t.Run("missing workdir", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+
+		err := runner.Fetch(t.Context(), "file:///repo", "main", 1)
+		require.ErrorIs(t, err, git.ErrNoWorkDir)
+	})
+}
+
+func TestGitRunner_RevParseCommit(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		wantErr error
+		name    string
+		workDir string
+		want    string
+		result  vexec.Result
+	}{
+		{
+			name:    "commit",
+			workDir: "/repo",
+			result:  vexec.Result{Stdout: []byte(headHash + "\n")},
+			want:    headHash,
+		},
+		{
+			name:    "unknown revision",
+			workDir: "/repo",
+			result:  vexec.Result{ExitCode: 1},
+			wantErr: git.ErrUnknownRevision,
+		},
+		{
+			name:    "spawn failure",
+			workDir: "/repo",
+			result:  vexec.Result{Err: errors.New("spawn failed")},
+			wantErr: git.ErrCommandSpawn,
+		},
+		{
+			name:    "missing workdir",
+			wantErr: git.ErrNoWorkDir,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, staticResult(tc.result))
+			if tc.workDir != "" {
+				runner = runner.WithWorkDir(tc.workDir)
+			}
+
+			got, err := runner.RevParseCommit(t.Context(), "HEAD")
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGitRunner_CatFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes object", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{
+			Stdout: []byte("content"),
+		})).WithWorkDir("/repo")
+
+		var output bytes.Buffer
+
+		require.NoError(t, runner.CatFile(t.Context(), headHash, &output))
+		assert.Equal(t, "content", output.String())
+	})
+
+	t.Run("command failure", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 128})).WithWorkDir("/repo")
+
+		err := runner.CatFile(t.Context(), headHash, &bytes.Buffer{})
+		require.ErrorIs(t, err, git.ErrCommandSpawn)
+	})
+
+	t.Run("missing workdir", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+
+		err := runner.CatFile(t.Context(), headHash, &bytes.Buffer{})
+		require.ErrorIs(t, err, git.ErrNoWorkDir)
+	})
+}
+
+func TestGitRunner_WorktreeCommands(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		invoke func(context.Context, *git.GitRunner) error
+		name   string
+		args   []string
+	}{
+		{
+			name: "create detached",
+			invoke: func(ctx context.Context, runner *git.GitRunner) error {
+				return runner.CreateDetachedWorktree(ctx, "/worktree", "HEAD")
+			},
+			args: []string{"worktree", "add", "--detach", "/worktree", "HEAD"},
+		},
+		{
+			name: "remove",
+			invoke: func(ctx context.Context, runner *git.GitRunner) error {
+				return runner.RemoveWorktree(ctx, "/worktree")
+			},
+			args: []string{"worktree", "remove", "--force", "/worktree"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, func(_ context.Context, inv vexec.Invocation) vexec.Result {
+				assert.Equal(t, tc.args, inv.Args)
+
+				return vexec.Result{}
+			}).WithWorkDir("/repo")
+
+			require.NoError(t, tc.invoke(t.Context(), runner))
+		})
+
+		t.Run(tc.name+" command failure", func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 128})).WithWorkDir("/repo")
+
+			err := tc.invoke(t.Context(), runner)
+			require.ErrorIs(t, err, git.ErrCommandSpawn)
+		})
+
+		t.Run(tc.name+" missing workdir", func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, staticResult(vexec.Result{}))
+
+			err := tc.invoke(t.Context(), runner)
+			require.ErrorIs(t, err, git.ErrNoWorkDir)
+		})
+	}
+}
+
+func TestGitRunner_Init(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{})).WithWorkDir("/repo")
+		require.NoError(t, runner.Init(t.Context()))
+	})
+
+	t.Run("command failure", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 128})).WithWorkDir("/repo")
+		err := runner.Init(t.Context())
+		require.ErrorIs(t, err, git.ErrCommandSpawn)
+	})
+
+	t.Run("missing workdir", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+		err := runner.Init(t.Context())
+		require.ErrorIs(t, err, git.ErrNoWorkDir)
+	})
+}
+
+func TestGitRunner_HasUncommittedChanges(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		result vexec.Result
+		want   bool
+	}{
+		{
+			name:   "dirty",
+			result: vexec.Result{Stdout: []byte(" M file.txt\n")},
+			want:   true,
+		},
+		{
+			name: "clean",
+		},
+		{
+			name:   "command failure",
+			result: vexec.Result{ExitCode: 128},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, staticResult(tc.result)).WithWorkDir("/repo")
+			assert.Equal(t, tc.want, runner.HasUncommittedChanges(t.Context()))
+		})
+	}
+}
+
+func TestGitRunner_ConfigAndRepositoryState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("config", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{
+			Stdout: []byte(" value \n"),
+		})).WithWorkDir("/repo")
+
+		got, err := runner.Config(t.Context(), "test.key")
+		require.NoError(t, err)
+		assert.Equal(t, "value", got)
+	})
+
+	t.Run("config command failure", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 1})).WithWorkDir("/repo")
+
+		_, err := runner.Config(t.Context(), "test.key")
+		require.ErrorIs(t, err, git.ErrCommandSpawn)
+		assert.Empty(t, runner.GetRemoteURL(t.Context()))
+	})
+
+	t.Run("config missing workdir", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+
+		_, err := runner.Config(t.Context(), "test.key")
+		require.ErrorIs(t, err, git.ErrNoWorkDir)
+	})
+
+	t.Run("remote url", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{
+			Stdout: []byte("https://example.com/repo.git\n"),
+		})).WithWorkDir("/repo")
+
+		assert.Equal(t, "https://example.com/repo.git", runner.GetRemoteURL(t.Context()))
+	})
+
+	testCases := []struct {
+		read func(context.Context, *git.GitRunner) string
+		name string
+		args []string
+	}{
+		{
+			name: "current branch",
+			read: func(ctx context.Context, runner *git.GitRunner) string {
+				return runner.GetCurrentBranch(ctx)
+			},
+			args: []string{"rev-parse", "--abbrev-ref", "HEAD"},
+		},
+		{
+			name: "head commit",
+			read: func(ctx context.Context, runner *git.GitRunner) string {
+				return runner.GetHeadCommit(ctx)
+			},
+			args: []string{"rev-parse", "HEAD"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, func(_ context.Context, inv vexec.Invocation) vexec.Result {
+				assert.Equal(t, tc.args, inv.Args)
+
+				return vexec.Result{Stdout: []byte("value\n")}
+			}).WithWorkDir("/repo")
+
+			assert.Equal(t, "value", tc.read(t.Context(), runner))
+		})
+
+		t.Run(tc.name+" command failure", func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 128})).WithWorkDir("/repo")
+			assert.Empty(t, tc.read(t.Context(), runner))
+		})
+
+		t.Run(tc.name+" missing workdir", func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, staticResult(vexec.Result{}))
+			assert.Empty(t, tc.read(t.Context(), runner))
+		})
+	}
+}
+
+func TestGitRunner_GetDefaultBranchLocal(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		wantErr error
+		name    string
+		workDir string
+		want    string
+		result  vexec.Result
+	}{
+		{
+			name:    "remote branch",
+			workDir: "/repo",
+			result:  vexec.Result{Stdout: []byte("origin/main\n")},
+			want:    "main",
+		},
+		{
+			name:    "plain branch",
+			workDir: "/repo",
+			result:  vexec.Result{Stdout: []byte("main\n")},
+			want:    "main",
+		},
+		{
+			name:    "unset remote head",
+			workDir: "/repo",
+			result:  vexec.Result{Stdout: []byte("origin/HEAD\n")},
+			wantErr: git.ErrNoMatchingReference,
+		},
+		{
+			name:    "command failure",
+			workDir: "/repo",
+			result:  vexec.Result{ExitCode: 128},
+			wantErr: git.ErrCommandSpawn,
+		},
+		{
+			name:    "missing workdir",
+			wantErr: git.ErrNoWorkDir,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, staticResult(tc.result))
+			if tc.workDir != "" {
+				runner = runner.WithWorkDir(tc.workDir)
+			}
+
+			got, err := runner.GetDefaultBranchLocal(t.Context())
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGitRunner_GetDefaultBranchRemote(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		wantErr error
+		name    string
+		workDir string
+		want    string
+		result  vexec.Result
+	}{
+		{
+			name:    "symbolic head",
+			workDir: "/repo",
+			result: vexec.Result{Stdout: []byte(
+				"\nref: refs/heads/main\tHEAD\n" + headHash + "\tHEAD\n",
+			)},
+			want: "main",
+		},
+		{
+			name:    "unparseable output",
+			workDir: "/repo",
+			result:  vexec.Result{Stdout: []byte(headHash + "\tHEAD\n")},
+			wantErr: git.ErrNoMatchingReference,
+		},
+		{
+			name:    "malformed symbolic head",
+			workDir: "/repo",
+			result:  vexec.Result{Stdout: []byte("ref:\n")},
+			wantErr: git.ErrNoMatchingReference,
+		},
+		{
+			name:    "command failure",
+			workDir: "/repo",
+			result:  vexec.Result{ExitCode: 128},
+			wantErr: git.ErrCommandSpawn,
+		},
+		{
+			name:    "missing workdir",
+			wantErr: git.ErrNoWorkDir,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, staticResult(tc.result))
+			if tc.workDir != "" {
+				runner = runner.WithWorkDir(tc.workDir)
+			}
+
+			got, err := runner.GetDefaultBranchRemote(t.Context())
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGitRunner_GetDefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		want    string
+		local   vexec.Result
+		remote  vexec.Result
+		config  vexec.Result
+		setHead vexec.Result
+	}{
+		{
+			name:  "local cache",
+			local: vexec.Result{Stdout: []byte("origin/main\n")},
+			want:  "main",
+		},
+		{
+			name:    "remote head",
+			local:   vexec.Result{Stdout: []byte("origin/HEAD\n")},
+			remote:  vexec.Result{Stdout: []byte("ref: refs/heads/trunk\tHEAD\n")},
+			setHead: vexec.Result{},
+			want:    "trunk",
+		},
+		{
+			name:    "remote head with cache failure",
+			local:   vexec.Result{Stdout: []byte("origin/HEAD\n")},
+			remote:  vexec.Result{Stdout: []byte("ref: refs/heads/trunk\tHEAD\n")},
+			setHead: vexec.Result{ExitCode: 1},
+			want:    "trunk",
+		},
+		{
+			name:   "configured fallback",
+			local:  vexec.Result{ExitCode: 1},
+			remote: vexec.Result{ExitCode: 1},
+			config: vexec.Result{Stdout: []byte("develop\n")},
+			want:   "develop",
+		},
+		{
+			name:   "main fallback",
+			local:  vexec.Result{ExitCode: 1},
+			remote: vexec.Result{ExitCode: 1},
+			config: vexec.Result{ExitCode: 1},
+			want:   "main",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, func(_ context.Context, inv vexec.Invocation) vexec.Result {
+				switch inv.Args[0] {
+				case "rev-parse":
+					return tc.local
+				case "ls-remote":
+					return tc.remote
+				case "remote":
+					return tc.setHead
+				case "config":
+					return tc.config
+				default:
+					t.Errorf("unexpected git command: %v", inv.Args)
+
+					return vexec.Result{ExitCode: 1}
+				}
+			}).WithWorkDir("/repo")
+
+			got := runner.GetDefaultBranch(t.Context(), logger.CreateLogger())
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGitRunner_SetRemoteHeadAuto(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{})).WithWorkDir("/repo")
+		require.NoError(t, runner.SetRemoteHeadAuto(t.Context()))
+	})
+
+	t.Run("command failure", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 1})).WithWorkDir("/repo")
+		err := runner.SetRemoteHeadAuto(t.Context())
+		require.ErrorIs(t, err, git.ErrCommandSpawn)
+	})
+
+	t.Run("missing workdir", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+		err := runner.SetRemoteHeadAuto(t.Context())
+		require.ErrorIs(t, err, git.ErrNoWorkDir)
+	})
+}
+
+func TestGitRunner_ObjectFormat(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sha256", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{
+			Stdout: []byte("sha256\n"),
+		})).WithWorkDir("/repo")
+
+		format, err := runner.ObjectFormat(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "sha256", format)
+	})
+
+	t.Run("unsupported command", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 129})).WithWorkDir("/repo")
+
+		format, err := runner.ObjectFormat(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "sha1", format)
+	})
+
+	t.Run("missing workdir", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{}))
+
+		_, err := runner.ObjectFormat(t.Context())
+		require.ErrorIs(t, err, git.ErrNoWorkDir)
+	})
+}
+
+func TestGitRunner_MutationCommandFailures(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		invoke func(context.Context, *git.GitRunner) error
+		name   string
+	}{
+		{
+			name: "add",
+			invoke: func(ctx context.Context, runner *git.GitRunner) error {
+				return runner.Add(ctx, "file.txt")
+			},
+		},
+		{
+			name: "commit",
+			invoke: func(ctx context.Context, runner *git.GitRunner) error {
+				return runner.Commit(ctx, "message")
+			},
+		},
+		{
+			name: "checkout",
+			invoke: func(ctx context.Context, runner *git.GitRunner) error {
+				return runner.Checkout(ctx, "main", false)
+			},
+		},
+		{
+			name: "config set",
+			invoke: func(ctx context.Context, runner *git.GitRunner) error {
+				return runner.ConfigSet(ctx, "user.name", "Terragrunt")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 1})).WithWorkDir("/repo")
+			err := tc.invoke(t.Context(), runner)
+			require.ErrorIs(t, err, git.ErrCommandSpawn)
+		})
+
+		t.Run(tc.name+" missing workdir", func(t *testing.T) {
+			t.Parallel()
+
+			runner := newMemRunner(t, staticResult(vexec.Result{}))
+			err := tc.invoke(t.Context(), runner)
+			require.ErrorIs(t, err, git.ErrNoWorkDir)
+		})
+	}
+}

--- a/internal/git/git_commands_test.go
+++ b/internal/git/git_commands_test.go
@@ -58,6 +58,27 @@ func TestGitRunner_WithWorkDir(t *testing.T) {
 		got := runner.WithWorkDir("/repo")
 		assert.Equal(t, "/repo", got.WorkDir)
 	})
+
+	t.Run("resets memoized repo root", func(t *testing.T) {
+		t.Parallel()
+
+		var dirs []string
+
+		parent := newMemRunner(t, func(_ context.Context, inv vexec.Invocation) vexec.Result {
+			dirs = append(dirs, inv.Dir)
+
+			return vexec.Result{Stdout: []byte(inv.Dir + "\n")}
+		}).WithWorkDir("/repo/a")
+
+		root, err := parent.GetRepoRoot(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "/repo/a", root)
+
+		root, err = parent.WithWorkDir("/repo/b").GetRepoRoot(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "/repo/b", root)
+		assert.Equal(t, []string{"/repo/a", "/repo/b"}, dirs)
+	})
 }
 
 func TestGitRunner_GetRepoRoot(t *testing.T) {
@@ -154,10 +175,11 @@ func TestGitRunner_LatestReleaseTag(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			runner := newMemRunner(t, staticResult(vexec.Result{
-				Stdout:   []byte(tc.stdout),
-				ExitCode: tc.exit,
-			}))
+			runner := newMemRunner(t, func(_ context.Context, inv vexec.Invocation) vexec.Result {
+				assert.Equal(t, []string{"ls-remote", "--", "origin", "refs/tags/*"}, inv.Args)
+
+				return vexec.Result{Stdout: []byte(tc.stdout), ExitCode: tc.exit}
+			})
 
 			got, err := runner.LatestReleaseTag(t.Context(), "origin")
 			if tc.wantErr != nil {
@@ -427,11 +449,14 @@ func TestGitRunner_HasUncommittedChanges(t *testing.T) {
 			want:   true,
 		},
 		{
-			name: "clean",
+			name:   "clean",
+			result: vexec.Result{},
+			want:   false,
 		},
 		{
-			name:   "command failure",
-			result: vexec.Result{ExitCode: 128},
+			name:   "command failure discards stdout",
+			result: vexec.Result{Stdout: []byte(" M file.txt\n"), ExitCode: 128},
+			want:   false,
 		},
 	}
 
@@ -439,8 +464,18 @@ func TestGitRunner_HasUncommittedChanges(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			runner := newMemRunner(t, staticResult(tc.result)).WithWorkDir("/repo")
+			spawned := 0
+			runner := newMemRunner(t, func(_ context.Context, inv vexec.Invocation) vexec.Result {
+				spawned++
+
+				assert.Equal(t, []string{"status", "--porcelain"}, inv.Args)
+				assert.Equal(t, "/repo", inv.Dir)
+
+				return tc.result
+			}).WithWorkDir("/repo")
+
 			assert.Equal(t, tc.want, runner.HasUncommittedChanges(t.Context()))
+			assert.Equal(t, 1, spawned)
 		})
 	}
 }
@@ -467,7 +502,6 @@ func TestGitRunner_ConfigAndRepositoryState(t *testing.T) {
 
 		_, err := runner.Config(t.Context(), "test.key")
 		require.ErrorIs(t, err, git.ErrCommandSpawn)
-		assert.Empty(t, runner.GetRemoteURL(t.Context()))
 	})
 
 	t.Run("config missing workdir", func(t *testing.T) {
@@ -487,6 +521,25 @@ func TestGitRunner_ConfigAndRepositoryState(t *testing.T) {
 		})).WithWorkDir("/repo")
 
 		assert.Equal(t, "https://example.com/repo.git", runner.GetRemoteURL(t.Context()))
+	})
+
+	t.Run("remote url command failure", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{
+			Stdout:   []byte("https://example.com/repo.git\n"),
+			ExitCode: 1,
+		})).WithWorkDir("/repo")
+
+		assert.Empty(t, runner.GetRemoteURL(t.Context()))
+	})
+
+	t.Run("remote url missing workdir", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, failIfSpawned(t))
+
+		assert.Empty(t, runner.GetRemoteURL(t.Context()))
 	})
 
 	testCases := []struct {
@@ -526,14 +579,18 @@ func TestGitRunner_ConfigAndRepositoryState(t *testing.T) {
 		t.Run(tc.name+" command failure", func(t *testing.T) {
 			t.Parallel()
 
-			runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 128})).WithWorkDir("/repo")
+			runner := newMemRunner(t, staticResult(vexec.Result{
+				Stdout:   []byte("value\n"),
+				ExitCode: 128,
+			})).WithWorkDir("/repo")
+
 			assert.Empty(t, tc.read(t.Context(), runner))
 		})
 
 		t.Run(tc.name+" missing workdir", func(t *testing.T) {
 			t.Parallel()
 
-			runner := newMemRunner(t, staticResult(vexec.Result{}))
+			runner := newMemRunner(t, failIfSpawned(t))
 			assert.Empty(t, tc.read(t.Context(), runner))
 		})
 	}
@@ -680,11 +737,10 @@ func TestGitRunner_GetDefaultBranch(t *testing.T) {
 			want:  "main",
 		},
 		{
-			name:    "remote head",
-			local:   vexec.Result{Stdout: []byte("origin/HEAD\n")},
-			remote:  vexec.Result{Stdout: []byte("ref: refs/heads/trunk\tHEAD\n")},
-			setHead: vexec.Result{},
-			want:    "trunk",
+			name:   "remote head",
+			local:  vexec.Result{Stdout: []byte("origin/HEAD\n")},
+			remote: vexec.Result{Stdout: []byte("ref: refs/heads/trunk\tHEAD\n")},
+			want:   "trunk",
 		},
 		{
 			name:    "remote head with cache failure",
@@ -847,5 +903,16 @@ func TestGitRunner_MutationCommandFailures(t *testing.T) {
 			err := tc.invoke(t.Context(), runner)
 			require.ErrorIs(t, err, git.ErrNoWorkDir)
 		})
+	}
+}
+
+// failIfSpawned returns a handler that fails the test if git is ever executed.
+func failIfSpawned(t *testing.T) vexec.Handler {
+	t.Helper()
+
+	return func(context.Context, vexec.Invocation) vexec.Result {
+		t.Error("git must not be spawned when no working directory is set")
+
+		return vexec.Result{Stdout: []byte("value\n")}
 	}
 }

--- a/internal/git/submodule_test.go
+++ b/internal/git/submodule_test.go
@@ -182,11 +182,7 @@ func TestGitRunner_SubmoduleURLs(t *testing.T) {
 	t.Run("missing workdir", func(t *testing.T) {
 		t.Parallel()
 
-		runner := newMemRunner(t, func(context.Context, vexec.Invocation) vexec.Result {
-			t.Error("git must not be spawned when no working directory is set")
-
-			return vexec.Result{}
-		})
+		runner := newMemRunner(t, failIfSpawned(t))
 
 		_, err := runner.SubmoduleURLs(t.Context(), headHash)
 		require.ErrorIs(t, err, git.ErrNoWorkDir)

--- a/internal/git/submodule_test.go
+++ b/internal/git/submodule_test.go
@@ -1,10 +1,13 @@
 package git_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveSubmoduleURL(t *testing.T) {
@@ -142,4 +145,50 @@ func TestParseSubmoduleConfig(t *testing.T) {
 			assert.Equal(t, tt.want, git.ParseSubmoduleConfig(tt.output))
 		})
 	}
+}
+
+func TestGitRunner_SubmoduleURLs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses blob config", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, func(_ context.Context, inv vexec.Invocation) vexec.Result {
+			assert.Equal(t, []string{"config", "--blob", headHash, "--list", "-z"}, inv.Args)
+			assert.Equal(t, "/repo", inv.Dir)
+
+			return vexec.Result{Stdout: []byte(
+				"submodule.child.path\nmodules/child\x00" +
+					"submodule.child.url\nhttps://example.com/child.git\x00",
+			)}
+		}).WithWorkDir("/repo")
+
+		urls, err := runner.SubmoduleURLs(t.Context(), headHash)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			"modules/child": "https://example.com/child.git",
+		}, urls)
+	})
+
+	t.Run("command failure", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 128})).WithWorkDir("/repo")
+
+		_, err := runner.SubmoduleURLs(t.Context(), headHash)
+		require.ErrorIs(t, err, git.ErrCommandSpawn)
+	})
+
+	t.Run("missing workdir", func(t *testing.T) {
+		t.Parallel()
+
+		runner := newMemRunner(t, func(context.Context, vexec.Invocation) vexec.Result {
+			t.Error("git must not be spawned when no working directory is set")
+
+			return vexec.Result{}
+		})
+
+		_, err := runner.SubmoduleURLs(t.Context(), headHash)
+		require.ErrorIs(t, err, git.ErrNoWorkDir)
+	})
 }

--- a/internal/git/tree_test.go
+++ b/internal/git/tree_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"strings"
@@ -58,7 +59,7 @@ func TestParseTree_RejectsInvalidOutput(t *testing.T) {
 		t.Parallel()
 
 		_, err := git.ParseTree([]byte(strings.Repeat("100644 blob hash path ", 4000)), ".")
-		require.Error(t, err)
+		require.ErrorIs(t, err, bufio.ErrTooLong)
 
 		var wrappedErr *git.WrappedError
 		require.ErrorAs(t, err, &wrappedErr)

--- a/internal/git/tree_test.go
+++ b/internal/git/tree_test.go
@@ -1,0 +1,88 @@
+package git_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTree_RoundTripsTree(t *testing.T) {
+	t.Parallel()
+
+	output := []byte(
+		"100644 blob aaaabeefcafefacedeadbeefcafefacedeadbeef\tREADME.md\n" +
+			"160000 commit bbbbbeefcafefacedeadbeefcafefacedeadbeef\tmodules/child repo\n",
+	)
+
+	tree, err := git.ParseTree(output, "modules")
+	require.NoError(t, err)
+
+	assert.Equal(t, "modules", tree.Path())
+	assert.Equal(t, output, tree.Data())
+	assert.Equal(t, []git.TreeEntry{
+		{
+			Mode: "100644",
+			Type: git.EntryTypeBlob,
+			Hash: "aaaabeefcafefacedeadbeefcafefacedeadbeef",
+			Path: "README.md",
+		},
+		{
+			Mode: "160000",
+			Type: git.EntryTypeCommit,
+			Hash: "bbbbbeefcafefacedeadbeefcafefacedeadbeef",
+			Path: "modules/child repo",
+		},
+	}, tree.Entries())
+
+	var rendered bytes.Buffer
+	require.NoError(t, tree.Write(&rendered))
+	assert.Equal(t, output, rendered.Bytes())
+}
+
+func TestParseTree_RejectsInvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid entry", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := git.ParseTree([]byte("100644 blob\n"), ".")
+		require.ErrorIs(t, err, git.ErrParseTree)
+	})
+
+	t.Run("oversized entry", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := git.ParseTree([]byte(strings.Repeat("100644 blob hash path ", 4000)), ".")
+		require.Error(t, err)
+
+		var wrappedErr *git.WrappedError
+		require.ErrorAs(t, err, &wrappedErr)
+	})
+}
+
+func TestTree_WritePropagatesWriterError(t *testing.T) {
+	t.Parallel()
+
+	tree, err := git.ParseTree(
+		[]byte("100644 blob aaaabeefcafefacedeadbeefcafefacedeadbeef\tREADME.md\n"),
+		".",
+	)
+	require.NoError(t, err)
+
+	wantErr := errors.New("write failed")
+	err = tree.Write(&failingWriter{err: wantErr})
+	require.ErrorIs(t, err, wantErr)
+}
+
+type failingWriter struct {
+	err error
+}
+
+func (w *failingWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}

--- a/internal/git/tree_test.go
+++ b/internal/git/tree_test.go
@@ -12,18 +12,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseTree_RoundTripsTree(t *testing.T) {
+// TestParseTree_RoundTripsCanonicalOutput pins the round trip for canonical ls-tree output only.
+func TestParseTree_RoundTripsCanonicalOutput(t *testing.T) {
 	t.Parallel()
 
 	output := []byte(
 		"100644 blob aaaabeefcafefacedeadbeefcafefacedeadbeef\tREADME.md\n" +
-			"160000 commit bbbbbeefcafefacedeadbeefcafefacedeadbeef\tmodules/child repo\n",
+			"160000 commit bbbbbeefcafefacedeadbeefcafefacedeadbeef\tchild repo\n" +
+			"040000 tree ccccbeefcafefacedeadbeefcafefacedeadbeef\tmodules\n",
 	)
 
-	tree, err := git.ParseTree(output, "modules")
+	tree, err := git.ParseTree(output, ".")
 	require.NoError(t, err)
 
-	assert.Equal(t, "modules", tree.Path())
+	assert.Equal(t, ".", tree.Path())
 	assert.Equal(t, output, tree.Data())
 	assert.Equal(t, []git.TreeEntry{
 		{
@@ -36,7 +38,13 @@ func TestParseTree_RoundTripsTree(t *testing.T) {
 			Mode: "160000",
 			Type: git.EntryTypeCommit,
 			Hash: "bbbbbeefcafefacedeadbeefcafefacedeadbeef",
-			Path: "modules/child repo",
+			Path: "child repo",
+		},
+		{
+			Mode: "040000",
+			Type: git.EntryTypeTree,
+			Hash: "ccccbeefcafefacedeadbeefcafefacedeadbeef",
+			Path: "modules",
 		},
 	}, tree.Entries())
 
@@ -55,15 +63,29 @@ func TestParseTree_RejectsInvalidOutput(t *testing.T) {
 		require.ErrorIs(t, err, git.ErrParseTree)
 	})
 
-	t.Run("oversized entry", func(t *testing.T) {
+	t.Run("entry longer than the scanner buffer", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := git.ParseTree([]byte(strings.Repeat("100644 blob hash path ", 4000)), ".")
+		entry := "100644 blob aaaabeefcafefacedeadbeefcafefacedeadbeef\t" + strings.Repeat("a", bufio.MaxScanTokenSize)
+
+		_, err := git.ParseTree([]byte(entry), ".")
 		require.ErrorIs(t, err, bufio.ErrTooLong)
 
 		var wrappedErr *git.WrappedError
 		require.ErrorAs(t, err, &wrappedErr)
 	})
+}
+
+func TestParseTree_SkipsBlankLines(t *testing.T) {
+	t.Parallel()
+
+	tree, err := git.ParseTree(
+		[]byte("\n100644 blob aaaabeefcafefacedeadbeefcafefacedeadbeef\tREADME.md\n\n"),
+		".",
+	)
+	require.NoError(t, err)
+	assert.Len(t, tree.Entries(), 1)
+	assert.Equal(t, "README.md", tree.Entries()[0].Path)
 }
 
 func TestTree_WritePropagatesWriterError(t *testing.T) {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

- Cover GitRunner command wrappers
- Cover tree, diff parsers
- Pin argv per command
- Test-only, no production changes

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for Git diff, tree, submodule, and repository operations.
  * Added validation for malformed output, command failures, missing working directories, and error propagation.
  * Improved confidence in branch, tag, worktree, remote, configuration, and object-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->