### PR TITLE
fix: Tightening file permissions for generated files

### DIFF
--- a/internal/providercache/providercache.go
+++ b/internal/providercache/providercache.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -632,7 +631,8 @@ func (pc *ProviderCache) saveCLIConfig(fs vfs.FS, cfg *cliconfig.Config, filenam
 	}
 
 	if !cfgDirExists {
-		if err := fs.MkdirAll(cfgDir, os.ModePerm); err != nil {
+		const ownerReadWriteExecutePerms = 0o700
+		if err := fs.MkdirAll(cfgDir, ownerReadWriteExecutePerms); err != nil {
 			return err
 		}
 	}

--- a/internal/runner/common/unit_runner.go
+++ b/internal/runner/common/unit_runner.go
@@ -3,7 +3,6 @@ package common
 import (
 	"bytes"
 	"context"
-	"os"
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
@@ -195,11 +194,16 @@ func (runner *UnitRunner) Run(
 		outputFile := runner.Unit.OutputJSONFile(opts.RootWorkingDir, opts.JSONOutputFolder)
 		jsonDir := filepath.Dir(outputFile)
 
-		if err := v.FS.MkdirAll(jsonDir, os.ModePerm); err != nil {
+		const (
+			ownerReadWriteExecutePerms = 0o700
+			ownerReadWritePerms        = 0o600
+		)
+
+		if err := v.FS.MkdirAll(jsonDir, ownerReadWriteExecutePerms); err != nil {
 			return err
 		}
 
-		if err := vfs.WriteFile(v.FS, outputFile, stdout.Bytes(), os.ModePerm); err != nil {
+		if err := vfs.WriteFile(v.FS, outputFile, stdout.Bytes(), ownerReadWritePerms); err != nil {
 			return err
 		}
 	}

--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -369,9 +368,11 @@ func (rnr *Runner) Run(
 	terraformCmd := stackOpts.TerraformCommand
 
 	if stackOpts.OutputFolder != "" {
+		const ownerReadWriteExecutePerms = 0o700
+
 		for _, u := range rnr.Stack.Units {
 			planFile := u.OutputFile(stackOpts.RootWorkingDir, stackOpts.OutputFolder)
-			if err := v.FS.MkdirAll(filepath.Dir(planFile), os.ModePerm); err != nil {
+			if err := v.FS.MkdirAll(filepath.Dir(planFile), ownerReadWriteExecutePerms); err != nil {
 				return err
 			}
 		}

--- a/internal/tf/cliconfig/config.go
+++ b/internal/tf/cliconfig/config.go
@@ -200,12 +200,12 @@ func (cfg *Config) Save(configPath string) error {
 	file := hclwrite.NewEmptyFile()
 	gohcl.EncodeIntoBody(cfg, file.Body())
 
-	const ownerWriteGlobalReadPerms = 0644
+	const ownerReadWritePerms = 0o600
 	if err := vfs.WriteFile(
 		cfg.FS(),
 		configPath,
 		file.Bytes(),
-		ownerWriteGlobalReadPerms,
+		ownerReadWritePerms,
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Tightens file permissions that were too lax for some generated files.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved protection for CLI configuration files by restricting access to the file owner.
  * Restricted generated output files and directories to owner-only access.
  * Applied consistent private permissions when creating configuration and result directories.
  * Reduced the risk of unintended access to locally stored configuration and generated data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->