### PR TITLE
chore: Increasing discovery boundary test coverage

### DIFF
--- a/internal/discovery/discovery_boundary_test.go
+++ b/internal/discovery/discovery_boundary_test.go
@@ -95,6 +95,28 @@ func (f *boundaryFixture) discover(t *testing.T, v *venv.Venv, query, boundary s
 	return d.Discover(t.Context(), logger.CreateLogger(), v, opts)
 }
 
+// Test that a dependent found by the upstream walk is returned when the
+// boundary encloses it. The walk searches directories above the working
+// directory, and the components it turns up are restamped as graph-discovered,
+// which is the same mark that decides what the boundary withholds. A boundary
+// wide enough to contain a dependent has to return it regardless.
+func TestDiscoveryBoundary_ReturnsDependentsFoundUpstream(t *testing.T) {
+	t.Parallel()
+
+	f, v := newBoundaryFixture(t)
+
+	// environments/ contains both staging (the working directory) and the
+	// production environment holding vpc's other dependent.
+	configs, err := f.discover(t, v, "...{"+f.vpcDir+"}", "..")
+	require.NoError(t, err)
+
+	assert.ElementsMatch(
+		t,
+		[]string{f.vpcDir, f.appDir, f.consumerDir},
+		configs.Filter(component.UnitKind).Paths(),
+	)
+}
+
 // Test that a discovery boundary encloses graph discovery in both directions,
 // while the default (git root) crosses out of the working directory. The
 // dependent direction (`...{vpc}`) reaches a dependent in a sibling
@@ -323,6 +345,70 @@ func TestDiscoveryBoundary_SurvivesFilterEvaluationWithRelationships(t *testing.
 
 			configs, err := d.Discover(t.Context(), logger.CreateLogger(), v, opts)
 			require.NoError(t, err)
+			assert.ElementsMatch(t, paths, configs.Filter(component.UnitKind).Paths())
+		})
+	}
+}
+
+// Test what the boundary withholds under filter shapes that do not bound their
+// own traversal. A filter that only excludes starts from every component
+// discovered, so the boundary is the only thing standing between a run and a
+// component traversal reached across it. An inline "(dir)" operand is the one
+// shape that overrides the flag, and it does so for the whole run.
+func TestDiscoveryBoundary_WithholdingAcrossFilterShapes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		queriesFor func(f boundaryFixture) []string
+		name       string
+		expected   []string
+	}{
+		{
+			name:       "a filter that only excludes still withholds what traversal reached",
+			queriesFor: func(_ boundaryFixture) []string { return []string{"!name=app"} },
+			expected:   []string{"vpc", "edge"},
+		},
+		{
+			name: "an inline operand on any filter stands the flag down",
+			queriesFor: func(f boundaryFixture) []string {
+				return []string{"{" + f.edgeDir + "}...(..)", "{" + f.vpcDir + "}"}
+			},
+			expected: []string{"vpc", "edge", "external"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f, v := newBoundaryFixture(t)
+
+			byName := map[string]string{
+				"vpc":      f.vpcDir,
+				"app":      f.appDir,
+				"edge":     f.edgeDir,
+				"external": f.externalDir,
+			}
+
+			paths := make([]string, len(tc.expected))
+			for i, n := range tc.expected {
+				paths[i] = byName[n]
+			}
+
+			opts := options.NewTerragruntOptions()
+			opts.WorkingDir = f.stagingDir
+			opts.RootWorkingDir = f.stagingDir
+
+			filters, err := filter.ParseFilterQueries(logger.CreateLogger(), tc.queriesFor(f))
+			require.NoError(t, err)
+
+			configs, err := discovery.NewDiscovery(f.stagingDir).
+				WithFilters(filters).
+				WithRelationships().
+				WithDiscoveryBoundary(".").
+				Discover(t.Context(), logger.CreateLogger(), v, opts)
+			require.NoError(t, err)
+
 			assert.ElementsMatch(t, paths, configs.Filter(component.UnitKind).Paths())
 		})
 	}

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -414,7 +414,8 @@ func WalkDir(fsys FS, root string, fn fs.WalkDirFunc) error {
 // WalkDirWithSymlinks walks the file tree rooted at root like [WalkDir] does,
 // additionally descending into the directories that symbolic links resolve to.
 // Paths handed to fn are logical: they read as if the link target lived at the
-// link's own location.
+// link's own location, and a root that is itself reached through a link keeps
+// the spelling the caller passed.
 //
 // Each logical path is reported once, so a directory reachable through several
 // links is visited once, and a link pointing back at an ancestor terminates
@@ -432,7 +433,7 @@ func WalkDirWithSymlinks(fsys FS, root string, fn fs.WalkDirFunc) error {
 		return fmt.Errorf("failed to evaluate symlinks for %s: %w", root, err)
 	}
 
-	return w.walk(realRoot, realRoot)
+	return w.walk(realRoot, filepath.Clean(root))
 }
 
 // symlinkWalker carries the bookkeeping [WalkDirWithSymlinks] needs across the

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -1273,6 +1273,37 @@ func TestWalkDirWithSymlinks(t *testing.T) {
 		}, walkSymlinkedPaths(t, root))
 	})
 
+	t.Run("root reached through a symlink", func(t *testing.T) {
+		t.Parallel()
+
+		base := evaledTempDir(t)
+		target := filepath.Join(base, "target")
+
+		require.NoError(t, os.Mkdir(target, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(target, "test.txt"), []byte("test"), 0644))
+
+		root := filepath.Join(base, "link")
+		require.NoError(t, os.Symlink(target, root))
+
+		var paths []string
+
+		require.NoError(t, vfs.WalkDirWithSymlinks(
+			vfs.NewOSFS(),
+			root,
+			func(path string, _ fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+
+				paths = append(paths, path)
+
+				return nil
+			},
+		))
+
+		assert.Equal(t, []string{root, filepath.Join(root, "test.txt")}, paths)
+	})
+
 	t.Run("missing root", func(t *testing.T) {
 		t.Parallel()
 

--- a/test/fixtures/discovery-boundary/prod/app/.terraform.lock.hcl
+++ b/test/fixtures/discovery-boundary/prod/app/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version = "3.2.4"
+  hashes = [
+    "h1:i+WKhUHL2REY5EGmiHjfUljJB8UKZ9QdhdM5uTeUhC4=",
+    "h1:jsKjBiLb+v3OIC3xuDiY4sR0r1OHUMSWPYKult9MhT0=",
+    "h1:wg0cxqzzWFNnEzw0LSlPL9Ovqy1VFW44A7ayHEU/A1I=",
+    "zh:1769783386610bed8bb1e861a119fe25058be41895e3996d9216dd6bb8a7aee3",
+    "zh:32c62a9387ad0b861b5262b41c5e9ed6e940eda729c2a0e58100e6629af27ddb",
+    "zh:339bf8c2f9733fce068eb6d5612701144c752425cebeafab36563a16be460fb2",
+    "zh:36731f23343aee12a7e078067a98644c0126714c4fe9ac930eecb0f2361788c4",
+    "zh:3d106c7e32a929e2843f732625a582e562ff09120021e510a51a6f5d01175b8d",
+    "zh:74bcb3567708171ad83b234b92c9d63ab441ef882b770b0210c2b14fdbe3b1b6",
+    "zh:90b55bdbffa35df9204282251059e62c178b0ac7035958b93a647839643c0072",
+    "zh:ae24c0e5adc692b8f94cb23a000f91a316070fdc19418578dcf2134ff57cf447",
+    "zh:b5c10d4ad860c4c21273203d1de6d2f0286845edf1c64319fa2362df526b5f58",
+    "zh:e05bbd88e82e1d6234988c85db62fd66f11502645838fff594a2ec25352ecd80",
+  ]
+}

--- a/test/fixtures/discovery-boundary/prod/app/main.tf
+++ b/test/fixtures/discovery-boundary/prod/app/main.tf
@@ -1,0 +1,19 @@
+variable "db_id" {
+  type = string
+}
+
+variable "dns_id" {
+  type = string
+}
+
+resource "null_resource" "app" {
+  triggers = {
+    name   = "app"
+    db_id  = var.db_id
+    dns_id = var.dns_id
+  }
+}
+
+output "app_id" {
+  value = "app-${var.db_id}-${var.dns_id}"
+}

--- a/test/fixtures/discovery-boundary/prod/app/terragrunt.hcl
+++ b/test/fixtures/discovery-boundary/prod/app/terragrunt.hcl
@@ -1,0 +1,22 @@
+terraform {
+  source = "."
+}
+
+dependency "db" {
+  config_path = "../db"
+  mock_outputs = {
+    db_id = "db-mocked"
+  }
+}
+
+dependency "dns" {
+  config_path = "../../shared/dns"
+  mock_outputs = {
+    dns_id = "dns-mocked"
+  }
+}
+
+inputs = {
+  db_id  = dependency.db.outputs.db_id
+  dns_id = dependency.dns.outputs.dns_id
+}

--- a/test/fixtures/discovery-boundary/prod/db/.terraform.lock.hcl
+++ b/test/fixtures/discovery-boundary/prod/db/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version = "3.2.4"
+  hashes = [
+    "h1:i+WKhUHL2REY5EGmiHjfUljJB8UKZ9QdhdM5uTeUhC4=",
+    "h1:jsKjBiLb+v3OIC3xuDiY4sR0r1OHUMSWPYKult9MhT0=",
+    "h1:wg0cxqzzWFNnEzw0LSlPL9Ovqy1VFW44A7ayHEU/A1I=",
+    "zh:1769783386610bed8bb1e861a119fe25058be41895e3996d9216dd6bb8a7aee3",
+    "zh:32c62a9387ad0b861b5262b41c5e9ed6e940eda729c2a0e58100e6629af27ddb",
+    "zh:339bf8c2f9733fce068eb6d5612701144c752425cebeafab36563a16be460fb2",
+    "zh:36731f23343aee12a7e078067a98644c0126714c4fe9ac930eecb0f2361788c4",
+    "zh:3d106c7e32a929e2843f732625a582e562ff09120021e510a51a6f5d01175b8d",
+    "zh:74bcb3567708171ad83b234b92c9d63ab441ef882b770b0210c2b14fdbe3b1b6",
+    "zh:90b55bdbffa35df9204282251059e62c178b0ac7035958b93a647839643c0072",
+    "zh:ae24c0e5adc692b8f94cb23a000f91a316070fdc19418578dcf2134ff57cf447",
+    "zh:b5c10d4ad860c4c21273203d1de6d2f0286845edf1c64319fa2362df526b5f58",
+    "zh:e05bbd88e82e1d6234988c85db62fd66f11502645838fff594a2ec25352ecd80",
+  ]
+}

--- a/test/fixtures/discovery-boundary/prod/db/main.tf
+++ b/test/fixtures/discovery-boundary/prod/db/main.tf
@@ -1,0 +1,9 @@
+resource "null_resource" "db" {
+  triggers = {
+    name = "db"
+  }
+}
+
+output "db_id" {
+  value = "db-12345"
+}

--- a/test/fixtures/discovery-boundary/prod/db/terragrunt.hcl
+++ b/test/fixtures/discovery-boundary/prod/db/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/fixtures/discovery-boundary/shared/dns/.terraform.lock.hcl
+++ b/test/fixtures/discovery-boundary/shared/dns/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version = "3.2.4"
+  hashes = [
+    "h1:i+WKhUHL2REY5EGmiHjfUljJB8UKZ9QdhdM5uTeUhC4=",
+    "h1:jsKjBiLb+v3OIC3xuDiY4sR0r1OHUMSWPYKult9MhT0=",
+    "h1:wg0cxqzzWFNnEzw0LSlPL9Ovqy1VFW44A7ayHEU/A1I=",
+    "zh:1769783386610bed8bb1e861a119fe25058be41895e3996d9216dd6bb8a7aee3",
+    "zh:32c62a9387ad0b861b5262b41c5e9ed6e940eda729c2a0e58100e6629af27ddb",
+    "zh:339bf8c2f9733fce068eb6d5612701144c752425cebeafab36563a16be460fb2",
+    "zh:36731f23343aee12a7e078067a98644c0126714c4fe9ac930eecb0f2361788c4",
+    "zh:3d106c7e32a929e2843f732625a582e562ff09120021e510a51a6f5d01175b8d",
+    "zh:74bcb3567708171ad83b234b92c9d63ab441ef882b770b0210c2b14fdbe3b1b6",
+    "zh:90b55bdbffa35df9204282251059e62c178b0ac7035958b93a647839643c0072",
+    "zh:ae24c0e5adc692b8f94cb23a000f91a316070fdc19418578dcf2134ff57cf447",
+    "zh:b5c10d4ad860c4c21273203d1de6d2f0286845edf1c64319fa2362df526b5f58",
+    "zh:e05bbd88e82e1d6234988c85db62fd66f11502645838fff594a2ec25352ecd80",
+  ]
+}

--- a/test/fixtures/discovery-boundary/shared/dns/main.tf
+++ b/test/fixtures/discovery-boundary/shared/dns/main.tf
@@ -1,0 +1,11 @@
+resource "null_resource" "dns" {
+  triggers = {
+    name = "dns"
+  }
+}
+
+# Deliberately unlike the mock the dependent declares, so a test can tell an
+# output read out of this unit's state from a mock standing in for it.
+output "dns_id" {
+  value = "dns-applied"
+}

--- a/test/fixtures/discovery-boundary/shared/dns/terragrunt.hcl
+++ b/test/fixtures/discovery-boundary/shared/dns/terragrunt.hcl
@@ -1,0 +1,3 @@
+terraform {
+  source = "."
+}

--- a/test/integration_discovery_boundary_test.go
+++ b/test/integration_discovery_boundary_test.go
@@ -1,0 +1,146 @@
+package test_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The fixture holds a dependency that crosses out of prod:
+//
+//	prod/app     depends on prod/db and shared/dns
+//	prod/db
+//	shared/dns
+const testFixtureDiscoveryBoundary = "fixtures/discovery-boundary"
+
+func TestDiscoveryBoundaryBoundsGraphTraversal(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureDiscoveryBoundary)
+	prodDir := filepath.Join(tmpEnvPath, testFixtureDiscoveryBoundary, "prod")
+
+	testCases := []struct {
+		name     string
+		args     string
+		expected []string
+	}{
+		{
+			name:     "dependency traversal leaves the working directory when unbounded",
+			args:     "--filter '{./app}...'",
+			expected: []string{"app", "db", "../shared/dns"},
+		},
+		{
+			name:     "dependency traversal stops at the boundary",
+			args:     "--filter '{./app}...' --discovery-boundary .",
+			expected: []string{"app", "db"},
+		},
+		{
+			name:     "dependent traversal keeps what the boundary encloses",
+			args:     "--filter '...{./db}' --discovery-boundary .",
+			expected: []string{"app", "db"},
+		},
+		{
+			name:     "inline operand reaches wider than the boundary it overrides",
+			args:     "--filter '{./app}...(..)' --discovery-boundary .",
+			expected: []string{"app", "db", "../shared/dns"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := "terragrunt find --experiment bounded-discovery --no-color --working-dir " + prodDir + " " + tc.args
+
+			stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+			require.NoError(t, err)
+
+			assert.ElementsMatch(t, tc.expected, discoveredPaths(stdout))
+		})
+	}
+}
+
+// Test that the edge to a dependency the boundary withholds survives. The unit
+// that stays has to be ordered against that dependency and has to read its
+// outputs, so the boundary drops the component without dropping the edge.
+func TestDiscoveryBoundaryKeepsEdgesToWithheldDependencies(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureDiscoveryBoundary)
+	prodDir := filepath.Join(tmpEnvPath, testFixtureDiscoveryBoundary, "prod")
+
+	cmd := "terragrunt dag graph --experiment bounded-discovery --no-color --working-dir " +
+		prodDir + " --discovery-boundary ."
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, `"app" -> "../shared/dns"`)
+	assert.Contains(t, stdout, `"app" -> "db"`)
+
+	// A node line carries no arrow, so its absence is what says shared/dns was
+	// withheld rather than merely pointed at.
+	assert.NotContains(t, stdout, `"../shared/dns" ;`)
+}
+
+// Test that a working directory reached through a symlink still compares as
+// inside its own boundary. Terragrunt resolves the boundary through the
+// filesystem while the walk keeps the path it was handed, and a component named
+// in one spelling and bounded in the other is a component silently dropped.
+func TestDiscoveryBoundaryUnderSymlinkedWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("creating symlinks on Windows requires elevated privileges")
+	}
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureDiscoveryBoundary)
+	fixtureDir := filepath.Join(tmpEnvPath, testFixtureDiscoveryBoundary)
+
+	linkDir := filepath.Join(t.TempDir(), "link")
+	require.NoError(t, os.Symlink(fixtureDir, linkDir))
+
+	cmd := "terragrunt find --experiment bounded-discovery --no-color --working-dir " +
+		filepath.Join(linkDir, "prod") + " --filter '...{./db}' --discovery-boundary ."
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"app", "db"}, discoveredPaths(stdout))
+}
+
+// Test that a boundary excluding the working directory is refused for filters
+// that traverse dependents, which search upward from the working directory and
+// could never reach anything within such a boundary.
+func TestDiscoveryBoundaryRejectsDependentTraversalOutsideIt(t *testing.T) {
+	t.Parallel()
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureDiscoveryBoundary)
+	fixtureDir := filepath.Join(tmpEnvPath, testFixtureDiscoveryBoundary)
+
+	cmd := "terragrunt find --experiment bounded-discovery --no-color --working-dir " +
+		fixtureDir + " --filter '...{./prod/db}' --discovery-boundary ./prod"
+
+	// The typed error does not survive the process boundary, so the class of
+	// failure is all a test at this level can pin.
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
+	require.ErrorContains(t, err, "discovery boundary")
+}
+
+// discoveredPaths returns the unit paths a discovery command printed.
+func discoveredPaths(stdout string) []string {
+	var paths []string
+
+	for _, line := range strings.Split(stdout, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			paths = append(paths, line)
+		}
+	}
+
+	return paths
+}

--- a/test/integration_discovery_boundary_tf_test.go
+++ b/test/integration_discovery_boundary_tf_test.go
@@ -1,0 +1,152 @@
+//go:build tf
+
+package test_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test which units a bounded run applies. Dependency traversal follows app's
+// declared path out of prod, so the boundary is what decides whether the run
+// reaches shared/dns or stops at the edge of prod.
+func TestTFDiscoveryBoundaryBoundsWhatRunAllApplies(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		args     string
+		expected []string
+	}{
+		{
+			name:     "unbounded traversal applies the unit outside the working directory",
+			args:     "--filter '{./app}...'",
+			expected: []string{"app", "db", "shared/dns"},
+		},
+		{
+			name:     "the boundary withholds it",
+			args:     "--filter '{./app}...' --discovery-boundary .",
+			expected: []string{"app", "db"},
+		},
+		{
+			name:     "an inline operand reaching wider overrides the boundary",
+			args:     "--filter '{./app}...(..)' --discovery-boundary .",
+			expected: []string{"app", "db", "shared/dns"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixtureDir, prodDir := copyDiscoveryBoundaryFixture(t)
+			reportFile := filepath.Join(prodDir, "report.json")
+
+			_, _, err := helpers.RunTerragruntCommandWithOutput(
+				t,
+				"terragrunt run --all --non-interactive --experiment bounded-discovery --working-dir "+prodDir+
+					" "+tc.args+" --report-file "+reportFile+" --report-format json -- apply -auto-approve",
+			)
+			require.NoError(t, err)
+
+			require.FileExists(t, reportFile)
+
+			runs, parseErr := report.ParseJSONRunsFromFile(reportFile)
+			require.NoError(t, parseErr)
+
+			assert.ElementsMatch(t, tc.expected, relativeRunNames(t, runs.Names(), fixtureDir))
+		})
+	}
+}
+
+// Test that the units a bounded run does apply are still ordered against the
+// dependency it withholds and still read that dependency's outputs. Withholding
+// a unit from the run is not the same as pretending it is not there.
+func TestTFDiscoveryBoundaryRunAllConsumesWithheldDependency(t *testing.T) {
+	t.Parallel()
+
+	fixtureDir, prodDir := copyDiscoveryBoundaryFixture(t)
+
+	// Apply the out-of-boundary dependency on its own, so its outputs come from
+	// state rather than from the mock prod/app declares.
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt apply -auto-approve --non-interactive --working-dir "+filepath.Join(fixtureDir, "shared", "dns"),
+	)
+	require.NoError(t, err)
+
+	reportFile := filepath.Join(prodDir, "report.json")
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt run --all --non-interactive --experiment bounded-discovery --working-dir "+prodDir+
+			" --filter '{./app}...' --discovery-boundary . --report-file "+reportFile+
+			" --report-format json -- apply -auto-approve",
+	)
+	require.NoError(t, err)
+
+	require.FileExists(t, reportFile)
+
+	runs, parseErr := report.ParseJSONRunsFromFile(reportFile)
+	require.NoError(t, parseErr)
+
+	require.ElementsMatch(t, []string{"app", "db"}, relativeRunNames(t, runs.Names(), fixtureDir))
+
+	app := runs.FindByName("app")
+	require.NotNil(t, app)
+
+	db := runs.FindByName("db")
+	require.NotNil(t, db)
+
+	assert.True(t, db.Started.Before(app.Started), "the in-boundary dependency still runs first")
+
+	// dns-applied is what shared/dns puts in state; dns-mocked is what app falls
+	// back to when the dependency cannot be read.
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt output -raw app_id -no-color --non-interactive --working-dir "+filepath.Join(prodDir, "app"),
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "dns-applied", "the withheld dependency's outputs were read from its state")
+}
+
+// copyDiscoveryBoundaryFixture stages the fixture and returns its root and the
+// prod directory the bounded runs work from.
+func copyDiscoveryBoundaryFixture(t *testing.T) (string, string) {
+	t.Helper()
+
+	helpers.CleanupTerraformFolder(t, testFixtureDiscoveryBoundary)
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureDiscoveryBoundary)
+	fixtureDir := filepath.Join(tmpEnvPath, testFixtureDiscoveryBoundary)
+
+	return fixtureDir, filepath.Join(fixtureDir, "prod")
+}
+
+// relativeRunNames restates the reported unit names against the fixture root, so
+// that a unit reported by absolute path because it sits outside the working
+// directory reads the same way as one reported relative to it.
+func relativeRunNames(t *testing.T, names []string, fixtureDir string) []string {
+	t.Helper()
+
+	relative := make([]string, 0, len(names))
+
+	for _, name := range names {
+		if filepath.IsAbs(name) {
+			rel, err := filepath.Rel(fixtureDir, name)
+			require.NoError(t, err)
+
+			name = filepath.ToSlash(rel)
+		}
+
+		relative = append(relative, name)
+	}
+
+	return relative
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Increases test coverage for the `bounded-discovery` experiment.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded discovery traversal to limit dependency and dependent discovery.
  * Added support for inline filter settings to override traversal boundaries.
  * Preserved dependency relationships and outputs when dependencies are outside the boundary.
  * Improved symlink-based traversal to retain logical paths, including symlinked roots.

* **Bug Fixes**
  * Rejected boundaries that exclude the current working directory.
  * Ensured discovery behavior remains consistent across environments and filter configurations.

* **Tests**
  * Added comprehensive unit and integration coverage for bounded discovery, Terraform execution, dependency ordering, and symlinked working directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->