### PR TITLE
chore: Increasing venv coverage further

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,7 +107,7 @@ linters:
     forbidigo:
       analyze-types: true
       forbid:
-        - pattern: ^os\.(ReadFile|WriteFile|Open|OpenFile|Create|CreateTemp|MkdirTemp|Stat|Lstat|Mkdir|MkdirAll|Remove|RemoveAll|ReadDir|Rename|Symlink|Readlink|Chmod|Chdir|Getwd|Link|Truncate)$
+        - pattern: ^os\.(ReadFile|WriteFile|Open|OpenFile|OpenRoot|Create|CreateTemp|MkdirTemp|Stat|Lstat|Mkdir|MkdirAll|Remove|RemoveAll|ReadDir|Rename|Symlink|Readlink|Chmod|Chdir|Getwd|Link|Truncate)$
           pkg: ^os$
           msg: read and write through the venv's vfs.FS instead of the real filesystem
         - pattern: ^os\.(Getenv|Setenv|Unsetenv|LookupEnv|Environ|ExpandEnv)$
@@ -116,6 +116,9 @@ linters:
         - pattern: ^os\.(UserHomeDir|UserCacheDir|UserConfigDir)$
           pkg: ^os$
           msg: use the venv's Platform handles instead of reading the invoking user's directories
+        - pattern: ^os\.(Stdin|Stdout|Stderr)$
+          pkg: ^os$
+          msg: read and write the venv's Reader and Writers, and ask its Terminal whether a stream is a tty
         - pattern: ^exec\.(Command|CommandContext|LookPath)$
           pkg: ^os/exec$
           msg: spawn through the venv's vexec.Exec instead of os/exec
@@ -125,9 +128,23 @@ linters:
         - pattern: ^http\.Default(Client|Transport)$
           pkg: ^net/http$
           msg: send through the venv's vhttp.Client instead of the shared default client
+        # A composite literal builds a client without calling anything the rules
+        # above match, so it is the remaining way to reach the network past the
+        # venv. The two production sites that survive it are the GCS client
+        # constructors, whose nolint directives cover this rule as well; both
+        # wrap a transport derived from the venv's own client.
+        - pattern: ^http\.Client$
+          pkg: ^net/http$
+          msg: take the client from the venv's vhttp.Client rather than building one
+        - pattern: ^net\.(Listen|ListenPacket|ListenConfig)$
+          pkg: ^net$
+          msg: open sockets through the venv's Listen handle instead of binding directly
         - pattern: ^filepath\.(Walk|WalkDir|Glob)$
           pkg: ^path/filepath$
           msg: walk the venv's vfs.FS via vfs.WalkDir or vfs.WalkDirParallel instead of the real filesystem
+        - pattern: ^filepath\.EvalSymlinks$
+          pkg: ^path/filepath$
+          msg: resolve links on the venv's vfs.FS via vfs.EvalSymlinks, or vfs.ResolveForCompare when the result is to be compared against another path
         - pattern: ^(vfs\.NewOSFS|vexec\.NewOSExec|vhttp\.NewOSClient|vsops\.NewOSDecrypter)$
           msg: take the handle from the venv already in scope rather than building a fresh OS-backed one
         # Cloud SDKs build their own transport when handed no client, so these
@@ -190,11 +207,20 @@ linters:
       - linters:
           - forbidigo
         path: (_test\.go|^test/|^internal/git/server\.go)
-      # The packages that implement venv, plus the console and pty
-      # layer they sit on, are where the real OS calls are supposed to live.
+      # The packages that implement venv, plus the pty layer they sit on, are
+      # where the real OS calls are supposed to live. internal/os/signal and
+      # internal/os/stdout are deliberately outside this list: neither reaches
+      # the real OS any more, so neither should be able to start.
       - linters:
           - forbidigo
-        path: ^internal/(vfs|vexec|vhttp|vsops|venv|os)/
+        path: ^internal/(vfs|vexec|vhttp|vsops|venv)/|^internal/os/exec/
+      # A pty is the real terminal by definition, so the two callers that
+      # decide whether to allocate one read the real descriptor to do it.
+      # Both are reached only once the venv's Terminal has already reported
+      # that the stream is a tty.
+      - linters:
+          - forbidigo
+        path: ^(internal/view/tui/tty\.go|internal/tf/run_cmd\.go)$
 
       # Everything below are the call sites that predate the forbidigo
       # rules above. They reach the real OS directly and still need porting to
@@ -221,7 +247,7 @@ linters:
         path: ^pkg/options/options\.go$
       - linters:
           - forbidigo
-        path: ^(internal/discovery/helpers\.go|internal/discovery/phase_worktree\.go|internal/engine/engine\.go|internal/engine/verification\.go|internal/getter/tfrhelpers\.go|internal/git/git\.go|internal/panicreport/panicreport\.go|internal/remotestate/remote_state\.go|internal/remotestate/terraform_state_file\.go|internal/report/writer\.go|internal/services/catalog/module/doc\.go|internal/services/catalog/module/module\.go|internal/shell/git\.go|internal/shell/run_cmd\.go|internal/stacks/clean/clean\.go|internal/tfimpl/tfimpl\.go|internal/util/lockfile\.go|internal/worktrees/worktrees\.go)$
+        path: ^(internal/discovery/phase_worktree\.go|internal/engine/engine\.go|internal/engine/verification\.go|internal/getter/tfrhelpers\.go|internal/git/git\.go|internal/remotestate/remote_state\.go|internal/remotestate/terraform_state_file\.go|internal/report/writer\.go|internal/services/catalog/module/doc\.go|internal/services/catalog/module/module\.go|internal/shell/run_cmd\.go|internal/stacks/clean/clean\.go|internal/tfimpl/tfimpl\.go|internal/util/lockfile\.go|internal/worktrees/worktrees\.go)$
       # We end up with duplicated content in this package to save us from duplicating code in other packages.
       - linters:
           - dupl

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/hashicorp/terraform-svchost v0.2.1
 	github.com/huandu/go-clone v1.7.3
 	github.com/labstack/echo/v4 v4.15.4
-	github.com/mattn/go-isatty v0.0.24
+	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mattn/go-zglob v0.0.6
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
@@ -89,7 +89,6 @@ require (
 	github.com/aws/smithy-go v1.27.6
 	github.com/charlievieth/fastwalk v1.0.14
 	github.com/charmbracelet/x/ansi v0.11.7
-	github.com/charmbracelet/x/term v0.2.2
 	github.com/getsops/sops/v3 v3.12.2
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/gobwas/glob v0.2.3
@@ -178,6 +177,7 @@ require (
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260713092251-4bee1914c0cf // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20260713092006-0d683c34c74b // indirect
+	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect

--- a/internal/azurehelper/blob_test.go
+++ b/internal/azurehelper/blob_test.go
@@ -175,7 +175,12 @@ func TestBlobClient_CopyBlob_RequiresArgs(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		assert.Panics(t, func() { _ = c.Container(tc[0]).CopyBlob(t.Context(), log.New(), tc[1], c.Container(tc[2]), tc[3]) }, "CopyBlob%v should panic", tc)
+		assert.Panics(
+			t,
+			func() { _ = c.Container(tc[0]).CopyBlob(t.Context(), log.New(), tc[1], c.Container(tc[2]), tc[3]) },
+			"CopyBlob%v should panic",
+			tc,
+		)
 	}
 }
 
@@ -201,8 +206,7 @@ func TestBlob_LiveRoundTrip(t *testing.T) {
 			StorageAccountName: account,
 			UseAzureADAuth:     new(true),
 		}).
-		WithVenv(testVenv).
-		Build(log.New())
+		Build(log.New(), testVenv)
 	require.NoError(t, err, "Build config")
 
 	bc, err := azurehelper.NewBlobClient(cfg)

--- a/internal/azurehelper/config.go
+++ b/internal/azurehelper/config.go
@@ -66,14 +66,12 @@ func isUnset(v *bool) bool {
 // Use NewAzureConfigBuilder to create, chain With* methods, then call Build().
 type AzureConfigBuilder struct {
 	sessionConfig *AzureSessionConfig
-	venv          *venv.Venv
 }
 
 // NewAzureConfigBuilder creates a new builder for AzureConfig.
 func NewAzureConfigBuilder() *AzureConfigBuilder {
 	return &AzureConfigBuilder{
 		sessionConfig: &AzureSessionConfig{},
-		venv:          (&venv.Venv{}).WithEnv(map[string]string{}),
 	}
 }
 
@@ -84,25 +82,6 @@ func (b *AzureConfigBuilder) WithSessionConfig(cfg *AzureSessionConfig) *AzureCo
 	}
 
 	b.sessionConfig = cfg
-
-	return b
-}
-
-// WithVenv sets the virtualized environment whose Env map feeds ARM_* /
-// AZURE_* fallback resolution; the builder never reads the process
-// environment itself.
-func (b *AzureConfigBuilder) WithVenv(v *venv.Venv) *AzureConfigBuilder {
-	if v == nil {
-		return b
-	}
-
-	// WithEnv panics on a nil map, so an unset Env resolves to no fallbacks.
-	env := v.Env
-	if env == nil {
-		env = map[string]string{}
-	}
-
-	b.venv = v.WithEnv(env)
 
 	return b
 }
@@ -168,10 +147,13 @@ type AzureConfig struct {
 //
 // Environment variable fallbacks (ARM_* / AZURE_*) are applied to subscription,
 // tenant, client id, client secret, SAS token, and access key when the session
-// config leaves them empty.
-func (b *AzureConfigBuilder) Build(l log.Logger) (*AzureConfig, error) {
+// config leaves them empty. They resolve from v.Env; the process environment is
+// never consulted, so resolution stays fully caller-controlled.
+func (b *AzureConfigBuilder) Build(l log.Logger, v *venv.Venv) (*AzureConfig, error) {
+	v.RequireEnv()
+
 	resolved := *b.sessionConfig
-	b.applyEnvFallbacks(&resolved)
+	applyEnvFallbacks(v.Env, &resolved)
 
 	cloudCfg, err := CloudConfigForEnvironment(resolved.CloudEnvironment)
 	if err != nil {
@@ -244,7 +226,7 @@ func (b *AzureConfigBuilder) Build(l log.Logger) (*AzureConfig, error) {
 		// over the token file, matching the native azurerm backend. Without
 		// this, a CI config that authenticates fine during `tofu init` would
 		// fail during Terragrunt's own lifecycle operations.
-		if getAssertion := b.oidcAssertionProvider(); getAssertion != nil {
+		if getAssertion := oidcAssertionProvider(v); getAssertion != nil {
 			cred, err := azidentity.NewClientAssertionCredential(
 				resolved.TenantID, resolved.ClientID, getAssertion,
 				&azidentity.ClientAssertionCredentialOptions{ClientOptions: clientOpts},
@@ -344,8 +326,8 @@ func chainedCredential(defaultCred azcore.TokenCredential, tenantID string, l lo
 
 // BuildBlobClient is a convenience that calls Build and then constructs a
 // BlobClient from the resulting AzureConfig.
-func (b *AzureConfigBuilder) BuildBlobClient(l log.Logger) (*BlobClient, error) {
-	cfg, err := b.Build(l)
+func (b *AzureConfigBuilder) BuildBlobClient(l log.Logger, v *venv.Venv) (*BlobClient, error) {
+	cfg, err := b.Build(l, v)
 	if err != nil {
 		return nil, err
 	}
@@ -361,12 +343,17 @@ func (b *AzureConfigBuilder) BuildBlobClient(l log.Logger) (*BlobClient, error) 
 // SAS-token and access-key auth methods are rejected up-front because they
 // cannot reach the ARM control plane; the rejection happens before Build
 // emits any auth-resolution debug logs, keeping the failure mode obvious.
-func (b *AzureConfigBuilder) BuildStorageAccountClient(l log.Logger) (*StorageAccountClient, error) {
+func (b *AzureConfigBuilder) BuildStorageAccountClient(
+	l log.Logger,
+	v *venv.Venv,
+) (*StorageAccountClient, error) {
+	v.RequireEnv()
+
 	// Pre-flight against env-resolved values as well, not just the explicitly
 	// supplied sessionConfig: ARM_SAS_TOKEN / ARM_ACCESS_KEY would otherwise
 	// reach Build and fail with a less obvious error from the ARM client.
 	preflight := *b.sessionConfig
-	b.applyEnvFallbacks(&preflight)
+	applyEnvFallbacks(v.Env, &preflight)
 
 	switch {
 	case preflight.SasToken != "":
@@ -375,7 +362,7 @@ func (b *AzureConfigBuilder) BuildStorageAccountClient(l log.Logger) (*StorageAc
 		return nil, &UnsupportedAuthForOpError{Method: AuthMethodAccessKey, Operation: "storage account operations"}
 	}
 
-	cfg, err := b.Build(l)
+	cfg, err := b.Build(l, v)
 	if err != nil {
 		return nil, err
 	}
@@ -383,9 +370,9 @@ func (b *AzureConfigBuilder) BuildStorageAccountClient(l log.Logger) (*StorageAc
 	return NewStorageAccountClient(cfg)
 }
 
-// applyEnvFallbacks fills empty fields on cfg from the builder's env map.
+// applyEnvFallbacks fills empty fields on cfg from env.
 // Mirrors the ARM_* and AZURE_* names used by the OpenTofu azurerm backend.
-func (b *AzureConfigBuilder) applyEnvFallbacks(cfg *AzureSessionConfig) {
+func applyEnvFallbacks(env map[string]string, cfg *AzureSessionConfig) {
 	fallbacks := []struct {
 		field *string
 		keys  []string
@@ -411,22 +398,22 @@ func (b *AzureConfigBuilder) applyEnvFallbacks(cfg *AzureSessionConfig) {
 		*fb.field = strings.TrimSpace(*fb.field)
 
 		if *fb.field == "" {
-			*fb.field = strings.TrimSpace(b.firstEnv(fb.keys...))
+			*fb.field = strings.TrimSpace(firstEnv(env, fb.keys...))
 		}
 	}
 
 	// Only an UNSET flag may be turned on by the environment. A user who wrote
 	// `use_msi = false` has said what they want, and a stray ARM_USE_MSI on the
 	// runner must not override it.
-	if isUnset(cfg.UseMSI) && parseBool(b.firstEnv("ARM_USE_MSI")) {
+	if isUnset(cfg.UseMSI) && parseBool(firstEnv(env, "ARM_USE_MSI")) {
 		cfg.UseMSI = new(true)
 	}
 
-	if isUnset(cfg.UseOIDC) && parseBool(b.firstEnv("ARM_USE_OIDC")) {
+	if isUnset(cfg.UseOIDC) && parseBool(firstEnv(env, "ARM_USE_OIDC")) {
 		cfg.UseOIDC = new(true)
 	}
 
-	if isUnset(cfg.UseAzureADAuth) && parseBool(b.firstEnv("ARM_USE_AZUREAD", "ARM_USE_AZUREAD_AUTH")) {
+	if isUnset(cfg.UseAzureADAuth) && parseBool(firstEnv(env, "ARM_USE_AZUREAD", "ARM_USE_AZUREAD_AUTH")) {
 		cfg.UseAzureADAuth = new(true)
 	}
 
@@ -443,17 +430,17 @@ func (b *AzureConfigBuilder) applyEnvFallbacks(cfg *AzureSessionConfig) {
 	// the same way a token file does. CI injects these without ARM_USE_OIDC, so
 	// without this the request-url flows would be unreachable.
 	if isUnset(cfg.UseOIDC) && !util.Deref(cfg.UseMSI) && !util.Deref(cfg.UseAzureADAuth) &&
-		b.firstEnv("ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL", "SYSTEM_OIDCREQUESTURI") != "" {
+		firstEnv(env, "ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL", "SYSTEM_OIDCREQUESTURI") != "" {
 		cfg.UseOIDC = new(true)
 	}
 }
 
-// firstEnv returns the first non-empty value found for keys in the builder's
-// venv environment; the process environment is never consulted, so resolution
-// stays hermetic and fully caller-controlled.
-func (b *AzureConfigBuilder) firstEnv(keys ...string) string {
+// firstEnv returns the first non-empty value found for keys in env; the process
+// environment is never consulted, so resolution stays hermetic and fully
+// caller-controlled.
+func firstEnv(env map[string]string, keys ...string) string {
 	for _, k := range keys {
-		if v := b.venv.Env[k]; v != "" {
+		if v := env[k]; v != "" {
 			return v
 		}
 	}

--- a/internal/azurehelper/config_test.go
+++ b/internal/azurehelper/config_test.go
@@ -109,8 +109,7 @@ func TestBuild_AuthMethodPrecedence(t *testing.T) {
 
 			got, err := azurehelper.NewAzureConfigBuilder().
 				WithSessionConfig(&tc.cfg).
-				WithVenv(isolatedEnv()).
-				Build(log.New())
+				Build(log.New(), isolatedEnv())
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, got.Method)
 
@@ -132,11 +131,10 @@ func TestBuild_EnvFallbacks(t *testing.T) {
 		WithSessionConfig(&azurehelper.AzureSessionConfig{
 			StorageAccountName: testAccount,
 		}).
-		WithVenv(isolatedEnv(
+		Build(log.New(), isolatedEnv(
 			"ARM_SAS_TOKEN", "sv=test",
 			"ARM_SUBSCRIPTION_ID", "sub-from-env",
-		)).
-		Build(log.New())
+		))
 	require.NoError(t, err)
 	assert.Equal(t, azurehelper.AuthMethodSasToken, cfg.Method)
 	assert.Equal(t, "sv=test", cfg.SasToken)
@@ -147,8 +145,7 @@ func TestBuild_TrimsWhitespaceFromEnvValues(t *testing.T) {
 	// CI often injects secrets with a trailing newline; it must be trimmed.
 	cfg, err := azurehelper.NewAzureConfigBuilder().
 		WithSessionConfig(&azurehelper.AzureSessionConfig{StorageAccountName: testAccount, SasToken: testSASToken}).
-		WithVenv(isolatedEnv("ARM_SUBSCRIPTION_ID", "sub-from-env\n")).
-		Build(log.New())
+		Build(log.New(), isolatedEnv("ARM_SUBSCRIPTION_ID", "sub-from-env\n"))
 	require.NoError(t, err)
 	assert.Equal(t, "sub-from-env", cfg.SubscriptionID, "env values must be trimmed")
 }
@@ -158,8 +155,7 @@ func TestBuild_StorageAccountNameEnvFallback(t *testing.T) {
 	// SAS auth requires a storage account; supply it only via AZURE_STORAGE_ACCOUNT.
 	cfg, err := azurehelper.NewAzureConfigBuilder().
 		WithSessionConfig(&azurehelper.AzureSessionConfig{SasToken: testSASToken}).
-		WithVenv(isolatedEnv("AZURE_STORAGE_ACCOUNT", "acct-from-env")).
-		Build(log.New())
+		Build(log.New(), isolatedEnv("AZURE_STORAGE_ACCOUNT", "acct-from-env"))
 	require.NoError(t, err)
 	assert.Equal(t, "acct-from-env", cfg.AccountName)
 }
@@ -176,8 +172,7 @@ func TestBuild_SubscriptionNotRequiredForDataPlane(t *testing.T) {
 			StorageAccountName: testAccount,
 			UseAzureADAuth:     new(true),
 		}).
-		WithVenv(isolatedEnv()).
-		Build(log.New())
+		Build(log.New(), isolatedEnv())
 	require.NoError(t, err)
 	assert.Empty(t, cfg.SubscriptionID)
 }
@@ -193,8 +188,7 @@ func TestSubscriptionRequiredAtArmBoundary(t *testing.T) {
 			ResourceGroupName:  "rg",
 			UseAzureADAuth:     new(true),
 		}).
-		WithVenv(isolatedEnv()).
-		Build(log.New())
+		Build(log.New(), isolatedEnv())
 	require.NoError(t, err)
 
 	_, err = azurehelper.NewStorageAccountClient(cfg)
@@ -211,8 +205,7 @@ func TestBuild_SasTokenWithoutAccountFails(t *testing.T) {
 		WithSessionConfig(&azurehelper.AzureSessionConfig{
 			SasToken: "sv=test",
 		}).
-		WithVenv(isolatedEnv()).
-		Build(log.New())
+		Build(log.New(), isolatedEnv())
 	require.ErrorIs(t, err, azurehelper.ErrStorageAccountRequired)
 }
 
@@ -224,8 +217,7 @@ func TestBuild_AccessKeyWithoutAccountFails(t *testing.T) {
 		WithSessionConfig(&azurehelper.AzureSessionConfig{
 			AccessKey: "a2V5", // base64("key")
 		}).
-		WithVenv(isolatedEnv()).
-		Build(log.New())
+		Build(log.New(), isolatedEnv())
 	require.ErrorIs(t, err, azurehelper.ErrStorageAccountRequired)
 }
 
@@ -254,8 +246,7 @@ func TestBuild_CloudEnvironmentMapping(t *testing.T) {
 					SasToken:           testSASToken,
 					CloudEnvironment:   tc.env,
 				}).
-				WithVenv(isolatedEnv()).
-				Build(log.New())
+				Build(log.New(), isolatedEnv())
 			require.NoError(t, err)
 			assert.Equal(t, tc.want.ActiveDirectoryAuthorityHost, cfg.CloudConfig.ActiveDirectoryAuthorityHost)
 		})
@@ -266,8 +257,7 @@ func TestBuild_NilSessionConfig(t *testing.T) {
 	t.Parallel()
 
 	cfg, err := azurehelper.NewAzureConfigBuilder().
-		WithVenv(isolatedEnv("ARM_SUBSCRIPTION_ID", "sub")).
-		Build(log.New())
+		Build(log.New(), isolatedEnv("ARM_SUBSCRIPTION_ID", "sub"))
 	require.NoError(t, err)
 	assert.Equal(t, "sub", cfg.SubscriptionID)
 	assert.Equal(t, azurehelper.AuthMethodAzureAD, cfg.Method)
@@ -281,8 +271,7 @@ func TestBuildBlobClient_SasToken(t *testing.T) {
 			StorageAccountName: testAccount,
 			SasToken:           testSASToken,
 		}).
-		WithVenv(isolatedEnv()).
-		BuildBlobClient(log.New())
+		BuildBlobClient(log.New(), isolatedEnv())
 	require.NoError(t, err, "BuildBlobClient")
 	require.NotNil(t, bc)
 	assert.Equal(t, testAccount, bc.AccountName)
@@ -293,8 +282,7 @@ func TestBuildBlobClient_PropagatesBuildError(t *testing.T) {
 	// No StorageAccountName set anywhere -> Build's validate() rejects.
 	_, err := azurehelper.NewAzureConfigBuilder().
 		WithSessionConfig(&azurehelper.AzureSessionConfig{SasToken: testSASToken}).
-		WithVenv(isolatedEnv()).
-		BuildBlobClient(log.New())
+		BuildBlobClient(log.New(), isolatedEnv())
 	require.ErrorIs(t, err, azurehelper.ErrStorageAccountRequired)
 }
 
@@ -307,8 +295,7 @@ func TestBuild_RejectsUnknownCloudEnvironment(t *testing.T) {
 			SasToken:           testSASToken,
 			CloudEnvironment:   "governmnt", // typo
 		}).
-		WithVenv(isolatedEnv()).
-		Build(log.New())
+		Build(log.New(), isolatedEnv())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cloud environment")
 }
@@ -321,8 +308,7 @@ func TestBuildStorageAccountClient_RequiresArmFields(t *testing.T) {
 			StorageAccountName: testAccount,
 			SasToken:           testSASToken,
 		}).
-		WithVenv(isolatedEnv()).
-		BuildStorageAccountClient(log.New())
+		BuildStorageAccountClient(log.New(), isolatedEnv())
 	require.Error(t, err, "ARM-plane fields are required for a storage account client")
 }
 
@@ -352,8 +338,7 @@ func TestBuild_CarriesAuthorizationMode(t *testing.T) {
 			StorageAccountName: testAccount,
 			UseAzureADAuth:     new(true),
 		}).
-		WithVenv(isolatedEnv()).
-		Build(log.New())
+		Build(log.New(), isolatedEnv())
 	require.NoError(t, err)
 	assert.True(t, entra.UseAzureADAuth, "use_azuread_auth must reach the resolved config")
 
@@ -365,8 +350,7 @@ func TestBuild_CarriesAuthorizationMode(t *testing.T) {
 			ClientID:           "cid",
 			ClientSecret:       "sec",
 		}).
-		WithVenv(isolatedEnv()).
-		Build(log.New())
+		Build(log.New(), isolatedEnv())
 	require.NoError(t, err)
 	assert.False(t, sharedKey.UseAzureADAuth, "an unset use_azuread_auth must not imply Entra authorization")
 }

--- a/internal/azurehelper/oidc.go
+++ b/internal/azurehelper/oidc.go
@@ -37,13 +37,11 @@ type assertionProvider func(ctx context.Context) (string, error)
 // request URL wins, then GitHub Actions, then Azure DevOps. It returns nil when
 // no request-URL flow is configured, leaving the token-file (workload identity)
 // path to handle it.
-func (b *AzureConfigBuilder) oidcAssertionProvider() assertionProvider {
-	v := b.venv
-
+func oidcAssertionProvider(v *venv.Venv) assertionProvider {
 	// GitHub Actions injects both variables into every job that requests the
 	// id-token permission.
-	if requestURL := b.firstEnv("ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL"); requestURL != "" {
-		token := b.firstEnv("ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+	if requestURL := firstEnv(v.Env, "ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL"); requestURL != "" {
+		token := firstEnv(v.Env, "ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN")
 
 		return func(ctx context.Context) (string, error) {
 			return fetchOIDCAssertion(ctx, v, requestURL, token, "value")
@@ -51,8 +49,8 @@ func (b *AzureConfigBuilder) oidcAssertionProvider() assertionProvider {
 	}
 
 	// Azure DevOps workload identity federation.
-	if requestURL := b.firstEnv("SYSTEM_OIDCREQUESTURI"); requestURL != "" {
-		token := b.firstEnv("SYSTEM_ACCESSTOKEN")
+	if requestURL := firstEnv(v.Env, "SYSTEM_OIDCREQUESTURI"); requestURL != "" {
+		token := firstEnv(v.Env, "SYSTEM_ACCESSTOKEN")
 
 		return func(ctx context.Context) (string, error) {
 			return fetchOIDCAssertion(ctx, v, requestURL, token, "oidcToken")

--- a/internal/azurehelper/oidc_internal_test.go
+++ b/internal/azurehelper/oidc_internal_test.go
@@ -26,7 +26,7 @@ func TestOIDCAssertionProvider_GitHubActions(t *testing.T) {
 
 	var gotURL, gotAuth string
 
-	b := oidcTestBuilder(map[string]string{
+	v := oidcTestVenv(map[string]string{
 		"ACTIONS_ID_TOKEN_REQUEST_URL":   "https://pipelines.example/token",
 		"ACTIONS_ID_TOKEN_REQUEST_TOKEN": "runner-token",
 	}, func(_ context.Context, req *http.Request) (*http.Response, error) {
@@ -36,7 +36,7 @@ func TestOIDCAssertionProvider_GitHubActions(t *testing.T) {
 		return oidcJSON(http.StatusOK, `{"value":"assertion-jwt"}`), nil
 	})
 
-	getAssertion := b.oidcAssertionProvider()
+	getAssertion := oidcAssertionProvider(v)
 	require.NotNil(t, getAssertion, "a request url must select the assertion flow")
 
 	assertion, err := getAssertion(t.Context())
@@ -51,7 +51,7 @@ func TestOIDCAssertionProvider_GitHubActions(t *testing.T) {
 func TestOIDCAssertionProvider_AzureDevOps(t *testing.T) {
 	t.Parallel()
 
-	b := oidcTestBuilder(map[string]string{
+	v := oidcTestVenv(map[string]string{
 		"SYSTEM_OIDCREQUESTURI": "https://dev.azure.example/oidc",
 		"SYSTEM_ACCESSTOKEN":    "ado-token",
 	}, func(_ context.Context, _ *http.Request) (*http.Response, error) {
@@ -59,7 +59,7 @@ func TestOIDCAssertionProvider_AzureDevOps(t *testing.T) {
 		return oidcJSON(http.StatusOK, `{"oidcToken":"assertion-jwt"}`), nil
 	})
 
-	getAssertion := b.oidcAssertionProvider()
+	getAssertion := oidcAssertionProvider(v)
 	require.NotNil(t, getAssertion)
 
 	assertion, err := getAssertion(t.Context())
@@ -70,7 +70,7 @@ func TestOIDCAssertionProvider_AzureDevOps(t *testing.T) {
 func TestOIDCAssertionProvider_MissingRequestToken(t *testing.T) {
 	t.Parallel()
 
-	b := oidcTestBuilder(map[string]string{
+	v := oidcTestVenv(map[string]string{
 		"ACTIONS_ID_TOKEN_REQUEST_URL": "https://pipelines.example/token",
 	}, func(_ context.Context, _ *http.Request) (*http.Response, error) {
 		t.Fatal("no request must be made without a bearer token")
@@ -78,7 +78,7 @@ func TestOIDCAssertionProvider_MissingRequestToken(t *testing.T) {
 		return nil, nil
 	})
 
-	_, err := b.oidcAssertionProvider()(t.Context())
+	_, err := oidcAssertionProvider(v)(t.Context())
 
 	var missing *OIDCRequestTokenMissingError
 	require.ErrorAs(t, err, &missing)
@@ -88,14 +88,14 @@ func TestOIDCAssertionProvider_MissingRequestToken(t *testing.T) {
 func TestOIDCAssertionProvider_EndpointFailure(t *testing.T) {
 	t.Parallel()
 
-	b := oidcTestBuilder(map[string]string{
+	v := oidcTestVenv(map[string]string{
 		"ACTIONS_ID_TOKEN_REQUEST_URL":   "https://pipelines.example/token",
 		"ACTIONS_ID_TOKEN_REQUEST_TOKEN": "runner-token",
 	}, func(_ context.Context, _ *http.Request) (*http.Response, error) {
 		return oidcJSON(http.StatusForbidden, `denied`), nil
 	})
 
-	_, err := b.oidcAssertionProvider()(t.Context())
+	_, err := oidcAssertionProvider(v)(t.Context())
 
 	var failed *OIDCTokenRequestFailedError
 	require.ErrorAs(t, err, &failed)
@@ -105,14 +105,14 @@ func TestOIDCAssertionProvider_EndpointFailure(t *testing.T) {
 func TestOIDCAssertionProvider_MissingField(t *testing.T) {
 	t.Parallel()
 
-	b := oidcTestBuilder(map[string]string{
+	v := oidcTestVenv(map[string]string{
 		"ACTIONS_ID_TOKEN_REQUEST_URL":   "https://pipelines.example/token",
 		"ACTIONS_ID_TOKEN_REQUEST_TOKEN": "runner-token",
 	}, func(_ context.Context, _ *http.Request) (*http.Response, error) {
 		return oidcJSON(http.StatusOK, `{"unexpected":"shape"}`), nil
 	})
 
-	_, err := b.oidcAssertionProvider()(t.Context())
+	_, err := oidcAssertionProvider(v)(t.Context())
 
 	var missing *OIDCTokenFieldMissingError
 	require.ErrorAs(t, err, &missing)
@@ -124,13 +124,13 @@ func TestOIDCAssertionProvider_MissingField(t *testing.T) {
 func TestOIDCAssertionProvider_NoRequestURL(t *testing.T) {
 	t.Parallel()
 
-	b := oidcTestBuilder(map[string]string{}, func(_ context.Context, _ *http.Request) (*http.Response, error) {
+	v := oidcTestVenv(map[string]string{}, func(_ context.Context, _ *http.Request) (*http.Response, error) {
 		t.Fatal("no request must be made when no request url is configured")
 
 		return nil, nil
 	})
 
-	assert.Nil(t, b.oidcAssertionProvider())
+	assert.Nil(t, oidcAssertionProvider(v))
 }
 
 // TestApplyEnvFallbacks_RequestURLImpliesOIDC verifies a federated token
@@ -143,23 +143,23 @@ func TestApplyEnvFallbacks_RequestURLImpliesOIDC(t *testing.T) {
 		t.Run(key, func(t *testing.T) {
 			t.Parallel()
 
-			b := oidcTestBuilder(map[string]string{key: "https://example/token"}, nil)
+			v := oidcTestVenv(map[string]string{key: "https://example/token"}, nil)
 
 			cfg := &AzureSessionConfig{}
-			b.applyEnvFallbacks(cfg)
+			applyEnvFallbacks(v.Env, cfg)
 
 			assert.True(t, util.Deref(cfg.UseOIDC), "%s must select the OIDC tier", key)
 		})
 	}
 }
 
-func oidcTestBuilder(env map[string]string, h vhttp.Handler) *AzureConfigBuilder {
+func oidcTestVenv(env map[string]string, h vhttp.Handler) *venv.Venv {
 	v := &venv.Venv{}
 	if h != nil {
 		v.HTTP = vhttp.NewMemClient(h)
 	}
 
-	return NewAzureConfigBuilder().WithVenv(v.WithEnv(env))
+	return v.WithEnv(env)
 }
 
 func oidcJSON(status int, body string) *http.Response {
@@ -178,7 +178,7 @@ func oidcJSON(status int, body string) *http.Response {
 func TestApplyEnvFallbacks_ExplicitFalseWins(t *testing.T) {
 	t.Parallel()
 
-	b := oidcTestBuilder(map[string]string{
+	v := oidcTestVenv(map[string]string{
 		"ARM_USE_MSI":     "true",
 		"ARM_USE_OIDC":    "true",
 		"ARM_USE_AZUREAD": "true",
@@ -189,7 +189,7 @@ func TestApplyEnvFallbacks_ExplicitFalseWins(t *testing.T) {
 		UseOIDC:        new(false),
 		UseAzureADAuth: new(false),
 	}
-	b.applyEnvFallbacks(cfg)
+	applyEnvFallbacks(v.Env, cfg)
 
 	assert.False(t, util.Deref(cfg.UseMSI), "an explicit use_msi = false must win over ARM_USE_MSI")
 	assert.False(t, util.Deref(cfg.UseOIDC), "an explicit use_oidc = false must win over ARM_USE_OIDC")
@@ -197,6 +197,6 @@ func TestApplyEnvFallbacks_ExplicitFalseWins(t *testing.T) {
 
 	// An UNSET flag is still enabled by the environment.
 	unset := &AzureSessionConfig{}
-	b.applyEnvFallbacks(unset)
+	applyEnvFallbacks(v.Env, unset)
 	assert.True(t, util.Deref(unset.UseMSI), "an unset flag must still honor ARM_USE_MSI")
 }

--- a/internal/cas/benchmark_test.go
+++ b/internal/cas/benchmark_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -24,7 +23,7 @@ func BenchmarkClone(b *testing.B) {
 
 	l := logger.CreateLogger()
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	b.Run("fresh clone", func(b *testing.B) {
 		tempDir := b.TempDir()
@@ -89,7 +88,7 @@ func BenchmarkContent(b *testing.B) {
 
 	l := logger.CreateLogger()
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	b.Run("store", func(b *testing.B) {
 		for i := 0; b.Loop(); i++ {

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -868,8 +868,8 @@ func (c *CAS) ensureBlob(
 	return nil
 }
 
-func hashFile(fs vfs.FS, path string) (string, error) {
-	file, err := fs.Open(path)
+func hashFile(fsys vfs.FS, path string) (string, error) {
+	file, err := fsys.Open(path)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cas/cas_test.go
+++ b/internal/cas/cas_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -21,7 +20,7 @@ func TestCAS_Clone(t *testing.T) {
 	l := logger.CreateLogger()
 	repoURL := startTestServer(t)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	t.Run("clone new repository", func(t *testing.T) {
 		t.Parallel()
@@ -108,7 +107,7 @@ func TestCAS_FallbackWhenGitStoreFails(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	err = c.Clone(t.Context(), logger.CreateLogger(), v, repoURL, cas.WithDir(targetPath),
 		cas.WithDepth(-1))
@@ -146,7 +145,7 @@ func TestCAS_CloneRepoWithSymlink(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	err = c.Clone(t.Context(), logger.CreateLogger(), v, repoURL, cas.WithDir(targetPath),
 		cas.WithDepth(-1))

--- a/internal/cas/clone_e2e_test.go
+++ b/internal/cas/clone_e2e_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -27,7 +26,7 @@ func TestCASClone_E2E_SymbolicRefSecondRunReusesCache(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 
@@ -68,7 +67,7 @@ func TestCASClone_E2E_CommitFormRefRoundTrip(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 
@@ -97,7 +96,7 @@ func TestCASClone_E2E_ThroughCASGetter(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 
@@ -144,7 +143,7 @@ func TestCASClone_E2E_RemainsOfflineAfterFirstClone(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 
@@ -182,7 +181,7 @@ func TestCASClone_E2E_MutableSetCopiesBlobs(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 

--- a/internal/cas/commitref_test.go
+++ b/internal/cas/commitref_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -25,7 +24,7 @@ func TestCASCloneByCommitRef(t *testing.T) {
 	repoURL := startTestServer(t)
 	headHash := resolveHead(t, repoURL)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	t.Run("clone with full commit SHA", func(t *testing.T) {
 		t.Parallel()
@@ -194,7 +193,7 @@ func TestCASClone_NonTipCommit(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	targetPath := filepath.Join(tempDir, "repo")
 	err = c.Clone(t.Context(), logger.CreateLogger(), v, repoURL, cas.WithDir(targetPath),
@@ -244,7 +243,7 @@ func TestCASClone_AbbreviatedHexBranchAdvancesAcrossClones(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 
@@ -297,7 +296,7 @@ func TestCASClone_HexBranchNameResolvesViaLsRemote(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	targetPath := filepath.Join(tempDir, "repo")
 	err = c.Clone(t.Context(), logger.CreateLogger(), v, repoURL, cas.WithDir(targetPath),
@@ -326,7 +325,7 @@ func TestCASClone_TagRef(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	targetPath := filepath.Join(tempDir, "repo")
 	err = c.Clone(t.Context(), logger.CreateLogger(), v, repoURL, cas.WithDir(targetPath),
@@ -484,7 +483,7 @@ func TestCASClone_OfflineWhenCommitCached(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 
@@ -520,7 +519,7 @@ func TestCASGetterGet_WithCommitRef(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &cas.CloneOptions{Depth: -1})
 	client := getter.Client{Getters: []getter.Getter{g}}
@@ -561,7 +560,7 @@ func TestCAS_CommitRefFallbackWhenGitStoreFails(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	targetPath := filepath.Join(tempDir, "repo")
 	err = c.Clone(t.Context(), logger.CreateLogger(), v, repoURL, cas.WithDir(targetPath),
@@ -590,7 +589,7 @@ func TestCASCloneByCommitRefConcurrentWithRacing(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	const workers = 4
 

--- a/internal/cas/content_test.go
+++ b/internal/cas/content_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -137,7 +136,7 @@ func TestContent_Link(t *testing.T) {
 	t.Run("create hard link on real filesystem", func(t *testing.T) {
 		t.Parallel()
 
-		v := venv.OSVenv()
+		v := venvtest.NewOSWithEmptyEnv()
 
 		storeDir := t.TempDir()
 		targetDir := t.TempDir()
@@ -166,7 +165,7 @@ func TestContent_Link(t *testing.T) {
 	t.Run("force copy creates independent inode on real filesystem", func(t *testing.T) {
 		t.Parallel()
 
-		v := venv.OSVenv()
+		v := venvtest.NewOSWithEmptyEnv()
 
 		storeDir := t.TempDir()
 		targetDir := t.TempDir()
@@ -212,7 +211,7 @@ func TestContent_Link(t *testing.T) {
 	t.Run("default path strips write bit from non-executable", func(t *testing.T) {
 		t.Parallel()
 
-		v := venv.OSVenv()
+		v := venvtest.NewOSWithEmptyEnv()
 
 		storeDir := t.TempDir()
 		targetDir := t.TempDir()
@@ -238,7 +237,7 @@ func TestContent_Link(t *testing.T) {
 		func(t *testing.T) {
 			t.Parallel()
 
-			v := venv.OSVenv()
+			v := venvtest.NewOSWithEmptyEnv()
 
 			storeDir := t.TempDir()
 			targetDir := t.TempDir()
@@ -274,7 +273,7 @@ func TestContent_Link(t *testing.T) {
 	t.Run("default path falls back to copy on perm collision", func(t *testing.T) {
 		t.Parallel()
 
-		v := venv.OSVenv()
+		v := venvtest.NewOSWithEmptyEnv()
 
 		storeDir := t.TempDir()
 		targetDir := t.TempDir()
@@ -307,7 +306,7 @@ func TestContent_Link(t *testing.T) {
 	t.Run("force copy preserves executable bits", func(t *testing.T) {
 		t.Parallel()
 
-		v := venv.OSVenv()
+		v := venvtest.NewOSWithEmptyEnv()
 
 		storeDir := t.TempDir()
 		targetDir := t.TempDir()
@@ -367,7 +366,7 @@ func TestContent_Link(t *testing.T) {
 	t.Run("copy path recovers from a stale read-only temp file", func(t *testing.T) {
 		t.Parallel()
 
-		v := venv.OSVenv()
+		v := venvtest.NewOSWithEmptyEnv()
 
 		storeDir := t.TempDir()
 		targetDir := t.TempDir()

--- a/internal/cas/getter_injection_test.go
+++ b/internal/cas/getter_injection_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -38,7 +37,7 @@ func TestCASGetterRefOptionInjection(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &cas.CloneOptions{Depth: 1})
 	client := getter.Client{Getters: []getter.Getter{g}}

--- a/internal/cas/getter_ssh_test.go
+++ b/internal/cas/getter_ssh_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -54,7 +53,7 @@ func TestSSHCASGetterGet(t *testing.T) {
 			c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 			require.NoError(t, err)
 
-			v := venv.OSVenv()
+			v := venvtest.NewOSWithEmptyEnv()
 
 			opts := &cas.CloneOptions{
 				Branch: "main",

--- a/internal/cas/getter_test.go
+++ b/internal/cas/getter_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -113,7 +112,7 @@ func TestCASGetterGet(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	opts := &cas.CloneOptions{
 		Depth: -1,
@@ -165,7 +164,7 @@ func TestCASGetterLocalDir(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	opts := &cas.CloneOptions{
 		Branch: "main",
@@ -221,7 +220,7 @@ func newTestCASGetter(t *testing.T, opts *cas.CloneOptions) *getter.CASGetter {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(helpers.TmpDirWOSymlinks(t), "store")))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	return getter.NewCASGetter(logger.CreateLogger(), c, v, opts)
 }

--- a/internal/cas/gitstore.go
+++ b/internal/cas/gitstore.go
@@ -302,8 +302,8 @@ func (s *GitStore) repoPaths(url string) (dir, repo, lockPath string) {
 // repository. Checking for HEAD is enough: `git init --bare` writes it as
 // part of repository setup, so its presence lets acquire skip the
 // per-call init spawn once a store entry exists.
-func bareRepoInitialized(fs vfs.FS, repoPath string) (bool, error) {
-	return vfs.FileExists(fs, filepath.Join(repoPath, "HEAD"))
+func bareRepoInitialized(fsys vfs.FS, repoPath string) (bool, error) {
+	return vfs.FileExists(fsys, filepath.Join(repoPath, "HEAD"))
 }
 
 // repoSession bundles the locked repo handle, the runner pointed at it,

--- a/internal/cas/gitstore_test.go
+++ b/internal/cas/gitstore_test.go
@@ -224,7 +224,7 @@ func newTestGitStore(t *testing.T) (*cas.GitStore, *venv.Venv, string) {
 
 	root := filepath.Join(helpers.TmpDirWOSymlinks(t), "gitstore")
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	store := cas.NewGitStore(root)
 

--- a/internal/cas/integration_test.go
+++ b/internal/cas/integration_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -23,7 +22,7 @@ func TestIntegration_CloneAndReuse(t *testing.T) {
 	l := logger.CreateLogger()
 	repoURL := startTestServer(t)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	t.Run("clone same repo twice uses store", func(t *testing.T) {
 		t.Parallel()
@@ -100,7 +99,7 @@ func TestIntegration_TreeStorage(t *testing.T) {
 	l := logger.CreateLogger()
 	repoURL := startTestServer(t)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	t.Run("stores tree objects", func(t *testing.T) {
 		t.Parallel()

--- a/internal/cas/local_test.go
+++ b/internal/cas/local_test.go
@@ -367,7 +367,7 @@ func newCAS(t *testing.T) (*cas.CAS, *venv.Venv) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	return c, v
 }

--- a/internal/cas/materialize_test.go
+++ b/internal/cas/materialize_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -29,7 +28,7 @@ func TestMaterializeTree_FromSynthStore(t *testing.T) {
 		require.NoError(t, os.MkdirAll(s.Path(), 0755))
 	}
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 
@@ -74,7 +73,7 @@ func TestMaterializeTree_FromGitTreeStore(t *testing.T) {
 		require.NoError(t, os.MkdirAll(s.Path(), 0755))
 	}
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 
@@ -112,7 +111,7 @@ func TestMaterializeTree_NotFound(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	destDir := helpers.TmpDirWOSymlinks(t)
 	l := logger.CreateLogger()
@@ -135,7 +134,7 @@ func TestMaterializeTree_SynthTakesPrecedence(t *testing.T) {
 		require.NoError(t, os.MkdirAll(s.Path(), 0755))
 	}
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 
@@ -203,7 +202,7 @@ func TestCASProtocolGetterGet(t *testing.T) {
 		require.NoError(t, os.MkdirAll(s.Path(), 0755))
 	}
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 
@@ -258,7 +257,7 @@ func TestCASProtocolGetterGet_Mutable(t *testing.T) {
 		require.NoError(t, os.MkdirAll(s.Path(), 0755))
 	}
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 
@@ -310,7 +309,7 @@ func TestCASProtocolGetterGet_InvalidRef(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 	g := getter.NewCASProtocolGetter(l, c, v)

--- a/internal/cas/protocol_getter_test.go
+++ b/internal/cas/protocol_getter_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
@@ -134,7 +133,7 @@ func TestCASProtocolGetterGet_MalformedHash(t *testing.T) {
 			c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(t.TempDir()))
 			require.NoError(t, err)
 
-			v := venv.OSVenv()
+			v := venvtest.NewOSWithEmptyEnv()
 
 			l := logger.CreateLogger()
 			g := getter.NewCASProtocolGetter(l, c, v)

--- a/internal/cas/race_test.go
+++ b/internal/cas/race_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -30,7 +29,7 @@ func TestCASGetterGetWithRacing(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	opts := &cas.CloneOptions{
 		Depth: -1,
@@ -86,7 +85,7 @@ func TestProcessStackComponentLocalSourceConcurrentWithRacing(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	const workers = 4
 
@@ -146,7 +145,7 @@ func TestContentLinkConcurrentSameTargetWithRacing(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	storeDir := t.TempDir()
 	store := cas.NewStore(storeDir)

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -556,7 +556,7 @@ func gitTreeMode(mode os.FileMode) string {
 // Remote URLs, go-getter forcers (git::), SSH shorthand (git@host:…), and
 // non-directory paths all return false and fall through to the remote
 // processing flow.
-func isLocalPath(fs vfs.FS, source string) bool {
+func isLocalPath(fsys vfs.FS, source string) bool {
 	if source == "" {
 		return false
 	}
@@ -581,7 +581,7 @@ func isLocalPath(fs vfs.FS, source string) bool {
 		return false
 	}
 
-	info, err := fs.Stat(source)
+	info, err := fsys.Stat(source)
 	if err != nil {
 		return false
 	}

--- a/internal/cas/stacks_local_test.go
+++ b/internal/cas/stacks_local_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -37,7 +36,7 @@ func TestProcessStackComponent_LocalSource_RewritesStackSources(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := root + "//stacks/my-stack"
 
@@ -79,7 +78,7 @@ func TestProcessStackComponent_LocalSource_RewritesUnitSources(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := root + "//stacks/my-stack"
 
@@ -127,7 +126,7 @@ func TestProcessStackComponent_LocalSource_DoesNotMutateInput(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := root + "//stacks/my-stack"
 
@@ -146,7 +145,7 @@ func TestProcessStackComponent_LocalSource_DeterministicOutput(t *testing.T) {
 	root := buildLocalStackFixture(t)
 	l := logger.CreateLogger()
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	readStackFile := func() string {
 		storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
@@ -474,7 +473,7 @@ func serviceUnitCASRef(t *testing.T, root string) string {
 	result, err := c.ProcessStackComponent(
 		t.Context(),
 		logger.CreateLogger(),
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		root+"//stacks/my-stack",
 		"stack",
 	)
@@ -557,7 +556,7 @@ func TestProcessStackComponent_GitForcerRoutesRemote(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := "git::" + repoURL + "//stacks/my-stack?ref=main"
 
@@ -618,7 +617,7 @@ func TestProcessStackComponent_LocalSource_MaterializeSynthTree(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := root + "//stacks/my-stack"
 
@@ -862,7 +861,7 @@ func TestProcessStackComponent_LocalSource_SharedUnitTemplate(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := root + "//stacks/my-stack"
 
@@ -914,7 +913,7 @@ func TestProcessStackComponent_LocalSource_SharedNestedStack(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := root + "//stacks/parent"
 

--- a/internal/cas/stacks_test.go
+++ b/internal/cas/stacks_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -159,7 +158,7 @@ func TestProcessStackComponent_RewritesStackSources(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	// Source mimics what a stack generates: <repo-url>//<subdir>?ref=<branch>
 	source := repoURL + "//stacks/my-stack?ref=main"
@@ -202,7 +201,7 @@ func TestProcessStackComponent_RewritesUnitSources(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := repoURL + "//stacks/my-stack?ref=main"
 
@@ -257,7 +256,7 @@ func TestProcessStackComponent_UnitSourceSyntheticTreeContainsSiblings(t *testin
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := repoURL + "//stacks/my-stack?ref=main"
 
@@ -318,7 +317,7 @@ func TestProcessStackComponent_UnitSourceWithoutDoubleSlash(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := repoURL + "//stacks/my-stack?ref=main"
 
@@ -377,7 +376,7 @@ func TestProcessStackComponent_CreatesSyntheticTrees(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := repoURL + "//stacks/my-stack?ref=main"
 
@@ -433,7 +432,7 @@ func TestProcessStackComponent_DeterministicOutput(t *testing.T) {
 	repoURL := startStackTestServer(t)
 	l := logger.CreateLogger()
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	readStackFile := func() string {
 		storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
@@ -478,7 +477,7 @@ func TestProcessStackComponent_MaterializeSynthTree(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := repoURL + "//stacks/my-stack?ref=main"
 
@@ -529,7 +528,7 @@ func TestProcessStackComponent_InvalidRefFails(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := repoURL + "//stacks/my-stack?ref=nonexistent-tag"
 
@@ -547,7 +546,7 @@ func TestProcessStackComponent_InvalidSubdirFails(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := repoURL + "//nonexistent/path?ref=main"
 
@@ -566,7 +565,7 @@ func TestProcessStackComponent_BlobsStoredInCAS(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := repoURL + "//stacks/my-stack?ref=main"
 
@@ -601,7 +600,7 @@ func TestProcessStackComponent_AcceptsExplicitGitPrefix(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := "git::" + repoURL + "//stacks/my-stack?ref=main"
 
@@ -622,7 +621,7 @@ func TestProcessStackComponent_ShorthandSourceReachesClone(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	// Bogus org so the network call fails fast. The error shape proves the
 	// shorthand was rewritten and reached `git ls-remote`.

--- a/internal/cas/submodule_test.go
+++ b/internal/cas/submodule_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -58,7 +57,7 @@ func TestCAS_CloneRepoWithSubmodule(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	storePath := filepath.Join(tempDir, "store")
@@ -130,7 +129,7 @@ func TestCAS_CloneRepoWithNestedSubmodules(t *testing.T) {
 	repoURL, err := srv.Start(t.Context())
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	targetPath := filepath.Join(tempDir, "repo")
@@ -180,7 +179,7 @@ func TestCAS_CloneRepoWithUnregisteredGitlink(t *testing.T) {
 	repoURL, err := srv.Start(t.Context())
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	targetPath := filepath.Join(tempDir, "repo")
@@ -251,7 +250,7 @@ func TestCAS_CloneSubmoduleWithRelativeURL(t *testing.T) {
 	// component for every request, so any path serves the main repo.
 	repoURL := srv.BaseURL() + "/parent.git"
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	targetPath := filepath.Join(tempDir, "repo")

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -23,13 +23,13 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/writer"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -920,7 +920,7 @@ func TestTerragruntVersion(t *testing.T) {
 		output := &bytes.Buffer{}
 		opts := options.NewTerragruntOptions()
 
-		testV := venv.OSVenv()
+		testV := venvtest.New()
 
 		testV.Writers = &writer.Writers{Writer: output, ErrWriter: os.Stderr}
 
@@ -942,7 +942,7 @@ func TestTerragruntHelp(t *testing.T) {
 	terragruntPrefix := flags.Prefix{flags.TerragruntPrefix}
 
 	opts := options.NewTerragruntOptions()
-	app := cli.NewApp(logger.CreateLogger(), opts, venv.OSVenv())
+	app := cli.NewApp(logger.CreateLogger(), opts, venvtest.New())
 
 	testCases := []struct {
 		expected    string
@@ -982,7 +982,7 @@ func TestTerragruntHelp(t *testing.T) {
 			output := &bytes.Buffer{}
 			opts := options.NewTerragruntOptions()
 
-			testV := venv.OSVenv()
+			testV := venvtest.New()
 
 			testV.Writers = &writer.Writers{Writer: output, ErrWriter: os.Stderr}
 
@@ -1008,7 +1008,7 @@ func TestTerraformHelp_wrongHelpFlag(t *testing.T) {
 
 	opts := options.NewTerragruntOptions()
 
-	testV := venv.OSVenv()
+	testV := venvtest.New()
 
 	testV.Writers = &writer.Writers{Writer: output, ErrWriter: os.Stderr}
 
@@ -1034,7 +1034,7 @@ func runAppTest(
 ) (*options.TerragruntOptions, error) {
 	emptyAction := func(ctx context.Context, cliCtx *clihelper.Context) error { return nil }
 
-	testV := venv.OSVenv()
+	testV := venvtest.New()
 
 	terragruntCommands := commands.New(l, opts, testV)
 	setCommandAction(emptyAction, terragruntCommands...)
@@ -1101,12 +1101,14 @@ func TestAutocomplete(t *testing.T) { //nolint:paralleltest
 	}
 
 	for _, tc := range testCases {
-		t.Setenv("COMP_LINE", "terragrunt "+tc.compLine)
-
 		output := &bytes.Buffer{}
 		opts := options.NewTerragruntOptions()
 
-		testV := venv.OSVenv()
+		// Autocomplete reads COMP_LINE from the venv's environment, so the
+		// completion request is handed over rather than exported to the process.
+		testV := venvtest.New().WithEnv(map[string]string{
+			"COMP_LINE": "terragrunt " + tc.compLine,
+		})
 
 		testV.Writers = &writer.Writers{Writer: output, ErrWriter: os.Stderr}
 

--- a/internal/cli/commands/browse/browse.go
+++ b/internal/cli/commands/browse/browse.go
@@ -69,7 +69,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *Options) error {
 	root := tui.NewRoot(opts.WorkingDir)
 
 	color := tui.ColorDisabled
-	if stdout.ShouldColor(l) {
+	if stdout.ShouldColor(l, v) {
 		color = tui.ColorEnabled
 	}
 

--- a/internal/cli/commands/browse/browse_test.go
+++ b/internal/cli/commands/browse/browse_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/browse"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +41,7 @@ func TestRunUnwindsCleanlyWhenContextCancelledWithRacing(t *testing.T) {
 	done := make(chan error, 1)
 
 	go func() {
-		done <- browse.Run(ctx, logger.CreateLogger(), venv.OSVenv(), browse.NewOptions(opts))
+		done <- browse.Run(ctx, logger.CreateLogger(), venvtest.NewOSWithEmptyEnv(), browse.NewOptions(opts))
 	}()
 
 	select {
@@ -55,7 +55,7 @@ func TestRunUnwindsCleanlyWhenContextCancelledWithRacing(t *testing.T) {
 func TestNewCommandIsNamedBrowse(t *testing.T) {
 	t.Parallel()
 
-	cmd := browse.NewCommand(logger.CreateLogger(), options.NewTerragruntOptions(), venv.OSVenv())
+	cmd := browse.NewCommand(logger.CreateLogger(), options.NewTerragruntOptions(), venvtest.NewOSWithEmptyEnv())
 
 	require.NotNil(t, cmd)
 	assert.Equal(t, browse.CommandName, cmd.Name)

--- a/internal/cli/commands/browse/tui/helpers_test.go
+++ b/internal/cli/commands/browse/tui/helpers_test.go
@@ -22,13 +22,13 @@ const (
 // models are driven through Update directly and never call Init, so the required
 // channels are wired but never read; tests that stream discovery inject a
 // [tui.DiscoveryResult] as a message instead.
-func newModel(t *testing.T, fs vfs.FS, root *tui.Node, color tui.ColorMode, opts ...tui.Option) tui.Model {
+func newModel(t *testing.T, fsys vfs.FS, root *tui.Node, color tui.ColorMode, opts ...tui.Option) tui.Model {
 	t.Helper()
 
 	resultCh := make(chan tui.DiscoveryResult, 1)
 	warnCh := make(chan viewtui.Warning)
 
-	m := tui.NewModel(logger.CreateLogger(), fs, root, color, resultCh, warnCh, opts...)
+	m := tui.NewModel(logger.CreateLogger(), fsys, root, color, resultCh, warnCh, opts...)
 
 	return update(t, m, tea.WindowSizeMsg{Width: testWidth, Height: testHeight})
 }

--- a/internal/cli/commands/browse/tui/model.go
+++ b/internal/cli/commands/browse/tui/model.go
@@ -36,7 +36,7 @@ const (
 
 // Model is the bubbletea model backing the Miller-columns browser.
 type Model struct {
-	fs           vfs.FS
+	fsys         vfs.FS
 	current      *Node
 	cursor       map[*Node]int
 	colorizer    *dag.Colorizer
@@ -68,13 +68,13 @@ type Model struct {
 // condition.
 var ErrChannelsRequired = errors.New("browse: result and warning channels must not be nil")
 
-// NewModel builds a Model rooted at the given tree. fs backs the on-demand reads
+// NewModel builds a Model rooted at the given tree. fsys backs the on-demand reads
 // of surrounding entries and file previews. resultCh delivers the background
 // discovery result, and warnCh the warnings logged while it runs; both are
 // required, and NewModel panics if either is nil.
 func NewModel(
 	l log.Logger,
-	fs vfs.FS,
+	fsys vfs.FS,
 	root *Node,
 	color ColorMode,
 	resultCh <-chan DiscoveryResult,
@@ -100,7 +100,7 @@ func NewModel(
 		current:      root,
 		cursor:       map[*Node]int{},
 		colorizer:    dag.NewColorizer(bool(color)),
-		fs:           fs,
+		fsys:         fsys,
 		keys:         newKeyMap(),
 		searchInput:  search,
 		previewLimit: previewByteLimit,

--- a/internal/cli/commands/browse/tui/preview.go
+++ b/internal/cli/commands/browse/tui/preview.go
@@ -71,7 +71,7 @@ func themeFor(color ColorMode, dark bool) previewTheme {
 // previewLimit bytes are read, since the pane shows just its head. It returns a
 // short dimmed placeholder for files that can't or shouldn't be previewed.
 func (m Model) renderFilePreview(n *Node, width int) string {
-	data, err := vfs.ReadFileLimit(m.fs, n.absPath, m.previewLimit)
+	data, err := vfs.ReadFileLimit(m.fsys, n.absPath, m.previewLimit)
 	if err != nil {
 		return dimStyle.Render("(unreadable)")
 	}

--- a/internal/cli/commands/browse/tui/tree.go
+++ b/internal/cli/commands/browse/tui/tree.go
@@ -180,7 +180,7 @@ func (m *Model) loadDir(n *Node) {
 
 	n.othersLoaded = true
 
-	entries, err := vfs.ReadDirEntries(m.fs, n.absPath)
+	entries, err := vfs.ReadDirEntries(m.fsys, n.absPath)
 	if err != nil {
 		return
 	}
@@ -262,7 +262,7 @@ func inIgnorableDir(parent *Node, name string) bool {
 // containsFile reports whether dir holds a file named name. A stat error means
 // the file can't be confirmed, so it counts as absent.
 func (m *Model) containsFile(dir, name string) bool {
-	exists, err := vfs.FileExists(m.fs, filepath.Join(dir, name))
+	exists, err := vfs.FileExists(m.fsys, filepath.Join(dir, name))
 
 	return err == nil && exists
 }

--- a/internal/cli/commands/browse/tui/tui.go
+++ b/internal/cli/commands/browse/tui/tui.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Run launches the Miller-columns browser over the given tree, blocking until
-// the user quits. fs backs the on-demand reads of surrounding entries and file
+// the user quits. fsys backs the on-demand reads of surrounding entries and file
 // previews. resultCh delivers the background discovery result, which annotates
 // the tree once it arrives, and warnCh the warnings logged while it runs, shown
 // as toasts; both are required (see [NewModel]). A cancelled context is treated
@@ -20,13 +20,13 @@ import (
 func Run(
 	ctx context.Context,
 	l log.Logger,
-	fs vfs.FS,
+	fsys vfs.FS,
 	root *Node,
 	color ColorMode,
 	resultCh <-chan DiscoveryResult,
 	warnCh <-chan viewtui.Warning,
 ) error {
-	_, err := tea.NewProgram(NewModel(l, fs, root, color, resultCh, warnCh), tea.WithContext(ctx)).Run()
+	_, err := tea.NewProgram(NewModel(l, fsys, root, color, resultCh, warnCh), tea.WithContext(ctx)).Run()
 	if err == nil {
 		return nil
 	}

--- a/internal/cli/commands/catalog/catalog_test.go
+++ b/internal/cli/commands/catalog/catalog_test.go
@@ -149,7 +149,12 @@ func TestRunWritesComponentsFromTheCatalogBlock(t *testing.T) {
 
 	var buf strings.Builder
 
-	v := venvtest.NewWithOSFS().WithWriter(&buf)
+	// The clone lands under the venv's temp dir, which has to be a real one
+	// here because the repo is cloned on the real filesystem.
+	tempDir := t.TempDir()
+	v := venvtest.NewWithOSFS().
+		WithWriter(&buf).
+		WithTempDir(func() string { return tempDir })
 
 	writeLocalRepo(t, v, repoDir)
 	require.NoError(t, vfs.WriteFile(

--- a/internal/cli/commands/catalog/tui/load.go
+++ b/internal/cli/commands/catalog/tui/load.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
@@ -15,12 +14,15 @@ import (
 )
 
 // CreateCatalogTempPath creates a fresh clone root under the resolved temp dir.
-// Resolving os.TempDir keeps filepath.Rel results inside the clone on systems
+// Resolving the temp dir keeps filepath.Rel results inside the clone on systems
 // where the temp dir itself is reported through a symlink.
-func CreateCatalogTempPath(fsys vfs.FS, repoURL string) (string, error) {
+func CreateCatalogTempPath(v *venv.Venv, repoURL string) (string, error) {
+	v.RequireFS()
+	v.RequireTempDir()
+
 	prefix := "catalog-" + util.EncodeBase64Sha1(repoURL) + "-"
 
-	return vfs.MkdirTemp(fsys, util.ResolvePath(os.TempDir()), prefix)
+	return vfs.MkdirTemp(v.FS, vfs.ResolveForCompare(v.FS, v.Platform.TempDir()), prefix)
 }
 
 // LoadURL clones repoURL via module.NewRepo, walks it with a
@@ -45,7 +47,7 @@ func LoadURL(
 	allowCAS := !opts.NoCAS
 	slowReporting := opts.Experiments.Evaluate(experiment.SlowTaskReporting)
 
-	tempPath, err := CreateCatalogTempPath(v.FS, repoURL)
+	tempPath, err := CreateCatalogTempPath(v, repoURL)
 	if err != nil {
 		return fmt.Errorf("failed to create catalog temporary directory for %s: %w", repoURL, err)
 	}

--- a/internal/cli/commands/catalog/tui/load_test.go
+++ b/internal/cli/commands/catalog/tui/load_test.go
@@ -10,20 +10,21 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
 	"github.com/gruntwork-io/terragrunt/internal/util"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // TestCreateCatalogTempPathResolvesSymlinkedTmpDir verifies the clone dir is
-// anchored at a symlink-resolved temp dir. macOS reports os.TempDir() as a
+// anchored at a symlink-resolved temp dir. macOS reports the temp dir as a
 // /var/folders symlink to /private/var/folders; an unresolved root makes
 // discovery's filepath.Rel emit a "../" traversal that go-getter rejects.
 func TestCreateCatalogTempPathResolvesSymlinkedTmpDir(t *testing.T) {
-	// t.Setenv forbids t.Parallel.
+	t.Parallel()
+
 	base, err := filepath.EvalSymlinks(t.TempDir())
 	require.NoError(t, err)
 
@@ -34,10 +35,10 @@ func TestCreateCatalogTempPathResolvesSymlinkedTmpDir(t *testing.T) {
 	linkTmp := filepath.Join(base, "link")
 	require.NoError(t, os.Symlink(realTmp, linkTmp))
 
-	t.Setenv("TMPDIR", linkTmp)
+	v := venvtest.NewWithOSFS().WithTempDir(func() string { return linkTmp })
 
 	got, err := tui.CreateCatalogTempPath(
-		vfs.NewOSFS(),
+		v,
 		"github.com/gruntwork-io/terragrunt-scale-catalog",
 	)
 	require.NoError(t, err)
@@ -51,13 +52,14 @@ func TestCreateCatalogTempPathResolvesSymlinkedTmpDir(t *testing.T) {
 func TestCreateCatalogTempPathUsesFreshDirectory(t *testing.T) {
 	t.Parallel()
 
-	fsys := vfs.NewMemMapFS()
+	v := venvtest.New()
+	fsys := v.FS
 	repoURL := "github.com/gruntwork-io/terragrunt-scale-catalog"
 
-	first, err := tui.CreateCatalogTempPath(fsys, repoURL)
+	first, err := tui.CreateCatalogTempPath(v, repoURL)
 	require.NoError(t, err)
 
-	second, err := tui.CreateCatalogTempPath(fsys, repoURL)
+	second, err := tui.CreateCatalogTempPath(v, repoURL)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, first, second)
@@ -88,7 +90,7 @@ func TestLoadURLKeepsTempDirAfterEmittingComponentOnCancel(t *testing.T) {
 	opts, err := options.NewTerragruntOptionsForTest("")
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 	tracker := tui.NewTempDirTracker(v.FS)
 	ctx, cancel := context.WithCancel(t.Context())
 	componentCh := make(chan *tui.ComponentEntry)

--- a/internal/cli/commands/catalog/tui/model_test.go
+++ b/internal/cli/commands/catalog/tui/model_test.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/component"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,7 +81,7 @@ func TestModelStreamingInsertsSortedWithRacing(t *testing.T) {
 		m := tui.NewModelStreaming(
 			t.Context(),
 			l,
-			venv.OSVenv(),
+			venvtest.NewOSWithEmptyEnv(),
 			opts,
 			components[len(components)-1],
 			componentCh,
@@ -154,7 +154,7 @@ func TestModelTabsFilterByKindWithRacing(t *testing.T) {
 		m := tui.NewModelStreaming(
 			t.Context(),
 			l,
-			venv.OSVenv(),
+			venvtest.NewOSWithEmptyEnv(),
 			opts,
 			components[0],
 			componentCh,
@@ -200,7 +200,7 @@ func TestModelTabShiftTabCyclesWithRacing(t *testing.T) {
 		m := tui.NewModelStreaming(
 			t.Context(),
 			l,
-			venv.OSVenv(),
+			venvtest.NewOSWithEmptyEnv(),
 			opts,
 			components[0],
 			componentCh,
@@ -266,7 +266,7 @@ func TestModelInteractiveScaffoldTransitionsToFormStateWithRacing(t *testing.T) 
 		m := tui.NewModelStreaming(
 			t.Context(),
 			logger.CreateLogger(),
-			venv.OSVenv(),
+			venvtest.NewOSWithEmptyEnv(),
 			opts,
 			entry,
 			componentCh,
@@ -322,7 +322,7 @@ func TestModelEnterOnPagerLaunchesInteractiveFormWithRacing(t *testing.T) {
 		m := tui.NewModelStreaming(
 			t.Context(),
 			logger.CreateLogger(),
-			venv.OSVenv(),
+			venvtest.NewOSWithEmptyEnv(),
 			opts,
 			entry,
 			componentCh,
@@ -375,7 +375,15 @@ func TestModelCtrlDOnPagerScaffoldsImmediatelyWithRacing(t *testing.T) {
 		componentCh := make(chan *tui.ComponentEntry)
 		close(componentCh)
 
-		m := tui.NewModelStreaming(t.Context(), logger.CreateLogger(), venv.OSVenv(), opts, entry, componentCh, nil)
+		m := tui.NewModelStreaming(
+			t.Context(),
+			logger.CreateLogger(),
+			venvtest.NewOSWithEmptyEnv(),
+			opts,
+			entry,
+			componentCh,
+			nil,
+		)
 
 		// First enter: list → pager. Then ctrl+d: pager → immediate
 		// placeholder scaffold, no form in between.
@@ -408,7 +416,7 @@ func TestModelStreamingDeduplicatesWithRacing(t *testing.T) {
 		m := tui.NewModelStreaming(
 			t.Context(),
 			l,
-			venv.OSVenv(),
+			venvtest.NewOSWithEmptyEnv(),
 			opts,
 			components[0],
 			componentCh,
@@ -448,7 +456,7 @@ func TestModelCopyFinishedWritesValuesExitMessage(t *testing.T) {
 	componentCh := make(chan *tui.ComponentEntry)
 	close(componentCh)
 
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, components[0], componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, components[0], componentCh, nil)
 
 	// Copy-written: 2 required TODOs (exercises the plural "entries" branch)
 	// and 1 optional (exercises the singular "default" branch).
@@ -492,7 +500,7 @@ func TestModelCopyFinishedSkippedValuesExitMessage(t *testing.T) {
 	componentCh := make(chan *tui.ComponentEntry)
 	close(componentCh)
 
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, components[0], componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, components[0], componentCh, nil)
 
 	msg := copyFinishedFromNames(workingDir,
 		[]string{"zeta"},
@@ -531,7 +539,7 @@ func TestModelCopyFinishedEmptyReferencesLeavesNoExitMessage(t *testing.T) {
 	componentCh := make(chan *tui.ComponentEntry)
 	close(componentCh)
 
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, components[0], componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, components[0], componentCh, nil)
 
 	msg := copyFinishedFromNames(opts.WorkingDir, nil, nil, false, false)
 
@@ -559,7 +567,7 @@ func TestModelScaffoldFinishedSetsExitMessage(t *testing.T) {
 	componentCh := make(chan *tui.ComponentEntry)
 	close(componentCh)
 
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, components[0], componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, components[0], componentCh, nil)
 
 	updated, _ := m.Update(tui.ScaffoldFinishedMsg{})
 	finalModel := updated.(tui.Model)
@@ -586,7 +594,7 @@ func TestModelScaffoldFinishedEmptyOutputDirHasNoExitMessage(t *testing.T) {
 	componentCh := make(chan *tui.ComponentEntry)
 	close(componentCh)
 
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, components[0], componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, components[0], componentCh, nil)
 
 	updated, _ := m.Update(tui.ScaffoldFinishedMsg{})
 	finalModel := updated.(tui.Model)
@@ -626,7 +634,7 @@ func TestModelCopyFinishedDisplayPathEscapesBaseDir(t *testing.T) {
 	componentCh := make(chan *tui.ComponentEntry)
 	close(componentCh)
 
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, components[0], componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, components[0], componentCh, nil)
 
 	msg := copyFinishedFromNames(baseTmp, []string{"a"}, nil, true, false)
 
@@ -657,7 +665,7 @@ func TestModelScaffoldFailureQuitsWithError(t *testing.T) {
 	componentCh := make(chan *tui.ComponentEntry)
 	close(componentCh)
 
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, components[0], componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, components[0], componentCh, nil)
 
 	scaffoldErr := errors.New("generate failed")
 
@@ -694,7 +702,7 @@ func TestModelCopyFailureQuitsWithError(t *testing.T) {
 	componentCh := make(chan *tui.ComponentEntry)
 	close(componentCh)
 
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, components[0], componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, components[0], componentCh, nil)
 
 	copyErr := errors.New("destination exists")
 
@@ -726,7 +734,7 @@ func TestModelCleanQuitHasNoErrorWithRacing(t *testing.T) {
 		m := tui.NewModelStreaming(
 			t.Context(),
 			l,
-			venv.OSVenv(),
+			venvtest.NewOSWithEmptyEnv(),
 			opts,
 			components[0],
 			componentCh,
@@ -756,7 +764,7 @@ func TestModelRendererErrMsgSetsViewportAndPagerState(t *testing.T) {
 	componentCh := make(chan *tui.ComponentEntry)
 	close(componentCh)
 
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, components[0], componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, components[0], componentCh, nil)
 
 	// Seed the viewport with a WindowSizeMsg so it has a positive size,
 	// otherwise the pager view will produce a degenerate string.
@@ -802,7 +810,7 @@ func TestModelPagerViewRendersAfterEnterWithRacing(t *testing.T) {
 		componentCh := make(chan *tui.ComponentEntry)
 		close(componentCh)
 
-		m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, entry, componentCh, nil)
+		m := tui.NewModelStreaming(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, entry, componentCh, nil)
 
 		msgs := []tea.Msg{
 			tea.KeyPressMsg{Code: tea.KeyEnter},
@@ -845,7 +853,7 @@ func TestModelPagerWToggleFlipsSoftWrapWithRacing(t *testing.T) {
 		componentCh := make(chan *tui.ComponentEntry)
 		close(componentCh)
 
-		m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, entry, componentCh, nil)
+		m := tui.NewModelStreaming(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, entry, componentCh, nil)
 
 		// Enter pager, then toggle `w` twice. driveModel runs the
 		// messages through Update in order and returns the final model.

--- a/internal/cli/commands/catalog/tui/toast_test.go
+++ b/internal/cli/commands/catalog/tui/toast_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/component"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	viewtui "github.com/gruntwork-io/terragrunt/internal/view/tui"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,7 +28,7 @@ func sizedWelcomeModel(t *testing.T) tui.WelcomeModel {
 		return nil
 	}
 
-	m := tui.NewWelcomeModel(t.Context(), logger.CreateLogger(), venv.OSVenv(), opts, noSourcesLoad)
+	m := tui.NewWelcomeModel(t.Context(), logger.CreateLogger(), venvtest.New(), opts, noSourcesLoad)
 
 	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 

--- a/internal/cli/commands/catalog/tui/view_test.go
+++ b/internal/cli/commands/catalog/tui/view_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/component"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +29,7 @@ func TestWelcomeLoadingView_RendersSpinnerAndStatus(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, blockingLoad)
+	m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, blockingLoad)
 	m = updateModel(m, windowSize).(tui.WelcomeModel)
 
 	view := m.View()
@@ -53,7 +53,7 @@ func TestWelcomeLoadingView_StatusTextUpdates(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, blockingLoad)
+	m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, blockingLoad)
 	m = updateModel(m, windowSize).(tui.WelcomeModel)
 
 	content := stripANSI(m.View().Content)
@@ -87,7 +87,7 @@ func TestWelcomeNoSourcesView_RendersHelpText(t *testing.T) {
 		return nil
 	}
 
-	m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, noSourcesLoad)
+	m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, noSourcesLoad)
 	m = updateModel(m, windowSize).(tui.WelcomeModel)
 
 	m = updateModel(m, tui.DiscoveryCompleteMsg{Err: nil}).(tui.WelcomeModel)
@@ -132,7 +132,7 @@ func TestWelcomeDiscoveryErrorView_RendersErrorAndHint(t *testing.T) {
 		return errors.New("network unreachable")
 	}
 
-	m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, erroringLoad)
+	m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, erroringLoad)
 	m = updateModel(m, windowSize).(tui.WelcomeModel)
 
 	m = updateModel(m, tui.DiscoveryCompleteMsg{Err: errors.New("network unreachable")}).(tui.WelcomeModel)
@@ -159,7 +159,7 @@ func TestWelcomeDiscoveryErrorView_AllSourcesFailedDetail(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, blockingLoad)
+	m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, blockingLoad)
 	m = updateModel(m, windowSize).(tui.WelcomeModel)
 
 	srcErr := &tui.SourceLoadError{
@@ -201,7 +201,7 @@ func TestComponentListView_LoadingTitle(t *testing.T) {
 	require.NotEmpty(t, components)
 
 	componentCh := make(chan *tui.ComponentEntry, 10)
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, components[0], componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.New(), opts, components[0], componentCh, nil)
 
 	updated, _ := m.Update(windowSize)
 	m = updated.(tui.Model)
@@ -240,7 +240,7 @@ func TestComponentListView_PartialSourceFailureNotice(t *testing.T) {
 	require.NotEmpty(t, components)
 
 	componentCh := make(chan *tui.ComponentEntry, 10)
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, components[0], componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.New(), opts, components[0], componentCh, nil)
 
 	updated, _ := m.Update(windowSize)
 	m = updated.(tui.Model)
@@ -286,7 +286,7 @@ func TestComponentListView_MetadataRowRendered(t *testing.T) {
 		WithSource("github.com/gruntwork-io/terragrunt-scale-catalog")
 
 	componentCh := make(chan *tui.ComponentEntry, 10)
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, entry, componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.New(), opts, entry, componentCh, nil)
 
 	updated, _ := m.Update(windowSize)
 	m = updated.(tui.Model)
@@ -318,7 +318,7 @@ func TestComponentListView_TemplateKindRendered(t *testing.T) {
 	)).WithSource("github.com/gruntwork-io/templates-repo")
 
 	componentCh := make(chan *tui.ComponentEntry, 10)
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, template, componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.New(), opts, template, componentCh, nil)
 
 	updated, _ := m.Update(windowSize)
 	m = updated.(tui.Model)
@@ -345,7 +345,7 @@ func TestComponentListView_NoVersionOmitsVersionPill(t *testing.T) {
 	entry := components[0].WithSource("github.com/gruntwork-io/terragrunt-scale-catalog")
 
 	componentCh := make(chan *tui.ComponentEntry, 10)
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, entry, componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.New(), opts, entry, componentCh, nil)
 
 	updated, _ := m.Update(windowSize)
 	m = updated.(tui.Model)
@@ -389,7 +389,7 @@ func TestComponentListView_LongSourceAbbreviatesWithEllipsis(t *testing.T) {
 	)).WithSource(longSource)
 
 	componentCh := make(chan *tui.ComponentEntry, 1)
-	m := tui.NewModelStreaming(t.Context(), l, venv.OSVenv(), opts, entry, componentCh, nil)
+	m := tui.NewModelStreaming(t.Context(), l, venvtest.New(), opts, entry, componentCh, nil)
 
 	// Narrow terminal forces the source column to shrink below the raw width,
 	// which forces abbreviateMiddle to truncate.
@@ -432,7 +432,7 @@ func TestWelcomeStreamingFlowWithRacing(t *testing.T) {
 			return nil
 		}
 
-		var m tea.Model = tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, streamingLoad)
+		var m tea.Model = tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, streamingLoad)
 
 		m = updateModel(m, windowSize)
 		m = runUntilQuiet(t, m, m.Init(), 5*time.Second)
@@ -555,7 +555,7 @@ func TestWelcomeStreamingFlow_LoadingIndicatorClearsAfterDiscoveryWithRacing(t *
 			return nil
 		}
 
-		var m tea.Model = tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, streamingLoad)
+		var m tea.Model = tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, streamingLoad)
 
 		m = updateModel(m, windowSize)
 
@@ -642,7 +642,7 @@ func TestWelcomeLoadingSpinnerWithRacing(t *testing.T) {
 			return nil
 		}
 
-		m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, slowLoad)
+		m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, slowLoad)
 
 		finalModel := driveModel(t, m, 120, 40, []tea.Msg{
 			tea.KeyPressMsg{Code: 'q', Text: "q"},

--- a/internal/cli/commands/catalog/tui/welcome_test.go
+++ b/internal/cli/commands/catalog/tui/welcome_test.go
@@ -12,9 +12,9 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -86,7 +86,7 @@ func TestWelcomeLoadingScreen_NoSourcesWithRacing(t *testing.T) {
 			return nil
 		}
 
-		m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, noSourcesLoad)
+		m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, noSourcesLoad)
 
 		msgs := []tea.Msg{tea.KeyPressMsg{Code: 'q', Text: "q"}}
 
@@ -114,7 +114,7 @@ func TestWelcomeDiscoveryErrorQuitPropagatesErrorWithRacing(t *testing.T) {
 			return discoveryErr
 		}
 
-		m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, erroringLoad)
+		m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, erroringLoad)
 
 		msgs := []tea.Msg{tea.KeyPressMsg{Code: 'q', Text: "q"}}
 
@@ -149,7 +149,7 @@ func TestWelcomeAllSourcesFailedPropagatesTypedErrorWithRacing(t *testing.T) {
 			}
 		}
 
-		m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, allFailedLoad)
+		m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, allFailedLoad)
 
 		msgs := []tea.Msg{tea.KeyPressMsg{Code: 'q', Text: "q"}}
 
@@ -189,7 +189,7 @@ func TestWelcomeCleanQuitReturnsNoErrorWithRacing(t *testing.T) {
 			return nil
 		}
 
-		m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, noSourcesLoad)
+		m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, noSourcesLoad)
 
 		msgs := []tea.Msg{tea.KeyPressMsg{Code: 'q', Text: "q"}}
 
@@ -226,7 +226,7 @@ func TestWelcomeLoadingScreen_TransitionsToComponentListWithRacing(t *testing.T)
 			return nil
 		}
 
-		m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, withComponentsLoad)
+		m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, withComponentsLoad)
 
 		msgs := []tea.Msg{tea.KeyPressMsg{Code: 'q', Text: "q"}}
 
@@ -268,7 +268,7 @@ func TestWelcomeLoadingScreen_ComponentListNavigationWithRacing(t *testing.T) {
 			return nil
 		}
 
-		m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, withComponentsLoad)
+		m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, withComponentsLoad)
 
 		msgs := []tea.Msg{
 			tea.KeyPressMsg{Code: tea.KeyEnter},
@@ -304,7 +304,7 @@ func TestWelcomeLoadingScreen_QuitDuringLoadingWithRacing(t *testing.T) {
 			return nil
 		}
 
-		m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, slowLoad)
+		m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, slowLoad)
 
 		msgs := []tea.Msg{tea.KeyPressMsg{Code: 'q', Text: "q"}}
 
@@ -332,7 +332,7 @@ func TestWelcomeNoSourcesScreen_HelpKeyOpensDocsWithRacing(t *testing.T) {
 
 		var openedURL string
 
-		m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, noSourcesLoad).
+		m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, noSourcesLoad).
 			WithOpenURL(func(url string) error {
 				openedURL = url
 				return nil
@@ -371,7 +371,7 @@ func TestWelcomeNoSourcesScreen_UnhandledKeyWithRacing(t *testing.T) {
 			return nil
 		}
 
-		m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, noSourcesLoad)
+		m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, noSourcesLoad)
 
 		msgs := []tea.Msg{
 			tea.KeyPressMsg{Code: 'x', Text: "x"},
@@ -411,7 +411,7 @@ func TestWelcomeStreamingComponentsWithRacing(t *testing.T) {
 			return nil
 		}
 
-		m := tui.NewWelcomeModel(t.Context(), l, venv.OSVenv(), opts, streamingLoad)
+		m := tui.NewWelcomeModel(t.Context(), l, venvtest.New(), opts, streamingLoad)
 
 		msgs := []tea.Msg{tea.KeyPressMsg{Code: 'q', Text: "q"}}
 

--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -230,7 +230,7 @@ func WrapWithTelemetry(
 // on a sufficiently new version of OpenTofu.
 func GiveWindowsSymlinksTip(
 	l log.Logger,
-	fs vfs.FS,
+	fsys vfs.FS,
 	goos string,
 	allTips tips.Tips,
 	envs map[string]string,
@@ -246,14 +246,14 @@ func GiveWindowsSymlinksTip(
 		return
 	}
 
-	tmp, err := vfs.MkdirTemp(fs, "", "terragrunt-test-symlink")
+	tmp, err := vfs.MkdirTemp(fsys, "", "terragrunt-test-symlink")
 	if err != nil {
 		l.Debugf("Failed to create temporary directory for testing symlink: %v", err)
 		return
 	}
 
 	defer func() {
-		if err := fs.RemoveAll(tmp); err != nil {
+		if err := fsys.RemoveAll(tmp); err != nil {
 			l.Debugf("Failed to remove temporary directory for testing symlink: %v", err)
 		}
 	}()
@@ -261,12 +261,12 @@ func GiveWindowsSymlinksTip(
 	source := filepath.Join(tmp, "source")
 	target := filepath.Join(tmp, "target")
 
-	if err := fs.Mkdir(source, 0755); err != nil { //nolint:mnd
+	if err := fsys.Mkdir(source, 0755); err != nil { //nolint:mnd
 		l.Debugf("Failed to create source directory for testing symlink: %v", err)
 		return
 	}
 
-	err = vfs.Symlink(fs, source, target)
+	err = vfs.Symlink(fsys, source, target)
 	if err == nil {
 		return
 	}
@@ -342,7 +342,7 @@ func RunAction(
 			return err
 		}
 
-		ln, err := server.Listen(actionCtx)
+		ln, err := server.Listen(actionCtx, v)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/commands/dag/graph/cli_test.go
+++ b/internal/cli/commands/dag/graph/cli_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/dag/graph"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,7 +68,7 @@ func BenchmarkRunGraphDependencies(b *testing.B) {
 			err = graph.Run(
 				b.Context(),
 				logger.CreateLogger(),
-				venv.OSVenv().WithWriter(io.Discard),
+				venvtest.NewOSWithEmptyEnv().WithWriter(io.Discard),
 				terragruntOptions,
 			)
 

--- a/internal/cli/commands/discoverysetup/discoverysetup_test.go
+++ b/internal/cli/commands/discoverysetup/discoverysetup_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/discoverysetup"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +20,7 @@ func TestWorktreesNoGitFilters(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	opts := options.NewTerragruntOptions()
@@ -43,7 +43,7 @@ func TestWorktreesCreationFailure(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	// A plain directory with no git repository makes worktree creation fail.
 	tmpDir := helpers.TmpDirWOSymlinks(t)
@@ -73,7 +73,7 @@ func TestWorktreesStackGenerationFailure(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 	runner := helpers.InitTestGitRunner(t, tmpDir)
 

--- a/internal/cli/commands/find/find.go
+++ b/internal/cli/commands/find/find.go
@@ -113,7 +113,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *Options) error {
 
 	switch opts.Format {
 	case FormatText:
-		return outputText(l, v.Writers.Writer, foundComponents)
+		return outputText(l, v, foundComponents)
 	case FormatJSON:
 		return outputJSON(v.Writers.Writer, foundComponents)
 	default:
@@ -303,16 +303,16 @@ func (c *Colorizer) Colorize(foundComponent *FoundComponent) string {
 }
 
 // outputText outputs the discovered components in text format.
-func outputText(l log.Logger, w io.Writer, components FoundComponents) error {
+func outputText(l log.Logger, v *venv.Venv, components FoundComponents) error {
 	var buf strings.Builder
 
-	colorizer := NewColorizer(stdout.ShouldColor(l))
+	colorizer := NewColorizer(stdout.ShouldColor(l, v))
 
 	for _, c := range components {
 		buf.WriteString(colorizer.Colorize(c) + "\n")
 	}
 
-	_, err := w.Write([]byte(buf.String()))
+	_, err := v.Writers.Writer.Write([]byte(buf.String()))
 
 	return err
 }

--- a/internal/cli/commands/find/find_test.go
+++ b/internal/cli/commands/find/find_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/find"
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -520,7 +519,7 @@ locals {
 			r, w, err := os.Pipe()
 			require.NoError(t, err)
 
-			err = find.Run(t.Context(), l, venv.OSVenv().WithWriter(w), opts)
+			err = find.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 			if tt.format == "invalid" || tt.mode == "invalid" {
 				require.Error(t, err)
 				return
@@ -582,7 +581,7 @@ dependency "target" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = find.Run(t.Context(), l, venv.OSVenv().WithWriter(w), opts)
+	err = find.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	require.NoError(t, w.Close())

--- a/internal/cli/commands/hcl/format/format.go
+++ b/internal/cli/commands/hcl/format/format.go
@@ -50,7 +50,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *options.Terragru
 			return errors.New("both stdin and path flags are specified")
 		}
 
-		return formatFromStdin(l, v.Reader, v.Writers.Writer)
+		return formatFromStdin(l, v)
 	}
 
 	if targetFile != "" {
@@ -60,7 +60,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *options.Terragru
 
 		l.Debugf("Formatting hcl file at: %s.", targetFile)
 
-		return formatTgHCL(l, v.FS, v.Writers.Writer, opts, targetFile)
+		return formatTgHCL(l, v, opts, targetFile)
 	}
 
 	var (
@@ -129,7 +129,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *options.Terragru
 
 	for i, c := range components {
 		g.Go(func() error {
-			err := formatTgHCL(l, v.FS, v.Writers.Writer, opts, c.Path())
+			err := formatTgHCL(l, v, opts, c.Path())
 			if err != nil {
 				errs[i] = err
 			}
@@ -179,7 +179,7 @@ func RunForFiles(
 		}
 
 		g.Go(func() error {
-			if err := formatTgHCL(l, v.FS, v.Writers.Writer, opts, file); err != nil {
+			if err := formatTgHCL(l, v, opts, file); err != nil {
 				mu.Lock()
 
 				errs = append(errs, err)
@@ -195,15 +195,15 @@ func RunForFiles(
 	return errors.Join(errs...)
 }
 
-func formatFromStdin(l log.Logger, r io.Reader, w io.Writer) error {
-	contents, err := io.ReadAll(r)
+func formatFromStdin(l log.Logger, v *venv.Venv) error {
+	contents, err := io.ReadAll(v.Stdin)
 	if err != nil {
 		l.Errorf("Error reading from stdin: %s", err)
 
 		return fmt.Errorf("error reading from stdin: %w", err)
 	}
 
-	if err = checkErrors(l, l.Formatter().DisabledColors(), contents, "stdin"); err != nil {
+	if err = checkErrors(l, v, contents, "stdin"); err != nil {
 		l.Errorf("Error parsing hcl from stdin")
 
 		return fmt.Errorf("error parsing hcl from stdin: %w", err)
@@ -211,7 +211,7 @@ func formatFromStdin(l log.Logger, r io.Reader, w io.Writer) error {
 
 	newContents := hclwrite.Format(contents)
 
-	buf := bufio.NewWriter(w)
+	buf := bufio.NewWriter(v.Writers.Writer)
 
 	if _, err = buf.Write(newContents); err != nil {
 		l.Errorf("Failed to write to stdout")
@@ -232,26 +232,25 @@ func formatFromStdin(l log.Logger, r io.Reader, w io.Writer) error {
 // ensure that there are no syntax errors, before attempting to format it.
 func formatTgHCL(
 	l log.Logger,
-	fsys vfs.FS,
-	w io.Writer,
+	v *venv.Venv,
 	opts *options.TerragruntOptions,
 	tgHclFile string,
 ) error {
 	l.Debugf("Formatting %s", tgHclFile)
 
-	info, err := fsys.Stat(tgHclFile)
+	info, err := v.FS.Stat(tgHclFile)
 	if err != nil {
 		l.Errorf("Error retrieving file info of %s", tgHclFile)
 		return fmt.Errorf("failed to get file info for %s: %w", tgHclFile, err)
 	}
 
-	contents, err := vfs.ReadFile(fsys, tgHclFile)
+	contents, err := vfs.ReadFile(v.FS, tgHclFile)
 	if err != nil {
 		l.Errorf("Error reading %s", tgHclFile)
 		return fmt.Errorf("failed to read %s: %w", tgHclFile, err)
 	}
 
-	err = checkErrors(l, l.Formatter().DisabledColors(), contents, tgHclFile)
+	err = checkErrors(l, v, contents, tgHclFile)
 	if err != nil {
 		l.Errorf("Error parsing %s", tgHclFile)
 		return err
@@ -262,7 +261,7 @@ func formatTgHCL(
 	fileUpdated := !bytes.Equal(newContents, contents)
 
 	if opts.Diff && fileUpdated {
-		if _, err := w.Write(bytesDiff(contents, newContents, tgHclFile)); err != nil {
+		if _, err := v.Writers.Writer.Write(bytesDiff(contents, newContents, tgHclFile)); err != nil {
 			l.Errorf("Failed to print diff for %s", tgHclFile)
 			return err
 		}
@@ -274,19 +273,19 @@ func formatTgHCL(
 
 	if fileUpdated {
 		l.Debugf("Updating %s", tgHclFile)
-		return vfs.WriteFile(fsys, tgHclFile, newContents, info.Mode())
+		return vfs.WriteFile(v.FS, tgHclFile, newContents, info.Mode())
 	}
 
 	return nil
 }
 
 // checkErrors takes in the contents of a hcl file and looks for syntax errors.
-func checkErrors(l log.Logger, disableColor bool, contents []byte, tgHclFile string) error {
+func checkErrors(l log.Logger, v *venv.Venv, contents []byte, tgHclFile string) error {
 	parser := hclparse.NewParser()
 	_, diags := parser.ParseHCL(contents, tgHclFile)
 
 	writer := writer.New(writer.WithLogger(l), writer.WithDefaultLevel(log.ErrorLevel))
-	diagWriter := parser.GetDiagnosticsWriter(writer, disableColor)
+	diagWriter := parser.GetDiagnosticsWriter(v, writer, l.Formatter().DisabledColors())
 
 	err := diagWriter.WriteDiagnostics(diags)
 	if err != nil {

--- a/internal/cli/commands/hcl/format/format_test.go
+++ b/internal/cli/commands/hcl/format/format_test.go
@@ -295,7 +295,7 @@ func TestHCLFmtStdin(t *testing.T) {
 	tgOptions.HclFromStdin = true
 
 	v := venvtest.New().
-		WithReader(strings.NewReader(unformatted)).
+		WithStdin(strings.NewReader(unformatted)).
 		WithWriter(&formatted)
 
 	err = format.Run(t.Context(), logger.CreateLogger(), v, tgOptions)

--- a/internal/cli/commands/hcl/validate/validate.go
+++ b/internal/cli/commands/hcl/validate/validate.go
@@ -275,7 +275,7 @@ func writeDiagnostics(
 	opts *options.TerragruntOptions,
 	diags diagnostic.Diagnostics,
 ) error {
-	render := view.NewHumanRender(l.Formatter().DisabledColors())
+	render := view.NewHumanRender(v, l.Formatter().DisabledColors())
 	if opts.HCLValidateJSONOutput {
 		render = view.NewJSONRender()
 	}

--- a/internal/cli/commands/list/list.go
+++ b/internal/cli/commands/list/list.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 
 	"charm.land/lipgloss/v2/tree"
-	"github.com/charmbracelet/x/term"
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/discoverysetup"
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
@@ -121,13 +120,13 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *Options) error {
 
 	switch opts.Format {
 	case FormatText:
-		return outputText(l, v.Writers.Writer, listedComponents)
+		return outputText(l, v, listedComponents)
 	case FormatTree:
-		return outputTree(l, v.Writers.Writer, opts, listedComponents, opts.Mode)
+		return outputTree(l, v, opts, listedComponents, opts.Mode)
 	case FormatLong:
-		return outputLong(l, v.Writers.Writer, opts, listedComponents)
+		return outputLong(l, v, opts, listedComponents)
 	case FormatDot:
-		return outputDot(v.Writers.Writer, listedComponents)
+		return outputDot(v, listedComponents)
 	default:
 		// This should never happen, because of validation in the command.
 		// If it happens, we want to throw so we can fix the validation.
@@ -215,17 +214,17 @@ func discoveredToListed(
 }
 
 // outputText outputs the discovered components in text format.
-func outputText(l log.Logger, w io.Writer, components dag.ListedComponents) error {
-	colorizer := dag.NewColorizer(stdout.ShouldColor(l))
+func outputText(l log.Logger, v *venv.Venv, components dag.ListedComponents) error {
+	colorizer := dag.NewColorizer(stdout.ShouldColor(l, v))
 
-	return renderTabular(w, components, colorizer)
+	return renderTabular(v, v.Writers.Writer, components, colorizer)
 }
 
 // outputLong outputs the discovered components in long format.
-func outputLong(l log.Logger, w io.Writer, opts *Options, components dag.ListedComponents) error {
-	colorizer := dag.NewColorizer(stdout.ShouldColor(l))
+func outputLong(l log.Logger, v *venv.Venv, opts *Options, components dag.ListedComponents) error {
+	colorizer := dag.NewColorizer(stdout.ShouldColor(l, v))
 
-	return renderLong(w, opts, components, colorizer)
+	return renderLong(v.Writers.Writer, opts, components, colorizer)
 }
 
 // renderLong renders the components in a long format.
@@ -293,10 +292,10 @@ func buildLongHeadings(opts *Options, c *dag.Colorizer, longestPathLen int) stri
 }
 
 // renderTabular renders the components in a tabular format.
-func renderTabular(w io.Writer, components dag.ListedComponents, c *dag.Colorizer) error {
+func renderTabular(v *venv.Venv, w io.Writer, components dag.ListedComponents, c *dag.Colorizer) error {
 	var buf strings.Builder
 
-	maxCols, colWidth := getMaxCols(components)
+	maxCols, colWidth := getMaxCols(v, components)
 
 	for i, component := range components {
 		if i > 0 && i%maxCols == 0 {
@@ -322,19 +321,19 @@ func renderTabular(w io.Writer, components dag.ListedComponents, c *dag.Colorize
 // outputTree outputs the discovered components in tree format.
 func outputTree(
 	l log.Logger,
-	w io.Writer,
+	v *venv.Venv,
 	opts *Options,
 	components dag.ListedComponents,
 	sort string,
 ) error {
-	s := dag.NewTreeStyler(stdout.ShouldColor(l))
+	s := dag.NewTreeStyler(stdout.ShouldColor(l, v))
 
-	return renderTree(w, opts, components, s, sort)
+	return renderTree(v.Writers.Writer, opts, components, s, sort)
 }
 
 // outputDot outputs the discovered components in GraphViz DOT format.
-func outputDot(w io.Writer, components dag.ListedComponents) error {
-	return renderDot(w, components)
+func outputDot(v *venv.Venv, components dag.ListedComponents) error {
+	return renderDot(v.Writers.Writer, components)
 }
 
 // generateTree creates a tree structure from dag.ListedComponents
@@ -428,10 +427,10 @@ func renderTree(
 // that can be displayed in the terminal.
 // It also returns the width of each column.
 // The width is the longest path length + 2 for padding.
-func getMaxCols(components dag.ListedComponents) (int, int) {
+func getMaxCols(v *venv.Venv, components dag.ListedComponents) (int, int) {
 	maxCols := 0
 
-	terminalWidth := getTerminalWidth()
+	terminalWidth := getTerminalWidth(v)
 	longestPathLen := getLongestPathLen(components)
 
 	const padding = 2
@@ -449,17 +448,19 @@ func getMaxCols(components dag.ListedComponents) (int, int) {
 	return maxCols, colWidth
 }
 
-// getTerminalWidth returns the width of the terminal.
-func getTerminalWidth() int {
-	// Default to 80 if we can't get the terminal width.
-	width := 80
+// defaultTerminalWidth is the column count assumed when the run has no
+// terminal to measure, as in a pipe or a CI log.
+const defaultTerminalWidth = 80
 
-	cols, _, err := term.GetSize(os.Stdout.Fd())
-	if err == nil {
-		width = cols
+// getTerminalWidth returns the width of the terminal.
+func getTerminalWidth(v *venv.Venv) int {
+	v.RequireTerminal()
+
+	if cols := v.Terminal.Width(); cols > 0 {
+		return cols
 	}
 
-	return width
+	return defaultTerminalWidth
 }
 
 // getLongestPathLen returns the length of the

--- a/internal/cli/commands/list/list_test.go
+++ b/internal/cli/commands/list/list_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/list"
 	"github.com/gruntwork-io/terragrunt/internal/component"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/view/dag"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -77,7 +76,7 @@ func TestBasicDiscovery(t *testing.T) {
 
 	l.Formatter().SetDisabledColors(true)
 
-	err = list.Run(t.Context(), l, venv.OSVenv().WithWriter(writer), opts)
+	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(writer), opts)
 	require.NoError(t, err)
 
 	// Close the write end of the pipe
@@ -154,7 +153,7 @@ func TestHiddenDiscovery(t *testing.T) {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venv.OSVenv().WithWriter(w), opts)
+	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	// Close the write end of the pipe
@@ -229,7 +228,7 @@ dependency "unit2" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venv.OSVenv().WithWriter(w), opts)
+	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	// Close the write end of the pipe
@@ -304,7 +303,7 @@ dependency "unit3" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venv.OSVenv().WithWriter(w), opts)
+	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	// Close the write end of the pipe
@@ -418,7 +417,7 @@ dependency "C" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venv.OSVenv().WithWriter(w), opts)
+	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	// Close the write end of the pipe
@@ -558,7 +557,7 @@ dependency "unit1" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venv.OSVenv().WithWriter(w), opts)
+	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()
@@ -618,7 +617,7 @@ func TestDotFormatWithoutDependencies(t *testing.T) {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venv.OSVenv().WithWriter(w), opts)
+	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()
@@ -691,7 +690,7 @@ dependency "unit2" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venv.OSVenv().WithWriter(w), opts)
+	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()
@@ -769,7 +768,7 @@ dependency "unit2" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venv.OSVenv().WithWriter(w), opts)
+	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()
@@ -840,7 +839,7 @@ dependency "unit1" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venv.OSVenv().WithWriter(w), opts)
+	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()
@@ -907,7 +906,7 @@ exclude {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venv.OSVenv().WithWriter(w), opts)
+	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()
@@ -989,7 +988,7 @@ dependency "unit3" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venv.OSVenv().WithWriter(w), opts)
+	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()

--- a/internal/cli/commands/profiling.go
+++ b/internal/cli/commands/profiling.go
@@ -69,7 +69,7 @@ type profilePaths struct {
 }
 
 // startProfiling starts the profiles configured via opts and returns a stop function that finalizes them.
-func startProfiling(l log.Logger, fs vfs.FS, opts *options.TerragruntOptions) (func(), error) {
+func startProfiling(l log.Logger, fsys vfs.FS, opts *options.TerragruntOptions) (func(), error) {
 	if opts.ProfileCPU == "" && opts.ProfileMem == "" && opts.ProfileGoroutine == "" && opts.ProfileDir == "" {
 		return noopStop, nil
 	}
@@ -78,7 +78,7 @@ func startProfiling(l log.Logger, fs vfs.FS, opts *options.TerragruntOptions) (f
 		return nil, ErrProfilingRequiresExperiment
 	}
 
-	paths, err := resolveProfilePaths(fs, opts)
+	paths, err := resolveProfilePaths(fsys, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -86,15 +86,15 @@ func startProfiling(l log.Logger, fs vfs.FS, opts *options.TerragruntOptions) (f
 	var memFile, goroutineFile, cpuFile vfs.File
 
 	if paths.mem != "" {
-		if memFile, err = createNamedProfileFile(l, fs, paths.mem, "memory"); err != nil {
+		if memFile, err = createNamedProfileFile(l, fsys, paths.mem, "memory"); err != nil {
 			return nil, err
 		}
 	}
 
 	if paths.goroutine != "" {
-		if goroutineFile, err = createNamedProfileFile(l, fs, paths.goroutine, "goroutine"); err != nil {
+		if goroutineFile, err = createNamedProfileFile(l, fsys, paths.goroutine, "goroutine"); err != nil {
 			if memFile != nil {
-				discardProfileFile(l, fs, paths.mem, memFile)
+				discardProfileFile(l, fsys, paths.mem, memFile)
 			}
 
 			return nil, err
@@ -102,13 +102,13 @@ func startProfiling(l log.Logger, fs vfs.FS, opts *options.TerragruntOptions) (f
 	}
 
 	if paths.cpu != "" {
-		if cpuFile, err = startCPUProfile(l, fs, paths.cpu); err != nil {
+		if cpuFile, err = startCPUProfile(l, fsys, paths.cpu); err != nil {
 			if memFile != nil {
-				discardProfileFile(l, fs, paths.mem, memFile)
+				discardProfileFile(l, fsys, paths.mem, memFile)
 			}
 
 			if goroutineFile != nil {
-				discardProfileFile(l, fs, paths.goroutine, goroutineFile)
+				discardProfileFile(l, fsys, paths.goroutine, goroutineFile)
 			}
 
 			return nil, err
@@ -138,7 +138,7 @@ func noopStop() {
 }
 
 // resolveProfilePaths resolves the output path for each profile type, filling in defaults under opts.ProfileDir.
-func resolveProfilePaths(fs vfs.FS, opts *options.TerragruntOptions) (profilePaths, error) {
+func resolveProfilePaths(fsys vfs.FS, opts *options.TerragruntOptions) (profilePaths, error) {
 	paths := profilePaths{
 		cpu:       opts.ProfileCPU,
 		mem:       opts.ProfileMem,
@@ -154,7 +154,7 @@ func resolveProfilePaths(fs vfs.FS, opts *options.TerragruntOptions) (profilePat
 		dir = filepath.Join(opts.WorkingDir, dir)
 	}
 
-	if err := fs.MkdirAll(dir, profileDirMode); err != nil {
+	if err := fsys.MkdirAll(dir, profileDirMode); err != nil {
 		return profilePaths{}, fmt.Errorf("could not create profile directory: %w", err)
 	}
 
@@ -177,14 +177,14 @@ func resolveProfilePaths(fs vfs.FS, opts *options.TerragruntOptions) (profilePat
 }
 
 // startCPUProfile creates the CPU profile file at the given non-empty path and starts CPU profiling.
-func startCPUProfile(l log.Logger, fs vfs.FS, path string) (vfs.File, error) {
-	f, err := createNamedProfileFile(l, fs, path, "CPU")
+func startCPUProfile(l log.Logger, fsys vfs.FS, path string) (vfs.File, error) {
+	f, err := createNamedProfileFile(l, fsys, path, "CPU")
 	if err != nil {
 		return nil, err
 	}
 
 	if err := pprof.StartCPUProfile(f); err != nil {
-		discardProfileFile(l, fs, path, f)
+		discardProfileFile(l, fsys, path, f)
 
 		return nil, fmt.Errorf("could not start CPU profile: %w", err)
 	}
@@ -223,8 +223,8 @@ func writeGoroutineProfile(l log.Logger, f vfs.File) {
 }
 
 // createNamedProfileFile creates the output file for the named profile at the given non-empty path.
-func createNamedProfileFile(l log.Logger, fs vfs.FS, path, name string) (vfs.File, error) {
-	f, err := createProfileFile(l, fs, path)
+func createNamedProfileFile(l log.Logger, fsys vfs.FS, path, name string) (vfs.File, error) {
+	f, err := createProfileFile(l, fsys, path)
 	if err != nil {
 		return nil, fmt.Errorf("could not create %s profile: %w", name, err)
 	}
@@ -233,13 +233,13 @@ func createNamedProfileFile(l log.Logger, fs vfs.FS, path, name string) (vfs.Fil
 }
 
 // createProfileFile creates a profile output file readable only by the owner, tightening permissions on pre-existing files.
-func createProfileFile(l log.Logger, fs vfs.FS, path string) (vfs.File, error) {
-	f, err := fs.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, profileFileMode)
+func createProfileFile(l log.Logger, fsys vfs.FS, path string) (vfs.File, error) {
+	f, err := fsys.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, profileFileMode)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := fs.Chmod(path, profileFileMode); err != nil {
+	if err := fsys.Chmod(path, profileFileMode); err != nil {
 		if closeErr := f.Close(); closeErr != nil {
 			l.Debugf("Could not close profile %s: %v", path, closeErr)
 		}
@@ -258,12 +258,12 @@ func closeProfileFile(l log.Logger, name string, f vfs.File) {
 }
 
 // discardProfileFile closes and removes a partially created profile file after a startup failure.
-func discardProfileFile(l log.Logger, fs vfs.FS, path string, f vfs.File) {
+func discardProfileFile(l log.Logger, fsys vfs.FS, path string, f vfs.File) {
 	if err := f.Close(); err != nil {
 		l.Debugf("Could not close discarded profile %s: %v", path, err)
 	}
 
-	if err := fs.Remove(path); err != nil {
+	if err := fsys.Remove(path); err != nil {
 		l.Debugf("Could not remove discarded profile %s: %v", path, err)
 	}
 }

--- a/internal/cli/commands/render/render_test.go
+++ b/internal/cli/commands/render/render_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/render"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +31,7 @@ func TestRenderJSON_Basic(t *testing.T) {
 	err := render.Run(
 		t.Context(),
 		logger.CreateLogger(),
-		venv.OSVenv().WithWriter(&outputBuffer),
+		venvtest.NewOSWithEmptyEnv().WithWriter(&outputBuffer),
 		opts,
 	)
 	require.NoError(t, err)
@@ -59,7 +59,7 @@ func TestRenderJSON_WithMetadata(t *testing.T) {
 	err := render.Run(
 		t.Context(),
 		logger.CreateLogger(),
-		venv.OSVenv().WithWriter(&outputBuffer),
+		venvtest.NewOSWithEmptyEnv().WithWriter(&outputBuffer),
 		opts,
 	)
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestRenderJSON_WriteToFile(t *testing.T) {
 	err := render.Run(
 		t.Context(),
 		logger.CreateLogger(),
-		venv.OSVenv().WithWriter(io.Discard),
+		venvtest.NewOSWithEmptyEnv().WithWriter(io.Discard),
 		opts,
 	)
 	require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestRenderJSON_InvalidFormat(t *testing.T) {
 	err := render.Run(
 		t.Context(),
 		logger.CreateLogger(),
-		venv.OSVenv().WithWriter(io.Discard),
+		venvtest.NewOSWithEmptyEnv().WithWriter(io.Discard),
 		opts,
 	)
 	require.Error(t, err)
@@ -131,7 +131,7 @@ func TestRenderJSON_HCLFormat(t *testing.T) {
 	err := render.Run(
 		t.Context(),
 		logger.CreateLogger(),
-		venv.OSVenv().WithWriter(&renderedBuffer),
+		venvtest.NewOSWithEmptyEnv().WithWriter(&renderedBuffer),
 		opts,
 	)
 	require.NoError(t, err)

--- a/internal/cli/commands/run/run.go
+++ b/internal/cli/commands/run/run.go
@@ -39,7 +39,7 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, v *
 	// This doesn't actually do anything for single-unit runs, but it's
 	// helpful to leave it in here for consistency, if we ever add
 	// support for run summaries in single-unit runs.
-	if l.Formatter().DisabledColors() || stdout.IsRedirected() {
+	if !stdout.ShouldColor(l, v) {
 		r.WithDisableColor()
 	}
 

--- a/internal/cli/commands/run_action_test.go
+++ b/internal/cli/commands/run_action_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/panicreport"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +39,7 @@ func TestRunActionInstallsRunScopedCache(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	require.NoError(t, commands.RunAction(t.Context(), nil, l, opts, venv.OSVenv(), action))
+	require.NoError(t, commands.RunAction(t.Context(), nil, l, opts, venvtest.New(), action))
 	assert.True(t, hasRunCmd, "RunCmdCacheContextKey missing from action context")
 	assert.True(t, hasRepoRoots, "RepoRootCacheContextKey missing from action context")
 }
@@ -54,7 +54,7 @@ func TestRunActionReturnsReportableErrorOnActionPanic(t *testing.T) {
 	opts := options.NewTerragruntOptions()
 	opts.NoAutoProviderCacheDir = true
 
-	err := commands.RunAction(t.Context(), nil, logger.CreateLogger(), opts, venv.OSVenv(), action)
+	err := commands.RunAction(t.Context(), nil, logger.CreateLogger(), opts, venvtest.New(), action)
 	require.Error(t, err)
 	assert.True(t, panicreport.IsPanic(err), "returned error should be classified as a panic")
 

--- a/internal/cli/commands/scaffold/copy_test.go
+++ b/internal/cli/commands/scaffold/copy_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/scaffold"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // unitConfig is a unit built the way catalog units are: its inputs come from
@@ -142,7 +142,7 @@ func TestScaffoldRefusesToOverwriteWhenCopying(t *testing.T) {
 	opts.WorkingDir = outputDir
 	opts.NonInteractive = true
 
-	err = scaffold.Run(t.Context(), logger.CreateLogger(), venv.OSVenv(), opts, source, "")
+	err = scaffold.Run(t.Context(), logger.CreateLogger(), venvtest.NewOSWithEmptyEnv(), opts, source, "")
 	require.Error(t, err)
 
 	assert.NoFileExists(t, filepath.Join(outputDir, "terragrunt.hcl"))
@@ -178,7 +178,7 @@ func runScaffold(t *testing.T, source string) string {
 
 	require.NoError(
 		t,
-		scaffold.Run(t.Context(), logger.CreateLogger(), venv.OSVenv(), opts, source, ""),
+		scaffold.Run(t.Context(), logger.CreateLogger(), venvtest.NewOSWithEmptyEnv(), opts, source, ""),
 	)
 
 	return outputDir

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -304,7 +304,7 @@ func Prepare(
 	}
 
 	// extract variables from downloaded module
-	requiredVariables, optionalVariables, err := parseVariables(l, v.FS, opts, tempDir)
+	requiredVariables, optionalVariables, err := parseVariables(l, v, opts, tempDir)
 	if err != nil {
 		return nil, err
 	}
@@ -783,11 +783,11 @@ func prepareBoilerplateFiles(
 // parseVariables - parse variables from tf files.
 func parseVariables(
 	l log.Logger,
-	fsys vfs.FS,
+	v *venv.Venv,
 	opts *options.TerragruntOptions,
 	moduleDir string,
 ) ([]*config.ParsedVariable, []*config.ParsedVariable, error) {
-	inputs, err := config.ParseVariables(l, fsys, opts.StrictControls, moduleDir)
+	inputs, err := config.ParseVariables(l, v, opts.StrictControls, moduleDir)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/cli/commands/scaffold/scaffold_test.go
+++ b/internal/cli/commands/scaffold/scaffold_test.go
@@ -118,7 +118,7 @@ func TestDefaultTemplateVariables(t *testing.T) {
 		t.Context(),
 		l,
 		pctx,
-		config.DefaultParserOptions(l, opts.StrictControls),
+		config.DefaultParserOptions(l, pctx.Venv, opts.StrictControls),
 	)
 	require.NoError(t, err)
 	require.NotEmpty(t, cfg.Inputs)
@@ -225,7 +225,7 @@ func TestDefaultTemplateUserValueOverridesTODO(t *testing.T) {
 		t.Context(),
 		l,
 		pctx,
-		config.DefaultParserOptions(l, opts.StrictControls),
+		config.DefaultParserOptions(l, pctx.Venv, opts.StrictControls),
 	)
 	require.NoError(t, err)
 

--- a/internal/codegen/generate_test.go
+++ b/internal/codegen/generate_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/codegen"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -335,7 +334,7 @@ func TestFmtGeneratedFile(t *testing.T) {
 			}
 
 			l := logger.CreateLogger()
-			err := codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config)
+			err := codegen.WriteToFile(t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config)
 			require.NoError(t, err)
 
 			assert.FileExists(t, tc.path)
@@ -390,7 +389,7 @@ func TestGenerateDisabling(t *testing.T) {
 			}
 
 			l := logger.CreateLogger()
-			err := codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config)
+			err := codegen.WriteToFile(t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config)
 			require.NoError(t, err)
 
 			if tc.disabled {
@@ -554,7 +553,7 @@ func TestWriteToFileOverwritesReadOnlyTarget(t *testing.T) {
 			}
 
 			l := logger.CreateLogger()
-			require.NoError(t, codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config))
+			require.NoError(t, codegen.WriteToFile(t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config))
 
 			fileContent, err := os.ReadFile(path)
 			require.NoError(t, err)
@@ -608,7 +607,7 @@ func TestWriteToFileSkipAndErrorLeaveExistingFileIntact(t *testing.T) {
 			}
 
 			l := logger.CreateLogger()
-			writeErr := codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config)
+			writeErr := codegen.WriteToFile(t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config)
 
 			if tc.wantErr {
 				var existsErr codegen.GenerateFileExistsError
@@ -657,7 +656,7 @@ func TestWriteToFileOverwriteDoesNotMutateHardlinkedStore(t *testing.T) {
 	}
 
 	l := logger.CreateLogger()
-	require.NoError(t, codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config))
+	require.NoError(t, codegen.WriteToFile(t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config))
 
 	storeContentAfter, err := os.ReadFile(storePath)
 	require.NoError(t, err)
@@ -700,7 +699,7 @@ func TestWriteToFileTargetIsDirectory(t *testing.T) {
 	}
 
 	l := logger.CreateLogger()
-	require.Error(t, codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config))
+	require.Error(t, codegen.WriteToFile(t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config))
 	assert.DirExists(t, targetPath)
 }
 
@@ -723,7 +722,7 @@ func TestWriteToFileDisabledRemovesReadOnlyFile(t *testing.T) {
 	}
 
 	l := logger.CreateLogger()
-	require.NoError(t, codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config))
+	require.NoError(t, codegen.WriteToFile(t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config))
 	assert.NoFileExists(t, targetPath)
 }
 
@@ -768,7 +767,7 @@ func TestWriteToFileSignatureWithoutTrailingNewline(t *testing.T) {
 			}
 
 			l := logger.CreateLogger()
-			require.NoError(t, codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config))
+			require.NoError(t, codegen.WriteToFile(t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config))
 
 			if tc.disable {
 				assert.NoFileExists(t, path)
@@ -835,7 +834,7 @@ func TestWriteToFileUnsignedFileWithoutTrailingNewline(t *testing.T) {
 			}
 
 			l := logger.CreateLogger()
-			writeErr := codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config)
+			writeErr := codegen.WriteToFile(t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config)
 
 			if tc.disable {
 				var removeErr codegen.GenerateFileRemoveError
@@ -884,7 +883,7 @@ func TestWriteToFileWithContentStoreDeduplicates(t *testing.T) {
 
 		l := logger.CreateLogger()
 		require.NoError(t, codegen.WriteToFile(
-			t.Context(), l, venv.OSVenv(), "", &config, codegen.WithContentStore(store),
+			t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config, codegen.WithContentStore(store),
 		))
 	}
 
@@ -940,7 +939,7 @@ func TestWriteToFileWithContentStoreMutableOptsOut(t *testing.T) {
 
 		l := logger.CreateLogger()
 		require.NoError(t, codegen.WriteToFile(
-			t.Context(), l, venv.OSVenv(), "", &config, codegen.WithContentStore(store),
+			t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config, codegen.WithContentStore(store),
 		))
 	}
 
@@ -961,7 +960,7 @@ func TestWriteToFileWithContentStoreMutableOptsOut(t *testing.T) {
 func TestWriteToFileWithContentStoreRegeneratesChangedContents(t *testing.T) {
 	t.Parallel()
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 	testDir := helpers.TmpDirWOSymlinks(t)
 	store := newTestContentStore(t, testDir)
 	targetPath := filepath.Join(testDir, "versions.tf")
@@ -1044,7 +1043,7 @@ func TestWriteToFileOverwritesDanglingSymlink(t *testing.T) {
 
 			l := logger.CreateLogger()
 			require.NoError(t, codegen.WriteToFile(
-				t.Context(), l, venv.OSVenv(), "", &config, opts...,
+				t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config, opts...,
 			))
 
 			info, err := os.Lstat(targetPath)
@@ -1106,7 +1105,7 @@ func TestWriteToFileSymlinkIsNotTerragruntGenerated(t *testing.T) {
 			}
 
 			l := logger.CreateLogger()
-			writeErr := codegen.WriteToFile(t.Context(), l, venv.OSVenv(), "", &config)
+			writeErr := codegen.WriteToFile(t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config)
 
 			if tc.disable {
 				var removeErr codegen.GenerateFileRemoveError

--- a/internal/component/component.go
+++ b/internal/component/component.go
@@ -14,7 +14,7 @@ import (
 
 	"errors"
 
-	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 )
 
 // Kind is the type of Terragrunt component.
@@ -241,8 +241,10 @@ func (c Components) CycleCheck() (Component, error) {
 
 // ThreadSafeComponents provides thread-safe access to a Components slice.
 // It uses an RWMutex to allow concurrent reads and serialized writes.
-// Resolved paths are cached to avoid repeated filepath.EvalSymlinks syscalls
-// and ensure consistent symlink-aware comparisons across all methods.
+// Resolved paths are cached to avoid repeated symlink resolution and to keep
+// symlink-aware comparisons consistent across all methods. Every method takes
+// the filesystem the cache was built against; resolving one component against
+// a different one would compare paths from two namespaces.
 type ThreadSafeComponents struct {
 	resolvedPaths map[string]string
 	components    Components
@@ -250,7 +252,7 @@ type ThreadSafeComponents struct {
 }
 
 // NewThreadSafeComponents creates a new ThreadSafeComponents instance with the given components.
-func NewThreadSafeComponents(components Components) *ThreadSafeComponents {
+func NewThreadSafeComponents(fsys vfs.FS, components Components) *ThreadSafeComponents {
 	tsc := &ThreadSafeComponents{
 		components:    components,
 		resolvedPaths: make(map[string]string, len(components)),
@@ -258,7 +260,7 @@ func NewThreadSafeComponents(components Components) *ThreadSafeComponents {
 
 	// Pre-populate resolved paths cache for initial components
 	for _, c := range components {
-		tsc.resolvedPaths[c.Path()] = util.ResolvePath(c.Path())
+		tsc.resolvedPaths[c.Path()] = vfs.ResolveForCompare(fsys, c.Path())
 	}
 
 	return tsc
@@ -267,12 +269,12 @@ func NewThreadSafeComponents(components Components) *ThreadSafeComponents {
 // resolvedPathFor returns the cached resolved path for a component path if present,
 // otherwise resolves the path on the fly without mutating the cache.
 // Caller must hold at least a read lock.
-func (tsc *ThreadSafeComponents) resolvedPathFor(path string) string {
+func (tsc *ThreadSafeComponents) resolvedPathFor(fsys vfs.FS, path string) string {
 	if resolved, ok := tsc.resolvedPaths[path]; ok {
 		return resolved
 	}
 
-	return util.ResolvePath(path)
+	return vfs.ResolveForCompare(fsys, path)
 }
 
 // EnsureComponent adds a component to the components list if it's not already present.
@@ -280,10 +282,10 @@ func (tsc *ThreadSafeComponents) resolvedPathFor(path string) string {
 // Path comparison uses resolved symlink paths for consistency.
 //
 // It returns the component if it was added, and a boolean indicating if it was added.
-func (tsc *ThreadSafeComponents) EnsureComponent(c Component) (Component, bool) {
-	found, ok := tsc.findComponent(c)
+func (tsc *ThreadSafeComponents) EnsureComponent(fsys vfs.FS, c Component) (Component, bool) {
+	found, ok := tsc.findComponent(fsys, c)
 	if !ok {
-		return tsc.addComponent(c)
+		return tsc.addComponent(fsys, c)
 	}
 
 	return found, false
@@ -292,14 +294,14 @@ func (tsc *ThreadSafeComponents) EnsureComponent(c Component) (Component, bool) 
 // findComponent checks if a component is in the components slice using resolved paths.
 // If it is, it returns the component and true.
 // If it is not, it returns nil and false.
-func (tsc *ThreadSafeComponents) findComponent(c Component) (Component, bool) {
+func (tsc *ThreadSafeComponents) findComponent(fsys vfs.FS, c Component) (Component, bool) {
 	tsc.mu.RLock()
 	defer tsc.mu.RUnlock()
 
-	searchResolved := util.ResolvePath(c.Path())
+	searchResolved := vfs.ResolveForCompare(fsys, c.Path())
 
 	idx := slices.IndexFunc(tsc.components, func(cc Component) bool {
-		return tsc.resolvedPathFor(cc.Path()) == searchResolved
+		return tsc.resolvedPathFor(fsys, cc.Path()) == searchResolved
 	})
 
 	if idx == -1 {
@@ -312,16 +314,16 @@ func (tsc *ThreadSafeComponents) findComponent(c Component) (Component, bool) {
 // addComponent adds a component to the components list, acquiring a write lock.
 // Uses a double-check pattern to avoid TOCTOU race conditions.
 // Caches the resolved path for the new component.
-func (tsc *ThreadSafeComponents) addComponent(c Component) (Component, bool) {
+func (tsc *ThreadSafeComponents) addComponent(fsys vfs.FS, c Component) (Component, bool) {
 	tsc.mu.Lock()
 	defer tsc.mu.Unlock()
 
-	searchResolved := util.ResolvePath(c.Path())
+	searchResolved := vfs.ResolveForCompare(fsys, c.Path())
 
 	// Do one last check to see if the component is already in the components list
 	// to avoid a TOCTOU race condition. Uses resolved paths for comparison.
 	idx := slices.IndexFunc(tsc.components, func(cc Component) bool {
-		return tsc.resolvedPathFor(cc.Path()) == searchResolved
+		return tsc.resolvedPathFor(fsys, cc.Path()) == searchResolved
 	})
 
 	if idx != -1 {
@@ -338,14 +340,14 @@ func (tsc *ThreadSafeComponents) addComponent(c Component) (Component, bool) {
 // FindByPath searches for a component by its path and returns it if found, otherwise returns nil.
 // Paths are resolved to handle symlinks consistently across platforms (e.g., macOS /var -> /private/var).
 // Uses cached resolved paths to avoid repeated syscalls.
-func (tsc *ThreadSafeComponents) FindByPath(path string) Component {
+func (tsc *ThreadSafeComponents) FindByPath(fsys vfs.FS, path string) Component {
 	tsc.mu.RLock()
 	defer tsc.mu.RUnlock()
 
-	resolvedSearchPath := util.ResolvePath(path)
+	resolvedSearchPath := vfs.ResolveForCompare(fsys, path)
 
 	for _, c := range tsc.components {
-		if tsc.resolvedPathFor(c.Path()) == resolvedSearchPath {
+		if tsc.resolvedPathFor(fsys, c.Path()) == resolvedSearchPath {
 			return c
 		}
 	}

--- a/internal/component/component_test.go
+++ b/internal/component/component_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -173,14 +174,15 @@ func TestUnitStringConcurrent(t *testing.T) {
 func TestThreadSafeComponentsEnsureNoDuplicates(t *testing.T) {
 	t.Parallel()
 
-	tsc := component.NewThreadSafeComponents(component.Components{})
+	fsys := vfs.NewMemMapFS()
+	tsc := component.NewThreadSafeComponents(fsys, component.Components{})
 
 	// Add same path twice - should not duplicate
 	unit1 := component.NewUnit("/test/path")
 	unit2 := component.NewUnit("/test/path")
 
-	added1, wasAdded1 := tsc.EnsureComponent(unit1)
-	added2, wasAdded2 := tsc.EnsureComponent(unit2)
+	added1, wasAdded1 := tsc.EnsureComponent(fsys, unit1)
+	added2, wasAdded2 := tsc.EnsureComponent(fsys, unit2)
 
 	assert.True(t, wasAdded1, "first component should be added")
 	assert.False(t, wasAdded2, "second component should not be added (duplicate)")
@@ -192,22 +194,24 @@ func TestThreadSafeComponentsFindByPath(t *testing.T) {
 	t.Parallel()
 
 	unit := component.NewUnit("/test/path")
-	tsc := component.NewThreadSafeComponents(component.Components{unit})
+	fsys := vfs.NewMemMapFS()
+	tsc := component.NewThreadSafeComponents(fsys, component.Components{unit})
 
 	// Find by exact path
-	found := tsc.FindByPath("/test/path")
+	found := tsc.FindByPath(fsys, "/test/path")
 	assert.NotNil(t, found, "should find component by exact path")
 	assert.Equal(t, "/test/path", found.Path())
 
 	// Find non-existent path
-	notFound := tsc.FindByPath("/nonexistent")
+	notFound := tsc.FindByPath(fsys, "/nonexistent")
 	assert.Nil(t, notFound, "should not find non-existent path")
 }
 
 func TestThreadSafeComponentsConcurrentAccess(t *testing.T) {
 	t.Parallel()
 
-	tsc := component.NewThreadSafeComponents(component.Components{})
+	fsys := vfs.NewMemMapFS()
+	tsc := component.NewThreadSafeComponents(fsys, component.Components{})
 
 	var wg sync.WaitGroup
 
@@ -217,7 +221,7 @@ func TestThreadSafeComponentsConcurrentAccess(t *testing.T) {
 	for range goroutines {
 		wg.Go(func() {
 			unit := component.NewUnit("/test/path")
-			tsc.EnsureComponent(unit)
+			tsc.EnsureComponent(fsys, unit)
 		})
 	}
 
@@ -225,7 +229,7 @@ func TestThreadSafeComponentsConcurrentAccess(t *testing.T) {
 	for range goroutines {
 		wg.Go(func() {
 			for range 100 {
-				_ = tsc.FindByPath("/test/path")
+				_ = tsc.FindByPath(fsys, "/test/path")
 				_ = tsc.Len()
 				_ = tsc.ToComponents()
 			}

--- a/internal/discovery/benchmark_test.go
+++ b/internal/discovery/benchmark_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,7 +63,7 @@ func benchmarkPathExpression(b *testing.B, n int) {
 	)
 	require.NoError(b, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	b.ResetTimer()
 
@@ -93,7 +93,7 @@ func benchmarkGraphExpression(b *testing.B, n int) {
 	filterQueries, err := filter.ParseFilterQueries(l, []string{"infra-0001..."})
 	require.NoError(b, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	b.ResetTimer()
 
@@ -126,7 +126,7 @@ func benchmarkPathAndGraphExpression(b *testing.B, n int) {
 	)
 	require.NoError(b, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	b.ResetTimer()
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 
@@ -227,7 +228,7 @@ func (d *Discovery) Discover(
 		components = filtered
 	}
 
-	components = d.dropOutsideBoundary(l, components)
+	components = d.dropOutsideBoundary(l, v.FS, components)
 
 	cycleCheckErr := telemetry.TelemeterFromContext(ctx).
 		Collect(ctx, l, "discovery_cycle_check", map[string]any{},
@@ -255,7 +256,7 @@ func (d *Discovery) Discover(
 	}
 
 	if d.graphTarget != "" {
-		components = d.filterGraphTarget(components)
+		components = d.filterGraphTarget(v.FS, components)
 	}
 
 	components = d.applyQueueFilters(opts, components)
@@ -554,7 +555,7 @@ func (d *Discovery) buildDependencyGraph(
 	opts *options.TerragruntOptions,
 	allComponents component.Components,
 ) []error {
-	threadSafeComponents := component.NewThreadSafeComponents(allComponents)
+	threadSafeComponents := component.NewThreadSafeComponents(v.FS, allComponents)
 
 	var (
 		errs []error
@@ -614,7 +615,7 @@ func (d *Discovery) buildComponentDependencies(
 
 	cfg := unit.Config()
 
-	depPaths, err := extractDependencyPaths(cfg, c)
+	depPaths, err := extractDependencyPaths(v.FS, cfg, c)
 	if err != nil {
 		return err
 	}
@@ -634,21 +635,21 @@ func (d *Discovery) buildComponentDependencies(
 	}
 
 	for _, depPath := range depPaths {
-		depComponent := componentFromDependencyPath(depPath, threadSafeComponents)
+		depComponent := componentFromDependencyPath(v.FS, depPath, threadSafeComponents)
 
 		if dctx := depComponent.DiscoveryContext(); dctx == nil || dctx.WorkingDir == "" {
 			depComponent.SetDiscoveryContext(
 				parentCtx.CopyWithNewOrigin(component.OriginGraphDiscovery),
 			)
 
-			if isExternal(parentCtx.WorkingDir, depPath) {
+			if isExternal(v.FS, parentCtx.WorkingDir, depPath) {
 				if ext, ok := depComponent.(*component.Unit); ok {
 					ext.SetExternal()
 				}
 			}
 		}
 
-		addedComponent, _ := threadSafeComponents.EnsureComponent(depComponent)
+		addedComponent, _ := threadSafeComponents.EnsureComponent(v.FS, depComponent)
 
 		c.AddDependency(addedComponent)
 	}
@@ -680,24 +681,24 @@ func removeCycles(components component.Components) (component.Components, error)
 }
 
 // filterGraphTarget prunes components to the target path and its dependents.
-func (d *Discovery) filterGraphTarget(components component.Components) component.Components {
+func (d *Discovery) filterGraphTarget(fsys vfs.FS, components component.Components) component.Components {
 	if d.graphTarget == "" {
 		return components
 	}
 
-	targetPath := canonicalizeGraphTarget(d.workingDir, d.graphTarget)
+	targetPath := canonicalizeGraphTarget(fsys, d.workingDir, d.graphTarget)
 
-	dependentUnits := buildDependentsIndex(components)
+	dependentUnits := buildDependentsIndex(fsys, components)
 	propagateTransitiveDependents(dependentUnits)
 
 	allowed := buildAllowSet(targetPath, dependentUnits)
 
-	return filterByAllowSet(components, allowed)
+	return filterByAllowSet(fsys, components, allowed)
 }
 
 // canonicalizeGraphTarget resolves the graph target to an absolute, cleaned path with symlinks resolved.
 // Returns an error if the path cannot be made absolute.
-func canonicalizeGraphTarget(baseDir, target string) string {
+func canonicalizeGraphTarget(fsys vfs.FS, baseDir, target string) string {
 	var abs string
 
 	// If already absolute, just clean it
@@ -715,25 +716,20 @@ func canonicalizeGraphTarget(baseDir, target string) string {
 	// EvalSymlinks can fail for: non-existent paths (expected during discovery),
 	// broken symlinks, or permission issues. In all cases, falling back to the
 	// absolute path is acceptable - the path will be validated later when used.
-	resolved, evalErr := filepath.EvalSymlinks(abs)
-	if evalErr != nil {
-		return abs
-	}
-
-	return resolved
+	return vfs.ResolveForCompare(fsys, abs)
 }
 
 // buildDependentsIndex builds an index mapping each unit path to the list of units
 // that directly depend on it. Duplicate entries are removed.
 // Paths are resolved to handle symlinks consistently across platforms.
-func buildDependentsIndex(components component.Components) map[string][]string {
+func buildDependentsIndex(fsys vfs.FS, components component.Components) map[string][]string {
 	dependentUnits := make(map[string][]string)
 
 	for _, c := range components {
-		cPath := util.ResolvePath(c.Path())
+		cPath := vfs.ResolveForCompare(fsys, c.Path())
 
 		for _, dep := range c.Dependencies() {
-			depPath := util.ResolvePath(dep.Path())
+			depPath := vfs.ResolveForCompare(fsys, dep.Path())
 			dependentUnits[depPath] = util.RemoveDuplicates(append(dependentUnits[depPath], cPath))
 		}
 	}
@@ -793,13 +789,14 @@ func buildAllowSet(targetPath string, dependentUnits map[string][]string) map[st
 // Paths are resolved to handle symlinks consistently across platforms.
 // The output order matches the input order (no sorting is performed here).
 func filterByAllowSet(
+	fsys vfs.FS,
 	components component.Components,
 	allowed map[string]struct{},
 ) component.Components {
 	filtered := make(component.Components, 0, len(components))
 
 	for _, c := range components {
-		resolvedPath := util.ResolvePath(c.Path())
+		resolvedPath := vfs.ResolveForCompare(fsys, c.Path())
 		if _, ok := allowed[resolvedPath]; ok {
 			filtered = append(filtered, c)
 		}
@@ -825,7 +822,11 @@ func (d *Discovery) applyQueueFilters(
 // do run can be ordered against them and can fetch their outputs. Components the
 // filesystem walk found are left alone, boundary or not: the boundary says how
 // far a run may follow the graph, not where discovery starts.
-func (d *Discovery) dropOutsideBoundary(l log.Logger, components component.Components) component.Components {
+func (d *Discovery) dropOutsideBoundary(
+	l log.Logger,
+	fsys vfs.FS,
+	components component.Components,
+) component.Components {
 	if d.discoveryBoundary == "" {
 		return components
 	}
@@ -840,7 +841,7 @@ func (d *Discovery) dropOutsideBoundary(l log.Logger, components component.Compo
 	kept := make(component.Components, 0, len(components))
 
 	for _, c := range components {
-		if reachedByTraversal(c) && isExternal(d.discoveryBoundary, c.Path()) {
+		if reachedByTraversal(c) && isExternal(fsys, d.discoveryBoundary, c.Path()) {
 			l.Debugf(
 				"Discovery: %s was reached across discovery boundary %s; not returning it",
 				c.Path(),

--- a/internal/discovery/discovery_integration_test.go
+++ b/internal/discovery/discovery_integration_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -95,7 +95,7 @@ func TestDiscovery_BasicWithHiddenDirectories(t *testing.T) {
 				d = d.WithNoHidden()
 			}
 
-			components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+			components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 
 			units := components.Filter(component.UnitKind).Paths()
@@ -130,7 +130,7 @@ func TestDiscovery_StackHiddenDiscovered(t *testing.T) {
 	d := discovery.NewDiscovery(tmpDir).
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir})
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 	assert.Contains(t, components.Filter(component.UnitKind).Paths(), stackHiddenDir)
 }
@@ -201,7 +201,7 @@ func TestDiscovery_WithDependencies(t *testing.T) {
 			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: internalDir}).
 			WithRelationships()
 
-		components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+		components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 		require.NoError(t, err)
 
 		// Should discover all internal components
@@ -249,7 +249,7 @@ func TestDiscovery_WithDependencies(t *testing.T) {
 			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: internalDir}).
 			WithFilters(filters)
 
-		components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+		components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 		require.NoError(t, err)
 
 		// Should discover all components including external dependency
@@ -318,7 +318,7 @@ dependency "foo" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err, "Discovery should complete even with cycles")
 
 	// Verify that a cycle is detected
@@ -387,7 +387,7 @@ dependency "foo" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err, "Discovery should complete")
 
 	// Verify that a cycle is NOT detected because one dependency is disabled
@@ -456,7 +456,7 @@ exclude {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithParseExclude()
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Verify we found all configurations
@@ -538,7 +538,7 @@ func TestDiscovery_WithCustomConfigFilenames(t *testing.T) {
 			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 			WithConfigFilenames([]string{"custom.hcl"})
 
-		components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+		components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 		require.NoError(t, err)
 
 		units := components.Filter(component.UnitKind).Paths()
@@ -553,7 +553,7 @@ func TestDiscovery_WithCustomConfigFilenames(t *testing.T) {
 			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 			WithConfigFilenames([]string{"terragrunt.hcl", "custom.hcl"})
 
-		components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+		components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 		require.NoError(t, err)
 
 		units := components.Filter(component.UnitKind).Paths()
@@ -611,7 +611,7 @@ func TestDiscovery_WithReadFiles(t *testing.T) {
 		WithFilters(filters).
 		WithReadFiles()
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Find the app component
@@ -699,7 +699,7 @@ inputs = {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Verify that both stack and unit configurations are discovered
@@ -789,7 +789,7 @@ func TestDiscovery_IncludeExcludeFilterSemantics(t *testing.T) {
 				WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 				WithFilters(filters)
 
-			components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+			components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tt.want, components.Filter(component.UnitKind).Paths())
 		})
@@ -822,7 +822,7 @@ func TestDiscovery_HiddenIncludedByIncludeDirs(t *testing.T) {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{hiddenUnitDir}, components.Filter(component.UnitKind).Paths())
 }
@@ -869,7 +869,7 @@ func TestDiscovery_ExternalDependencies(t *testing.T) {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: internalDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Find app config and assert it has external dependency
@@ -948,7 +948,7 @@ dependency "foo" {
 		WithFilters(filters).
 		WithBreakCycles()
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err, "Discovery should complete with break cycles enabled")
 
 	// With break cycles enabled, the cycle should be resolved (one component removed)
@@ -980,7 +980,7 @@ func TestDiscovery_WithNumWorkers(t *testing.T) {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithNumWorkers(2)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 	assert.Len(t, components, 5)
 }
@@ -1044,7 +1044,7 @@ dependency "d" {
 			WithFilters(filters).
 			WithMaxDependencyDepth(100)
 
-		components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+		components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 		require.NoError(t, err)
 
 		paths := components.Paths()
@@ -1065,7 +1065,7 @@ dependency "d" {
 			WithFilters(filters).
 			WithMaxDependencyDepth(1)
 
-		components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+		components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 		require.NoError(t, err)
 
 		paths := components.Paths()
@@ -1108,7 +1108,7 @@ terraform {
 		WithParseExclude().
 		WithSuppressParseErrors()
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err, "Discovery should succeed with suppressed parse errors")
 
 	// Valid config should be discovered
@@ -1191,7 +1191,7 @@ dependency "dependency" {
 				WithParseExclude().
 				WithRelationships()
 
-			components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+			components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 
 			var dependentUnit, dependencyUnit *component.Unit
@@ -1276,7 +1276,7 @@ dependency "db" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Find the app component

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -267,7 +267,7 @@ func TestDiscovery_SimpleFilesystem(t *testing.T) {
 		WorkingDir: tmpDir,
 	})
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 	assert.Len(t, components, 3, "should discover 3 components")
 }
@@ -307,7 +307,7 @@ func TestDiscovery_WithPathFilter(t *testing.T) {
 		}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 	assert.Len(t, components, 2, "should discover 2 components in apps/")
 }
@@ -347,7 +347,7 @@ func TestDiscovery_WithNegatedFilter(t *testing.T) {
 		}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 	assert.Len(t, components, 2, "should discover 2 components (excluding bar)")
 
@@ -392,7 +392,7 @@ func TestDiscovery_CombinedFilters(t *testing.T) {
 		}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 	assert.Len(t, components, 2, "should discover 2 components (apps/* minus baz)")
 
@@ -513,7 +513,7 @@ func TestDiscovery_PopulatesReadingField(t *testing.T) {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithReadFiles()
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Find the app component
@@ -564,7 +564,7 @@ func TestDiscovery_BothHclAndStackFileInSameDir(t *testing.T) {
 	d := discovery.NewDiscovery(tmpDir).
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir})
 
-	_, err := d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	_, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.Error(t, err)
 
 	var coexistErr discovery.CoexistenceError
@@ -595,7 +595,7 @@ func TestDiscovery_SingleUnitNoDuplicateError(t *testing.T) {
 	d := discovery.NewDiscovery(tmpDir).
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir})
 
-	components, err := d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 	assert.Len(t, components, 1)
 	assert.Equal(t, component.UnitKind, components[0].Kind())
@@ -640,7 +640,7 @@ unit "app" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithParseStackConfigs()
 
-	components, err := d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	stacks := make(map[string]*component.Stack)

--- a/internal/discovery/filter_test.go
+++ b/internal/discovery/filter_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -100,7 +100,7 @@ dependency "vpc" {
 				WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 				WithFilters(filters)
 
-			components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+			components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 
 			units := components.Filter(component.UnitKind).Paths()
@@ -182,7 +182,7 @@ dependency "vpc" {
 			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 			WithFilters(filters)
 
-		configs, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+		configs, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 		require.NoError(t, err)
 
 		units := configs.Filter(component.UnitKind).Paths()
@@ -241,7 +241,7 @@ dependency "db" {
 			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 			WithFilters(filters)
 
-		configs, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+		configs, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 		require.NoError(t, err)
 
 		units := configs.Filter(component.UnitKind).Paths()
@@ -306,7 +306,7 @@ dependency "vpc" {
 			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 			WithFilters(filters)
 
-		configs, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+		configs, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 		require.NoError(t, err)
 
 		units := configs.Filter(component.UnitKind).Paths()
@@ -491,7 +491,7 @@ locals {
 				WithFilters(filters).
 				WithReadFiles()
 
-			configs, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+			configs, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 
 			units := configs.Filter(component.UnitKind).Paths()
@@ -543,7 +543,7 @@ locals {
 		WithFilters(filters).
 		WithReadFiles()
 
-	configs, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	configs, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Should find the app component when filtering by absolute path
@@ -750,7 +750,7 @@ unit "test" {
 				WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 				WithFilters(filters)
 
-			configs, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+			configs, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 
 			units := configs.Filter(component.UnitKind).Paths()
@@ -844,7 +844,7 @@ func TestDiscovery_FilterEdgeCases(t *testing.T) {
 				WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 				WithFilters(filters)
 
-			configs, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+			configs, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 
 			units := configs.Filter(component.UnitKind).Paths()
@@ -931,7 +931,7 @@ func TestDiscovery_FilterErrorHandling(t *testing.T) {
 				WithFilters(filters)
 
 			// Attempt discovery - errors should occur during evaluation
-			_, err = d.Discover(ctx, l, venv.OSVenv(), opts)
+			_, err = d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 			if tt.errorExpected {
 				require.Error(t, err, "Expected error for filter: %v", tt.filterQueries)
 			} else {
@@ -998,7 +998,7 @@ dependency "external" {
 			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: internalDir}).
 			WithFilters(filters)
 
-		components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+		components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 		require.NoError(t, err)
 
 		units := components.Filter(component.UnitKind).Paths()
@@ -1015,7 +1015,7 @@ dependency "external" {
 			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: internalDir}).
 			WithFilters(filters)
 
-		components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+		components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 		require.NoError(t, err)
 
 		units := components.Filter(component.UnitKind).Paths()
@@ -1086,7 +1086,7 @@ dependency "vpc" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Should include vpc (target) and db (direct dependent) and app (transitive dependent)
@@ -1151,7 +1151,7 @@ dependency "vpc" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Should include only app (dependent), not vpc (target is excluded)
@@ -1228,7 +1228,7 @@ dependency "vpc" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Should include only db and vpc (dependencies), not app (target is excluded)
@@ -1303,7 +1303,7 @@ dependency "vpc" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Should include: app (dependent), db (target), vpc (dependency)
@@ -1383,7 +1383,7 @@ dependency "vpc" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: appDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Should include vpc (target) and consumer (dependent outside working dir)
@@ -1478,7 +1478,7 @@ dependency "api" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: infraDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Should include vpc (target), api (direct dependent), and frontend (transitive dependent)
@@ -1564,7 +1564,7 @@ dependency "db" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Should include db (target), api (dependent), web (dependent)
@@ -1678,7 +1678,7 @@ dependency "vpc" {
 				WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 				WithFilters(filters)
 
-			components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+			components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 
 			paths := components.Filter(component.UnitKind).Paths()

--- a/internal/discovery/graph_dependency_race_test.go
+++ b/internal/discovery/graph_dependency_race_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -87,7 +87,7 @@ func TestGraphPhase_ConcurrentDependencyDiscoveryWithRacing(t *testing.T) {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workingDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	paths := components.Paths()
@@ -180,7 +180,7 @@ func TestGraphPhase_ConcurrentUpstreamDownstreamSharedDependencyWithRacing(t *te
 		WithGitRoot(workingDir).
 		WithFilters(filters)
 
-	components, err := d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	require.Contains(t, components.Paths(), filepath.Join(extDir, "shared"))
@@ -279,6 +279,6 @@ func TestGraphPhase_UpstreamCandidatePublishBeforeContextWithRacing(t *testing.T
 		WithGitRoot(gitRoot).
 		WithFilters(filters)
 
-	_, err = d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	_, err = d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 }

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	iofs "io/fs"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -128,44 +127,27 @@ func RelPathOrAbs(l log.Logger, base, target, desc string) string {
 // isExternal checks if a component path is outside the given working directory.
 // A path is considered external if it's not within or equal to the working directory.
 // We conservatively evaluate paths as external if we cannot determine their absolute path.
-func isExternal(workingDir string, componentPath string) bool {
+func isExternal(fsys vfs.FS, workingDir string, componentPath string) bool {
 	if workingDir == "" {
 		return true
 	}
 
-	workingDirClean := filepath.Clean(workingDir)
-	componentPathClean := filepath.Clean(componentPath)
-
-	workingDirResolved, err := filepath.EvalSymlinks(workingDirClean)
-	if err != nil {
-		workingDirResolved = workingDirClean
-	}
-
-	componentPathResolved, err := filepath.EvalSymlinks(componentPathClean)
-	if err != nil {
-		componentPathResolved = componentPathClean
-	}
-
-	relPath, err := filepath.Rel(workingDirResolved, componentPathResolved)
-	if err != nil {
-		return true
-	}
-
-	return relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator))
+	return !vfs.Within(fsys, workingDir, componentPath)
 }
 
 // componentFromDependencyPath returns a component for a dependency path. If the path already
 // exists in the thread-safe components, it returns that. If the path contains a stack file,
 // it creates a stack. Otherwise, it creates a unit.
 func componentFromDependencyPath(
+	fsys vfs.FS,
 	path string,
 	components *component.ThreadSafeComponents,
 ) component.Component {
-	if existing := components.FindByPath(path); existing != nil {
+	if existing := components.FindByPath(fsys, path); existing != nil {
 		return existing
 	}
 
-	if _, err := os.Stat(filepath.Join(path, config.DefaultStackFile)); err == nil {
+	if _, err := fsys.Stat(filepath.Join(path, config.DefaultStackFile)); err == nil {
 		return component.NewStack(path)
 	}
 
@@ -274,7 +256,7 @@ func sanitizeReadFiles(files []string) []string {
 }
 
 // extractDependencyPaths extracts all dependency paths from a Terragrunt configuration.
-func extractDependencyPaths(cfg *config.TerragruntConfig, c component.Component) ([]string, error) {
+func extractDependencyPaths(fsys vfs.FS, cfg *config.TerragruntConfig, c component.Component) ([]string, error) {
 	if cfg == nil {
 		return nil, nil
 	}
@@ -307,7 +289,7 @@ func extractDependencyPaths(cfg *config.TerragruntConfig, c component.Component)
 			depPath = filepath.Clean(filepath.Join(c.Path(), depPath))
 		}
 
-		deduped[util.ResolvePath(depPath)] = struct{}{}
+		deduped[vfs.ResolveForCompare(fsys, depPath)] = struct{}{}
 	}
 
 	if cfg.Dependencies != nil {
@@ -316,7 +298,7 @@ func extractDependencyPaths(cfg *config.TerragruntConfig, c component.Component)
 				dependency = filepath.Clean(filepath.Join(c.Path(), dependency))
 			}
 
-			deduped[util.ResolvePath(dependency)] = struct{}{}
+			deduped[vfs.ResolveForCompare(fsys, dependency)] = struct{}{}
 		}
 	}
 

--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"golang.org/x/sync/errgroup"
@@ -94,7 +95,7 @@ func (p *GraphPhase) Run(
 	allComponents := make([]component.Component, 0, len(input.Components)+len(candidateComponents))
 	allComponents = append(allComponents, input.Components...)
 	allComponents = append(allComponents, candidateComponents...)
-	threadSafeComponents := component.NewThreadSafeComponents(allComponents)
+	threadSafeComponents := component.NewThreadSafeComponents(v.FS, allComponents)
 
 	graphTargetCandidates := make([]DiscoveryResult, 0, len(input.Candidates))
 	otherCandidates := make([]DiscoveryResult, 0, len(input.Candidates))
@@ -245,7 +246,7 @@ func (p *GraphPhase) processGraphTarget(
 				return rerr
 			}
 
-			if isExternal(resolved, startDir) {
+			if isExternal(v.FS, resolved, startDir) {
 				return NewDiscoveryBoundaryScopeError(resolved, startDir)
 			}
 
@@ -325,7 +326,7 @@ func (p *GraphPhase) discoverDependencies(
 
 	cfg := unit.Config()
 
-	depPaths, err := extractDependencyPaths(cfg, c)
+	depPaths, err := extractDependencyPaths(v.FS, cfg, c)
 	if err != nil {
 		return err
 	}
@@ -349,13 +350,13 @@ func (p *GraphPhase) discoverDependencies(
 
 	for _, depPath := range depPaths {
 		g.Go(func() error {
-			if boundary != "" && isExternal(boundary, depPath) {
+			if boundary != "" && isExternal(v.FS, boundary, depPath) {
 				l.Debugf("Dependency %s is outside discovery boundary %s; skipping", depPath, boundary)
 				return nil
 			}
 
 			depComponent, err := p.resolveDependency(
-				c, depPath, state.threadSafeComponents,
+				v.FS, c, depPath, state.threadSafeComponents,
 			)
 			if err != nil {
 				errMu.Lock()
@@ -528,7 +529,7 @@ func (p *GraphPhase) discoverDependentsUpstream(
 		return nil
 	}
 
-	resolvedTargetPath := util.ResolvePath(target.Path())
+	resolvedTargetPath := vfs.ResolveForCompare(v.FS, target.Path())
 
 	// When the target is from a worktree, we need to compare using relative suffixes
 	// because the absolute paths will differ (worktree vs original directory).
@@ -536,12 +537,12 @@ func (p *GraphPhase) discoverDependentsUpstream(
 	targetRelSuffix := ""
 
 	if targetDCtx := target.DiscoveryContext(); targetDCtx != nil && targetDCtx.WorkingDir != "" {
-		resolvedWorkingDir := util.ResolvePath(targetDCtx.WorkingDir)
+		resolvedWorkingDir := vfs.ResolveForCompare(v.FS, targetDCtx.WorkingDir)
 		targetRelSuffix = strings.TrimPrefix(resolvedTargetPath, resolvedWorkingDir)
 	}
 
 	// Resolve discovery.workingDir for consistent path comparison.
-	resolvedDiscoveryWorkingDir := util.ResolvePath(state.discovery.workingDir)
+	resolvedDiscoveryWorkingDir := vfs.ResolveForCompare(v.FS, state.discovery.workingDir)
 
 	var candidates []component.Component
 
@@ -739,7 +740,7 @@ func (p *GraphPhase) processUpstreamCandidate(
 
 	cfg := unit.Config()
 
-	deps, err := extractDependencyPaths(cfg, candidate)
+	deps, err := extractDependencyPaths(v.FS, cfg, candidate)
 	if err != nil {
 		state.errMu.Lock()
 
@@ -773,6 +774,7 @@ func (p *GraphPhase) processUpstreamCandidate(
 	}
 
 	canonicalCandidate, _ := state.graphTraversalState.threadSafeComponents.EnsureComponent(
+		v.FS,
 		candidate,
 	)
 
@@ -782,21 +784,23 @@ func (p *GraphPhase) processUpstreamCandidate(
 
 	for _, dep := range deps {
 		depComponent := componentFromDependencyPath(
+			v.FS,
 			dep,
 			state.graphTraversalState.threadSafeComponents,
 		)
 
 		if parentCtx != nil {
-			assignGraphDiscoveryContext(depComponent, parentCtx, dep)
+			assignGraphDiscoveryContext(v.FS, depComponent, parentCtx, dep)
 		}
 
 		depComponent, _ = state.graphTraversalState.threadSafeComponents.EnsureComponent(
+			v.FS,
 			depComponent,
 		)
 
 		// Compare paths: first try exact match, then try relative suffix match
 		// for worktree scenarios where target is in a different directory.
-		resolvedDep := util.ResolvePath(dep)
+		resolvedDep := vfs.ResolveForCompare(v.FS, dep)
 
 		switch {
 		case resolvedDep == state.resolvedTargetPath:
@@ -832,6 +836,7 @@ func (p *GraphPhase) processUpstreamCandidate(
 
 // resolveDependency resolves a dependency path to a component.
 func (p *GraphPhase) resolveDependency(
+	fsys vfs.FS,
 	parent component.Component,
 	depPath string,
 	threadSafeComponents *component.ThreadSafeComponents,
@@ -845,11 +850,11 @@ func (p *GraphPhase) resolveDependency(
 		return nil, NewMissingWorkingDirectoryError(parent.Path())
 	}
 
-	depComponent := componentFromDependencyPath(depPath, threadSafeComponents)
+	depComponent := componentFromDependencyPath(fsys, depPath, threadSafeComponents)
 
-	assignGraphDiscoveryContext(depComponent, parentCtx, depPath)
+	assignGraphDiscoveryContext(fsys, depComponent, parentCtx, depPath)
 
-	addedComponent, _ := threadSafeComponents.EnsureComponent(depComponent)
+	addedComponent, _ := threadSafeComponents.EnsureComponent(fsys, depComponent)
 
 	parent.AddDependency(addedComponent)
 
@@ -867,6 +872,7 @@ func (p *GraphPhase) resolveDependency(
 // It is a no-op once the component already has a working directory, which keeps
 // the assignment to the first goroutine to reach the component along any path.
 func assignGraphDiscoveryContext(
+	fsys vfs.FS,
 	dep component.Component,
 	parentCtx *component.DiscoveryContext,
 	depPath string,
@@ -884,7 +890,7 @@ func assignGraphDiscoveryContext(
 
 	dep.SetDiscoveryContext(copiedCtx)
 
-	if isExternal(parentCtx.WorkingDir, depPath) {
+	if isExternal(fsys, parentCtx.WorkingDir, depPath) {
 		if ext, ok := dep.(*component.Unit); ok {
 			ext.SetExternal()
 		}

--- a/internal/discovery/phase_relationship.go
+++ b/internal/discovery/phase_relationship.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"golang.org/x/sync/errgroup"
@@ -83,7 +84,7 @@ func (p *RelationshipPhase) runRelationshipDiscovery(
 		return nil
 	}
 
-	interTransientComponents := component.NewThreadSafeComponents(component.Components{})
+	interTransientComponents := component.NewThreadSafeComponents(v.FS, component.Components{})
 
 	state := &relationshipTraversalState{
 		opts:                     input.Opts,
@@ -171,7 +172,7 @@ func (p *RelationshipPhase) discoverRelationships(
 
 	cfg := unit.Config()
 
-	paths, err := extractDependencyPaths(cfg, c)
+	paths, err := extractDependencyPaths(v.FS, cfg, c)
 	if err != nil {
 		return err
 	}
@@ -193,6 +194,7 @@ func (p *RelationshipPhase) discoverRelationships(
 		// it and fetch its outputs. [Discovery.dropOutsideBoundary] decides what
 		// is returned.
 		dep, created := p.dependencyToDiscover(
+			v.FS,
 			c,
 			path,
 			state.allComponents,
@@ -259,6 +261,7 @@ func (p *RelationshipPhase) discoverRelationships(
 
 // dependencyToDiscover resolves a dependency path and links it to the component.
 func (p *RelationshipPhase) dependencyToDiscover(
+	fsys vfs.FS,
 	c component.Component,
 	path string,
 	allComponents *component.Components,
@@ -277,14 +280,14 @@ func (p *RelationshipPhase) dependencyToDiscover(
 
 	newUnit := component.NewUnit(path)
 
-	dep, created := interTransientComponents.EnsureComponent(newUnit)
+	dep, created := interTransientComponents.EnsureComponent(fsys, newUnit)
 
 	if created && discovery.discoveryContext != nil {
 		discoveryCtx := discovery.discoveryContext.Copy()
 		discoveryCtx.SuggestOrigin(component.OriginRelationshipDiscovery)
 		dep.SetDiscoveryContext(discoveryCtx)
 
-		if isExternal(discoveryCtx.WorkingDir, path) {
+		if isExternal(fsys, discoveryCtx.WorkingDir, path) {
 			dep.SetExternal()
 		}
 	}

--- a/internal/discovery/phase_relationship_race_test.go
+++ b/internal/discovery/phase_relationship_race_test.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -66,7 +66,7 @@ func TestRelationshipPhase_ConcurrentSharedDependencyWithRacing(t *testing.T) {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workingDir}).
 		WithRelationships()
 
-	components, err := d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	sharedPath := filepath.Join(extDir, "shared")

--- a/internal/discovery/phase_test.go
+++ b/internal/discovery/phase_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +55,7 @@ func TestFilesystemPhase_BasicDiscovery(t *testing.T) {
 	d := discovery.NewDiscovery(tmpDir).
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir})
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Verify phase discovered all components
@@ -98,7 +98,7 @@ func TestFilesystemPhase_SkipsIgnorableDirs(t *testing.T) {
 	d := discovery.NewDiscovery(tmpDir).
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir})
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Should only find the valid unit, not the ones in ignorable directories
@@ -135,7 +135,7 @@ func TestFilesystemPhase_WithNoHidden(t *testing.T) {
 		d := discovery.NewDiscovery(tmpDir).
 			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir})
 
-		components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+		components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 		require.NoError(t, err)
 		assert.Len(t, components, 2, "Should find both visible and hidden")
 	})
@@ -147,7 +147,7 @@ func TestFilesystemPhase_WithNoHidden(t *testing.T) {
 			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 			WithNoHidden()
 
-		components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+		components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 		require.NoError(t, err)
 		assert.Len(t, components, 1, "Should find only visible")
 		assert.Equal(t, visibleDir, components[0].Path())
@@ -194,7 +194,7 @@ locals {
 		WithFilters(filters).
 		WithReadFiles()
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	assert.Len(t, components, 1)
@@ -253,7 +253,7 @@ dependency "vpc" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Graph phase should discover all dependencies
@@ -333,7 +333,7 @@ dependency "vpc" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// The vpc component should always be discovered (it's the target)
@@ -384,7 +384,7 @@ dependency "db" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithRelationships()
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Verify relationships are built
@@ -784,7 +784,7 @@ dependency "vpc" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(ctx, l, venv.OSVenv(), opts)
+	components, err := d.Discover(ctx, l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// With pre-built dependency graph, dependent discovery should now find all dependents

--- a/internal/discovery/phase_worktree.go
+++ b/internal/discovery/phase_worktree.go
@@ -82,7 +82,7 @@ func (p *WorktreePhase) Run(
 		return results, nil
 	}
 
-	discoveredComponents := component.NewThreadSafeComponents(component.Components{})
+	discoveredComponents := component.NewThreadSafeComponents(v.FS, component.Components{})
 
 	discoveryGroup, discoveryCtx := errgroup.WithContext(ctx)
 	discoveryGroup.SetLimit(p.numWorkers)
@@ -111,7 +111,7 @@ func (p *WorktreePhase) Run(
 					}
 
 					for _, c := range components {
-						discoveredComponents.EnsureComponent(c)
+						discoveredComponents.EnsureComponent(v.FS, c)
 					}
 
 					return nil
@@ -151,7 +151,7 @@ func (p *WorktreePhase) Run(
 					}
 
 					for _, c := range components {
-						discoveredComponents.EnsureComponent(c)
+						discoveredComponents.EnsureComponent(v.FS, c)
 					}
 
 					return nil
@@ -169,7 +169,7 @@ func (p *WorktreePhase) Run(
 		}
 
 		for _, c := range components {
-			discoveredComponents.EnsureComponent(c)
+			discoveredComponents.EnsureComponent(v.FS, c)
 		}
 
 		return nil
@@ -330,7 +330,7 @@ func (p *WorktreePhase) discoverChangesInWorktreeStacks(
 	input *PhaseInput,
 	w *worktrees.Worktrees,
 ) (component.Components, error) {
-	discoveredComponents := component.NewThreadSafeComponents(component.Components{})
+	discoveredComponents := component.NewThreadSafeComponents(v.FS, component.Components{})
 
 	stackDiff := w.Stacks()
 
@@ -380,7 +380,7 @@ func (p *WorktreePhase) discoverChangesInWorktreeStacks(
 			}
 
 			for _, c := range components {
-				discoveredComponents.EnsureComponent(c)
+				discoveredComponents.EnsureComponent(v.FS, c)
 			}
 
 			return nil

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -475,7 +475,7 @@ func TestWorktreePhase_Integration_CommandArgs(t *testing.T) {
 				WorkingDir:     tmpDir,
 				GitExpressions: gitExpressions,
 			}
-			w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
+			w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -506,7 +506,7 @@ func TestWorktreePhase_Integration_CommandArgs(t *testing.T) {
 
 			discovery = discovery.WithFilters(filters)
 
-			components, err := discovery.Discover(t.Context(), l, venv.OSVenv(), opts)
+			components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 
 			if tt.expectError {
 				require.Error(t, err, "Expected error for: %s", tt.description)
@@ -761,7 +761,7 @@ unit "unit_to_be_untouched" {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -781,7 +781,7 @@ unit "unit_to_be_untouched" {
 	err = opts.Experiments.EnableExperiment(experiment.FilterFlag)
 	require.NoError(t, err)
 
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venv.OSVenv(), opts, w)
+	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// Run discovery
@@ -803,7 +803,7 @@ unit "unit_to_be_untouched" {
 
 	discovery = discovery.WithFilters(filters)
 
-	components, err := discovery.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Verify that components were discovered
@@ -916,7 +916,7 @@ func TestWorktreePhase_Integration_StackSourceOnlyInOneRef(t *testing.T) {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -936,7 +936,7 @@ func TestWorktreePhase_Integration_StackSourceOnlyInOneRef(t *testing.T) {
 	// The from-ref stack references catalog/units/app, which was removed from the checked-out
 	// tree; before the fix, get_repo_root() resolved to the original checkout and generation
 	// failed to fetch the source.
-	err = generate.WorktreeStacks(t.Context(), l, venv.OSVenv(), opts, w)
+	err = generate.WorktreeStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	pair := w.WorktreePairs["[HEAD~1...HEAD]"]
@@ -1219,7 +1219,7 @@ locals {
 				WorkingDir:     tmpDir,
 				GitExpressions: filters.UniqueGitFilters(),
 			}
-			w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
+			w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -1240,7 +1240,7 @@ locals {
 				WithWorktrees(w).
 				WithFilters(filters)
 
-			components, err := discovery.Discover(t.Context(), l, venv.OSVenv(), opts)
+			components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 
 			// Filter results by type
@@ -1317,7 +1317,7 @@ locals {
 		WorkingDir:     basicDir,
 		GitExpressions: filters.UniqueGitFilters(),
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1338,7 +1338,7 @@ locals {
 		WithWorktrees(w).
 		WithFilters(filters)
 
-	components, err := discovery.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Filter results by type
@@ -1594,7 +1594,7 @@ locals {
 				WorkingDir:     tmpDir,
 				GitExpressions: filters.UniqueGitFilters(),
 			}
-			w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
+			w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -1615,7 +1615,7 @@ locals {
 				WithWorktrees(w).
 				WithFilters(filters)
 
-			components, err := discovery.Discover(t.Context(), l, venv.OSVenv(), opts)
+			components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 
 			// Filter results by type
@@ -1702,7 +1702,7 @@ func TestWorktreePhase_Integration_FromSubdirectory_MultipleCommits(t *testing.T
 				WorkingDir:     basicDir,
 				GitExpressions: filters.UniqueGitFilters(),
 			}
-			w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
+			w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -1723,7 +1723,7 @@ func TestWorktreePhase_Integration_FromSubdirectory_MultipleCommits(t *testing.T
 				WithWorktrees(w).
 				WithFilters(filters)
 
-			components, err := discovery.Discover(t.Context(), l, venv.OSVenv(), opts)
+			components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 
 			// Filter results by type
@@ -1891,7 +1891,7 @@ unit "app" {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1912,7 +1912,7 @@ unit "app" {
 	err = opts.Experiments.EnableExperiment(experiment.FilterFlag)
 	require.NoError(t, err)
 
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venv.OSVenv(), opts, w)
+	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// Run discovery
@@ -1934,7 +1934,7 @@ unit "app" {
 
 	disc = disc.WithFilters(filters)
 
-	components, err := disc.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := disc.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Get worktree paths
@@ -2085,7 +2085,7 @@ unit "app" {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -2105,7 +2105,7 @@ unit "app" {
 	err = opts.Experiments.EnableExperiment(experiment.FilterFlag)
 	require.NoError(t, err)
 
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venv.OSVenv(), opts, w)
+	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// Run discovery
@@ -2127,7 +2127,7 @@ unit "app" {
 
 	disc = disc.WithFilters(filters)
 
-	components, err := disc.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := disc.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Get worktree pair path
@@ -2269,7 +2269,7 @@ unit "app" {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -2289,7 +2289,7 @@ unit "app" {
 	err = opts.Experiments.EnableExperiment(experiment.FilterFlag)
 	require.NoError(t, err)
 
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venv.OSVenv(), opts, w)
+	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// Run discovery
@@ -2311,7 +2311,7 @@ unit "app" {
 
 	disc = disc.WithFilters(filters)
 
-	components, err := disc.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := disc.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Get worktree paths
@@ -2434,7 +2434,7 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -2459,7 +2459,7 @@ unit "myapp" {
 
 	// Generate stacks — using tmpDir as working directory so that only
 	// worktreeStacksToGenerate can cause generation inside worktrees.
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venv.OSVenv(), opts, w)
+	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// Verify: no .terragrunt-stack directories should exist in the worktrees,
@@ -2575,7 +2575,7 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -2603,7 +2603,7 @@ unit "myapp" {
 	require.NoError(t, err)
 
 	// Generate stacks
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venv.OSVenv(), opts, w)
+	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// The marker file should NOT exist — the land-mine stack should not have been parsed.
@@ -2701,7 +2701,7 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -2732,7 +2732,7 @@ unit "myapp" {
 	err = opts.Experiments.EnableExperiment(experiment.FilterFlag)
 	require.NoError(t, err)
 
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venv.OSVenv(), opts, w)
+	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// The marker file should NOT exist — negation should prevent parsing
@@ -2758,7 +2758,7 @@ func runWorktreeDiscovery(
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), wtOpts)
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -2788,7 +2788,7 @@ func runWorktreeDiscovery(
 		WithWorktrees(w).
 		WithFilters(filters)
 
-	components, err := discovery.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	return components, w
@@ -2871,7 +2871,7 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -2899,13 +2899,13 @@ unit "myapp" {
 		fromOpts := opts.Clone()
 		fromOpts.WorkingDir = pair.FromWorktree.Path
 		fromOpts.RootWorkingDir = pair.FromWorktree.Path
-		err = generate.NewGenerator().GenerateStacks(t.Context(), l, venv.OSVenv(), fromOpts, w)
+		err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), fromOpts, w)
 		require.NoError(t, err)
 
 		toOpts := opts.Clone()
 		toOpts.WorkingDir = pair.ToWorktree.Path
 		toOpts.RootWorkingDir = pair.ToWorktree.Path
-		err = generate.NewGenerator().GenerateStacks(t.Context(), l, venv.OSVenv(), toOpts, w)
+		err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), toOpts, w)
 		require.NoError(t, err)
 	}
 
@@ -2927,7 +2927,7 @@ unit "myapp" {
 
 	d = d.WithFilters(filters)
 
-	components, err := d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Collect component paths and kinds for debugging
@@ -3025,7 +3025,7 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -3048,7 +3048,7 @@ unit "app" {
 
 	require.NoError(
 		t,
-		generate.NewGenerator().GenerateStacks(t.Context(), l, venv.OSVenv(), opts, w),
+		generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w),
 	)
 
 	readingAffectedDirs := make([]string, 0, len(w.ReadingAffectedStacks))
@@ -3150,7 +3150,7 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -3173,7 +3173,7 @@ unit "app" {
 
 	require.NoError(
 		t,
-		generate.NewGenerator().GenerateStacks(t.Context(), l, venv.OSVenv(), opts, w),
+		generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w),
 	)
 
 	readingAffectedDirs := make([]string, 0, len(w.ReadingAffectedStacks))
@@ -3250,7 +3250,7 @@ locals {
 	filters, parseErr := filter.ParseFilterQueries(l, filterQueries)
 	require.NoError(t, parseErr)
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: filters.UniqueGitFilters(),
 	})
@@ -3274,7 +3274,7 @@ locals {
 		WithRelationships().
 		WithFilters(filters)
 
-	components, err := d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	unitPaths := components.Filter(component.UnitKind).Paths()
@@ -3333,7 +3333,7 @@ locals {
 	filters, parseErr := filter.ParseFilterQueries(l, []string{"[HEAD~1...HEAD]", "!./land-mine"})
 	require.NoError(t, parseErr)
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: filters.UniqueGitFilters(),
 	})
@@ -3355,7 +3355,7 @@ locals {
 		WithFilters(filters)
 
 	// If the land-mine unit is parsed, run_cmd("exit 1") causes a fatal error.
-	components, err := d.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	unitPaths := components.Filter(component.UnitKind).Paths()
@@ -3439,7 +3439,7 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -3464,7 +3464,7 @@ unit "myapp" {
 
 	// GenerateStacks internally calls discoverStacks with reading filters.
 	// If the land-mine unit is parsed, run_cmd("exit 1") causes a fatal error.
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venv.OSVenv(), opts, w)
+	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 }
 
@@ -3544,7 +3544,7 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venv.OSVenv(), worktrees.WorktreeOpts{
+	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
@@ -3566,7 +3566,7 @@ unit "app" {
 	opts.Experiments = experiment.NewExperiments()
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.FilterFlag))
 
-	require.NoError(t, generate.WorktreeStacks(t.Context(), l, venv.OSVenv(), opts, w))
+	require.NoError(t, generate.WorktreeStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w))
 
 	// The working tree must stay untouched: no stack was generated under it.
 	_, statErr := os.Stat(filepath.Join(stackDir, ".terragrunt-stack"))
@@ -3588,7 +3588,7 @@ unit "app" {
 		WithWorktrees(w).
 		WithFilters(filters)
 
-	components, err := disc.Discover(t.Context(), l, venv.OSVenv(), opts)
+	components, err := disc.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	require.Contains(t, w.WorktreePairs, "[HEAD~1...HEAD]")

--- a/internal/discovery/symlinks_test.go
+++ b/internal/discovery/symlinks_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +32,7 @@ func TestDiscoverySymlinksExperiment(t *testing.T) {
 	}
 
 	root := helpers.TmpDirWOSymlinks(t)
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	unitDir := filepath.Join(root, "a")
 	require.NoError(t, v.FS.MkdirAll(unitDir, 0755))

--- a/internal/getter/casgetter_detect_test.go
+++ b/internal/getter/casgetter_detect_test.go
@@ -352,7 +352,7 @@ func TestCASGetterDetect_SchemeNotInRegistryFallsThrough(t *testing.T) {
 	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	// No generic dispatch wired: only the git+file paths are active.
 	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{})
@@ -413,7 +413,7 @@ func TestNewCASGetter_PanicsOnNilVenvHTTPWithDispatch(t *testing.T) {
 	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 	v.HTTP = nil
 
 	require.PanicsWithValue(t, venv.ErrVenvHTTPUnset, func() {
@@ -496,7 +496,7 @@ func newCASGetterForDetect(t *testing.T) *getter.CASGetter {
 	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	return getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},
 		getter.WithDefaultGenericDispatch(getter.WithHTTPClient(vhttp.NewNoNetworkClient())))

--- a/internal/getter/casgetter_forced_test.go
+++ b/internal/getter/casgetter_forced_test.go
@@ -13,7 +13,6 @@ import (
 
 	tgcas "github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -42,7 +41,7 @@ func TestCASGetter_ForcedThreadedToInnerClient(t *testing.T) {
 	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},
 		getter.WithGenericFetchers(map[string]gogetter.Getter{scheme: stub}),
@@ -96,7 +95,7 @@ func TestCASGetter_GetCanonicalizesForcedAlias(t *testing.T) {
 	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},
 		getter.WithGenericFetchers(map[string]gogetter.Getter{getter.SchemeGCS: stub}),

--- a/internal/getter/casgetter_generic_test.go
+++ b/internal/getter/casgetter_generic_test.go
@@ -16,7 +16,6 @@ import (
 
 	tgcas "github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -98,7 +97,7 @@ func TestCASGetter_HTTPArchiveCachesSecondRun(t *testing.T) {
 	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 
@@ -166,7 +165,7 @@ func TestCASGetter_HTTPArchiveFalseSkipsExtraction(t *testing.T) {
 	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 
@@ -221,7 +220,7 @@ func TestCASGetter_HTTPMissingETagFallsBackToContentHash(t *testing.T) {
 	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	l := logger.CreateLogger()
 

--- a/internal/getter/casgetter_oci_test.go
+++ b/internal/getter/casgetter_oci_test.go
@@ -11,7 +11,6 @@ import (
 
 	tgcas "github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -149,7 +148,7 @@ func TestCASGetterDoesNotClaimOCIWithoutFetcher(t *testing.T) {
 	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{})
 
@@ -216,7 +215,11 @@ func TestCASGetterOCISubdirSelectionSharesOneEntry(t *testing.T) {
 			assert.FileExists(t, filepath.Join(dstRoot, "main.tf"))
 			assert.FileExists(t, filepath.Join(dstRoot, "subdir", "sub.tf"))
 			assert.FileExists(t, filepath.Join(dstSub, "sub.tf"))
-			assert.NoFileExists(t, filepath.Join(dstSub, "main.tf"), "the root tree must not leak into a subdir request")
+			assert.NoFileExists(
+				t,
+				filepath.Join(dstSub, "main.tf"),
+				"the root tree must not leak into a subdir request",
+			)
 			assert.NoFileExists(t, filepath.Join(dstSub, "subdir"), "the selector must be applied, not the full tree")
 		})
 	}
@@ -269,7 +272,7 @@ func newOCICASHarness(
 	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	g := getter.NewCASGetter(logger.CreateLogger(), c, v, &tgcas.CloneOptions{},
 		getter.WithGenericFetchers(map[string]gogetter.Getter{

--- a/internal/getter/casgetter_tfr_test.go
+++ b/internal/getter/casgetter_tfr_test.go
@@ -16,7 +16,6 @@ import (
 	tgcas "github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -51,7 +50,7 @@ func TestCASGetter_TFRRoutesThroughCAS(t *testing.T) {
 	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	// Inner client builder injects a TLS-trusting HttpGetter so the
 	// RegistryGetter's delegated archive download trusts the
@@ -131,7 +130,7 @@ func TestCASGetter_TFRBareSchemeIsClaimed(t *testing.T) {
 	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	g := getter.NewCASGetter(l, c, v, &tgcas.CloneOptions{},
 		getter.WithGenericFetchers(map[string]gogetter.Getter{

--- a/internal/getter/defaults.go
+++ b/internal/getter/defaults.go
@@ -33,7 +33,7 @@ type GenericFetcherOption func(*genericFetcherConfig)
 
 type genericFetcherConfig struct {
 	logger     log.Logger
-	fs         vfs.FS
+	fsys       vfs.FS
 	env        map[string]string
 	ociHolder  *ociStoreHolder
 	httpExtra  http.Header
@@ -58,13 +58,13 @@ func (h *ociStoreHolder) store(l log.Logger) OCINewStoreFunc {
 	return h.fn
 }
 
-// requireLoggerFS panics when logger or fs is unset for a scheme that needs them.
+// requireLoggerFS panics when logger or fsys is unset for a scheme that needs them.
 func requireLoggerFS(c *genericFetcherConfig, scheme string) {
 	if c.logger == nil {
 		panic("getter: " + scheme + " requires WithDispatchLogger")
 	}
 
-	if c.fs == nil {
+	if c.fsys == nil {
 		panic("getter: " + scheme + " requires WithDispatchFS")
 	}
 }
@@ -81,13 +81,13 @@ func WithDispatchLogger(l log.Logger) GenericFetcherOption {
 }
 
 // WithDispatchFS sets the shared filesystem for tfr and oci dispatch entries.
-func WithDispatchFS(fs vfs.FS) GenericFetcherOption {
+func WithDispatchFS(fsys vfs.FS) GenericFetcherOption {
 	return func(c *genericFetcherConfig) {
-		if fs == nil {
+		if fsys == nil {
 			panic("getter: WithDispatchFS requires a non-nil filesystem")
 		}
 
-		c.fs = fs
+		c.fsys = fsys
 	}
 }
 
@@ -175,7 +175,7 @@ func DefaultGenericFetchers(v *venv.Venv, opts ...GenericFetcherOption) map[stri
 		m[SchemeOCI] = &OCIGetter{
 			NewStore: cfg.ociHolder.store(cfg.logger),
 			Logger:   cfg.logger,
-			FS:       cfg.fs,
+			FS:       cfg.fsys,
 		}
 	}
 

--- a/internal/getter/filecopy.go
+++ b/internal/getter/filecopy.go
@@ -137,8 +137,8 @@ func (g *FileCopyGetter) Detect(req *getter.Request) (bool, error) {
 
 // NewFileCopyGetter returns a FileCopyGetter backed by the supplied
 // filesystem. Use the With* methods to customize other behavior.
-func NewFileCopyGetter(fs vfs.FS) *FileCopyGetter {
-	return &FileCopyGetter{FS: fs}
+func NewFileCopyGetter(fsys vfs.FS) *FileCopyGetter {
+	return &FileCopyGetter{FS: fsys}
 }
 
 // WithLogger sets the logger used by [util.CopyFolderContents] during a copy.
@@ -148,8 +148,8 @@ func (g *FileCopyGetter) WithLogger(l log.Logger) *FileCopyGetter {
 }
 
 // WithFS sets the filesystem every read and write of the copy runs through.
-func (g *FileCopyGetter) WithFS(fs vfs.FS) *FileCopyGetter {
-	g.FS = fs
+func (g *FileCopyGetter) WithFS(fsys vfs.FS) *FileCopyGetter {
+	g.FS = fsys
 	return g
 }
 

--- a/internal/getter/oci_auth_test.go
+++ b/internal/getter/oci_auth_test.go
@@ -1234,12 +1234,12 @@ func credentialFor(t *testing.T, store getter.OCIRepositoryStore, registry strin
 }
 
 // writeAuthFile writes a config.json-format credential file granting user/pass for registry.
-func writeAuthFile(t *testing.T, fs vfs.FS, path, registry, user, pass string) {
+func writeAuthFile(t *testing.T, fsys vfs.FS, path, registry, user, pass string) {
 	t.Helper()
 
 	writeRawAuthFile(
 		t,
-		fs,
+		fsys,
 		path,
 		registry,
 		base64.StdEncoding.EncodeToString([]byte(user+":"+pass)),
@@ -1248,7 +1248,7 @@ func writeAuthFile(t *testing.T, fs vfs.FS, path, registry, user, pass string) {
 
 // writeAuthFileKeys writes a credential file declaring every key in users, each
 // granting its own username, so key selection can be observed.
-func writeAuthFileKeys(t *testing.T, fs vfs.FS, path string, users map[string]string) {
+func writeAuthFileKeys(t *testing.T, fsys vfs.FS, path string, users map[string]string) {
 	t.Helper()
 
 	auths := map[string]any{}
@@ -1261,11 +1261,11 @@ func writeAuthFileKeys(t *testing.T, fs vfs.FS, path string, users map[string]st
 
 	data, err := json.Marshal(map[string]any{"auths": auths})
 	require.NoError(t, err)
-	require.NoError(t, vfs.WriteFile(fs, path, data, 0o600))
+	require.NoError(t, vfs.WriteFile(fsys, path, data, 0o600))
 }
 
 // writeRawAuthFile writes a config.json credential file with a raw base64 auth value.
-func writeRawAuthFile(t *testing.T, fs vfs.FS, path, registry, encodedAuth string) {
+func writeRawAuthFile(t *testing.T, fsys vfs.FS, path, registry, encodedAuth string) {
 	t.Helper()
 
 	content := map[string]any{
@@ -1276,7 +1276,7 @@ func writeRawAuthFile(t *testing.T, fs vfs.FS, path, registry, encodedAuth strin
 
 	data, err := json.Marshal(content)
 	require.NoError(t, err)
-	require.NoError(t, vfs.WriteFile(fs, path, data, 0o600))
+	require.NoError(t, vfs.WriteFile(fsys, path, data, 0o600))
 }
 
 // stubHelperExec builds a MemExec that dispatches docker-credential-<name> get
@@ -1312,17 +1312,17 @@ func stubHelperExec(t *testing.T, name string, reply func(stdin string) vexec.Re
 }
 
 // writeHelperConfig writes a docker config.json with only credHelpers/credsStore.
-func writeHelperConfig(t *testing.T, fs vfs.FS, path string, credHelpers map[string]string, credsStore string) {
+func writeHelperConfig(t *testing.T, fsys vfs.FS, path string, credHelpers map[string]string, credsStore string) {
 	t.Helper()
 
-	writeDockerConfig(t, fs, path, nil, credHelpers, credsStore)
+	writeDockerConfig(t, fsys, path, nil, credHelpers, credsStore)
 }
 
 // writeDockerConfig writes a docker config.json with inline auths (registry ->
 // "user:pass"), credHelpers, and credsStore, omitting empty sections.
 func writeDockerConfig(
 	t *testing.T,
-	fs vfs.FS,
+	fsys vfs.FS,
 	path string,
 	inlineAuths, credHelpers map[string]string,
 	credsStore string,
@@ -1350,7 +1350,7 @@ func writeDockerConfig(
 
 	data, err := json.Marshal(config)
 	require.NoError(t, err)
-	require.NoError(t, vfs.WriteFile(fs, path, data, 0o600))
+	require.NoError(t, vfs.WriteFile(fsys, path, data, 0o600))
 }
 
 // credentialForErr resolves the credential the store would send, returning any error.

--- a/internal/getter/oci_toforc_test.go
+++ b/internal/getter/oci_toforc_test.go
@@ -1089,10 +1089,10 @@ func newStoreForRepo(t *testing.T, v *venv.Venv, registry, repositoryName string
 }
 
 // writeTofuConfig writes an OpenTofu CLI config file with the given body.
-func writeTofuConfig(t *testing.T, fs vfs.FS, path, body string) {
+func writeTofuConfig(t *testing.T, fsys vfs.FS, path, body string) {
 	t.Helper()
 
-	require.NoError(t, vfs.WriteFile(fs, path, []byte(body), 0o600))
+	require.NoError(t, vfs.WriteFile(fsys, path, []byte(body), 0o600))
 }
 
 // tofuJSONBasicAuth renders a JSON oci_credentials block, keeping credential pairs out of source literals.

--- a/internal/getter/options_test.go
+++ b/internal/getter/options_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -32,7 +31,7 @@ func TestWithCASRegistersCASGetter(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(helpers.TmpDirWOSymlinks(t), "store")))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	client := getter.NewClient(v,
 		getter.WithCAS(c, &cas.CloneOptions{}),
@@ -57,7 +56,7 @@ func TestWithCASRoutesCASProtocolURLs(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(helpers.TmpDirWOSymlinks(t), "store")))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	client := getter.NewClient(v,
 		getter.WithCAS(c, &cas.CloneOptions{}),

--- a/internal/getter/resolver.go
+++ b/internal/getter/resolver.go
@@ -42,7 +42,7 @@ func DefaultSourceResolvers(
 
 	tfr := NewTFRResolver().
 		WithHTTPClient(vhttp.WithTimeout(v.HTTP, tfrResolverTimeout)).
-		WithAuth(RegistryAuth{Env: cfg.env, ReadUserConfig: vfs.IsOSFS(cfg.fs)})
+		WithAuth(RegistryAuth{Env: cfg.env, ReadUserConfig: vfs.IsOSFS(cfg.fsys)})
 
 	if cfg.tfrEnabled {
 		requireLoggerFS(&cfg, SchemeTFR)

--- a/internal/getter/tfr.go
+++ b/internal/getter/tfr.go
@@ -223,25 +223,25 @@ func (r *RegistryGetter) getSubdir(
 
 // copySubdirContents resolves subDir under srcRoot and copies its contents
 // into dstPath, replacing whatever was there. source only labels errors.
-func copySubdirContents(l log.Logger, fs vfs.FS, srcRoot, subDir, dstPath, source string) error {
+func copySubdirContents(l log.Logger, fsys vfs.FS, srcRoot, subDir, dstPath, source string) error {
 	sourcePath, err := SubdirGlob(srcRoot, subDir)
 	if err != nil {
 		return fmt.Errorf("resolving module subdir %q: %w", subDir, err)
 	}
 
-	if _, err := fs.Stat(sourcePath); err != nil {
+	if _, err := fsys.Stat(sourcePath); err != nil {
 		return ModuleDownloadErr{
 			sourceURL: source,
 			details:   fmt.Sprintf("could not stat download path %s: %s", sourcePath, err),
 		}
 	}
 
-	if err := fs.RemoveAll(dstPath); err != nil {
+	if err := fsys.RemoveAll(dstPath); err != nil {
 		return fmt.Errorf("clearing destination path %s: %w", dstPath, err)
 	}
 
 	const ownerWriteGlobalReadExecutePerms = 0755
-	if err := fs.MkdirAll(dstPath, ownerWriteGlobalReadExecutePerms); err != nil {
+	if err := fsys.MkdirAll(dstPath, ownerWriteGlobalReadExecutePerms); err != nil {
 		return fmt.Errorf("creating destination path %s: %w", dstPath, err)
 	}
 
@@ -249,14 +249,14 @@ func copySubdirContents(l log.Logger, fs vfs.FS, srcRoot, subDir, dstPath, sourc
 	manifestPath := filepath.Join(dstPath, manifestFname)
 
 	defer func(name string) {
-		if err := fs.Remove(name); err != nil {
+		if err := fsys.Remove(name); err != nil {
 			l.Warnf("Error removing manifest file %s: %v", name, err)
 		}
 	}(manifestPath)
 
 	return util.CopyFolderContentsWithFilter(
 		l,
-		fs,
+		fsys,
 		sourcePath,
 		dstPath,
 		manifestFname,

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -95,16 +95,16 @@ func WithBoundary(boundary string) ExpandOption {
 	}
 }
 
-// Expand returns the absolute paths that match pattern on fs. The pattern
+// Expand returns the absolute paths that match pattern on fsys. The pattern
 // uses '/' as the separator on all platforms and '\' as the escape character.
 // A pattern that matches nothing returns an empty slice and a nil error.
 //
 // Pass [WithBoundary] to constrain the walk to a directory; a pattern whose
 // walk root falls outside it returns [ErrOutsideBoundary].
 //
-// Most callers pass [vfs.NewOSFS] for fs; tests can pass an in-memory
+// Most callers pass [vfs.NewOSFS] for fsys; tests can pass an in-memory
 // filesystem from [vfs.NewMemMapFS].
-func Expand(fs vfs.FS, pattern string, opts ...ExpandOption) ([]string, error) {
+func Expand(fsys vfs.FS, pattern string, opts ...ExpandOption) ([]string, error) {
 	var o expandOptions
 	for _, opt := range opts {
 		opt(&o)
@@ -114,12 +114,12 @@ func Expand(fs vfs.FS, pattern string, opts ...ExpandOption) ([]string, error) {
 
 	root, hasMeta := splitRoot(pattern)
 
-	if err := o.checkBoundary(fs, root); err != nil {
+	if err := o.checkBoundary(fsys, root); err != nil {
 		return nil, err
 	}
 
 	if !hasMeta {
-		info, err := fs.Stat(root)
+		info, err := fsys.Stat(root)
 		if err != nil {
 			if errors.Is(err, iofs.ErrNotExist) {
 				return nil, nil
@@ -142,7 +142,7 @@ func Expand(fs vfs.FS, pattern string, opts ...ExpandOption) ([]string, error) {
 
 	var matches []string
 
-	walkErr := vfs.WalkDir(fs, root, func(entry string, d iofs.DirEntry, walkErr error) error {
+	walkErr := vfs.WalkDir(fsys, root, func(entry string, d iofs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			if d != nil && d.IsDir() {
 				return iofs.SkipDir
@@ -204,45 +204,14 @@ func splitRoot(pattern string) (string, bool) {
 
 // checkBoundary reports whether walking from root is permitted. An empty
 // boundary imposes no constraint; otherwise root must fall inside it.
-func (o expandOptions) checkBoundary(fs vfs.FS, root string) error {
+func (o expandOptions) checkBoundary(fsys vfs.FS, root string) error {
 	if o.boundary == "" {
 		return nil
 	}
 
-	// Compare symlink-resolved paths so a boundary and a walk root that differ
-	// only by a symlinked parent are recognized as the same location.
-	if !withinBoundary(resolvePath(fs, o.boundary), resolvePath(fs, root)) {
+	if !vfs.Within(fsys, o.boundary, root) {
 		return fmt.Errorf("%w: %q is outside %q", ErrOutsideBoundary, root, o.boundary)
 	}
 
 	return nil
-}
-
-// resolvePath returns the symlink-resolved form of p. EvalSymlinks resolves
-// only paths that exist, so resolving the longest existing ancestor and
-// rejoining the remaining components keeps an absent path comparable with a
-// resolved one instead of leaving it merely cleaned.
-func resolvePath(fs vfs.FS, p string) string {
-	p = filepath.Clean(p)
-
-	if resolved, err := vfs.EvalSymlinks(fs, p); err == nil {
-		return resolved
-	}
-
-	if parent := filepath.Dir(p); parent != p {
-		return filepath.Join(resolvePath(fs, parent), filepath.Base(p))
-	}
-
-	return p
-}
-
-// withinBoundary reports whether p is boundary or a descendant of it. Both
-// paths must already be cleaned.
-func withinBoundary(boundary, p string) bool {
-	rel, err := filepath.Rel(boundary, p)
-	if err != nil {
-		return false
-	}
-
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }

--- a/internal/hclparse/autoinclude.go
+++ b/internal/hclparse/autoinclude.go
@@ -8,7 +8,6 @@ import (
 
 	"errors"
 
-	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -255,19 +254,19 @@ func configPathEvalReason(diags hcl.Diagnostics) string {
 
 // AutoIncludeDependencyPaths reads the autoinclude file in unitDir and returns resolved dependency config_path values. Returns EmptyArgError when unitDir is empty so callers can distinguish bad input from a missing file.
 // It is off the production parse path (the partial-parse merge folds autoinclude dependencies into the config); it is retained for test-time introspection of generated autoinclude files.
-func AutoIncludeDependencyPaths(fs vfs.FS, unitDir string) ([]string, error) {
-	if fs == nil {
-		panic(fmt.Sprintf("hclparse.AutoIncludeDependencyPaths: fs is nil (unitDir=%q)", unitDir))
+func AutoIncludeDependencyPaths(fsys vfs.FS, unitDir string) ([]string, error) {
+	if fsys == nil {
+		panic(fmt.Sprintf("hclparse.AutoIncludeDependencyPaths: fsys is nil (unitDir=%q)", unitDir))
 	}
 
 	if unitDir == "" {
 		return nil, EmptyArgError{Func: "AutoIncludeDependencyPaths", Arg: "unitDir"}
 	}
 
-	unitDir = util.ResolvePath(unitDir)
+	unitDir = vfs.ResolveForCompare(fsys, unitDir)
 	autoIncludePath := filepath.Join(unitDir, AutoIncludeFile)
 
-	body, err := readAutoIncludeBody(fs, autoIncludePath)
+	body, err := readAutoIncludeBody(fsys, autoIncludePath)
 	if err != nil || body == nil {
 		return nil, err
 	}
@@ -294,7 +293,7 @@ func AutoIncludeDependencyPaths(fs vfs.FS, unitDir string) ([]string, error) {
 			continue
 		}
 
-		depPath, extractErr := extractDepPath(block, autoIncludePath, unitDir)
+		depPath, extractErr := extractDepPath(fsys, block, autoIncludePath, unitDir)
 		if extractErr != nil {
 			errs = append(errs, extractErr)
 
@@ -312,8 +311,8 @@ func AutoIncludeDependencyPaths(fs vfs.FS, unitDir string) ([]string, error) {
 }
 
 // readAutoIncludeBody reads and parses an autoinclude file, returning (nil, nil) when the file does not exist.
-func readAutoIncludeBody(fs vfs.FS, path string) (*hclsyntax.Body, error) {
-	data, err := vfs.ReadFile(fs, path)
+func readAutoIncludeBody(fsys vfs.FS, path string) (*hclsyntax.Body, error) {
+	data, err := vfs.ReadFile(fsys, path)
 	if errors.Is(err, iofs.ErrNotExist) {
 		return nil, nil
 	}
@@ -345,7 +344,7 @@ func blockLabelsString(block *hclsyntax.Block) string {
 }
 
 // extractDepPath returns the resolved config_path for a dependency block. Caller must ensure the block has exactly one label.
-func extractDepPath(block *hclsyntax.Block, autoIncludePath, unitDir string) (string, error) {
+func extractDepPath(fsys vfs.FS, block *hclsyntax.Block, autoIncludePath, unitDir string) (string, error) {
 	name := block.Labels[0]
 
 	configPathAttr, exists := block.Body.Attributes[attrConfigPath]
@@ -396,7 +395,7 @@ func extractDepPath(block *hclsyntax.Block, autoIncludePath, unitDir string) (st
 		depPath = filepath.Clean(filepath.Join(unitDir, depPath))
 	}
 
-	return util.ResolvePath(depPath), nil
+	return vfs.ResolveForCompare(fsys, depPath), nil
 }
 
 // StackAutoIncludeDepValuesError scans a stack autoinclude body for the unsupported cross-level pattern: an injected unit/stack whose values reference dependency outputs, which are not available at stack generate time. Returns the populated typed error, or nil when absent. Shared by the fail-fast generation check and the pkg/config backstop so the two cannot drift.

--- a/internal/hclparse/generate.go
+++ b/internal/hclparse/generate.go
@@ -69,18 +69,18 @@ func AutoIncludeFileNameForKind(kind AutoIncludeKind) string {
 //     evaluated the same way: only dependency.* (and any expression referencing it) is
 //     preserved verbatim for runtime resolution.
 //
-// Requires non-nil fs and non-empty targetDir (panics otherwise). resolved may be nil (no-op). srcBytes must be the bytes of the file resolved.RawBody was parsed from; for includes pass resolved.SourceBytes. evalCtx may be nil.
+// Requires non-nil fsys and non-empty targetDir (panics otherwise). resolved may be nil (no-op). srcBytes must be the bytes of the file resolved.RawBody was parsed from; for includes pass resolved.SourceBytes. evalCtx may be nil.
 func GenerateAutoIncludeFile(
-	fs vfs.FS,
+	fsys vfs.FS,
 	resolved *AutoIncludeResolved,
 	targetDir string,
 	srcBytes []byte,
 	evalCtx *hcl.EvalContext,
 ) error {
-	if fs == nil {
+	if fsys == nil {
 		panic(
 			fmt.Sprintf(
-				"hclparse.GenerateAutoIncludeFile: fs is nil (targetDir=%q, sourceFile=%q)",
+				"hclparse.GenerateAutoIncludeFile: fsys is nil (targetDir=%q, sourceFile=%q)",
 				targetDir,
 				resolvedSourceFile(resolved),
 			),
@@ -140,20 +140,20 @@ func GenerateAutoIncludeFile(
 
 	filePath := filepath.Join(targetDir, AutoIncludeFileNameForKind(resolved.Kind))
 
-	if err := fs.MkdirAll(targetDir, autoIncludeDirPerm); err != nil {
+	if err := fsys.MkdirAll(targetDir, autoIncludeDirPerm); err != nil {
 		return DirCreateError{DirPath: targetDir, Err: err}
 	}
 
 	formatted := hclwrite.Format(out.Bytes())
 
 	// CAS may materialize the target as a read-only hard link, so remove it before writing
-	if info, statErr := fs.Stat(filePath); statErr == nil && info.Mode().IsRegular() {
-		if err := fs.Remove(filePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if info, statErr := fsys.Stat(filePath); statErr == nil && info.Mode().IsRegular() {
+		if err := fsys.Remove(filePath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return FileWriteError{FilePath: filePath, Err: err}
 		}
 	}
 
-	if err := vfs.WriteFile(fs, filePath, formatted, autoIncludeFilePerm); err != nil {
+	if err := vfs.WriteFile(fsys, filePath, formatted, autoIncludeFilePerm); err != nil {
 		return FileWriteError{FilePath: filePath, Err: err}
 	}
 

--- a/internal/hclparse/panic_test.go
+++ b/internal/hclparse/panic_test.go
@@ -28,7 +28,7 @@ func assertPanicsContaining(t *testing.T, want string, fn func()) {
 
 func TestParseStackFile_NilFS_Panics(t *testing.T) {
 	t.Parallel()
-	assertPanicsContaining(t, "hclparse.ParseStackFile: fs is nil", func() {
+	assertPanicsContaining(t, "hclparse.ParseStackFile: fsys is nil", func() {
 		_, _ = hclparse.ParseStackFile(nil, &hclparse.ParseStackFileInput{StackDir: "/x"})
 	})
 }
@@ -49,7 +49,7 @@ func TestParseStackFile_EmptyStackDir_Panics(t *testing.T) {
 
 func TestParseStackFileFromPath_NilFS_Panics(t *testing.T) {
 	t.Parallel()
-	assertPanicsContaining(t, "hclparse.ParseStackFileFromPath: fs is nil", func() {
+	assertPanicsContaining(t, "hclparse.ParseStackFileFromPath: fsys is nil", func() {
 		_, _ = hclparse.ParseStackFileFromPath(nil, "/x")
 	})
 }
@@ -63,7 +63,7 @@ func TestParseStackFileFromPath_EmptyStackDir_Panics(t *testing.T) {
 
 func TestUnitPathsFromStackDir_NilFS_Panics(t *testing.T) {
 	t.Parallel()
-	assertPanicsContaining(t, "hclparse.UnitPathsFromStackDir: fs is nil", func() {
+	assertPanicsContaining(t, "hclparse.UnitPathsFromStackDir: fsys is nil", func() {
 		_, _ = hclparse.UnitPathsFromStackDir(nil, "/x", noFuncs)
 	})
 }
@@ -84,7 +84,7 @@ func TestUnitPathsFromStackDir_NilFuncsFactory_Panics(t *testing.T) {
 
 func TestAutoIncludeDependencyPaths_NilFS_Panics(t *testing.T) {
 	t.Parallel()
-	assertPanicsContaining(t, "hclparse.AutoIncludeDependencyPaths: fs is nil", func() {
+	assertPanicsContaining(t, "hclparse.AutoIncludeDependencyPaths: fsys is nil", func() {
 		_, _ = hclparse.AutoIncludeDependencyPaths(nil, "/x")
 	})
 }
@@ -103,7 +103,7 @@ func TestAutoIncludeDependencyPaths_EmptyUnitDir_ReturnsError(t *testing.T) {
 
 func TestGenerateAutoIncludeFile_NilFS_Panics(t *testing.T) {
 	t.Parallel()
-	assertPanicsContaining(t, "hclparse.GenerateAutoIncludeFile: fs is nil", func() {
+	assertPanicsContaining(t, "hclparse.GenerateAutoIncludeFile: fsys is nil", func() {
 		_ = hclparse.GenerateAutoIncludeFile(nil, nil, "/x", nil, nil)
 	})
 }

--- a/internal/hclparse/parse.go
+++ b/internal/hclparse/parse.go
@@ -67,8 +67,8 @@ type ParseResult struct {
 }
 
 // ParseStackFile runs the phase flow and returns partial results when decode partially succeeds.
-func ParseStackFile(fs vfs.FS, input *ParseStackFileInput) (*ParseResult, error) {
-	validateParseStackFileInput(fs, input)
+func ParseStackFile(fsys vfs.FS, input *ParseStackFileInput) (*ParseResult, error) {
+	validateParseStackFileInput(fsys, input)
 
 	result := &ParseResult{AutoIncludes: map[string]*AutoIncludeResolved{}}
 
@@ -91,7 +91,7 @@ func ParseStackFile(fs vfs.FS, input *ParseStackFileInput) (*ParseResult, error)
 	srcByFilename := map[string][]byte{input.Filename: input.Src}
 
 	// Phase 3 resolves include blocks and merges included Remain bodies.
-	mergedRemain, err := mergeIncludes(fs, parsedStackFile, input.StackDir, evalCtx, srcByFilename)
+	mergedRemain, err := mergeIncludes(fsys, parsedStackFile, input.StackDir, evalCtx, srcByFilename)
 	if err != nil {
 		return result, err
 	}
@@ -129,14 +129,14 @@ func ParseStackFile(fs vfs.FS, input *ParseStackFileInput) (*ParseResult, error)
 }
 
 // validateParseStackFileInput panics on malformed parser input.
-func validateParseStackFileInput(fs vfs.FS, input *ParseStackFileInput) {
-	if fs == nil {
+func validateParseStackFileInput(fsys vfs.FS, input *ParseStackFileInput) {
+	if fsys == nil {
 		filename := ""
 		if input != nil {
 			filename = input.Filename
 		}
 
-		panic(fmt.Sprintf("hclparse.ParseStackFile: fs is nil (filename=%q)", filename))
+		panic(fmt.Sprintf("hclparse.ParseStackFile: fsys is nil (filename=%q)", filename))
 	}
 
 	if input == nil {
@@ -391,7 +391,7 @@ type resolvedInclude struct {
 
 // mergeIncludes resolves include paths and merges included Remain bodies.
 func mergeIncludes(
-	fs vfs.FS,
+	fsys vfs.FS,
 	parsedFile *StackFileHCL,
 	stackDir string,
 	evalCtx *hcl.EvalContext,
@@ -400,7 +400,7 @@ func mergeIncludes(
 	bodies := []hcl.Body{parsedFile.Remain}
 
 	for _, inc := range parsedFile.Includes {
-		resolved, err := mergeOneInclude(fs, inc, stackDir, evalCtx)
+		resolved, err := mergeOneInclude(fsys, inc, stackDir, evalCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -419,7 +419,7 @@ func mergeIncludes(
 
 // mergeOneInclude reads and parses one included file.
 func mergeOneInclude(
-	fs vfs.FS,
+	fsys vfs.FS,
 	inc *StackIncludeHCL,
 	stackDir string,
 	evalCtx *hcl.EvalContext,
@@ -473,7 +473,7 @@ func mergeOneInclude(
 		includePath = filepath.Join(stackDir, includePath)
 	}
 
-	data, err := vfs.ReadFile(fs, includePath)
+	data, err := vfs.ReadFile(fsys, includePath)
 	if err != nil {
 		return resolvedInclude{}, FileReadError{FilePath: includePath, Err: err}
 	}

--- a/internal/hclparse/stack.go
+++ b/internal/hclparse/stack.go
@@ -164,19 +164,19 @@ type discoveryAutoIncludeDecode struct {
 }
 
 // ParseStackFileFromPath reads a terragrunt.stack.hcl from disk and runs ParseStackFile; returns (nil, nil) when the file is absent.
-func ParseStackFileFromPath(fs vfs.FS, stackDir string) (*ParseResult, error) {
-	if fs == nil {
-		panic(fmt.Sprintf("hclparse.ParseStackFileFromPath: fs is nil (stackDir=%q)", stackDir))
+func ParseStackFileFromPath(fsys vfs.FS, stackDir string) (*ParseResult, error) {
+	if fsys == nil {
+		panic(fmt.Sprintf("hclparse.ParseStackFileFromPath: fsys is nil (stackDir=%q)", stackDir))
 	}
 
 	if stackDir == "" {
 		panic("hclparse.ParseStackFileFromPath: stackDir is empty")
 	}
 
-	stackDir = util.ResolvePath(stackDir)
+	stackDir = vfs.ResolveForCompare(fsys, stackDir)
 	stackFile := filepath.Join(stackDir, stackFileName)
 
-	data, err := vfs.ReadFile(fs, stackFile)
+	data, err := vfs.ReadFile(fsys, stackFile)
 	if err != nil {
 		if errors.Is(err, iofs.ErrNotExist) {
 			return nil, nil
@@ -185,7 +185,7 @@ func ParseStackFileFromPath(fs vfs.FS, stackDir string) (*ParseResult, error) {
 		return nil, FileReadError{FilePath: stackFile, Err: err}
 	}
 
-	return ParseStackFile(fs, &ParseStackFileInput{
+	return ParseStackFile(fsys, &ParseStackFileInput{
 		Src:      data,
 		Filename: stackFileName,
 		StackDir: stackDir,
@@ -210,12 +210,12 @@ type StackFuncFactory func(stackDir string) (map[string]function.Function, error
 // funcsFor builds the dir-scoped HCL function map for each stack directory visited; it
 // must be non-nil and must return a non-nil map.
 func UnitPathsFromStackDir(
-	fs vfs.FS,
+	fsys vfs.FS,
 	stackDir string,
 	funcsFor StackFuncFactory,
 ) ([]string, error) {
-	if fs == nil {
-		panic(fmt.Sprintf("hclparse.UnitPathsFromStackDir: fs is nil (stackDir=%q)", stackDir))
+	if fsys == nil {
+		panic(fmt.Sprintf("hclparse.UnitPathsFromStackDir: fsys is nil (stackDir=%q)", stackDir))
 	}
 
 	if stackDir == "" {
@@ -228,7 +228,7 @@ func UnitPathsFromStackDir(
 		)
 	}
 
-	return unitPathsFromStackDir(fs, stackDir, funcsFor, make(map[string]struct{}), 0)
+	return unitPathsFromStackDir(fsys, stackDir, funcsFor, make(map[string]struct{}), 0)
 }
 
 // DirectComponentPaths returns the generated on-disk paths of the direct unit and
@@ -237,12 +237,12 @@ func UnitPathsFromStackDir(
 // file yields empty slices and a nil error. funcsFor must be non-nil and return a
 // non-nil map.
 func DirectComponentPaths(
-	fs vfs.FS,
+	fsys vfs.FS,
 	stackDir string,
 	funcsFor StackFuncFactory,
 ) (unitPaths, stackPaths []string, err error) {
-	if fs == nil {
-		panic(fmt.Sprintf("hclparse.DirectComponentPaths: fs is nil (stackDir=%q)", stackDir))
+	if fsys == nil {
+		panic(fmt.Sprintf("hclparse.DirectComponentPaths: fsys is nil (stackDir=%q)", stackDir))
 	}
 
 	if stackDir == "" {
@@ -253,7 +253,7 @@ func DirectComponentPaths(
 		panic(fmt.Sprintf("hclparse.DirectComponentPaths: funcsFor is nil (stackDir=%q)", stackDir))
 	}
 
-	stackDir = util.ResolvePath(stackDir)
+	stackDir = vfs.ResolveForCompare(fsys, stackDir)
 	stackFile := filepath.Join(stackDir, stackFileName)
 
 	funcs, err := funcsFor(stackDir)
@@ -270,7 +270,7 @@ func DirectComponentPaths(
 		)
 	}
 
-	units, stacks, err := decodeDiscovery(fs, stackDir, stackFile, funcs)
+	units, stacks, err := decodeDiscovery(fsys, stackDir, stackFile, funcs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -291,7 +291,7 @@ func DirectComponentPaths(
 // ancestor symlink loops), and depth caps the chain length (backstop for symlink cycles
 // EvalSymlinks reports as errors and therefore cannot collapse to a seen path).
 func unitPathsFromStackDir(
-	fs vfs.FS,
+	fsys vfs.FS,
 	stackDir string,
 	funcsFor StackFuncFactory,
 	visited map[string]struct{},
@@ -304,7 +304,7 @@ func unitPathsFromStackDir(
 		}
 	}
 
-	stackDir = util.ResolvePath(stackDir)
+	stackDir = vfs.ResolveForCompare(fsys, stackDir)
 
 	if _, seen := visited[stackDir]; seen {
 		return nil, nil
@@ -329,7 +329,7 @@ func unitPathsFromStackDir(
 		)
 	}
 
-	units, stacks, err := decodeDiscovery(fs, stackDir, stackFile, funcs)
+	units, stacks, err := decodeDiscovery(fsys, stackDir, stackFile, funcs)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +352,7 @@ func unitPathsFromStackDir(
 			stack.NoStack != nil && *stack.NoStack,
 		)
 
-		nestedPaths, nestedErr := unitPathsFromStackDir(fs, nestedDir, funcsFor, visited, depth+1)
+		nestedPaths, nestedErr := unitPathsFromStackDir(fsys, nestedDir, funcsFor, visited, depth+1)
 		if nestedErr != nil {
 			return nil, nestedErr
 		}
@@ -368,11 +368,11 @@ func unitPathsFromStackDir(
 // funcs is the function map injected into the discovery eval context; callers
 // must supply a non-nil map (validated at the public entrypoint).
 func decodeDiscovery(
-	fs vfs.FS,
+	fsys vfs.FS,
 	stackDir, stackFile string,
 	funcs map[string]function.Function,
 ) ([]*unitPathOnlyHCL, []*stackPathOnlyHCL, error) {
-	data, err := vfs.ReadFile(fs, stackFile)
+	data, err := vfs.ReadFile(fsys, stackFile)
 	if err != nil {
 		if errors.Is(err, iofs.ErrNotExist) {
 			return nil, nil, nil
@@ -395,7 +395,7 @@ func decodeDiscovery(
 	// as the `values` variable, so locals (and unit/stack attributes) referencing
 	// values.* resolve during discovery exactly as they do in the full stack parse.
 	// An absent file leaves the variable unset, matching a stack that received no values.
-	values, err := readDiscoveryValues(fs, stackDir, funcs)
+	values, err := readDiscoveryValues(fsys, stackDir, funcs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -412,7 +412,7 @@ func decodeDiscovery(
 
 	srcByFilename := map[string][]byte{stackFile: data}
 
-	mergedRemain, err := mergeIncludes(fs, parsedFile, stackDir, evalCtx, srcByFilename)
+	mergedRemain, err := mergeIncludes(fsys, parsedFile, stackDir, evalCtx, srcByFilename)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -442,7 +442,7 @@ func decodeDiscovery(
 	// Merge units and stacks injected by a sibling terragrunt.autoinclude.stack.hcl, overriding same-name
 	// base blocks the same way a full stack parse does. The autoinclude file's own names are validated for
 	// uniqueness inside the merge.
-	if err := mergeDiscoveryStackAutoInclude(fs, stackDir, evalCtx, decoded); err != nil {
+	if err := mergeDiscoveryStackAutoInclude(fsys, stackDir, evalCtx, decoded); err != nil {
 		return nil, nil, err
 	}
 
@@ -465,13 +465,13 @@ func decodeDiscovery(
 // function call in a (normally literal-only, generated) values file resolves
 // against the stack directory being expanded.
 func readDiscoveryValues(
-	fs vfs.FS,
+	fsys vfs.FS,
 	stackDir string,
 	funcs map[string]function.Function,
 ) (*cty.Value, error) {
 	valuesPath := filepath.Join(stackDir, valuesFileName)
 
-	data, err := vfs.ReadFile(fs, valuesPath)
+	data, err := vfs.ReadFile(fsys, valuesPath)
 	if err != nil {
 		if errors.Is(err, iofs.ErrNotExist) {
 			return nil, nil
@@ -509,14 +509,14 @@ func readDiscoveryValues(
 // edges the full parse would reject: the dependency-values backstop, and a strict decode that allows only
 // unit and stack blocks at the top level.
 func mergeDiscoveryStackAutoInclude(
-	fs vfs.FS,
+	fsys vfs.FS,
 	stackDir string,
 	evalCtx *hcl.EvalContext,
 	decoded *discoveryDecode,
 ) error {
 	autoIncludePath := filepath.Join(stackDir, AutoIncludeStackFile)
 
-	data, err := vfs.ReadFile(fs, autoIncludePath)
+	data, err := vfs.ReadFile(fsys, autoIncludePath)
 	if err != nil {
 		if errors.Is(err, iofs.ErrNotExist) {
 			return nil

--- a/internal/hclparse/stack_test.go
+++ b/internal/hclparse/stack_test.go
@@ -845,7 +845,7 @@ func TestParseStackFileFromPath_StackDirIsFileReturnsError(t *testing.T) {
 
 	var readErr hclparse.FileReadError
 	require.ErrorAs(t, err, &readErr)
-	// On macOS, t.TempDir() returns paths under /var/folders/... where /var is a symlink to /private/var; util.ResolvePath follows it, so resolve our side too before comparing.
+	// On macOS, t.TempDir() returns paths under /var/folders/... where /var is a symlink to /private/var; vfs.ResolveForCompare follows it, so resolve our side too before comparing.
 	resolvedFilePath, evalErr := filepath.EvalSymlinks(filePath)
 	require.NoError(t, evalErr)
 	assert.Equal(t, filepath.Join(resolvedFilePath, "terragrunt.stack.hcl"), readErr.FilePath)
@@ -878,7 +878,7 @@ unit "app" {
 	assert.Equal(t, "app", result.Units[0].Name)
 }
 
-// Uses OSFS because MemMapFS does not faithfully reproduce os.Symlink semantics that util.ResolvePath relies on.
+// Uses OSFS because MemMapFS does not faithfully reproduce os.Symlink semantics that vfs.ResolveForCompare relies on.
 func TestUnitPathsFromStackDir_Symlink(t *testing.T) {
 	t.Parallel()
 

--- a/internal/os/exec/cmd.go
+++ b/internal/os/exec/cmd.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/os/signal"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"golang.org/x/text/cases"
@@ -39,12 +40,17 @@ type Cmd struct {
 	gracefulShutdownRegistered atomic.Bool
 }
 
-// Command returns a `Cmd` configured to execute the named program with
-// the given arguments via the provided vexec.Exec. PTY allocation requires
-// an OS-backed Exec; non-OS backends are accepted but `WithUsePTY(true)`
-// will fail at Start with ErrPTYRequiresOSBackend.
-func Command(ctx context.Context, e vexec.Exec, name string, args ...string) *Cmd {
-	vc := e.Command(ctx, name, args...)
+// Command returns a `Cmd` configured to execute the named program with the
+// given arguments through v's executor, with the three standard streams wired
+// to v's console handles. PTY allocation requires an OS-backed Exec; non-OS
+// backends are accepted but `WithUsePTY(true)` will fail at Start with
+// ErrPTYRequiresOSBackend.
+func Command(ctx context.Context, v *venv.Venv, name string, args ...string) *Cmd {
+	v.RequireExec()
+	v.RequireStdin()
+	v.RequireWriters()
+
+	vc := v.Exec.Command(ctx, name, args...)
 
 	cmd := &Cmd{
 		vc:              vc,
@@ -52,9 +58,9 @@ func Command(ctx context.Context, e vexec.Exec, name string, args ...string) *Cm
 		interruptSignal: signal.InterruptSignal,
 	}
 
-	cmd.SetStdin(os.Stdin)
-	cmd.SetStdout(os.Stdout)
-	cmd.SetStderr(os.Stderr)
+	cmd.SetStdin(v.Stdin)
+	cmd.SetStdout(v.Writers.Writer)
+	cmd.SetStderr(v.Writers.ErrWriter)
 
 	vc.SetWaitDelay(DefaultGracefulShutdownDelay)
 

--- a/internal/os/exec/cmd_test.go
+++ b/internal/os/exec/cmd_test.go
@@ -3,11 +3,14 @@ package exec_test
 import (
 	"bytes"
 	"context"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/os/exec"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,7 +31,7 @@ func TestCommandWithMemBackend(t *testing.T) {
 
 	stdout := &bytes.Buffer{}
 
-	cmd := exec.Command(t.Context(), e, "tofu", "plan")
+	cmd := exec.Command(t.Context(), venvtest.New().WithExec(e), "tofu", "plan")
 	cmd.SetStdout(stdout)
 	cmd.SetDir("/work")
 	cmd.SetEnv([]string{"FOO=bar"})
@@ -43,6 +46,65 @@ func TestCommandWithMemBackend(t *testing.T) {
 	assert.Equal(t, "/work", cmd.Dir())
 }
 
+// TestCommandDefaultsStreamsToTheVenv pins where an unconfigured command's
+// three standard streams come from. A subprocess that prompts must read the
+// console the rest of the run reads, not whatever the process was launched
+// with, or a driven run blocks on the invoking terminal.
+func TestCommandDefaultsStreamsToTheVenv(t *testing.T) {
+	t.Parallel()
+
+	var stdin io.Reader
+
+	e := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		stdin = inv.Stdin
+
+		return vexec.Result{Stdout: []byte("out"), Stderr: []byte("err")}
+	})
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+
+	v := venvtest.New().
+		WithExec(e).
+		WithStdin(strings.NewReader("yes\n")).
+		WithWriter(stdout).
+		WithErrWriter(stderr)
+
+	require.NoError(t, exec.Command(t.Context(), v, "tofu", "apply").Run(logger.CreateLogger()))
+
+	require.NotNil(t, stdin)
+	consumed, err := io.ReadAll(stdin)
+	require.NoError(t, err)
+
+	assert.Equal(t, "yes\n", string(consumed))
+	assert.Equal(t, "out", stdout.String())
+	assert.Equal(t, "err", stderr.String())
+}
+
+// TestCommandPassesStdinThroughUnwrapped pins that the child gets the venv's
+// stdin itself, not a wrapper around it. Anything that buffered in between
+// would hold read-ahead no other consumer can reach: os/exec copies a non-file
+// stdin into the child's pipe and that copy runs to EOF whether the child reads
+// or not, which is enough for one incidental `tofu -version` to swallow input
+// that a later prompt, or `hcl fmt --stdin`, still needs.
+func TestCommandPassesStdinThroughUnwrapped(t *testing.T) {
+	t.Parallel()
+
+	var handed io.Reader
+
+	e := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		handed = inv.Stdin
+
+		return vexec.Result{}
+	})
+
+	stdin := strings.NewReader("console input\n")
+	v := venvtest.New().WithExec(e).WithStdin(stdin)
+
+	require.NoError(t, exec.Command(t.Context(), v, "tofu", "-version").Run(logger.CreateLogger()))
+
+	assert.Same(t, stdin, handed)
+}
+
 // TestCommandWithMemBackendExitCode verifies that handler-reported exit codes
 // are recoverable via vexec.ExitCode.
 func TestCommandWithMemBackendExitCode(t *testing.T) {
@@ -52,7 +114,7 @@ func TestCommandWithMemBackendExitCode(t *testing.T) {
 		return vexec.Result{ExitCode: 7}
 	})
 
-	cmd := exec.Command(t.Context(), e, "tofu", "apply")
+	cmd := exec.Command(t.Context(), venvtest.New().WithExec(e), "tofu", "apply")
 
 	err := cmd.Run(logger.CreateLogger())
 	require.Error(t, err)
@@ -69,7 +131,7 @@ func TestCommandWithMemBackendPTYRejected(t *testing.T) {
 		return vexec.Result{}
 	})
 
-	cmd := exec.Command(t.Context(), e, "tofu", "apply")
+	cmd := exec.Command(t.Context(), venvtest.New().WithExec(e), "tofu", "apply")
 	cmd.Configure(exec.WithUsePTY(true))
 
 	err := cmd.Run(logger.CreateLogger())

--- a/internal/os/exec/cmd_unix_test.go
+++ b/internal/os/exec/cmd_unix_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,7 +47,7 @@ func TestExitCodeUnix(t *testing.T) {
 	for index := 0; index <= 255; index++ {
 		cmd := exec.Command(
 			t.Context(),
-			vexec.NewOSExec(),
+			venvtest.New().WithExec(vexec.NewOSExec()),
 			"testdata/test_exit_code.sh",
 			strconv.Itoa(index),
 		)
@@ -81,7 +82,7 @@ func TestNewSignalsForwarderWaitUnix(t *testing.T) {
 
 	cmd := exec.Command(
 		t.Context(),
-		vexec.NewOSExec(),
+		venvtest.New().WithExec(vexec.NewOSExec()),
 		"testdata/test_sigint_wait.sh",
 		strconv.Itoa(expectedWait),
 		readyPath,
@@ -126,7 +127,7 @@ func TestNewSignalsForwarderMultipleUnix(t *testing.T) {
 	readyPath := filepath.Join(t.TempDir(), "sigint-ready")
 
 	cmd := exec.Command(
-		t.Context(), vexec.NewOSExec(),
+		t.Context(), venvtest.New().WithExec(vexec.NewOSExec()),
 		"testdata/test_sigint_multiple.sh", strconv.Itoa(expectedInterrupts), readyPath,
 	)
 
@@ -181,7 +182,12 @@ func TestGracefulShutdownOnContextCancelUnix(t *testing.T) {
 
 	readyPath := filepath.Join(t.TempDir(), "sigint-ready")
 
-	cmd := exec.Command(ctx, vexec.NewOSExec(), "testdata/test_graceful_shutdown.sh", readyPath)
+	cmd := exec.Command(
+		ctx,
+		venvtest.New().WithExec(vexec.NewOSExec()),
+		"testdata/test_graceful_shutdown.sh",
+		readyPath,
+	)
 
 	cmd.Configure(exec.WithGracefulShutdownDelay(5 * time.Second))
 

--- a/internal/os/exec/cmd_windows_test.go
+++ b/internal/os/exec/cmd_windows_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 
 	"github.com/gruntwork-io/terragrunt/internal/os/exec"
 	"github.com/stretchr/testify/assert"
@@ -42,7 +43,7 @@ func TestWindowsExitCode(t *testing.T) {
 	for i := 0; i <= 255; i++ {
 		cmd := exec.Command(
 			t.Context(),
-			vexec.NewOSExec(),
+			venvtest.New().WithExec(vexec.NewOSExec()),
 			`testdata\test_exit_code.bat`,
 			strconv.Itoa(i),
 		)
@@ -75,7 +76,7 @@ func TestWindowsNewSignalsForwarderWait(t *testing.T) {
 
 	cmd := exec.Command(
 		t.Context(),
-		vexec.NewOSExec(),
+		venvtest.New().WithExec(vexec.NewOSExec()),
 		`testdata\test_sigint_wait.bat`,
 		strconv.Itoa(expectedWait),
 	)

--- a/internal/os/exec/console_windows_test.go
+++ b/internal/os/exec/console_windows_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
@@ -248,7 +249,7 @@ func TestWindowsConsoleSubprocessSaveRestore(t *testing.T) {
 
 	before := getMode(t, conout)
 
-	cmd := exec.Command(t.Context(), vexec.NewOSExec(), "cmd.exe", "/C", "echo hello")
+	cmd := exec.Command(t.Context(), venvtest.New().WithExec(vexec.NewOSExec()), "cmd.exe", "/C", "echo hello")
 	cmd.SetStdout(nil)
 	cmd.SetStderr(nil)
 

--- a/internal/os/stdout/stdout.go
+++ b/internal/os/stdout/stdout.go
@@ -2,22 +2,16 @@
 package stdout
 
 import (
-	"os"
-
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
-// IsRedirected returns true if the stdout is redirected.
-func IsRedirected() bool {
-	stat, err := os.Stdout.Stat()
-	if err != nil {
-		return false
-	}
-
-	return (stat.Mode() & os.ModeCharDevice) == 0
-}
-
 // ShouldColor returns true if output written to stdout should be colored.
-func ShouldColor(l log.Logger) bool {
-	return !l.Formatter().DisabledColors() && !IsRedirected()
+// Anything other than a terminal on the other end, a pipe, a file, or a
+// character device such as /dev/null, reads escape sequences as text rather
+// than as color, so it gets none.
+func ShouldColor(l log.Logger, v *venv.Venv) bool {
+	v.RequireTerminal()
+
+	return !l.Formatter().DisabledColors() && v.Terminal.StdoutIsTTY()
 }

--- a/internal/panicreport/panicreport.go
+++ b/internal/panicreport/panicreport.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/zclconf/go-cty/cty/function"
 
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+
 	// Imports pkg/log; pkg/log must never import internal/panicreport (would cycle via internal/vfs).
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -104,6 +106,8 @@ Stack trace:
 )
 
 // Reporter writes the crash banner and persists a crash log file on panic.
+// Every field is required; build one through [New] rather than by literal, so
+// a report cannot be assembled from a mix of supplied and real-OS details.
 type Reporter struct {
 	FS        vfs.FS
 	Now       func() time.Time
@@ -119,15 +123,21 @@ type RecoveredError struct {
 	stack []byte
 }
 
-// New returns a Reporter that writes its crash report through fsys and reads
-// the remaining process details from the OS.
-func New(fsys vfs.FS) *Reporter {
+// New returns a Reporter that writes its crash report through v's filesystem
+// and takes the process details it records from v's platform handles.
+func New(v *venv.Venv) *Reporter {
+	v.RequireFS()
+	v.RequirePlatform()
+
 	return &Reporter{
-		FS:        fsys,
+		FS:     v.FS,
+		Getwd:  v.Platform.Getwd,
+		GetPID: v.Platform.GetPID,
+		// TempDir is where the report lands when the working directory is not
+		// writable, so it is the last place a crash can still be recorded.
+		TempDir: v.Platform.TempDir,
+		// The venv carries no clock yet, so the wall clock is read here.
 		Now:       time.Now,
-		Getwd:     os.Getwd,
-		GetPID:    os.Getpid,
-		TempDir:   os.TempDir,
 		BuildInfo: readBuildInfo,
 	}
 }
@@ -335,8 +345,8 @@ func (r *Reporter) writeLog(
 	stack []byte,
 	args []string,
 ) (string, string, error) {
-	now := r.now()
-	pid := r.getPID()
+	now := r.Now()
+	pid := r.GetPID()
 	workingDir := r.workingDir()
 	content := r.formatLog(version, panicMsg, stack, args, now, workingDir, pid)
 	fileName := r.formatLogPath(now, pid)
@@ -348,7 +358,7 @@ func (r *Reporter) writeLog(
 	}
 
 	// Cwd write rejected; try TempDir before giving up.
-	tempDir := r.tempDir()
+	tempDir := r.TempDir()
 	if tempDir == "" || tempDir == workingDir {
 		return "", content, err
 	}
@@ -363,50 +373,18 @@ func (r *Reporter) writeLog(
 	return "", content, stdErrors.Join(err, tempErr)
 }
 
-// tempDir returns r.TempDir() when set, else os.TempDir.
-func (r *Reporter) tempDir() string {
-	if r.TempDir != nil {
-		return r.TempDir()
-	}
-
-	return os.TempDir()
-}
-
-// now returns r.Now() or time.Now if r.Now is nil.
-func (r *Reporter) now() time.Time {
-	if r.Now != nil {
-		return r.Now()
-	}
-
-	return time.Now()
-}
-
-// getPID returns r.GetPID() or os.Getpid if r.GetPID is nil.
-func (r *Reporter) getPID() int {
-	if r.GetPID != nil {
-		return r.GetPID()
-	}
-
-	return os.Getpid()
-}
-
 // writeFile writes through r.FS.
 func (r *Reporter) writeFile(name string, data []byte, perm os.FileMode) error {
 	return vfs.WriteFile(r.FS, name, data, perm)
 }
 
-// workingDir returns cwd, or TempDir if cwd is empty or errors.
+// workingDir returns cwd, or TempDir when cwd is empty or errors.
 func (r *Reporter) workingDir() string {
-	getwd := os.Getwd
-	if r.Getwd != nil {
-		getwd = r.Getwd
-	}
-
-	if wd, err := getwd(); err == nil && wd != "" {
+	if wd, err := r.Getwd(); err == nil && wd != "" {
 		return wd
 	}
 
-	return r.tempDir()
+	return r.TempDir()
 }
 
 // formatLog renders the crashLogTemplate with runtime context.

--- a/internal/panicreport/panicreport_test.go
+++ b/internal/panicreport/panicreport_test.go
@@ -27,8 +27,8 @@ func TestReportPanicWritesCrashLog(t *testing.T) {
 	t.Parallel()
 
 	when := time.Date(2026, 5, 15, 12, 30, 45, 0, time.UTC)
-	fs := vfs.NewMemMapFS()
-	r := newStubReporter(fs, "/wd", when, 8080)
+	fsys := vfs.NewMemMapFS()
+	r := newStubReporter(fsys, "/wd", when, 8080)
 	l, output := newPanicLogger()
 
 	r.ReportPanic(
@@ -55,7 +55,7 @@ func TestReportPanicWritesCrashLog(t *testing.T) {
 	assert.NotContains(t, logOutput, "stack-frames")
 	assert.NotContains(t, logOutput, "Terragrunt panic report")
 
-	body, err := vfs.ReadFile(fs, expectedPath)
+	body, err := vfs.ReadFile(fsys, expectedPath)
 	require.NoError(t, err)
 
 	content := string(body)
@@ -78,8 +78,8 @@ func TestReportPanicFallsBackWhenWriteFails(t *testing.T) {
 	t.Parallel()
 
 	// All writes are rejected; cwd-write fails, TempDir retry also fails (same FS), inline fallback fires.
-	fs := &rejectWritesFS{FS: vfs.NewMemMapFS(), err: errors.New("disk full")}
-	r := newStubReporter(fs, "/wd", time.Now().UTC(), os.Getpid())
+	fsys := &rejectWritesFS{FS: vfs.NewMemMapFS(), err: errors.New("disk full")}
+	r := newStubReporter(fsys, "/wd", time.Now().UTC(), os.Getpid())
 
 	l, output := newPanicLogger()
 	r.ReportPanic(l, "1.7.9", "slice bounds out of range", []byte("stack"), []string{"terragrunt"})
@@ -98,13 +98,13 @@ func TestReportPanicFallsBackWhenWriteFails(t *testing.T) {
 func TestReportPanicFallbacksOnEmptyInputs(t *testing.T) {
 	t.Parallel()
 
-	fs := vfs.NewMemMapFS()
+	fsys := vfs.NewMemMapFS()
 	when := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
-	r := newStubReporter(fs, "/wd", when, 1)
+	r := newStubReporter(fsys, "/wd", when, 1)
 
 	r.ReportPanic(logger.CreateLogger(), "", "", nil, []string{})
 
-	body, err := vfs.ReadFile(fs, "/wd/terragrunt-crash-20260102T030405Z-1.log")
+	body, err := vfs.ReadFile(fsys, "/wd/terragrunt-crash-20260102T030405Z-1.log")
 	require.NoError(t, err)
 
 	content := string(body)
@@ -118,10 +118,10 @@ func TestReportPanicFallbacksOnEmptyInputs(t *testing.T) {
 func TestReportPanicFallsBackToTempDirWhenGetwdFails(t *testing.T) {
 	t.Parallel()
 
-	fs := vfs.NewMemMapFS()
+	fsys := vfs.NewMemMapFS()
 	when := time.Now().UTC()
 	pid := os.Getpid()
-	r := newStubReporter(fs, "/wd", when, pid)
+	r := newStubReporter(fsys, "/wd", when, pid)
 	r.Getwd = func() (string, error) { return "", errors.New("denied") }
 
 	r.ReportPanic(logger.CreateLogger(), "1.7.9", "divide by zero", []byte("stack"), nil)
@@ -130,7 +130,7 @@ func TestReportPanicFallsBackToTempDirWhenGetwdFails(t *testing.T) {
 		"/tmp",
 		"terragrunt-crash-"+when.UTC().Format("20060102T150405Z")+"-"+strconv.Itoa(pid)+".log",
 	)
-	_, err := vfs.ReadFile(fs, expectedPath)
+	_, err := vfs.ReadFile(fsys, expectedPath)
 	require.NoError(t, err, "expected crash file at %s", expectedPath)
 }
 
@@ -138,16 +138,16 @@ func TestReportPanicRetriesTempDirWhenCwdWriteFails(t *testing.T) {
 	t.Parallel()
 
 	// Reject writes under /readonly; accept anywhere else (i.e. /tmp).
-	fs := &readOnlyDirsFS{FS: vfs.NewMemMapFS(), readOnlyDirs: []string{"/readonly"}}
+	fsys := &readOnlyDirsFS{FS: vfs.NewMemMapFS(), readOnlyDirs: []string{"/readonly"}}
 	when := time.Date(2026, 5, 22, 12, 30, 45, 0, time.UTC)
 	pid := 4242
-	r := newStubReporter(fs, "/readonly", when, pid)
+	r := newStubReporter(fsys, "/readonly", when, pid)
 
 	l, output := newPanicLogger()
 	r.ReportPanic(l, "1.7.9", "boom", []byte("stack"), []string{"terragrunt"})
 
 	tempPath := "/tmp/terragrunt-crash-20260522T123045Z-4242.log"
-	_, err := vfs.ReadFile(fs, tempPath)
+	_, err := vfs.ReadFile(fsys, tempPath)
 	require.NoError(t, err, "expected fallback file at %s", tempPath)
 
 	assert.Contains(t, output.String(), tempPath)
@@ -175,9 +175,9 @@ func TestPanicHandler(t *testing.T) {
 	t.Run("returns true and writes report when rec is set", func(t *testing.T) {
 		t.Parallel()
 
-		fs := vfs.NewMemMapFS()
+		fsys := vfs.NewMemMapFS()
 		when := time.Date(2026, 5, 22, 12, 30, 45, 0, time.UTC)
-		r := newStubReporter(fs, "/wd", when, 9999)
+		r := newStubReporter(fsys, "/wd", when, 9999)
 
 		l, output := newPanicLogger()
 
@@ -201,7 +201,7 @@ func TestPanicHandler(t *testing.T) {
 
 		expectedPath := "/wd/terragrunt-crash-20260522T123045Z-9999.log"
 
-		body, err := vfs.ReadFile(fs, expectedPath)
+		body, err := vfs.ReadFile(fsys, expectedPath)
 		require.NoError(t, err)
 		assert.Contains(t, output.String(), "TERRAGRUNT CRASH")
 		assert.Contains(t, output.String(), "boom")
@@ -442,9 +442,9 @@ func newPanicLogger() (log.Logger, *bytes.Buffer) {
 	), buf
 }
 
-func newStubReporter(fs vfs.FS, workDir string, now time.Time, pid int) *panicreport.Reporter {
+func newStubReporter(fsys vfs.FS, workDir string, now time.Time, pid int) *panicreport.Reporter {
 	return &panicreport.Reporter{
-		FS:        fs,
+		FS:        fsys,
 		Now:       func() time.Time { return now },
 		Getwd:     func() (string, error) { return workDir, nil },
 		GetPID:    func() int { return pid },

--- a/internal/providercache/archive_staging_test.go
+++ b/internal/providercache/archive_staging_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -135,7 +135,7 @@ func startProviderCacheRun(t *testing.T, registryName, upstreamURL string) *prov
 		helpers.TmpDirWOSymlinks(t),
 		nil,
 		l,
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 	)
 
 	// The pre-populated discovery cache points version and platform lookups at
@@ -163,7 +163,7 @@ func startProviderCacheRun(t *testing.T, registryName, upstreamURL string) *prov
 
 	ctx, cancel := context.WithCancel(t.Context())
 
-	ln, err := server.Listen(ctx)
+	ln, err := server.Listen(ctx, venvtest.NewOSWithEmptyEnv())
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/internal/providercache/concurrent_warmup_test.go
+++ b/internal/providercache/concurrent_warmup_test.go
@@ -23,10 +23,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -121,7 +121,13 @@ func TestProviderCacheConcurrentWarmupWithRacing(t *testing.T) {
 	providerCacheDir := helpers.TmpDirWOSymlinks(t)
 	pluginCacheDir := helpers.TmpDirWOSymlinks(t)
 
-	providerService := services.NewProviderService(providerCacheDir, pluginCacheDir, nil, l, venv.OSVenv())
+	providerService := services.NewProviderService(
+		providerCacheDir,
+		pluginCacheDir,
+		nil,
+		l,
+		venvtest.NewOSWithEmptyEnv(),
+	)
 
 	// The pre-populated discovery cache points version and platform lookups at
 	// the fake upstream over plain HTTP, without DNS lookups.
@@ -149,7 +155,7 @@ func TestProviderCacheConcurrentWarmupWithRacing(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	ln, err := server.Listen(ctx)
+	ln, err := server.Listen(ctx, venvtest.NewOSWithEmptyEnv())
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/internal/providercache/nested_modules_credentials_test.go
+++ b/internal/providercache/nested_modules_credentials_test.go
@@ -18,10 +18,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -103,7 +103,13 @@ func TestNestedModuleCredentials(t *testing.T) {
 	pluginCacheDir := helpers.TmpDirWOSymlinks(t)
 
 	l := logger.CreateLogger()
-	providerService := services.NewProviderService(providerCacheDir, pluginCacheDir, nil, l, venv.OSVenv())
+	providerService := services.NewProviderService(
+		providerCacheDir,
+		pluginCacheDir,
+		nil,
+		l,
+		venvtest.NewOSWithEmptyEnv(),
+	)
 	proxyProviderHandler := handlers.NewProxyProviderHandler(
 		l,
 		vhttp.NewNoNetworkClient(),
@@ -132,7 +138,7 @@ func TestNestedModuleCredentials(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	ln, err := server.Listen(ctx)
+	ln, err := server.Listen(ctx, venvtest.NewOSWithEmptyEnv())
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/internal/providercache/providercache.go
+++ b/internal/providercache/providercache.go
@@ -623,17 +623,17 @@ func (pc *ProviderCache) registrySupportsModules(
 }
 
 // saveCLIConfig writes the CLI config to disk, creating the directory if needed.
-func (pc *ProviderCache) saveCLIConfig(fs vfs.FS, cfg *cliconfig.Config, filename string) error {
+func (pc *ProviderCache) saveCLIConfig(fsys vfs.FS, cfg *cliconfig.Config, filename string) error {
 	cfgDir := filepath.Dir(filename)
 
-	cfgDirExists, err := vfs.FileExists(fs, cfgDir)
+	cfgDirExists, err := vfs.FileExists(fsys, cfgDir)
 	if err != nil {
 		return err
 	}
 
 	if !cfgDirExists {
 		const ownerReadWriteExecutePerms = 0o700
-		if err := fs.MkdirAll(cfgDir, ownerReadWriteExecutePerms); err != nil {
+		if err := fsys.MkdirAll(cfgDir, ownerReadWriteExecutePerms); err != nil {
 			return err
 		}
 	}

--- a/internal/providercache/providercache_test.go
+++ b/internal/providercache/providercache_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/models"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -157,7 +156,7 @@ func testProviderCache(t *testing.T, c vhttp.Client) {
 				pluginCacheDir,
 				nil,
 				l,
-				venv.OSVenv().WithHTTP(c),
+				venvtest.NewOSWithEmptyEnv().WithHTTP(c),
 			)
 			providerHandler := handlers.NewDirectProviderHandler(
 				l,
@@ -175,7 +174,7 @@ func testProviderCache(t *testing.T, c vhttp.Client) {
 
 			server := cache.NewServer(tc.opts...)
 
-			ln, err := server.Listen(t.Context())
+			ln, err := server.Listen(t.Context(), venvtest.NewOSWithEmptyEnv())
 			require.NoError(t, err)
 
 			defer ln.Close()
@@ -383,7 +382,7 @@ func TestProviderCacheHomeless(t *testing.T) {
 
 	_, err := providercache.InitServer(
 		logger.CreateLogger(),
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		&pcoptions.ProviderCacheOptions{
 			Dir: cacheDir,
 		},

--- a/internal/remotestate/backend/azurerm/backend.go
+++ b/internal/remotestate/backend/azurerm/backend.go
@@ -75,8 +75,7 @@ func resolveConfig(
 
 	cfg, err := azurehelper.NewAzureConfigBuilder().
 		WithSessionConfig(extCfg.GetAzureSessionConfig()).
-		WithVenv(v).
-		Build(l)
+		Build(l, v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -100,7 +99,11 @@ func armWorkRequested(extCfg *ExtendedRemoteStateConfigAzurerm) bool {
 // warnArmWorkSkipped logs that account creation or versioning/soft-delete
 // convergence was requested but cannot run under data-plane-only auth.
 func warnArmWorkSkipped(l log.Logger, name string, method azurehelper.AuthMethod) {
-	l.Warnf("Cannot manage the storage account for %s backend with %s authentication; skipping account creation and versioning/soft-delete convergence.", name, method)
+	l.Warnf(
+		"Cannot manage the storage account for %s backend with %s authentication; skipping account creation and versioning/soft-delete convergence.",
+		name,
+		method,
+	)
 }
 
 // cloudName describes a cloud for an error message. The configured value is
@@ -213,7 +216,11 @@ func (b *Backend) NeedsBootstrap(ctx context.Context, l log.Logger, v *venv.Venv
 
 // accountNeedsBootstrap reports whether the storage account is missing (and
 // creatable) or has versioning / soft-delete drift to converge.
-func accountNeedsBootstrap(ctx context.Context, cfg *azurehelper.AzureConfig, extCfg *ExtendedRemoteStateConfigAzurerm) (bool, error) {
+func accountNeedsBootstrap(
+	ctx context.Context,
+	cfg *azurehelper.AzureConfig,
+	extCfg *ExtendedRemoteStateConfigAzurerm,
+) (bool, error) {
 	saClient, err := azurehelper.NewStorageAccountClient(cfg)
 	if err != nil {
 		return false, err
@@ -551,7 +558,8 @@ func (b *Backend) Migrate(ctx context.Context, l log.Logger, srcV, dstV *venv.Ve
 
 	// Move (copy + delete source), mirroring the S3 and GCS backends: refuse to
 	// overwrite an existing destination and leave no stale state at the old key.
-	return blobClient.Container(src.ContainerName).MoveBlobIfNecessary(ctx, l, src.Key, blobClient.Container(dst.ContainerName), dst.Key)
+	return blobClient.Container(src.ContainerName).
+		MoveBlobIfNecessary(ctx, l, src.Key, blobClient.Container(dst.ContainerName), dst.Key)
 }
 
 // Delete deletes the Terraform state blob (config "key") from its container.
@@ -572,8 +580,12 @@ func (b *Backend) Delete(ctx context.Context, l log.Logger, v *venv.Venv, backen
 		return err
 	}
 
-	prompt := fmt.Sprintf("The Terraform state blob %q in container %q (storage account %q) will be deleted. Do you want to continue?",
-		rs.Key, rs.ContainerName, rs.StorageAccountName)
+	prompt := fmt.Sprintf(
+		"The Terraform state blob %q in container %q (storage account %q) will be deleted. Do you want to continue?",
+		rs.Key,
+		rs.ContainerName,
+		rs.StorageAccountName,
+	)
 
 	yes, err := shell.PromptUserForYesNo(ctx, l, v, prompt, opts.NonInteractive)
 	if err != nil {
@@ -605,8 +617,11 @@ func (b *Backend) DeleteBucket(ctx context.Context, l log.Logger, v *venv.Venv, 
 		return err
 	}
 
-	prompt := fmt.Sprintf("The blob container %q in storage account %q will be completely deleted. Do you want to continue?",
-		rs.ContainerName, rs.StorageAccountName)
+	prompt := fmt.Sprintf(
+		"The blob container %q in storage account %q will be completely deleted. Do you want to continue?",
+		rs.ContainerName,
+		rs.StorageAccountName,
+	)
 
 	yes, err := shell.PromptUserForYesNo(ctx, l, v, prompt, opts.NonInteractive)
 	if err != nil {

--- a/internal/remotestate/backend/azurerm/backend_test.go
+++ b/internal/remotestate/backend/azurerm/backend_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend/azurerm"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,37 +36,41 @@ func TestExperimentGate(t *testing.T) {
 	t.Run("NeedsBootstrap is a no-op", func(t *testing.T) {
 		t.Parallel()
 
-		needs, err := b.NeedsBootstrap(ctx, l, &venv.Venv{}, bcfg, opts)
+		needs, err := b.NeedsBootstrap(ctx, l, venvtest.New(), bcfg, opts)
 		require.NoError(t, err)
 		assert.False(t, needs)
 	})
 
 	t.Run("Bootstrap is a no-op", func(t *testing.T) {
 		t.Parallel()
-		require.NoError(t, b.Bootstrap(ctx, l, &venv.Venv{}, bcfg, opts))
+		require.NoError(t, b.Bootstrap(ctx, l, venvtest.New(), bcfg, opts))
 	})
 
 	t.Run("IsVersionControlEnabled is a no-op", func(t *testing.T) {
 		t.Parallel()
 
-		enabled, err := b.IsVersionControlEnabled(ctx, l, &venv.Venv{}, bcfg, opts)
+		enabled, err := b.IsVersionControlEnabled(ctx, l, venvtest.New(), bcfg, opts)
 		require.NoError(t, err)
 		assert.False(t, enabled)
 	})
 
 	t.Run("Delete reports the experiment", func(t *testing.T) {
 		t.Parallel()
-		require.ErrorIs(t, b.Delete(ctx, l, &venv.Venv{}, bcfg, opts), azurerm.ErrAzureBackendExperimentRequired)
+		require.ErrorIs(t, b.Delete(ctx, l, venvtest.New(), bcfg, opts), azurerm.ErrAzureBackendExperimentRequired)
 	})
 
 	t.Run("DeleteBucket reports the experiment", func(t *testing.T) {
 		t.Parallel()
-		require.ErrorIs(t, b.DeleteBucket(ctx, l, &venv.Venv{}, bcfg, opts), azurerm.ErrAzureBackendExperimentRequired)
+		require.ErrorIs(
+			t,
+			b.DeleteBucket(ctx, l, venvtest.New(), bcfg, opts),
+			azurerm.ErrAzureBackendExperimentRequired,
+		)
 	})
 
 	t.Run("Migrate reports the experiment", func(t *testing.T) {
 		t.Parallel()
-		require.ErrorIs(t, b.Migrate(ctx, l, &venv.Venv{}, &venv.Venv{}, bcfg, bcfg, opts), azurerm.ErrAzureBackendExperimentRequired)
+		require.ErrorIs(t, b.Migrate(ctx, l, venvtest.New(), venvtest.New(), bcfg, bcfg, opts), azurerm.ErrAzureBackendExperimentRequired)
 	})
 }
 
@@ -82,7 +86,7 @@ func TestExperimentEnabled_InvalidConfigSurfaces(t *testing.T) {
 	b := azurerm.NewBackend()
 
 	// Missing required keys -> validation error, NOT the experiment error.
-	_, err := b.NeedsBootstrap(ctx, l, &venv.Venv{}, backend.Config{}, opts)
+	_, err := b.NeedsBootstrap(ctx, l, venvtest.New(), backend.Config{}, opts)
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, azurerm.ErrAzureBackendExperimentRequired)
 }
@@ -122,7 +126,7 @@ func TestMigrate_CrossAccountRefused(t *testing.T) {
 	dstRaw["storage_account_name"] = "differentaccount"
 	dstCfg := backend.Config(dstRaw)
 
-	err := b.Migrate(ctx, l, &venv.Venv{}, &venv.Venv{}, srcCfg, dstCfg, opts)
+	err := b.Migrate(ctx, l, venvtest.New(), venvtest.New(), srcCfg, dstCfg, opts)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cross-account")
 	assert.NotContains(t, err.Error(), "server-side", "copy is client-side streaming, not server-side")
@@ -147,7 +151,7 @@ func TestMigrate_CrossCloudRefused(t *testing.T) {
 	dstRaw["environment"] = "usgovernment"
 
 	err := b.Migrate(
-		t.Context(), logger.CreateLogger(), &venv.Venv{}, &venv.Venv{},
+		t.Context(), logger.CreateLogger(), venvtest.New(), venvtest.New(),
 		backend.Config(srcRaw), backend.Config(dstRaw), opts)
 
 	require.Error(t, err)
@@ -177,7 +181,7 @@ func TestMigrate_SameCloudAliasAllowed(t *testing.T) {
 	dstRaw["storage_account_name"] = "otheraccount"
 
 	err := b.Migrate(
-		t.Context(), logger.CreateLogger(), &venv.Venv{}, &venv.Venv{},
+		t.Context(), logger.CreateLogger(), venvtest.New(), venvtest.New(),
 		backend.Config(srcRaw), backend.Config(dstRaw), opts)
 
 	var crossCloud *azurerm.CrossCloudMigrationError
@@ -194,7 +198,8 @@ func TestNeedsBootstrap_SkipsArmPlaneWhenNoArmWork(t *testing.T) {
 	t.Parallel()
 
 	needs, err := azurerm.NewBackend().NeedsBootstrap(
-		t.Context(), logger.CreateLogger(), &venv.Venv{}, backend.Config(rgLessSkipAllConfig()), optsWithExperiment(t, true))
+		t.Context(),
+		logger.CreateLogger(), venvtest.New(), backend.Config(rgLessSkipAllConfig()), optsWithExperiment(t, true))
 	require.NoError(t, err)
 	assert.False(t, needs)
 }
@@ -205,7 +210,8 @@ func TestBootstrap_SkipsArmPlaneWhenNoArmWork(t *testing.T) {
 	t.Parallel()
 
 	err := azurerm.NewBackend().Bootstrap(
-		t.Context(), logger.CreateLogger(), &venv.Venv{}, backend.Config(rgLessSkipAllConfig()), optsWithExperiment(t, true))
+		t.Context(),
+		logger.CreateLogger(), venvtest.New(), backend.Config(rgLessSkipAllConfig()), optsWithExperiment(t, true))
 	require.NoError(t, err)
 }
 
@@ -218,7 +224,7 @@ func TestIsVersionControlEnabled_NoResourceGroupDegrades(t *testing.T) {
 	delete(cfg, "resource_group_name")
 
 	enabled, err := azurerm.NewBackend().IsVersionControlEnabled(
-		t.Context(), logger.CreateLogger(), &venv.Venv{}, backend.Config(cfg), optsWithExperiment(t, true))
+		t.Context(), logger.CreateLogger(), venvtest.New(), backend.Config(cfg), optsWithExperiment(t, true))
 	require.NoError(t, err)
 	assert.False(t, enabled)
 }
@@ -259,8 +265,8 @@ func rgLessSkipAllConfig() azurerm.Config {
 func TestMigrate_CrossCloudFromDestinationEnvRefused(t *testing.T) {
 	t.Parallel()
 
-	srcV := (&venv.Venv{}).WithEnv(map[string]string{"ARM_ENVIRONMENT": "public"})
-	dstV := (&venv.Venv{}).WithEnv(map[string]string{"ARM_ENVIRONMENT": "usgovernment"})
+	srcV := (venvtest.New()).WithEnv(map[string]string{"ARM_ENVIRONMENT": "public"})
+	dstV := (venvtest.New()).WithEnv(map[string]string{"ARM_ENVIRONMENT": "usgovernment"})
 
 	cfg := backend.Config(fullConfig()) // identical config on both sides
 

--- a/internal/remotestate/backend/s3/client_test.go
+++ b/internal/remotestate/backend/s3/client_test.go
@@ -29,6 +29,7 @@ import (
 const defaultTestRegion = "us-east-1"
 
 // CreateS3ClientForTest creates a DynamoDB client we can use at test time. If there are any errors creating the client, fail the test.
+// The client it returns talks to real AWS, so it gets the OS venv rather than a hermetic one.
 func CreateS3ClientForTest(t *testing.T) *s3backend.Client {
 	t.Helper()
 

--- a/internal/runner/common/runner.go
+++ b/internal/runner/common/runner.go
@@ -26,6 +26,7 @@ type StackRunner interface {
 	// LogUnitDeployOrder logs the order in which units will be deployed.
 	LogUnitDeployOrder(
 		l log.Logger,
+		v *venv.Venv,
 		isDestroy bool,
 		showAbsPaths bool,
 		experiments experiment.Experiments,

--- a/internal/runner/graph/graph.go
+++ b/internal/runner/graph/graph.go
@@ -81,7 +81,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *options.Terragru
 
 	r := report.NewReport().WithWorkingDir(opts.WorkingDir)
 
-	if l.Formatter().DisabledColors() || stdout.IsRedirected() {
+	if !stdout.ShouldColor(l, v) {
 		r.WithDisableColor()
 	}
 

--- a/internal/runner/run/context_test.go
+++ b/internal/runner/run/context_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +29,7 @@ func TestModuleVersionResolverSharedPerRunWithRacing(t *testing.T) {
 	source := "tfr://" + server.Listener.Addr().String() + "/foo/bar/baz"
 	l := logger.CreateLogger()
 
-	v := venv.OSVenv().WithHTTP(server.Client())
+	v := venvtest.NewOSWithEmptyEnv().WithHTTP(server.Client())
 	ctx := run.WithModuleVersionResolver(t.Context(), v)
 
 	var wg sync.WaitGroup
@@ -82,7 +82,7 @@ func TestModuleVersionResolverFromContextFallback(t *testing.T) {
 	source := "tfr://" + server.Listener.Addr().String() + "/foo/bar/baz"
 	l := logger.CreateLogger()
 
-	v := venv.OSVenv().WithHTTP(server.Client())
+	v := venvtest.NewOSWithEmptyEnv().WithHTTP(server.Client())
 
 	first := run.ModuleVersionResolverFromContext(t.Context(), v)
 

--- a/internal/runner/run/creds/providers/externalcmd/provider_test.go
+++ b/internal/runner/run/creds/providers/externalcmd/provider_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds/providers/externalcmd"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +25,7 @@ func TestGetCredentialsHandlesJSONNullResponse(t *testing.T) {
 
 	provider := externalcmd.NewProvider(l, "printf null", opts)
 
-	creds, err := provider.GetCredentials(t.Context(), l, venv.OSVenv())
+	creds, err := provider.GetCredentials(t.Context(), l, venvtest.NewOSWithEmptyEnv())
 
 	require.NoError(t, err)
 	require.NotNil(t, creds)

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -386,7 +386,7 @@ func DownloadTerraformSourceIfNecessary(
 				return util.NotifyIfSlow(
 					childCtx,
 					l,
-					util.SpinnerWriter(),
+					util.SpinnerWriter(v),
 					time.Second,
 					util.SlowNotifyMsg{
 						Spinner: "Downloading source from " + sourceURL + "...",

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
 	"github.com/gruntwork-io/terragrunt/internal/util"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
@@ -369,7 +368,7 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirSameVe
 	_, err = run.DownloadTerraformSourceIfNecessary(
 		t.Context(),
 		logger.CreateLogger(),
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		terraformSource,
 		configbridge.NewRunOptions(opts),
 		cfg,
@@ -437,7 +436,7 @@ func TestDownloadTerraformSourceIfNecessaryInvalidTerraformSource(t *testing.T) 
 	_, err = run.DownloadTerraformSourceIfNecessary(
 		t.Context(),
 		logger.CreateLogger(),
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		terraformSource,
 		configbridge.NewRunOptions(opts),
 		cfg,
@@ -600,7 +599,7 @@ func testDownloadTerraformSourceIfNecessary(
 	_, err = run.DownloadTerraformSourceIfNecessary(
 		t.Context(),
 		logger.CreateLogger(),
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		terraformSource,
 		configbridge.NewRunOptions(opts),
 		cfg,
@@ -684,7 +683,7 @@ func createConfig(
 		return vexec.Result{Stdout: []byte("OpenTofu v1.7.2\n")}
 	})
 
-	versionV := venvtest.New().WithExec(versionExec).WithEnv(venv.OSVenv().Env)
+	versionV := venvtest.New().WithExec(versionExec).WithEnv(venvtest.NewOSWithEmptyEnv().Env)
 	_, ver, impl, err := run.PopulateTFVersion(
 		t.Context(),
 		l,
@@ -726,7 +725,7 @@ func testAlreadyHaveLatestCode(
 
 	actual, err := run.AlreadyHaveLatestCode(
 		l,
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		terraformSource,
 		configbridge.NewRunOptions(opts),
 	)
@@ -826,7 +825,7 @@ func TestUpdateGettersExcludeFromCopy(t *testing.T) {
 
 			client, err := run.BuildDownloadClient(
 				logger.CreateLogger(),
-				venv.OSVenv(),
+				venvtest.NewOSWithEmptyEnv(),
 				configbridge.NewRunOptions(terragruntOptions),
 				tc.cfg,
 			)
@@ -855,7 +854,7 @@ func TestBuildDownloadClientHTTPNetrc(t *testing.T) {
 
 	client, err := run.BuildDownloadClient(
 		logger.CreateLogger(),
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		configbridge.NewRunOptions(terragruntOptions),
 		&runcfg.RunConfig{Terraform: runcfg.TerraformConfig{}},
 	)
@@ -883,7 +882,7 @@ func TestBuildDownloadClientCoversDefaultSchemes(t *testing.T) {
 
 	client, err := run.BuildDownloadClient(
 		logger.CreateLogger(),
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		configbridge.NewRunOptions(terragruntOptions),
 		&runcfg.RunConfig{Terraform: runcfg.TerraformConfig{}},
 	)
@@ -949,7 +948,7 @@ func TestDownloadWithNoSourceCreatesCache(t *testing.T) {
 	updatedOpts, err := run.DownloadTerraformSource(
 		t.Context(),
 		l,
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		".",
 		configbridge.NewRunOptions(opts),
 		cfg,
@@ -1010,7 +1009,7 @@ func TestDownloadSourceWithCASExperimentDisabled(t *testing.T) {
 	_, err = run.DownloadTerraformSourceIfNecessary(
 		t.Context(),
 		l,
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		src,
 		configbridge.NewRunOptions(opts),
 		cfg,
@@ -1058,7 +1057,7 @@ func TestDownloadSourceWithCASExperimentEnabled(t *testing.T) {
 	_, err = run.DownloadTerraformSourceIfNecessary(
 		t.Context(),
 		l,
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		src,
 		configbridge.NewRunOptions(opts),
 		cfg,
@@ -1126,7 +1125,7 @@ func TestDownloadSourceOCIThroughCASExperimentGate(t *testing.T) {
 			// Hermetic env and home so a developer's local Docker or tofu
 			// credentials cannot change how the source authenticates.
 			hermeticHome := t.TempDir()
-			v := venv.OSVenv().
+			v := venvtest.NewOSWithEmptyEnv().
 				WithEnv(map[string]string{"HOME": hermeticHome}).
 				WithUserHomeDir(func() (string, error) { return hermeticHome, nil })
 
@@ -1147,13 +1146,23 @@ func TestDownloadSourceOCIThroughCASExperimentGate(t *testing.T) {
 
 			if tc.enableOCI {
 				require.ErrorAs(t, err, &resolutionErr, "the oci getter must run when the experiment is on")
-				assert.Contains(t, logBuf.String(), casAttempt, "the oci source must enter the CAS path when the experiment is on")
+				assert.Contains(
+					t,
+					logBuf.String(),
+					casAttempt,
+					"the oci source must enter the CAS path when the experiment is on",
+				)
 
 				return
 			}
 
 			assert.NotErrorAs(t, err, &resolutionErr, "no oci getter must run when the experiment is off")
-			assert.NotContains(t, logBuf.String(), casAttempt, "the CAS attempt must be skipped when the experiment is off")
+			assert.NotContains(
+				t,
+				logBuf.String(),
+				casAttempt,
+				"the CAS attempt must be skipped when the experiment is off",
+			)
 		})
 	}
 }
@@ -1192,7 +1201,7 @@ func TestDownloadSourceOCIAgainstLocalRegistry(t *testing.T) {
 
 	// Hermetic home so a developer's own credentials cannot authenticate the pull.
 	hermeticHome := t.TempDir()
-	v := venv.OSVenv().
+	v := venvtest.NewOSWithEmptyEnv().
 		WithEnv(map[string]string{"HOME": hermeticHome}).
 		WithUserHomeDir(func() (string, error) { return hermeticHome, nil })
 	v.HTTP = registry.Client()
@@ -1246,7 +1255,7 @@ func TestDownloadSourceWithCASGitSource(t *testing.T) {
 	_, err = run.DownloadTerraformSourceIfNecessary(
 		t.Context(),
 		l,
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		src,
 		configbridge.NewRunOptions(opts),
 		cfg,
@@ -1292,7 +1301,7 @@ func TestDownloadSourceCASInitializationFailure(t *testing.T) {
 	_, err = run.DownloadTerraformSourceIfNecessary(
 		t.Context(),
 		l,
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		src,
 		configbridge.NewRunOptions(opts),
 		cfg,
@@ -1336,7 +1345,7 @@ func TestDownloadSourceUpdateSourceWithCASRequiresCAS(t *testing.T) {
 	l.SetOptions(log.WithOutput(io.Discard))
 
 	_, err = run.DownloadTerraformSourceIfNecessary(
-		t.Context(), l, venv.OSVenv(), src,
+		t.Context(), l, venvtest.NewOSWithEmptyEnv(), src,
 		configbridge.NewRunOptions(opts),
 		cfg, report.NewReport(),
 	)
@@ -1402,7 +1411,7 @@ func TestDownloadSourceWithCASMultipleSources(t *testing.T) {
 			_, err = run.DownloadTerraformSourceIfNecessary(
 				t.Context(),
 				l,
-				venv.OSVenv(),
+				venvtest.NewOSWithEmptyEnv(),
 				src,
 				configbridge.NewRunOptions(opts),
 				cfg,
@@ -1462,7 +1471,7 @@ func TestHTTPGetterNetrcAuthentication(t *testing.T) {
 
 	client, err := run.BuildDownloadClient(
 		logger.CreateLogger(),
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		configbridge.NewRunOptions(opts),
 		cfg,
 	)
@@ -1537,7 +1546,7 @@ func TestDownloadTerraformSourceRejectsNonOSFilesystemPerSource(t *testing.T) {
 			opts, err := options.NewTerragruntOptionsForTest("./test")
 			require.NoError(t, err)
 
-			v := venv.OSVenv()
+			v := venvtest.NewOSWithEmptyEnv()
 			v.FS = vfs.NewMemMapFS()
 			v.HTTP = vhttp.NewNoNetworkClient()
 
@@ -1578,7 +1587,7 @@ func TestDownloadTerraformSourceIfNecessaryPanicsOnNilSource(t *testing.T) {
 		run.DownloadTerraformSourceIfNecessary(
 			t.Context(),
 			logger.CreateLogger(),
-			venv.OSVenv(),
+			venvtest.NewOSWithEmptyEnv(),
 			nil,
 			configbridge.NewRunOptions(opts),
 			&runcfg.RunConfig{Terraform: runcfg.TerraformConfig{}},
@@ -1595,7 +1604,7 @@ func TestDownloadTerraformSourceIfNecessaryRejectsNonOSFilesystem(t *testing.T) 
 	opts, err := options.NewTerragruntOptionsForTest("./test")
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 	v.FS = vfs.NewMemMapFS()
 
 	src, err := tf.NewSource(
@@ -1657,7 +1666,7 @@ func TestBuildDownloadClientOCIExperimentGate(t *testing.T) {
 
 			client, err := run.BuildDownloadClient(
 				logger.CreateLogger(),
-				venv.OSVenv(),
+				venvtest.NewOSWithEmptyEnv(),
 				configbridge.NewRunOptions(terragruntOptions),
 				&runcfg.RunConfig{Terraform: runcfg.TerraformConfig{}},
 			)
@@ -1702,7 +1711,7 @@ func TestBuildDownloadClientThreadsVenvToOCIStore(t *testing.T) {
 		0o600,
 	))
 
-	v := venv.OSVenv().
+	v := venvtest.NewOSWithEmptyEnv().
 		WithEnv(map[string]string{"HOME": home}).
 		WithUserHomeDir(func() (string, error) { return home, nil })
 

--- a/internal/runner/run/prepare_internal_test.go
+++ b/internal/runner/run/prepare_internal_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -107,7 +107,7 @@ func TestPrepareInitCommandRunCfg(t *testing.T) {
 			err := prepareInitCommandRunCfg(
 				t.Context(),
 				logger.CreateLogger(),
-				venv.OSVenv(),
+				venvtest.New(),
 				opts,
 				&cfg,
 			)

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -538,7 +538,7 @@ func CheckFolderContainsTerraformCode(fsys vfs.FS, opts *Options) error {
 }
 
 // Check that the specified Terraform code defines a backend { ... } block and return an error if doesn't.
-func checkTerraformCodeDefinesBackend(fs vfs.FS, opts *Options, backendType string) error {
+func checkTerraformCodeDefinesBackend(fsys vfs.FS, opts *Options, backendType string) error {
 	terraformBackendRegexp, err := regexp.Compile(
 		fmt.Sprintf(`backend[[:blank:]]+"%s"`, backendType),
 	)
@@ -547,7 +547,7 @@ func checkTerraformCodeDefinesBackend(fs vfs.FS, opts *Options, backendType stri
 	}
 
 	// Check for backend definitions in .tf and .tofu files using WalkDir
-	definesBackend, err := util.RegexFoundInTFFiles(fs, opts.CacheDir, terraformBackendRegexp)
+	definesBackend, err := util.RegexFoundInTFFiles(fsys, opts.CacheDir, terraformBackendRegexp)
 	if err != nil {
 		return err
 	}
@@ -564,7 +564,7 @@ func checkTerraformCodeDefinesBackend(fs vfs.FS, opts *Options, backendType stri
 	}
 
 	definesJSONBackend, err := util.GrepFilesWithSuffix(
-		fs,
+		fsys,
 		terraformJSONBackendRegexp,
 		opts.CacheDir,
 		".tf.json",
@@ -1018,7 +1018,8 @@ func SetTofuCPUProfileEnv(l log.Logger, v *venv.Venv, opts *Options) error {
 	v.RequireEnv()
 
 	unitRelDir := filepath.Join("external", filepath.Base(opts.UnitDir)+"-"+util.EncodeBase64Sha1(opts.UnitDir))
-	if relPath, err := filepath.Rel(opts.RootWorkingDir, opts.OriginalTerragruntConfigPath); err == nil && filepath.IsLocal(relPath) {
+	if relPath, err := filepath.Rel(opts.RootWorkingDir, opts.OriginalTerragruntConfigPath); err == nil &&
+		filepath.IsLocal(relPath) {
 		unitRelDir = filepath.Dir(relPath)
 	}
 

--- a/internal/runner/run/version_check.go
+++ b/internal/runner/run/version_check.go
@@ -290,7 +290,7 @@ func computeVersionFilesCacheKey(
 			continue
 		}
 
-		sanitizedPath, err := util.SanitizePath(workingDir, file)
+		sanitizedPath, err := util.SanitizePath(fsys, workingDir, file)
 		if err != nil {
 			sanitizedPath = path
 		}

--- a/internal/runner/runall/runall.go
+++ b/internal/runner/runall/runall.go
@@ -75,7 +75,7 @@ func Run(
 
 	r := report.NewReport().WithWorkingDir(opts.WorkingDir)
 
-	if l.Formatter().DisabledColors() || stdout.IsRedirected() {
+	if !stdout.ShouldColor(l, v) {
 		r.WithDisableColor()
 	}
 
@@ -219,6 +219,7 @@ func RunAllOnStack(
 	isDestroy := opts.TerraformCliArgs.IsDestroyCommand(opts.TerraformCommand)
 	if err := rnr.LogUnitDeployOrder(
 		l,
+		v,
 		isDestroy,
 		opts.LogShowAbsPaths,
 		opts.Experiments,

--- a/internal/runner/runall/runall_test.go
+++ b/internal/runner/runall/runall_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/runner/runall"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +21,7 @@ func TestMissingRunAllArguments(t *testing.T) {
 
 	tgOptions.TerraformCommand = ""
 
-	err = runall.Run(t.Context(), logger.CreateLogger(), venv.OSVenv(), tgOptions)
+	err = runall.Run(t.Context(), logger.CreateLogger(), venvtest.New(), tgOptions)
 	require.Error(t, err)
 
 	var missingCommand runall.MissingCommand

--- a/internal/runner/runnerpool/graph_fallback_test.go
+++ b/internal/runner/runnerpool/graph_fallback_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runnerpool"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	thlogger "github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // Test that the runner-level fallback (WithGraphTarget) limits the stack to target + dependents,
@@ -73,7 +73,7 @@ dependency "db" {
 
 	optsOn.Filters = parsedFilters
 	// Build runner
-	runnerOn, err := runnerpool.Build(ctx, l, venv.OSVenv(), optsOn)
+	runnerOn, err := runnerpool.Build(ctx, l, venvtest.NewOSWithEmptyEnv(), optsOn)
 	require.NoError(t, err)
 	// Collect unit paths
 	onPaths := make([]string, 0, len(runnerOn.GetStack().Units))
@@ -89,7 +89,7 @@ dependency "db" {
 	runnerOff, err := runnerpool.Build(
 		ctx,
 		l,
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		optsOff,
 		discovery.WithGraphTarget(vpcDir),
 	)

--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -736,21 +736,21 @@ func (rnr *Runner) Run(
 // showing dependency relationships between units.
 func (rnr *Runner) LogUnitDeployOrder(
 	l log.Logger,
+	v *venv.Venv,
 	isDestroy bool,
 	showAbsPaths bool,
 	experiments experiment.Experiments,
 ) error {
-	return rnr.logUnitDeployOrderDAG(l, isDestroy, showAbsPaths)
+	return rnr.logUnitDeployOrderDAG(l, v, isDestroy, showAbsPaths)
 }
 
 // logUnitDeployOrderDAG renders the queue as a DAG tree showing dependency relationships.
 // Independent units (siblings in the tree) may run concurrently.
-func (rnr *Runner) logUnitDeployOrderDAG(l log.Logger, isDestroy bool, showAbsPaths bool) error {
+func (rnr *Runner) logUnitDeployOrderDAG(l log.Logger, v *venv.Venv, isDestroy bool, showAbsPaths bool) error {
 	components := rnr.queueComponents()
 	listed := rnr.buildListedComponents(components, isDestroy, showAbsPaths)
 
-	shouldColor := !l.Formatter().DisabledColors() && !stdout.IsRedirected()
-	s := dag.NewTreeStyler(shouldColor)
+	s := dag.NewTreeStyler(stdout.ShouldColor(l, v))
 	t := dag.GenerateDAGTree(listed, s)
 	t = s.Style(t)
 

--- a/internal/runner/runnerpool/runner_functions_test.go
+++ b/internal/runner/runnerpool/runner_functions_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	thlogger "github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestLogUnitDeployOrder_Flat(t *testing.T) {
@@ -25,7 +26,7 @@ func TestLogUnitDeployOrder_Flat(t *testing.T) {
 	runner := buildTestRunner(t, "/tmp/test", []string{"/tmp/test/vpc", "/tmp/test/app"})
 	l := thlogger.CreateLogger()
 
-	err := runner.LogUnitDeployOrder(l, false, false, nil)
+	err := runner.LogUnitDeployOrder(l, venvtest.New(), false, false, nil)
 	require.NoError(t, err)
 }
 
@@ -35,7 +36,7 @@ func TestLogUnitDeployOrder_Destroy(t *testing.T) {
 	runner := buildTestRunner(t, "/tmp/test", []string{"/tmp/test/vpc", "/tmp/test/app"})
 	l := thlogger.CreateLogger()
 
-	err := runner.LogUnitDeployOrder(l, true, false, nil)
+	err := runner.LogUnitDeployOrder(l, venvtest.New(), true, false, nil)
 	require.NoError(t, err)
 }
 
@@ -148,7 +149,7 @@ func TestLogUnitDeployOrder_DAGExperiment(t *testing.T) {
 
 	exps := experiment.NewExperiments()
 
-	err := runner.LogUnitDeployOrder(l, false, false, exps)
+	err := runner.LogUnitDeployOrder(l, venvtest.New(), false, false, exps)
 	require.NoError(t, err)
 }
 

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -550,7 +550,7 @@ func (repo *Repo) performClone(
 	}
 
 	if repo.slowReporting {
-		err = util.NotifyIfSlow(ctx, l, util.SpinnerWriter(), time.Second, util.SlowNotifyMsg{
+		err = util.NotifyIfSlow(ctx, l, util.SpinnerWriter(v), time.Second, util.SlowNotifyMsg{
 			Spinner: "Cloning repository " + repo.cloneURL + "...",
 			Done:    "Cloned repository " + repo.cloneURL,
 		}, cloneFunc)

--- a/internal/services/catalog/module/repo_security_test.go
+++ b/internal/services/catalog/module/repo_security_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestNewRepoRejectsSymlinkRootBeforeCleanup(t *testing.T) {
@@ -29,7 +29,7 @@ func TestNewRepoRejectsSymlinkRootBeforeCleanup(t *testing.T) {
 	require.NoError(t, os.WriteFile(sentinel, []byte("do not remove\n"), 0o644))
 	require.NoError(t, os.Symlink(attackerParent, predictableRoot))
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 	v.HTTP = vhttp.NewNoNetworkClient()
 
 	_, err := module.NewRepo(t.Context(), logger.CreateLogger(), v, &module.RepoOpts{

--- a/internal/services/catalog/module/repo_test.go
+++ b/internal/services/catalog/module/repo_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -68,7 +67,7 @@ func TestFindModules(t *testing.T) {
 
 			ctx := t.Context()
 
-			v := venv.OSVenv()
+			v := venvtest.NewOSWithEmptyEnv()
 			v.HTTP = vhttp.NewNoNetworkClient()
 
 			repo, err := module.NewRepo(

--- a/internal/shell/git.go
+++ b/internal/shell/git.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
@@ -56,9 +57,9 @@ func (e *NestedGitScanDepthExceededError) Error() string {
 // captured to local buffers, so v.Writers is overridden for this call.
 func GitTopLevelDir(ctx context.Context, l log.Logger, v *venv.Venv, path string) (string, error) {
 	repoRoots := cache.ContextRepoRootCache(ctx, cache.RepoRootCacheContextKey)
-	normalized := normalizeRepoPath(path)
+	normalized := normalizeRepoPath(v.FS, path)
 
-	if root, ok, err := lookupRepoRoot(ctx, repoRoots, normalized); err != nil {
+	if root, ok, err := lookupRepoRoot(ctx, v.FS, repoRoots, normalized); err != nil {
 		return "", err
 	} else if ok {
 		return root, nil
@@ -67,7 +68,7 @@ func GitTopLevelDir(ctx context.Context, l log.Logger, v *venv.Venv, path string
 	repoRoots.BeginResolve()
 	defer repoRoots.EndResolve()
 
-	if root, ok, err := lookupRepoRoot(ctx, repoRoots, normalized); err != nil {
+	if root, ok, err := lookupRepoRoot(ctx, v.FS, repoRoots, normalized); err != nil {
 		return "", err
 	} else if ok {
 		return root, nil
@@ -107,7 +108,7 @@ func GitTopLevelDir(ctx context.Context, l log.Logger, v *venv.Venv, path string
 
 	l.Debugf("git show-toplevel result: %s", cmdOutput)
 
-	repoRoots.Add(ctx, normalizeRepoPath(cmdOutput))
+	repoRoots.Add(ctx, normalizeRepoPath(v.FS, cmdOutput))
 
 	return cmdOutput, nil
 }
@@ -117,6 +118,7 @@ func GitTopLevelDir(ctx context.Context, l log.Logger, v *venv.Venv, path string
 // the caller falls through to a fresh git resolution.
 func lookupRepoRoot(
 	ctx context.Context,
+	fsys vfs.FS,
 	repoRoots *cache.RepoRootCache,
 	path string,
 ) (string, bool, error) {
@@ -125,7 +127,7 @@ func lookupRepoRoot(
 		return "", false, nil
 	}
 
-	nested, err := hasNestedGit(path, cached)
+	nested, err := hasNestedGit(fsys, path, cached)
 	if err != nil {
 		return "", false, err
 	}
@@ -140,7 +142,7 @@ func lookupRepoRoot(
 // hasNestedGit reports whether any directory between path and root (exclusive
 // of root) contains a `.git` entry, meaning a nested repository sits below
 // root and would invalidate root as the answer for path.
-func hasNestedGit(path, root string) (bool, error) {
+func hasNestedGit(fsys vfs.FS, path, root string) (bool, error) {
 	if path == root {
 		return false, nil
 	}
@@ -151,7 +153,7 @@ func hasNestedGit(path, root string) (bool, error) {
 			return false, nil
 		}
 
-		_, err := os.Stat(filepath.Join(current, ".git"))
+		_, err := fsys.Stat(filepath.Join(current, ".git"))
 		if err == nil {
 			return true, nil
 		}
@@ -175,22 +177,15 @@ func hasNestedGit(path, root string) (bool, error) {
 	}
 }
 
-// normalizeRepoPath canonicalizes a directory path for cache comparison. The
-// EvalSymlinks step is best-effort: failures (e.g. the path does not exist)
-// fall through to the lexical clean so the surrounding git call still
-// produces the real error.
-func normalizeRepoPath(path string) string {
+// normalizeRepoPath canonicalizes a directory path for cache comparison.
+// An empty path stays empty rather than becoming the working directory, so a
+// caller that has no path yet cannot collide in the cache with one that does.
+func normalizeRepoPath(fsys vfs.FS, path string) string {
 	if path == "" {
 		return ""
 	}
 
-	cleaned := filepath.Clean(path)
-
-	if resolved, err := filepath.EvalSymlinks(cleaned); err == nil {
-		return resolved
-	}
-
-	return cleaned
+	return vfs.ResolveForCompare(fsys, filepath.Clean(path))
 }
 
 // GitRepoTags fetches git repository tags from passed url.

--- a/internal/shell/prompt.go
+++ b/internal/shell/prompt.go
@@ -2,12 +2,40 @@ package shell
 
 import (
 	"context"
+	"io"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/os/exec"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
+
+// readLine reads up to and including the next newline, a byte at a time, and
+// returns the line without it. Buffering the reads would be cheaper, but it
+// would also pull in whatever follows the answer, and that read-ahead is
+// unreachable afterwards: not to the next prompt, and not to a subprocess that
+// inherits the same stream. A prompt is a handful of bytes typed by a person,
+// so the syscall per byte costs nothing worth having.
+func readLine(r io.Reader) (string, error) {
+	var line []byte
+
+	buf := make([]byte, 1)
+
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			if buf[0] == '\n' {
+				return string(line), nil
+			}
+
+			line = append(line, buf[0])
+		}
+
+		if err != nil {
+			return "", err
+		}
+	}
+}
 
 // PromptUserForInput prompts the user for text in the CLI. Returns the text entered by the user.
 func PromptUserForInput(
@@ -17,7 +45,7 @@ func PromptUserForInput(
 	prompt string,
 	nonInteractive bool,
 ) (string, error) {
-	v.RequireReader()
+	v.RequireStdin()
 
 	errWriter := v.Writers.ErrWriter
 
@@ -50,7 +78,7 @@ func PromptUserForInput(
 	errCh := make(chan error)
 
 	go func() {
-		input, err := v.Reader.ReadString('\n')
+		input, err := readLine(v.Stdin)
 		if err != nil {
 			errCh <- err
 			return

--- a/internal/shell/prompt_test.go
+++ b/internal/shell/prompt_test.go
@@ -20,7 +20,7 @@ func TestPromptUserForInputSequential(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	v := venvtest.New().WithReader(strings.NewReader("first\nsecond\n"))
+	v := venvtest.New().WithStdin(strings.NewReader("first\nsecond\n"))
 
 	first, err := shell.PromptUserForInput(t.Context(), l, v, "one: ", false)
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestPromptUserForYesNo(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			v := venvtest.New().WithReader(strings.NewReader(tt.input))
+			v := venvtest.New().WithStdin(strings.NewReader(tt.input))
 
 			got, err := shell.PromptUserForYesNo(t.Context(), l, v, "proceed?", false)
 			require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestPromptUserForYesNoNonInteractive(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	v := venvtest.New().WithReader(strings.NewReader("no\n"))
+	v := venvtest.New().WithStdin(strings.NewReader("no\n"))
 
 	got, err := shell.PromptUserForYesNo(t.Context(), l, v, "proceed?", true)
 	require.NoError(t, err)
@@ -77,9 +77,9 @@ func TestPromptUserForInputPanicsOnUnsetReader(t *testing.T) {
 	t.Parallel()
 
 	v := venvtest.New()
-	v.Reader = nil
+	v.Stdin = nil
 
-	assert.PanicsWithError(t, venv.ErrVenvReaderUnset.Error(), func() {
+	assert.PanicsWithError(t, venv.ErrVenvStdinUnset.Error(), func() {
 		_, _ = shell.PromptUserForInput(t.Context(), logger.CreateLogger(), v, "one: ", false)
 	})
 }

--- a/internal/shell/run_cmd.go
+++ b/internal/shell/run_cmd.go
@@ -335,7 +335,7 @@ func runCommand(
 		forwardSignalDelay = SignalForwardingDelay
 	}
 
-	cmd := exec.Command(ctx, v.Exec, cmdOpts.Command, cmdOpts.Args...)
+	cmd := exec.Command(ctx, v, cmdOpts.Command, cmdOpts.Args...)
 	cmd.SetDir(cmdOpts.CommandDir)
 	cmd.SetStdout(cmdStdout)
 	cmd.SetStderr(cmdStderr)

--- a/internal/shell/run_cmd_test.go
+++ b/internal/shell/run_cmd_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,7 +46,7 @@ func TestGitTopLevelDirPrefixHit(t *testing.T) {
 	c := cache.ContextRepoRootCache(ctx, cache.RepoRootCacheContextKey)
 	c.Add(ctx, root)
 
-	got, err := shell.GitTopLevelDir(ctx, logger.CreateLogger(), venv.OSVenv(), subdir)
+	got, err := shell.GitTopLevelDir(ctx, logger.CreateLogger(), venvtest.NewOSWithEmptyEnv(), subdir)
 	require.NoError(t, err)
 	assert.Equal(t, root, got)
 }
@@ -69,7 +69,7 @@ func TestGitTopLevelDirNestedRepoBypass(t *testing.T) {
 	c := cache.ContextRepoRootCache(ctx, cache.RepoRootCacheContextKey)
 	c.Add(ctx, root)
 
-	got, err := shell.GitTopLevelDir(ctx, logger.CreateLogger(), venv.OSVenv(), deep)
+	got, err := shell.GitTopLevelDir(ctx, logger.CreateLogger(), venvtest.NewOSWithEmptyEnv(), deep)
 	if err == nil {
 		assert.NotEqual(
 			t,

--- a/internal/shell/run_cmd_unix_test.go
+++ b/internal/shell/run_cmd_unix_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/os/signal"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/util"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/assert"
@@ -48,7 +48,7 @@ func TestRunCommandWithOutputInterrupt(t *testing.T) {
 		_, err := shell.RunCommandWithOutput(
 			ctx,
 			l,
-			venv.OSVenv(),
+			venvtest.NewOSWithEmptyEnv(),
 			shellOpts,
 			"",
 			false,

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -130,7 +130,7 @@ func (g *Generator) generateStacks(
 	wts *worktrees.Worktrees,
 	scope stackScope,
 ) error {
-	workingDir, err := util.CanonicalResolvedPath(opts.WorkingDir, opts.WorkingDir)
+	workingDir, err := util.CanonicalResolvedPath(v.FS, opts.WorkingDir, opts.WorkingDir)
 	if err != nil {
 		return &CanonicalizeWorkingDirError{Path: opts.WorkingDir, Err: err}
 	}
@@ -463,12 +463,12 @@ func ListStackFiles(
 
 	foundFiles := make([]string, 0, len(discoveredComponents)+len(worktreeStacks))
 
-	foundFiles, err = appendStackFilePaths(foundFiles, discoveredComponents, opts.WorkingDir)
+	foundFiles, err = appendStackFilePaths(v.FS, foundFiles, discoveredComponents, opts.WorkingDir)
 	if err != nil {
 		return nil, err
 	}
 
-	foundFiles, err = appendStackFilePaths(foundFiles, worktreeStacks, opts.WorkingDir)
+	foundFiles, err = appendStackFilePaths(v.FS, foundFiles, worktreeStacks, opts.WorkingDir)
 	if err != nil {
 		return nil, err
 	}
@@ -509,6 +509,7 @@ func ListStackFilesWithExcludes(
 	}
 
 	foundFiles, excludedPaths, err := collectStackAndExcludedPaths(
+		v.FS,
 		discoveredComponents,
 		opts.WorkingDir,
 	)
@@ -516,7 +517,7 @@ func ListStackFilesWithExcludes(
 		return nil, nil, err
 	}
 
-	foundFiles, err = appendStackFilePaths(foundFiles, worktreeStacks, opts.WorkingDir)
+	foundFiles, err = appendStackFilePaths(v.FS, foundFiles, worktreeStacks, opts.WorkingDir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -526,6 +527,7 @@ func ListStackFilesWithExcludes(
 
 // collectStackAndExcludedPaths splits discovered components into canonical stack-file paths and excluded unit paths.
 func collectStackAndExcludedPaths(
+	fsys vfs.FS,
 	components component.Components,
 	workingDir string,
 ) ([]string, map[string]struct{}, error) {
@@ -536,6 +538,7 @@ func collectStackAndExcludedPaths(
 		switch v := c.(type) {
 		case *component.Stack:
 			canonical, err := util.CanonicalResolvedPath(
+				fsys,
 				filepath.Join(c.Path(), config.DefaultStackFile),
 				workingDir,
 			)
@@ -549,7 +552,7 @@ func collectStackAndExcludedPaths(
 				continue
 			}
 
-			canonical, err := util.CanonicalResolvedPath(v.Path(), workingDir)
+			canonical, err := util.CanonicalResolvedPath(fsys, v.Path(), workingDir)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -564,6 +567,7 @@ func collectStackAndExcludedPaths(
 // appendStackFilePaths appends the canonical terragrunt.stack.hcl path of every stack component in
 // components to dst, resolving each against workingDir. Non-stack components are skipped.
 func appendStackFilePaths(
+	fsys vfs.FS,
 	dst []string,
 	components component.Components,
 	workingDir string,
@@ -574,6 +578,7 @@ func appendStackFilePaths(
 		}
 
 		canonical, err := util.CanonicalResolvedPath(
+			fsys,
 			filepath.Join(c.Path(), config.DefaultStackFile),
 			workingDir,
 		)
@@ -605,7 +610,7 @@ func worktreeStacksToGenerate(
 		return component.Components{}, nil
 	}
 
-	stacksToGenerate := component.NewThreadSafeComponents(component.Components{})
+	stacksToGenerate := component.NewThreadSafeComponents(v.FS, component.Components{})
 
 	// If we edit a stack in a worktree, we need to generate it, at the minimum.
 	stackDiff := w.Stacks()
@@ -620,7 +625,7 @@ func worktreeStacksToGenerate(
 	}
 
 	for _, stack := range editedStacks {
-		stacksToGenerate.EnsureComponent(stack)
+		stacksToGenerate.EnsureComponent(v.FS, stack)
 	}
 
 	// When the expanded filter for a given Git expression requires parsing,
@@ -722,11 +727,11 @@ func worktreeStacksToGenerate(
 			}
 
 			for _, c := range allFromStacks {
-				stacksToGenerate.EnsureComponent(c)
+				stacksToGenerate.EnsureComponent(v.FS, c)
 			}
 
 			for _, c := range allToStacks {
-				stacksToGenerate.EnsureComponent(c)
+				stacksToGenerate.EnsureComponent(v.FS, c)
 			}
 
 			matchedToStacks, err := stacksReadingFiles(l, toReadFilters, allToStacks)

--- a/internal/stacks/generate/generate_test.go
+++ b/internal/stacks/generate/generate_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -58,7 +58,7 @@ func TestGenerateStacksCyclicSource_FailsAtMaxLevel(t *testing.T) {
 
 	err := generate.NewGenerator().
 		WithMaxLevel(maxLevel).
-		GenerateStacks(t.Context(), l, venv.OSVenv(), opts, nil)
+		GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, nil)
 
 	require.ErrorContains(
 		t,

--- a/internal/tf/cache/download_auth_test.go
+++ b/internal/tf/cache/download_auth_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -39,7 +39,7 @@ func TestDownloadRouteRequiresSecretSegment(t *testing.T) {
 		cache.WithHostname("127.0.0.1"),
 		cache.WithToken(token),
 		cache.WithLogger(l),
-		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, venv.OSVenv())),
+		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, venvtest.NewOSWithEmptyEnv())),
 		cache.WithProxyProviderHandler(
 			handlers.NewProxyProviderHandler(l, vhttp.NewNoNetworkClient(), nil),
 		),
@@ -48,7 +48,7 @@ func TestDownloadRouteRequiresSecretSegment(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
-	ln, err := server.Listen(ctx)
+	ln, err := server.Listen(ctx, venvtest.NewOSWithEmptyEnv())
 	require.NoError(t, err)
 
 	errGroup, ctx := errgroup.WithContext(ctx)
@@ -109,7 +109,7 @@ func TestDownloadSegmentIsRedactedFromLogs(t *testing.T) {
 	server := cache.NewServer(
 		cache.WithHostname("127.0.0.1"),
 		cache.WithLogger(l),
-		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, venv.OSVenv())),
+		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, venvtest.NewOSWithEmptyEnv())),
 		cache.WithProxyProviderHandler(
 			handlers.NewProxyProviderHandler(l, vhttp.NewNoNetworkClient(), nil),
 		),
@@ -118,7 +118,7 @@ func TestDownloadSegmentIsRedactedFromLogs(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
-	ln, err := server.Listen(ctx)
+	ln, err := server.Listen(ctx, venvtest.NewOSWithEmptyEnv())
 	require.NoError(t, err)
 
 	errGroup, ctx := errgroup.WithContext(ctx)

--- a/internal/tf/cache/server.go
+++ b/internal/tf/cache/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/middleware"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/router"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -96,10 +97,10 @@ func (server *Server) DiscoveryURL(
 }
 
 // Listen starts listening to the given configuration address. It also automatically chooses a free port if not explicitly specified.
-func (server *Server) Listen(ctx context.Context) (net.Listener, error) {
-	lc := &net.ListenConfig{}
+func (server *Server) Listen(ctx context.Context, v *venv.Venv) (net.Listener, error) {
+	v.RequireListen()
 
-	ln, err := lc.Listen(ctx, "tcp", server.Addr())
+	ln, err := v.Listen(ctx, "tcp", server.Addr())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tf/cache/server_init_test.go
+++ b/internal/tf/cache/server_init_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // serveTimeout bounds how long the test waits for a server that should never
@@ -35,10 +35,10 @@ func TestServerRunInitializesServicesBeforeServing(t *testing.T) {
 	server := cache.NewServer(
 		cache.WithHostname("127.0.0.1"),
 		cache.WithLogger(l),
-		cache.WithProviderService(services.NewProviderService("", t.TempDir(), nil, l, venv.OSVenv())),
+		cache.WithProviderService(services.NewProviderService("", t.TempDir(), nil, l, venvtest.NewOSWithEmptyEnv())),
 	)
 
-	ln, err := server.Listen(t.Context())
+	ln, err := server.Listen(t.Context(), venvtest.NewOSWithEmptyEnv())
 	require.NoError(t, err)
 
 	done := make(chan error, 1)

--- a/internal/tf/cache/server_test.go
+++ b/internal/tf/cache/server_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/models"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 // TestServerDiscoveryURLUsesTheHandlerThatClaimsTheRegistry pins that discovery is answered by the first handler whose include and exclude settings claim the registry, so the mirror a user configured for a host is the one asked where that host's API lives, and no other handler is contacted.
@@ -203,7 +203,7 @@ func TestServerListenReportsBindFailure(t *testing.T) {
 		cache.WithLogger(logger.CreateLogger()),
 	)
 
-	ln, err := server.Listen(t.Context())
+	ln, err := server.Listen(t.Context(), venvtest.NewOSWithEmptyEnv())
 	assert.Nil(t, ln, "no listener is handed back when the address cannot be bound")
 
 	var opErr *net.OpError
@@ -221,10 +221,10 @@ func TestServerRunReportsServeFailure(t *testing.T) {
 	server := cache.NewServer(
 		cache.WithHostname("127.0.0.1"),
 		cache.WithLogger(l),
-		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, venv.OSVenv())),
+		cache.WithProviderService(services.NewProviderService(tmp, tmp, nil, l, venvtest.NewOSWithEmptyEnv())),
 	)
 
-	ln, err := server.Listen(t.Context())
+	ln, err := server.Listen(t.Context(), venvtest.NewOSWithEmptyEnv())
 	require.NoError(t, err)
 	require.NoError(t, ln.Close())
 

--- a/internal/tf/cache/services/provider_cache.go
+++ b/internal/tf/cache/services/provider_cache.go
@@ -339,9 +339,9 @@ func (cache *ProviderCache) setSignature(ctx context.Context) ([]byte, error) {
 // 1. Checks if the required provider exists in the user plugins directory, located at %APPDATA%\terraform.d\plugins on Windows and ~/.terraform.d/plugins on other systems. If so, creates a symlink to this folder. (Some providers are not available for darwin_arm64, in this case we can use https://github.com/kreuzwerker/m1-terraform-provider-helper which compiles and saves providers to the user plugins directory)
 // 2. Downloads the provider from the original registry, unpacks and saves it into the cache directory.
 func (cache *ProviderCache) warmUp(ctx context.Context) error {
-	fs := cache.ProviderService.FS()
+	fsys := cache.ProviderService.FS()
 
-	exists, err := vfs.FileExists(fs, cache.packageDir)
+	exists, err := vfs.FileExists(fsys, cache.packageDir)
 	if err != nil {
 		return err
 	}
@@ -355,15 +355,15 @@ func (cache *ProviderCache) warmUp(ctx context.Context) error {
 	// before that directory was moved or deleted) reports as non-existent here
 	// but still trips MkdirAll downstream with "file exists". Remove only the
 	// symlink itself before the download or user-plugin symlink path runs.
-	if err := RemoveStaleSymlink(fs, cache.packageDir); err != nil {
+	if err := RemoveStaleSymlink(fsys, cache.packageDir); err != nil {
 		return err
 	}
 
-	if err := fs.MkdirAll(filepath.Dir(cache.packageDir), os.ModePerm); err != nil {
+	if err := fsys.MkdirAll(filepath.Dir(cache.packageDir), os.ModePerm); err != nil {
 		return err
 	}
 
-	userProviderExists, err := vfs.FileExists(fs, cache.userProviderDir)
+	userProviderExists, err := vfs.FileExists(fsys, cache.userProviderDir)
 	if err != nil {
 		return err
 	}
@@ -371,7 +371,7 @@ func (cache *ProviderCache) warmUp(ctx context.Context) error {
 	if userProviderExists {
 		cache.logger.Debugf("Create symlink file %s to %s", cache.packageDir, cache.userProviderDir)
 
-		if err := vfs.Symlink(fs, cache.userProviderDir, cache.packageDir); err != nil {
+		if err := vfs.Symlink(fsys, cache.userProviderDir, cache.packageDir); err != nil {
 			return err
 		}
 
@@ -384,7 +384,7 @@ func (cache *ProviderCache) warmUp(ctx context.Context) error {
 		return errors.New("not found provider download url")
 	}
 
-	downloadURLIsLocalFile, err := cache.isLocalFile(fs, cache.DownloadURL)
+	downloadURLIsLocalFile, err := cache.isLocalFile(fsys, cache.DownloadURL)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func (cache *ProviderCache) warmUp(ctx context.Context) error {
 		vfs.WithFilesLimit(DefaultProviderFilesLimit),
 	).Unzip(
 		cache.logger,
-		fs,
+		fsys,
 		cache.packageDir,
 		cache.archivePath,
 		unzipFileMode,
@@ -460,8 +460,8 @@ func (cache *ProviderCache) newRequest(ctx context.Context, url string) (*http.R
 // RemoveStaleSymlink removes a dangling symlink at path. A regular file or
 // directory there returns UnexpectedProviderCachePathError without deletion;
 // a missing path returns nil.
-func RemoveStaleSymlink(fs vfs.FS, path string) error {
-	info, err := vfs.Lstat(fs, path)
+func RemoveStaleSymlink(fsys vfs.FS, path string) error {
+	info, err := vfs.Lstat(fsys, path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
@@ -474,7 +474,7 @@ func RemoveStaleSymlink(fs vfs.FS, path string) error {
 		return &UnexpectedProviderCachePathError{Path: path, Mode: info.Mode()}
 	}
 
-	if err := fs.Remove(path); err != nil {
+	if err := fsys.Remove(path); err != nil {
 		return fmt.Errorf("failed to clear stale provider package symlink %q: %w", path, err)
 	}
 
@@ -484,12 +484,12 @@ func RemoveStaleSymlink(fs vfs.FS, path string) error {
 // isLocalFile checks whether the given path refers to an existing local file.
 // Remote URLs (containing "://") are never checked against the filesystem because
 // on Windows the colon in "https:" is invalid path syntax and causes an error.
-func (cache *ProviderCache) isLocalFile(fs vfs.FS, path string) (bool, error) {
+func (cache *ProviderCache) isLocalFile(fsys vfs.FS, path string) (bool, error) {
 	if strings.Contains(path, "://") {
 		return false, nil
 	}
 
-	return vfs.FileExists(fs, path)
+	return vfs.FileExists(fsys, path)
 }
 
 func (cache *ProviderCache) acquireLockFile(ctx context.Context) (*util.Lockfile, error) {

--- a/internal/tf/cache/services/provider_cache_test.go
+++ b/internal/tf/cache/services/provider_cache_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/services"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestRemoveStaleSymlink(t *testing.T) {
@@ -21,39 +21,39 @@ func TestRemoveStaleSymlink(t *testing.T) {
 	const path = "/cache/registry.terraform.io/hashicorp/aws/5.31.0/linux_amd64"
 
 	testCases := []struct {
-		setup     func(t *testing.T, fs vfs.FS)
+		setup     func(t *testing.T, fsys vfs.FS)
 		assertErr func(t *testing.T, err error)
-		assertFS  func(t *testing.T, fs vfs.FS)
+		assertFS  func(t *testing.T, fsys vfs.FS)
 		name      string
 	}{
 		{
 			name:  "no entry returns nil",
-			setup: func(t *testing.T, fs vfs.FS) { t.Helper() },
+			setup: func(t *testing.T, fsys vfs.FS) { t.Helper() },
 			assertErr: func(t *testing.T, err error) {
 				t.Helper()
 				require.NoError(t, err)
 			},
-			assertFS: func(t *testing.T, fs vfs.FS) {
+			assertFS: func(t *testing.T, fsys vfs.FS) {
 				t.Helper()
 
-				_, err := vfs.Lstat(fs, path)
+				_, err := vfs.Lstat(fsys, path)
 				assert.ErrorIs(t, err, os.ErrNotExist, "expected NotExist, got %v", err)
 			},
 		},
 		{
 			name: "dangling symlink is removed",
-			setup: func(t *testing.T, fs vfs.FS) {
+			setup: func(t *testing.T, fsys vfs.FS) {
 				t.Helper()
-				require.NoError(t, vfs.Symlink(fs, "/missing/target", path))
+				require.NoError(t, vfs.Symlink(fsys, "/missing/target", path))
 			},
 			assertErr: func(t *testing.T, err error) {
 				t.Helper()
 				require.NoError(t, err)
 			},
-			assertFS: func(t *testing.T, fs vfs.FS) {
+			assertFS: func(t *testing.T, fsys vfs.FS) {
 				t.Helper()
 
-				_, err := vfs.Lstat(fs, path)
+				_, err := vfs.Lstat(fsys, path)
 				assert.ErrorIs(
 					t,
 					err,
@@ -65,13 +65,13 @@ func TestRemoveStaleSymlink(t *testing.T) {
 		},
 		{
 			name: "regular file returns typed error and is left in place",
-			setup: func(t *testing.T, fs vfs.FS) {
+			setup: func(t *testing.T, fsys vfs.FS) {
 				t.Helper()
 				require.NoError(
 					t,
-					fs.MkdirAll("/cache/registry.terraform.io/hashicorp/aws/5.31.0", 0o755),
+					fsys.MkdirAll("/cache/registry.terraform.io/hashicorp/aws/5.31.0", 0o755),
 				)
-				require.NoError(t, afero.WriteFile(fs, path, []byte("user content"), 0o644))
+				require.NoError(t, afero.WriteFile(fsys, path, []byte("user content"), 0o644))
 			},
 			assertErr: func(t *testing.T, err error) {
 				t.Helper()
@@ -82,19 +82,19 @@ func TestRemoveStaleSymlink(t *testing.T) {
 				assert.Equal(t, path, unexpected.Path)
 				assert.Zero(t, unexpected.Mode&os.ModeSymlink)
 			},
-			assertFS: func(t *testing.T, fs vfs.FS) {
+			assertFS: func(t *testing.T, fsys vfs.FS) {
 				t.Helper()
 
-				exists, err := vfs.FileExists(fs, path)
+				exists, err := vfs.FileExists(fsys, path)
 				require.NoError(t, err)
 				assert.True(t, exists, "regular file must not be deleted")
 			},
 		},
 		{
 			name: "regular directory returns typed error and is left in place",
-			setup: func(t *testing.T, fs vfs.FS) {
+			setup: func(t *testing.T, fsys vfs.FS) {
 				t.Helper()
-				require.NoError(t, fs.MkdirAll(path, 0o755))
+				require.NoError(t, fsys.MkdirAll(path, 0o755))
 			},
 			assertErr: func(t *testing.T, err error) {
 				t.Helper()
@@ -106,10 +106,10 @@ func TestRemoveStaleSymlink(t *testing.T) {
 				assert.True(t, unexpected.Mode.IsDir())
 				assert.Zero(t, unexpected.Mode&os.ModeSymlink)
 			},
-			assertFS: func(t *testing.T, fs vfs.FS) {
+			assertFS: func(t *testing.T, fsys vfs.FS) {
 				t.Helper()
 
-				exists, err := vfs.FileExists(fs, path)
+				exists, err := vfs.FileExists(fsys, path)
 				require.NoError(t, err)
 				assert.True(t, exists, "directory must not be deleted")
 			},
@@ -120,11 +120,11 @@ func TestRemoveStaleSymlink(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			fs := vfs.NewMemMapFS()
-			tc.setup(t, fs)
+			fsys := vfs.NewMemMapFS()
+			tc.setup(t, fsys)
 
-			tc.assertErr(t, services.RemoveStaleSymlink(fs, path))
-			tc.assertFS(t, fs)
+			tc.assertErr(t, services.RemoveStaleSymlink(fsys, path))
+			tc.assertFS(t, fsys)
 		})
 	}
 }
@@ -133,9 +133,9 @@ func TestRemoveStaleSymlinkLstatErrorIsWrapped(t *testing.T) {
 	t.Parallel()
 
 	wantInner := errors.New("synthetic lstat failure")
-	fs := &lstatErrorFS{FS: vfs.NewMemMapFS(), err: wantInner}
+	fsys := &lstatErrorFS{FS: vfs.NewMemMapFS(), err: wantInner}
 
-	err := services.RemoveStaleSymlink(fs, "/anything")
+	err := services.RemoveStaleSymlink(fsys, "/anything")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, wantInner)
 }
@@ -145,8 +145,8 @@ type lstatErrorFS struct {
 	err error
 }
 
-func (fs *lstatErrorFS) LstatIfPossible(string) (os.FileInfo, bool, error) {
-	return nil, false, fs.err
+func (fsys *lstatErrorFS) LstatIfPossible(string) (os.FileInfo, bool, error) {
+	return nil, false, fsys.err
 }
 
 // TestProviderServiceInitIsIdempotent covers the server initializing a
@@ -156,7 +156,7 @@ func TestProviderServiceInitIsIdempotent(t *testing.T) {
 	t.Parallel()
 
 	service := services.NewProviderService(
-		t.TempDir(), t.TempDir(), nil, logger.CreateLogger(), venv.OSVenv(),
+		t.TempDir(), t.TempDir(), nil, logger.CreateLogger(), venvtest.NewOSWithEmptyEnv(),
 	)
 
 	require.NoError(t, service.Init())
@@ -167,7 +167,7 @@ func TestProviderServiceInitWithoutCacheDir(t *testing.T) {
 	t.Parallel()
 
 	service := services.NewProviderService(
-		"", t.TempDir(), nil, logger.CreateLogger(), venv.OSVenv(),
+		"", t.TempDir(), nil, logger.CreateLogger(), venvtest.NewOSWithEmptyEnv(),
 	)
 
 	require.ErrorIs(t, service.Init(), services.ErrCacheDirNotSpecified)

--- a/internal/tf/cliconfig/config.go
+++ b/internal/tf/cliconfig/config.go
@@ -34,9 +34,9 @@ type ConfigOption func(*Config) *Config
 
 // WithFS sets the filesystem for file operations.
 // If not set, defaults to the real OS filesystem.
-func WithFS(fs vfs.FS) ConfigOption {
+func WithFS(fsys vfs.FS) ConfigOption {
 	return func(cfg *Config) *Config {
-		cfg.fs = fs
+		cfg.fsys = fsys
 		return cfg
 	}
 }
@@ -44,7 +44,7 @@ func WithFS(fs vfs.FS) ConfigOption {
 // NewConfig creates a new Config that saves through fsys.
 func NewConfig(fsys vfs.FS) *Config {
 	return &Config{
-		fs: fsys,
+		fsys: fsys,
 	}
 }
 
@@ -54,9 +54,9 @@ type Config struct {
 	CredentialsHelpers   *ConfigCredentialsHelper `hcl:"credentials_helper,block"`
 	ProviderInstallation *ProviderInstallation    `hcl:"provider_installation,block"`
 
-	// fs is the filesystem for saving config. Unexported to skip HCL encoding.
+	// fsys is the filesystem for saving config. Unexported to skip HCL encoding.
 	// Defaults to vfs.NewOsFs() if nil.
-	fs vfs.FS
+	fsys vfs.FS
 
 	PluginCacheDir             string              `hcl:"plugin_cache_dir"`
 	Credentials                []ConfigCredentials `hcl:"credentials,block"`
@@ -76,7 +76,7 @@ func (cfg *Config) WithOptions(opts ...ConfigOption) *Config {
 
 // FS returns the configured filesystem.
 func (cfg *Config) FS() vfs.FS {
-	return cfg.fs
+	return cfg.fsys
 }
 
 // WithDisableCheckpoint sets DisableCheckpoint to true and returns the Config for chaining.
@@ -142,7 +142,7 @@ func (cfg *Config) Clone() *Config {
 		CredentialsHelpers:         cfg.CredentialsHelpers,
 		Hosts:                      hosts,
 		ProviderInstallation:       providerInstallation,
-		fs:                         cfg.fs,
+		fsys:                       cfg.fsys,
 	}
 }
 

--- a/internal/tf/run_cmd.go
+++ b/internal/tf/run_cmd.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
 	logwriter "github.com/gruntwork-io/terragrunt/pkg/log/writer"
-	"github.com/mattn/go-isatty"
 )
 
 const (
@@ -34,8 +33,8 @@ const (
 )
 
 // Commands that implement a REPL need a pseudo TTY when run as a subprocess in order for the readline properties to be
-// preserved. This is a list of terraform commands that have this property, which is used to determine if terragrunt
-// should allocate a ptty when running that terraform command.
+// preserved. This is a list of tofu commands that have this property, which is used to determine if terragrunt
+// should allocate a ptty when running that tofu command.
 var commandsThatNeedPty = []string{
 	CommandNameConsole,
 }
@@ -51,7 +50,7 @@ type TFOptions struct {
 	JSONLogFormat                bool
 }
 
-// RunCommand runs the given Terraform command using the supplied venv.
+// RunCommand runs the given OpenTofu/Terraform command using the supplied venv.
 // Pass a venv whose Exec is a [vexec.NewMemExec] from tests and fuzzers to
 // intercept invocations so tofu/terraform are never forked.
 func RunCommand(
@@ -66,7 +65,7 @@ func RunCommand(
 	return err
 }
 
-// RunCommandWithOutput runs the given Terraform command using the supplied
+// RunCommandWithOutput runs the given OpenTofu/Terraform command using the supplied
 // venv, writing its stdout/stderr to the terminal AND returning
 // stdout/stderr to this method's caller.
 func RunCommandWithOutput(
@@ -82,7 +81,7 @@ func RunCommandWithOutput(
 		return fn(ctx, l, v, runOpts, args)
 	}
 
-	needsPTY, err := isCommandThatNeedsPty(args)
+	needsPTY, err := isCommandThatNeedsPty(v, args)
 	if err != nil {
 		return nil, err
 	}
@@ -181,9 +180,16 @@ func logTFOutput(
 	return outWriter, errWriter
 }
 
-// isCommandThatNeedsPty returns true if the sub command of terraform we are running requires a pty.
-func isCommandThatNeedsPty(args []string) (bool, error) {
+// isCommandThatNeedsPty returns true if the sub command of tofu we are running requires a pty.
+func isCommandThatNeedsPty(v *venv.Venv, args []string) (bool, error) {
 	if len(args) == 0 || !slices.Contains(commandsThatNeedPty, args[0]) {
+		return false, nil
+	}
+
+	v.RequireTerminal()
+
+	// if the stdin is not a terminal, then the tofu console is used in non-interactive mode
+	if !v.Terminal.StdinIsTTY() {
 		return false, nil
 	}
 
@@ -192,13 +198,8 @@ func isCommandThatNeedsPty(args []string) (bool, error) {
 		return false, err
 	}
 
-	// if there is data in the stdin, then the terraform console is used in non-interactive mode, for example `echo "1 + 5" | terragrunt console`.
+	// if there is data in the stdin, then the tofu console is used in non-interactive mode, for example `echo "1 + 5" | terragrunt console`.
 	if fi.Size() > 0 {
-		return false, nil
-	}
-
-	// if the stdin is not a terminal, then the terraform console is used in non-interactive mode
-	if !isatty.IsTerminal(os.Stdin.Fd()) {
 		return false, nil
 	}
 

--- a/internal/tflint/tflint.go
+++ b/internal/tflint/tflint.go
@@ -194,7 +194,7 @@ func (err ConfigNotFound) Error() string {
 }
 
 // TFArgumentsToVar converts variables from the terraform config to a list of tflint variables.
-func TFArgumentsToVar(l log.Logger, fs vfs.FS, hook *runcfg.Hook,
+func TFArgumentsToVar(l log.Logger, fsys vfs.FS, hook *runcfg.Hook,
 	tfCfg *runcfg.TerraformConfig) ([]string, error) {
 	var variables []string
 
@@ -252,7 +252,7 @@ func TFArgumentsToVar(l log.Logger, fs vfs.FS, hook *runcfg.Hook,
 		if len(arg.OptionalVarFiles) > 0 {
 			// extract optional variables
 			for _, file := range util.RemoveDuplicatesKeepLast(arg.OptionalVarFiles) {
-				exists, err := vfs.FileExists(fs, file)
+				exists, err := vfs.FileExists(fsys, file)
 				if err != nil {
 					l.Debugf("Skipping tflint var-file %s: %v", file, err)
 					continue
@@ -276,7 +276,7 @@ func TFArgumentsToVar(l log.Logger, fs vfs.FS, hook *runcfg.Hook,
 // FindConfigInProject looks for a .tflint.hcl file in the current
 // folder or it's parents. When running from cache, we start searching
 // from the original config directory to find config in the source directory.
-func FindConfigInProject(l log.Logger, fs vfs.FS, opts *TFLintOptions) (string, error) {
+func FindConfigInProject(l log.Logger, fsys vfs.FS, opts *TFLintOptions) (string, error) {
 	startDir := opts.WorkingDir
 	if opts.TerragruntConfigPath != "" {
 		startDir = filepath.Dir(opts.TerragruntConfigPath)
@@ -298,7 +298,7 @@ func FindConfigInProject(l log.Logger, fs vfs.FS, opts *TFLintOptions) (string, 
 
 		fileToFind := filepath.Join(previousDir, ".tflint.hcl")
 
-		exists, err := vfs.FileExists(fs, fileToFind)
+		exists, err := vfs.FileExists(fsys, fileToFind)
 		if err != nil {
 			return "", err
 		}
@@ -322,7 +322,7 @@ func FindConfigInProject(l log.Logger, fs vfs.FS, opts *TFLintOptions) (string, 
 // or the result of walking parents to find a .tflint.hcl file.
 func ConfigFilePath(
 	l log.Logger,
-	fs vfs.FS,
+	fsys vfs.FS,
 	opts *TFLintOptions,
 	arguments []string,
 ) (string, error) {
@@ -341,7 +341,7 @@ func ConfigFilePath(
 		}
 	}
 	// find .tflint.hcl configuration in project files if it is not provided in arguments
-	projectConfigFile, err := FindConfigInProject(l, fs, opts)
+	projectConfigFile, err := FindConfigInProject(l, fsys, opts)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tflint/tflint_test.go
+++ b/internal/tflint/tflint_test.go
@@ -2,18 +2,16 @@ package tflint_test
 
 import (
 	"context"
-	"io"
 	"slices"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/tflint"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
-	"github.com/gruntwork-io/terragrunt/internal/writer"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -190,11 +188,11 @@ func TestTFArgumentsToVar(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			fs := vfs.NewMemMapFS()
-			require.NoError(t, vfs.WriteFile(fs, optionalPresent, []byte("x = 1"), 0o644))
+			fsys := vfs.NewMemMapFS()
+			require.NoError(t, vfs.WriteFile(fsys, optionalPresent, []byte("x = 1"), 0o644))
 
 			l := logger.CreateLogger()
-			actual, err := tflint.TFArgumentsToVar(l, fs, &tc.hook, &tc.cfg)
+			actual, err := tflint.TFArgumentsToVar(l, fsys, &tc.hook, &tc.cfg)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, actual)
 		})
@@ -242,10 +240,10 @@ func TestConfigFilePath_ShortCircuitsOnConfigFlag(t *testing.T) {
 
 			// An empty FS makes the parent walk impossible, so a successful
 			// return can only have come from the arguments.
-			fs := vfs.NewMemMapFS()
+			fsys := vfs.NewMemMapFS()
 			l := logger.CreateLogger()
 
-			got, err := tflint.ConfigFilePath(l, fs, &tflint.TFLintOptions{
+			got, err := tflint.ConfigFilePath(l, fsys, &tflint.TFLintOptions{
 				WorkingDir:        "/work/unit",
 				RootWorkingDir:    "/work",
 				MaxFoldersToCheck: 5,
@@ -286,12 +284,12 @@ func TestConfigFilePath_IgnoresNonConfigArguments(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			fs := vfs.NewMemMapFS()
-			require.NoError(t, vfs.WriteFile(fs, "/work/.tflint.hcl", []byte("config {}"), 0o644))
+			fsys := vfs.NewMemMapFS()
+			require.NoError(t, vfs.WriteFile(fsys, "/work/.tflint.hcl", []byte("config {}"), 0o644))
 
 			l := logger.CreateLogger()
 
-			got, err := tflint.ConfigFilePath(l, fs, &tflint.TFLintOptions{
+			got, err := tflint.ConfigFilePath(l, fsys, &tflint.TFLintOptions{
 				WorkingDir:        "/work/unit",
 				RootWorkingDir:    "/work",
 				MaxFoldersToCheck: 5,
@@ -380,14 +378,14 @@ func TestFindConfigInProject(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			fs := vfs.NewMemMapFS()
+			fsys := vfs.NewMemMapFS()
 			for _, p := range tc.seedFiles {
-				require.NoError(t, vfs.WriteFile(fs, p, []byte("config {}"), 0o644))
+				require.NoError(t, vfs.WriteFile(fsys, p, []byte("config {}"), 0o644))
 			}
 
 			l := logger.CreateLogger()
 
-			got, err := tflint.FindConfigInProject(l, fs, &tc.opts)
+			got, err := tflint.FindConfigInProject(l, fsys, &tc.opts)
 			if tc.wantErrType != nil {
 				require.Error(t, err)
 
@@ -408,8 +406,8 @@ func TestFindConfigInProject(t *testing.T) {
 func TestRunTflintWithOpts_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	fs := vfs.NewMemMapFS()
-	require.NoError(t, vfs.WriteFile(fs, "/work/unit/.tflint.hcl", []byte("config {}"), 0o644))
+	fsys := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fsys, "/work/unit/.tflint.hcl", []byte("config {}"), 0o644))
 
 	var calls []vexec.Invocation
 
@@ -419,7 +417,7 @@ func TestRunTflintWithOpts_HappyPath(t *testing.T) {
 		return vexec.Result{}
 	})
 
-	runErr := runWithOpts(t, fs, exec, &runcfg.Hook{
+	runErr := runWithOpts(t, fsys, exec, &runcfg.Hook{
 		Name:     "tflint",
 		Commands: []string{"plan"},
 		Execute:  []string{"tflint"},
@@ -464,10 +462,10 @@ func TestRunTflintWithOpts_HappyPath(t *testing.T) {
 func TestRunTflintWithOpts_HonorsConfigFlagInHook(t *testing.T) {
 	t.Parallel()
 
-	fs := vfs.NewMemMapFS()
+	fsys := vfs.NewMemMapFS()
 	// Deliberately not seeded anywhere the parent walk would reach, so the
 	// run can only succeed by reading the path out of the hook arguments.
-	require.NoError(t, vfs.WriteFile(fs, "/elsewhere/custom.tflint.hcl", []byte("config {}"), 0o644))
+	require.NoError(t, vfs.WriteFile(fsys, "/elsewhere/custom.tflint.hcl", []byte("config {}"), 0o644))
 
 	var calls []vexec.Invocation
 
@@ -477,7 +475,7 @@ func TestRunTflintWithOpts_HonorsConfigFlagInHook(t *testing.T) {
 		return vexec.Result{}
 	})
 
-	require.NoError(t, runWithOpts(t, fs, exec, &runcfg.Hook{
+	require.NoError(t, runWithOpts(t, fsys, exec, &runcfg.Hook{
 		Name:     "tflint",
 		Commands: []string{"plan"},
 		Execute:  []string{"tflint", "--config=/elsewhere/custom.tflint.hcl"},
@@ -494,8 +492,8 @@ func TestRunTflintWithOpts_HonorsConfigFlagInHook(t *testing.T) {
 func TestRunTflintWithOpts_StripsExternalTflintFlag(t *testing.T) {
 	t.Parallel()
 
-	fs := vfs.NewMemMapFS()
-	require.NoError(t, vfs.WriteFile(fs, "/work/unit/.tflint.hcl", []byte("config {}"), 0o644))
+	fsys := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fsys, "/work/unit/.tflint.hcl", []byte("config {}"), 0o644))
 
 	var calls []vexec.Invocation
 
@@ -505,7 +503,7 @@ func TestRunTflintWithOpts_StripsExternalTflintFlag(t *testing.T) {
 		return vexec.Result{}
 	})
 
-	require.NoError(t, runWithOpts(t, fs, exec, &runcfg.Hook{
+	require.NoError(t, runWithOpts(t, fsys, exec, &runcfg.Hook{
 		Name:     "tflint",
 		Commands: []string{"plan"},
 		Execute: []string{
@@ -528,8 +526,8 @@ func TestRunTflintWithOpts_StripsExternalTflintFlag(t *testing.T) {
 func TestRunTflintWithOpts_InitFailureWraps(t *testing.T) {
 	t.Parallel()
 
-	fs := vfs.NewMemMapFS()
-	require.NoError(t, vfs.WriteFile(fs, "/work/unit/.tflint.hcl", []byte("config {}"), 0o644))
+	fsys := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fsys, "/work/unit/.tflint.hcl", []byte("config {}"), 0o644))
 
 	exec := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
 		if slices.Contains(inv.Args, "--init") {
@@ -539,7 +537,7 @@ func TestRunTflintWithOpts_InitFailureWraps(t *testing.T) {
 		return vexec.Result{}
 	})
 
-	err := runWithOpts(t, fs, exec, &runcfg.Hook{
+	err := runWithOpts(t, fsys, exec, &runcfg.Hook{
 		Name:     "tflint",
 		Commands: []string{"plan"},
 		Execute:  []string{"tflint"},
@@ -556,8 +554,8 @@ func TestRunTflintWithOpts_InitFailureWraps(t *testing.T) {
 func TestRunTflintWithOpts_LintFailureWraps(t *testing.T) {
 	t.Parallel()
 
-	fs := vfs.NewMemMapFS()
-	require.NoError(t, vfs.WriteFile(fs, "/work/unit/.tflint.hcl", []byte("config {}"), 0o644))
+	fsys := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fsys, "/work/unit/.tflint.hcl", []byte("config {}"), 0o644))
 
 	exec := vexec.NewMemExec(func(_ context.Context, inv vexec.Invocation) vexec.Result {
 		if slices.Contains(inv.Args, "--init") {
@@ -567,7 +565,7 @@ func TestRunTflintWithOpts_LintFailureWraps(t *testing.T) {
 		return vexec.Result{ExitCode: 2, Stderr: []byte("3 issue(s) found\n")}
 	})
 
-	err := runWithOpts(t, fs, exec, &runcfg.Hook{
+	err := runWithOpts(t, fsys, exec, &runcfg.Hook{
 		Name:     "tflint",
 		Commands: []string{"plan"},
 		Execute:  []string{"tflint"},
@@ -584,13 +582,13 @@ func TestRunTflintWithOpts_LintFailureWraps(t *testing.T) {
 func TestRunTflintWithOpts_MissingConfigSurfacesNotFound(t *testing.T) {
 	t.Parallel()
 
-	fs := vfs.NewMemMapFS()
+	fsys := vfs.NewMemMapFS()
 	exec := vexec.NewMemExec(func(_ context.Context, _ vexec.Invocation) vexec.Result {
 		t.Fatal("subprocess invoked despite missing config")
 		return vexec.Result{}
 	})
 
-	err := runWithOpts(t, fs, exec, &runcfg.Hook{
+	err := runWithOpts(t, fsys, exec, &runcfg.Hook{
 		Name:     "tflint",
 		Commands: []string{"plan"},
 		Execute:  []string{"tflint"},
@@ -607,7 +605,7 @@ func TestRunTflintWithOpts_MissingConfigSurfacesNotFound(t *testing.T) {
 // rebuild the same TFLintOptions and Venv.
 func runWithOpts(
 	t *testing.T,
-	fs vfs.FS,
+	fsys vfs.FS,
 	exec vexec.Exec,
 	hook *runcfg.Hook,
 	cfg *runcfg.RunConfig,
@@ -621,16 +619,11 @@ func runWithOpts(
 		MaxFoldersToCheck: 5,
 	}
 
-	v := venv.Venv{
-		Exec:    exec,
-		FS:      fs,
-		Env:     map[string]string{},
-		Writers: &writer.Writers{Writer: io.Discard, ErrWriter: io.Discard},
-	}
+	v := venvtest.New().WithExec(exec).WithFS(fsys)
 
 	l := logger.CreateLogger()
 
-	return tflint.RunTflintWithOpts(t.Context(), l, &v, opts, cfg, hook)
+	return tflint.RunTflintWithOpts(t.Context(), l, v, opts, cfg, hook)
 }
 
 func cloneInvocation(inv *vexec.Invocation) vexec.Invocation {

--- a/internal/tips/stack_nested_generate.go
+++ b/internal/tips/stack_nested_generate.go
@@ -17,7 +17,7 @@ import (
 // The user likely expected the whole subtree, so the tip shows how to include it.
 func GiveStackNestedGenerateTip(
 	l log.Logger,
-	fs vfs.FS,
+	fsys vfs.FS,
 	funcsFor inthclparse.StackFuncFactory,
 	workingDir string,
 	filters filter.Filters,
@@ -45,7 +45,7 @@ func GiveStackNestedGenerateTip(
 			dir = filepath.Join(workingDir, dir)
 		}
 
-		if !stackHasUngeneratedNestedStacks(l, fs, funcsFor, dir) {
+		if !stackHasUngeneratedNestedStacks(l, fsys, funcsFor, dir) {
 			continue
 		}
 
@@ -94,18 +94,18 @@ func literalStackFilterPath(f *filter.Filter) string {
 // exist on disk (honoring no_dot_terragrunt_stack).
 func stackHasUngeneratedNestedStacks(
 	l log.Logger,
-	fs vfs.FS,
+	fsys vfs.FS,
 	funcsFor inthclparse.StackFuncFactory,
 	dir string,
 ) bool {
-	_, nestedStackDirs, err := inthclparse.DirectComponentPaths(fs, dir, funcsFor)
+	_, nestedStackDirs, err := inthclparse.DirectComponentPaths(fsys, dir, funcsFor)
 	if err != nil {
 		l.Debugf("stack-nested-generate tip: skipping %q: %v", dir, err)
 		return false
 	}
 
 	for _, nestedDir := range nestedStackDirs {
-		if !nestedStackGenerated(l, fs, funcsFor, nestedDir) {
+		if !nestedStackGenerated(l, fsys, funcsFor, nestedDir) {
 			return true
 		}
 	}
@@ -117,23 +117,23 @@ func stackHasUngeneratedNestedStacks(
 // generated at nestedDir exists on disk, i.e. the nested stack was itself generated.
 func nestedStackGenerated(
 	l log.Logger,
-	fs vfs.FS,
+	fsys vfs.FS,
 	funcsFor inthclparse.StackFuncFactory,
 	nestedDir string,
 ) bool {
-	unitPaths, stackPaths, err := inthclparse.DirectComponentPaths(fs, nestedDir, funcsFor)
+	unitPaths, stackPaths, err := inthclparse.DirectComponentPaths(fsys, nestedDir, funcsFor)
 	if err != nil {
 		l.Debugf("stack-nested-generate tip: skipping %q: %v", nestedDir, err)
 		return true
 	}
 
-	return !anyPathMissing(l, fs, unitPaths) && !anyPathMissing(l, fs, stackPaths)
+	return !anyPathMissing(l, fsys, unitPaths) && !anyPathMissing(l, fsys, stackPaths)
 }
 
-// anyPathMissing reports whether any of paths does not exist on fs.
-func anyPathMissing(l log.Logger, fs vfs.FS, paths []string) bool {
+// anyPathMissing reports whether any of paths does not exist on fsys.
+func anyPathMissing(l log.Logger, fsys vfs.FS, paths []string) bool {
 	for _, p := range paths {
-		exists, err := vfs.FileExists(fs, p)
+		exists, err := vfs.FileExists(fsys, p)
 		if err != nil {
 			l.Debugf("stack-nested-generate tip: cannot stat %q: %v", p, err)
 			continue

--- a/internal/tips/stack_nested_generate_test.go
+++ b/internal/tips/stack_nested_generate_test.go
@@ -47,12 +47,12 @@ func emptyStackFuncFactory() inthclparse.StackFuncFactory {
 	}
 }
 
-func writeFile(t *testing.T, fs vfs.FS, path, content string) {
+func writeFile(t *testing.T, fsys vfs.FS, path, content string) {
 	t.Helper()
 
-	require.NoError(t, fs.MkdirAll(filepath.Dir(path), 0o755)) //nolint:mnd
+	require.NoError(t, fsys.MkdirAll(filepath.Dir(path), 0o755)) //nolint:mnd
 
-	f, err := fs.Create(path)
+	f, err := fsys.Create(path)
 	require.NoError(t, err)
 	_, err = f.Write([]byte(content))
 	require.NoError(t, err)

--- a/internal/tips/stack_target.go
+++ b/internal/tips/stack_target.go
@@ -20,7 +20,7 @@ import (
 // suggested rewrite can be pasted verbatim.
 func GiveStackTargetTip(
 	l log.Logger,
-	fs vfs.FS,
+	fsys vfs.FS,
 	workingDir string,
 	filters filter.Filters,
 	allTips Tips,
@@ -41,7 +41,7 @@ func GiveStackTargetTip(
 			continue
 		}
 
-		if filterTargetsStackDir(l, f, fs, workingDir) {
+		if filterTargetsStackDir(l, f, fsys, workingDir) {
 			offenders = append(offenders, f.String())
 		}
 	}
@@ -87,7 +87,7 @@ func filterMentionsTypeAttribute(f *filter.Filter) bool {
 	return found
 }
 
-func filterTargetsStackDir(l log.Logger, f *filter.Filter, fs vfs.FS, workingDir string) bool {
+func filterTargetsStackDir(l log.Logger, f *filter.Filter, fsys vfs.FS, workingDir string) bool {
 	var hit bool
 
 	filter.WalkExpressions(f.Expression(), func(e filter.Expression) bool {
@@ -107,7 +107,7 @@ func filterTargetsStackDir(l log.Logger, f *filter.Filter, fs vfs.FS, workingDir
 
 		stackFile := filepath.Join(candidate, config.DefaultStackFile)
 
-		exists, err := vfs.FileExists(fs, stackFile)
+		exists, err := vfs.FileExists(fsys, stackFile)
 		if err != nil {
 			l.Debugf("stack-target tip: skipping %q: %v", stackFile, err)
 			return true

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -81,13 +81,13 @@ func CanonicalPath(path string, basePath string) (string, error) {
 }
 
 // CanonicalResolvedPath returns the cleaned absolute path with symlinks resolved best-effort.
-func CanonicalResolvedPath(path, basePath string) (string, error) {
+func CanonicalResolvedPath(fsys vfs.FS, path, basePath string) (string, error) {
 	canonical, err := CanonicalPath(path, basePath)
 	if err != nil {
 		return "", err
 	}
 
-	return ResolvePath(canonical), nil
+	return vfs.ResolveForCompare(fsys, canonical), nil
 }
 
 // GrepFilesWithSuffix returns true if regex matches the contents of any file
@@ -1831,14 +1831,20 @@ func Copy(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
 	return num, err
 }
 
+// ErrPathEscapesBaseDir reports that a path handed to [SanitizePath] would
+// resolve outside the base directory it was to be read from.
+var ErrPathEscapesBaseDir = errors.New("path escapes its base directory")
+
 // SanitizePath resolves a file path within a base directory, returning the sanitized path or an error if it attempts
-// to access anything outside the base directory.
-func SanitizePath(baseDir string, file string) (sanitized string, err error) {
+// to access anything outside the base directory. An absolute file, a "../"
+// traversal, and a symlink that leads out of baseDir are all rejected; the
+// resolved file must exist.
+func SanitizePath(fsys vfs.FS, baseDir string, file string) (string, error) {
 	if baseDir == "" || file == "" {
 		return "", errors.New("baseDir and file must be provided")
 	}
 
-	file, err = url.QueryUnescape(file)
+	file, err := url.QueryUnescape(file)
 	if err != nil {
 		return "", err
 	}
@@ -1848,29 +1854,23 @@ func SanitizePath(baseDir string, file string) (sanitized string, err error) {
 		return "", err
 	}
 
-	root, err := os.OpenRoot(baseDir)
-	if err != nil {
+	if filepath.IsAbs(file) {
+		return "", fmt.Errorf("%w: %q must be relative to %q", ErrPathEscapesBaseDir, file, baseDir)
+	}
+
+	// Join preserves nested directories from the input, so "a/b/c.txt" keeps
+	// its shape instead of flattening onto baseDir.
+	sanitized := filepath.Join(baseDir, filepath.Clean(file))
+
+	if !vfs.Within(fsys, baseDir, sanitized) {
+		return "", fmt.Errorf("%w: %q is outside %q", ErrPathEscapesBaseDir, file, baseDir)
+	}
+
+	if _, err := fsys.Stat(sanitized); err != nil {
 		return "", err
 	}
 
-	defer func() {
-		if cerr := root.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
-	}()
-
-	if _, err := root.Stat(file); err != nil {
-		return "", err
-	}
-
-	// Preserve nested directories from the validated input. Using
-	// fileInfo.Name() would flatten "a/b/c.txt" to "<baseDir>/c.txt".
-	// root.Stat already rejects paths that escape baseDir, so we only need
-	// to clean the input and join it back onto baseDir.
-	cleanedRelative := filepath.Clean(file)
-	cleanedRelative = strings.TrimLeft(cleanedRelative, string(os.PathSeparator))
-
-	return filepath.Join(baseDir, cleanedRelative), nil
+	return sanitized, nil
 }
 
 // RelPathForLog returns a relative path suitable for logging.
@@ -1896,18 +1896,6 @@ func RelPathForLog(basePath, targetPath string, showAbsPath bool) string {
 	}
 
 	return targetPath
-}
-
-// ResolvePath resolves symlinks in a path for consistent comparison across platforms.
-// On macOS, /var is a symlink to /private/var, so paths must be resolved.
-// Returns the original path if symlink resolution fails.
-func ResolvePath(path string) string {
-	resolved, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return path
-	}
-
-	return resolved
 }
 
 // MoveFile attempts to rename a file from source to destination, if this fails

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -1148,7 +1148,7 @@ func Test_sanitizePath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := util.SanitizePath(tt.baseDir, tt.file)
+			got, err := util.SanitizePath(vfs.NewOSFS(), tt.baseDir, tt.file)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -1160,6 +1160,26 @@ func Test_sanitizePath(t *testing.T) {
 			assert.Equalf(t, tt.want, got, "sanitizePath(%v, %v)", tt.baseDir, tt.file)
 		})
 	}
+}
+
+// TestSanitizePathRejectsSymlinkOutOfBaseDir pins the containment check against
+// a link, not just a "../" traversal. A relative path that stays inside baseDir
+// on paper still reaches outside it when a component along the way is a symlink.
+func TestSanitizePathRejectsSymlinkOutOfBaseDir(t *testing.T) {
+	t.Parallel()
+
+	base := helpers.TmpDirWOSymlinks(t)
+
+	baseDir := filepath.Join(base, "unit")
+	require.NoError(t, os.MkdirAll(baseDir, 0o755))
+
+	outside := filepath.Join(base, "outside.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("secret"), 0o644))
+
+	require.NoError(t, os.Symlink(outside, filepath.Join(baseDir, "escape.txt")))
+
+	_, err := util.SanitizePath(vfs.NewOSFS(), baseDir, "escape.txt")
+	require.ErrorIs(t, err, util.ErrPathEscapesBaseDir)
 }
 
 func TestMoveFile(t *testing.T) {

--- a/internal/util/slow_notify.go
+++ b/internal/util/slow_notify.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"golang.org/x/term"
 )
 
 // spinnerFrames are braille dot characters used for the progress spinner.
@@ -34,11 +33,13 @@ type SlowNotifyMsg struct {
 	Done string
 }
 
-// SpinnerWriter returns os.Stderr if it is an interactive terminal, nil otherwise.
-// Use the returned writer as the spinnerW argument to NotifyIfSlow.
-func SpinnerWriter() io.Writer {
-	if term.IsTerminal(int(os.Stderr.Fd())) {
-		return os.Stderr
+// SpinnerWriter returns v's error writer if it is an interactive terminal, nil
+// otherwise. Use the returned writer as the spinnerW argument to NotifyIfSlow.
+func SpinnerWriter(v *venv.Venv) io.Writer {
+	v.RequireTerminal()
+
+	if v.Terminal.StderrIsTTY() {
+		return v.Writers.ErrWriter
 	}
 
 	return nil

--- a/internal/venv/venv.go
+++ b/internal/venv/venv.go
@@ -5,8 +5,8 @@
 // to do its work: [vfs.FS] for filesystem reads and writes, [vexec.Exec]
 // for spawning subprocesses, [vhttp.Client] for outbound HTTP,
 // [vsops.Decrypter] for SOPS decryption, the shell environment variables and
-// platform handles read at startup, the stdin reader, and the stdout/stderr
-// writers. Production
+// platform handles read at startup, the stdin reader, the console
+// characteristics output adapts to, and the stdout/stderr writers. Production
 // code constructs the real bundle once at the top via [OSVenv]; tests
 // construct an in-memory bundle and drive the full CLI through it.
 //
@@ -16,10 +16,11 @@
 package venv
 
 import (
-	"bufio"
+	"context"
 	"errors"
 	"io"
 	"maps"
+	"net"
 	"os"
 	"runtime"
 	"strings"
@@ -29,6 +30,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/internal/vsops"
 	"github.com/gruntwork-io/terragrunt/internal/writer"
+	"golang.org/x/term"
 )
 
 // ErrVenvEnvUnset is the panic value [Venv.RequireEnv] raises when Env is
@@ -56,10 +58,31 @@ var ErrVenvExecUnset = errors.New("venv.Venv.Exec is required but unset")
 // test that forgot to set HTTP rather than a runtime condition.
 var ErrVenvHTTPUnset = errors.New("venv.Venv.HTTP is required but unset")
 
-// ErrVenvReaderUnset is the panic value [Venv.RequireReader] raises when
-// Reader is nil. Production callers build the Venv through [OSVenv], so it
-// points at a test that forgot to set Reader rather than a runtime condition.
-var ErrVenvReaderUnset = errors.New("venv.Venv.Reader is required but unset")
+// ErrVenvStdinUnset is the panic value [Venv.RequireStdin] raises when Stdin is
+// nil. Production callers build the Venv through [OSVenv], so it points at a
+// test that forgot to set Stdin rather than a runtime condition.
+var ErrVenvStdinUnset = errors.New("venv.Venv.Stdin is required but unset")
+
+// ErrVenvTerminalUnset is the panic value [Venv.RequireTerminal] raises when
+// Terminal is nil. Production callers build the Venv through [OSVenv], so it
+// points at a test that forgot to set Terminal rather than a runtime condition.
+var ErrVenvTerminalUnset = errors.New("venv.Venv.Terminal is required but unset")
+
+// ErrVenvWritersUnset is the panic value [Venv.RequireWriters] raises when
+// Writers, or either writer it carries, is nil. Production callers build the
+// Venv through [OSVenv], so it points at a test that forgot to set Writers
+// rather than a runtime condition.
+var ErrVenvWritersUnset = errors.New("venv.Venv.Writers is required but unset")
+
+// ErrVenvListenUnset is the panic value [Venv.RequireListen] raises when Listen
+// is nil. Production callers build the Venv through [OSVenv], so it points at a
+// test that forgot to set Listen rather than a runtime condition.
+var ErrVenvListenUnset = errors.New("venv.Venv.Listen is required but unset")
+
+// ErrVenvPlatformUnset is the panic value [Venv.RequirePlatform] raises when
+// Platform is nil. Production callers build the Venv through [OSVenv], so it
+// points at a test that forgot to set Platform rather than a runtime condition.
+var ErrVenvPlatformUnset = errors.New("venv.Venv.Platform is required but unset")
 
 // ErrVenvGOOSUnset is the panic value [Venv.RequireGOOS] raises when GOOS is empty.
 var ErrVenvGOOSUnset = errors.New("venv.Venv.Platform.GOOS is required but unset")
@@ -81,7 +104,20 @@ type Platform struct {
 	UserHomeDir  func() (string, error)
 	UserCacheDir func() (string, error)
 	TempDir      func() string
+	Getwd        func() (string, error)
+	GetPID       func() int
 	GOOS         string
+}
+
+// Terminal reports the console a run's output is adapting to: whether each
+// standard stream is attached to a terminal, and how wide that terminal is.
+// Width reports 0 when no width is available, which callers read as "do not
+// wrap" or replace with a default of their own.
+type Terminal struct {
+	StdinIsTTY  func() bool
+	StdoutIsTTY func() bool
+	StderrIsTTY func() bool
+	Width       func() int
 }
 
 // Venv is the root virtualized environment. It carries the filesystem,
@@ -91,28 +127,40 @@ type Platform struct {
 // inputs contributions resolve. Writers is held as a pointer so per-call
 // overrides via [writer.Writers.WithWriter] and [writer.Writers.WithErrWriter]
 // produce fresh pointers without mutating the caller's value; never mutate its
-// fields in place, since shallow-copied Venvs share the pointer. Reader is
-// buffered once and held as a pointer for the same reason: a run that prompts
-// more than once must keep reading from a single buffer, or the first prompt's
-// read-ahead swallows the input the next prompt is waiting for.
+// fields in place, since shallow-copied Venvs share the pointer.
+//
+// Stdin is the one console input for the whole run: Terragrunt's own prompts
+// read it, and a spawned command inherits it. Nothing between them may buffer
+// it. Read-ahead held in a buffer is invisible to every other consumer, so a
+// prompt that grabbed more than its line strands the rest, and handing a
+// buffered reader to os/exec makes it copy the stream into the child's pipe to
+// EOF whether the child reads or not, which is enough for one incidental
+// `tofu -version` to swallow the whole input.
 type Venv struct {
 	FS       vfs.FS
 	Exec     vexec.Exec
 	HTTP     vhttp.Client
 	Sops     vsops.Decrypter
-	Reader   *bufio.Reader
+	Listen   Listener
+	Stdin    io.Reader
 	Env      map[string]string
 	Platform *Platform
+	Terminal *Terminal
 	Writers  *writer.Writers
 }
 
-// WithReader returns a copy of v that reads console input from r, buffered so
-// that every consumer shares one position in the stream. A consumer that wraps
-// its own buffer around [Venv.Reader] strands whatever that buffer read past
-// the bytes it needed.
-func (v *Venv) WithReader(r io.Reader) *Venv {
+// Listener opens a socket to serve on. Terragrunt listens for one thing, the
+// provider-cache server that the tofu subprocess fetches providers from, so
+// production supplies the real dialer and an in-memory bundle supplies one that
+// refuses: a run with no subprocess has nothing to serve.
+type Listener func(ctx context.Context, network, addr string) (net.Listener, error)
+
+// WithStdin returns a copy of v whose subprocess standard input is r. This is
+// the stream a spawned command inherits, not the one Terragrunt prompts from;
+// see [Venv] for why they are separate.
+func (v *Venv) WithStdin(r io.Reader) *Venv {
 	c := *v
-	c.Reader = bufio.NewReader(r)
+	c.Stdin = r
 
 	return &c
 }
@@ -168,21 +216,19 @@ func (v *Venv) WithSops(d vsops.Decrypter) *Venv {
 	return &c
 }
 
-// WithFS returns a copy of v backed by fs.
-func (v *Venv) WithFS(fs vfs.FS) *Venv {
+// WithFS returns a copy of v backed by fsys.
+func (v *Venv) WithFS(fsys vfs.FS) *Venv {
 	c := *v
-	c.FS = fs
+	c.FS = fsys
 
 	return &c
 }
 
 // WithGOOS returns a copy of v whose operating-system identifier is goos.
 func (v *Venv) WithGOOS(goos string) *Venv {
-	platform := Platform{}
-	if v.Platform != nil {
-		platform = *v.Platform
-	}
+	v.RequirePlatform()
 
+	platform := *v.Platform
 	platform.GOOS = goos
 
 	c := *v
@@ -193,12 +239,23 @@ func (v *Venv) WithGOOS(goos string) *Venv {
 
 // WithUserHomeDir returns a copy of v whose home-directory lookup is userHomeDir.
 func (v *Venv) WithUserHomeDir(userHomeDir func() (string, error)) *Venv {
-	platform := Platform{}
-	if v.Platform != nil {
-		platform = *v.Platform
-	}
+	v.RequirePlatform()
 
+	platform := *v.Platform
 	platform.UserHomeDir = userHomeDir
+
+	c := *v
+	c.Platform = &platform
+
+	return &c
+}
+
+// WithTempDir returns a copy of v whose temp-directory lookup is tempDir.
+func (v *Venv) WithTempDir(tempDir func() string) *Venv {
+	v.RequirePlatform()
+
+	platform := *v.Platform
+	platform.TempDir = tempDir
 
 	c := *v
 	c.Platform = &platform
@@ -269,13 +326,52 @@ func (v *Venv) RequireHTTP() {
 	}
 }
 
-// RequireReader panics with [ErrVenvReaderUnset] when Reader is nil.
-// Functions that read console input call this as their first statement so a
-// missing handle panics at the offending call site instead of inside an
+// RequireTerminal panics with [ErrVenvTerminalUnset] when Terminal is nil.
+// Functions that size or color their output call this as their first
+// statement so a missing handle panics at the offending call site instead of
+// inside an unrelated stack frame.
+func (v *Venv) RequireTerminal() {
+	if v.Terminal == nil {
+		panic(ErrVenvTerminalUnset)
+	}
+}
+
+// RequireWriters panics with [ErrVenvWritersUnset] when Writers, or either
+// writer it carries, is nil. A nil writer reaching a subprocess or a formatter
+// panics wherever the write happens, which is nowhere near the caller that
+// dropped it, so functions that hand the writers onwards assert them first.
+func (v *Venv) RequireWriters() {
+	if v.Writers == nil || v.Writers.Writer == nil || v.Writers.ErrWriter == nil {
+		panic(ErrVenvWritersUnset)
+	}
+}
+
+// RequireStdin panics with [ErrVenvStdinUnset] when Stdin is nil. Functions
+// that hand a subprocess its standard input call this as their first statement
+// so a missing handle panics at the offending call site instead of inside an
 // unrelated stack frame.
-func (v *Venv) RequireReader() {
-	if v.Reader == nil {
-		panic(ErrVenvReaderUnset)
+func (v *Venv) RequireStdin() {
+	if v.Stdin == nil {
+		panic(ErrVenvStdinUnset)
+	}
+}
+
+// RequireListen panics with [ErrVenvListenUnset] when Listen is nil. Functions
+// that open a socket call this as their first statement so a missing handle
+// panics at the offending call site instead of inside an unrelated stack frame.
+func (v *Venv) RequireListen() {
+	if v.Listen == nil {
+		panic(ErrVenvListenUnset)
+	}
+}
+
+// RequirePlatform panics with [ErrVenvPlatformUnset] when Platform is nil.
+// The platform builders call this so that refining one handle on a Venv that
+// carries no platform at all fails at the builder rather than silently
+// producing a platform whose other handles are nil.
+func (v *Venv) RequirePlatform() {
+	if v.Platform == nil {
+		panic(ErrVenvPlatformUnset)
 	}
 }
 
@@ -324,16 +420,37 @@ func OSVenv() *Venv {
 		Exec:   vexec.NewOSExec(),
 		HTTP:   vhttp.NewOSClient(),
 		Sops:   vsops.NewOSDecrypter(),
-		Reader: bufio.NewReader(os.Stdin),
+		Listen: (&net.ListenConfig{}).Listen,
+		Stdin:  os.Stdin,
 		Env:    ParseEnviron(os.Environ()),
 		Platform: &Platform{
 			UserHomeDir:  os.UserHomeDir,
 			UserCacheDir: os.UserCacheDir,
 			TempDir:      os.TempDir,
+			Getwd:        os.Getwd,
+			GetPID:       os.Getpid,
 			GOOS:         runtime.GOOS,
+		},
+		Terminal: &Terminal{
+			StdinIsTTY:  func() bool { return term.IsTerminal(int(os.Stdin.Fd())) },
+			StdoutIsTTY: func() bool { return term.IsTerminal(int(os.Stdout.Fd())) },
+			StderrIsTTY: func() bool { return term.IsTerminal(int(os.Stderr.Fd())) },
+			Width:       osTerminalWidth,
 		},
 		Writers: &writer.Writers{Writer: os.Stdout, ErrWriter: os.Stderr},
 	}
+}
+
+// osTerminalWidth reports the real terminal's width, and 0 when stdout is not
+// a terminal (a pipe, a file, a CI log). Callers that need a number either way
+// substitute their own default for the 0.
+func osTerminalWidth() int {
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		return 0
+	}
+
+	return width
 }
 
 // ParseEnviron turns os.Environ-style KEY=VALUE entries into a map, splitting

--- a/internal/venv/venv_test.go
+++ b/internal/venv/venv_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/internal/vsops"
+	"github.com/gruntwork-io/terragrunt/internal/writer"
 )
 
 func TestParseEnviron(t *testing.T) {
@@ -181,6 +182,41 @@ func TestVenvPlatformRequirements(t *testing.T) {
 	assert.PanicsWithValue(t, venv.ErrVenvUserHomeDirUnset, func() {
 		(&venv.Venv{}).RequireUserHomeDir()
 	})
+	assert.PanicsWithValue(t, venv.ErrVenvPlatformUnset, func() {
+		(&venv.Venv{}).RequirePlatform()
+	})
+	assert.PanicsWithValue(t, venv.ErrVenvWritersUnset, func() {
+		(&venv.Venv{}).RequireWriters()
+	})
+	assert.PanicsWithValue(t, venv.ErrVenvListenUnset, func() {
+		(&venv.Venv{}).RequireListen()
+	})
+	assert.PanicsWithValue(t, venv.ErrVenvStdinUnset, func() {
+		(&venv.Venv{}).RequireStdin()
+	})
+	assert.PanicsWithValue(t, venv.ErrVenvWritersUnset, func() {
+		// A non-nil Writers whose fields are nil is the case a bare nil check
+		// would wave through, and the one that fails furthest from its cause.
+		(&venv.Venv{Writers: &writer.Writers{}}).RequireWriters()
+	})
+}
+
+// TestVenvPlatformBuildersRequireAPlatform pins that refining one platform
+// handle on a Venv carrying no platform fails at the builder. Filling in a
+// blank platform instead would hand back a Venv whose other handles are nil,
+// and the nil would surface somewhere else entirely.
+func TestVenvPlatformBuildersRequireAPlatform(t *testing.T) {
+	t.Parallel()
+
+	assert.PanicsWithValue(t, venv.ErrVenvPlatformUnset, func() {
+		(&venv.Venv{}).WithGOOS("plan9")
+	})
+	assert.PanicsWithValue(t, venv.ErrVenvPlatformUnset, func() {
+		(&venv.Venv{}).WithUserHomeDir(func() (string, error) { return "", nil })
+	})
+	assert.PanicsWithValue(t, venv.ErrVenvPlatformUnset, func() {
+		(&venv.Venv{}).WithTempDir(func() string { return "" })
+	})
 }
 
 // TestVenvHandleBuildersReturnCopies pins the builder contract: the returned
@@ -254,49 +290,39 @@ func TestVenvHandleBuildersReturnCopies(t *testing.T) {
 	}
 }
 
-// TestVenvWithReaderBuffersOneStream pins the reader contract: the copy reads
-// from r through a buffer every derived venv shares, so a second prompt resumes
-// where the first stopped, and a later replacement leaves that buffer intact.
-func TestVenvWithReaderBuffersOneStream(t *testing.T) {
+// TestVenvWithStdinSharesOneStream pins the stdin contract: every derived venv
+// reads the one stream, unwrapped, so a second consumer resumes exactly where
+// the first stopped, and a later replacement swaps the stream for that copy
+// alone.
+func TestVenvWithStdinSharesOneStream(t *testing.T) {
 	t.Parallel()
 
 	original := &venv.Venv{}
-	got := original.WithReader(strings.NewReader("first\nsecond\n"))
+	stdin := strings.NewReader("first\nsecond\n")
+	got := original.WithStdin(stdin)
 
-	assert.Nil(t, original.Reader)
-	require.NotNil(t, got.Reader)
-
-	line, err := got.Reader.ReadString('\n')
-	require.NoError(t, err)
-	assert.Equal(t, "first\n", line)
-	assert.Positive(t, got.Reader.Buffered())
+	assert.Nil(t, original.Stdin)
+	require.Same(t, stdin, got.Stdin)
 
 	derived := got.WithFS(vfs.NewMemMapFS())
-	require.Same(t, got.Reader, derived.Reader)
+	require.Same(t, got.Stdin, derived.Stdin)
 
-	line, err = derived.Reader.ReadString('\n')
-	require.NoError(t, err)
-	assert.Equal(t, "second\n", line)
-
-	replaced := got.WithReader(strings.NewReader("third\n"))
-	require.NotSame(t, got.Reader, replaced.Reader)
-
-	line, err = replaced.Reader.ReadString('\n')
-	require.NoError(t, err)
-	assert.Equal(t, "third\n", line)
+	replaced := got.WithStdin(strings.NewReader("third\n"))
+	require.NotSame(t, got.Stdin, replaced.Stdin)
+	require.Same(t, stdin, got.Stdin)
 }
 
-// TestVenvRequireReaderAndHTTP pins the Reader and HTTP contracts: the zero
+// TestVenvRequireStdinAndHTTP pins the Stdin and HTTP contracts: the zero
 // Venv panics with the sentinel, a populated Venv passes.
-func TestVenvRequireReaderAndHTTP(t *testing.T) {
+func TestVenvRequireStdinAndHTTP(t *testing.T) {
 	t.Parallel()
 
-	assert.PanicsWithValue(t, venv.ErrVenvReaderUnset, func() {
-		(&venv.Venv{FS: vfs.NewMemMapFS()}).RequireReader()
+	assert.PanicsWithValue(t, venv.ErrVenvStdinUnset, func() {
+		(&venv.Venv{FS: vfs.NewMemMapFS()}).RequireStdin()
 	})
 
 	assert.NotPanics(t, func() {
-		(&venv.Venv{}).WithReader(strings.NewReader("")).RequireReader()
+		(&venv.Venv{}).WithStdin(strings.NewReader("")).RequireStdin()
 	})
 
 	assert.PanicsWithValue(t, venv.ErrVenvHTTPUnset, func() {

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
+	iofs "io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -74,12 +74,12 @@ func NewOSFS() FS {
 	return &osFS{afero.NewOsFs()}
 }
 
-// IsOSFS reports whether fs is the OS-backed filesystem from [NewOSFS].
+// IsOSFS reports whether fsys is the OS-backed filesystem from [NewOSFS].
 // Callers that shell out to processes which only see the real disk (e.g.
 // `git`) should reject other filesystems up front rather than failing
 // inside the subprocess.
-func IsOSFS(fs FS) bool {
-	_, ok := fs.(*osFS)
+func IsOSFS(fsys FS) bool {
+	_, ok := fsys.(*osFS)
 	return ok
 }
 
@@ -96,13 +96,13 @@ func NewMemMapFS() FS {
 // FileExists checks if a path exists using the given filesystem.
 // Returns (true, nil) if the file exists, (false, nil) if it does not exist,
 // and (false, error) for other errors (e.g., permission denied).
-func FileExists(vfs FS, path string) (bool, error) {
-	_, err := vfs.Stat(path)
+func FileExists(fsys FS, path string) (bool, error) {
+	_, err := fsys.Stat(path)
 	if err == nil {
 		return true, nil
 	}
 
-	if errors.Is(err, fs.ErrNotExist) {
+	if errors.Is(err, iofs.ErrNotExist) {
 		return false, nil
 	}
 
@@ -218,7 +218,7 @@ func WriteFileWithSamePermissions(fsys FS, source, destination string, contents 
 	}
 
 	// CAS may place read-only files at the destination, which would block a plain open.
-	if err := fsys.Remove(destination); err != nil && !errors.Is(err, fs.ErrNotExist) {
+	if err := fsys.Remove(destination); err != nil && !errors.Is(err, iofs.ErrNotExist) {
 		return err
 	}
 
@@ -244,18 +244,18 @@ func Lstat(fsys FS, path string) (os.FileInfo, error) {
 }
 
 // WriteFile writes data to a file on the given filesystem.
-func WriteFile(fs FS, filename string, data []byte, perm os.FileMode) error {
+func WriteFile(fsys FS, filename string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(filename)
-	if err := fs.MkdirAll(dir, os.ModePerm); err != nil {
+	if err := fsys.MkdirAll(dir, os.ModePerm); err != nil {
 		return err
 	}
 
-	return afero.WriteFile(fs, filename, data, perm)
+	return afero.WriteFile(fsys, filename, data, perm)
 }
 
 // ReadFile reads the contents of a file from the given filesystem.
-func ReadFile(fs FS, filename string) ([]byte, error) {
-	return afero.ReadFile(fs, filename)
+func ReadFile(fsys FS, filename string) ([]byte, error) {
+	return afero.ReadFile(fsys, filename)
 }
 
 // ReadFileAsString reads the contents of a file from the given filesystem as a
@@ -273,8 +273,8 @@ func ReadFileAsString(fsys FS, filename string) (string, error) {
 // ReadFileLimit reads up to limit bytes from the start of a file on the given
 // filesystem, for callers that only need a bounded prefix (such as previewing
 // the head of a possibly-large file) rather than the whole thing.
-func ReadFileLimit(fs FS, filename string, limit int64) (data []byte, err error) {
-	f, err := fs.Open(filename)
+func ReadFileLimit(fsys FS, filename string, limit int64) (data []byte, err error) {
+	f, err := fsys.Open(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -300,6 +300,40 @@ func EvalSymlinks(fsys FS, path string) (string, error) {
 	return walkSymlinks(fsys, path)
 }
 
+// ResolveForCompare returns the symlink-resolved form of path, for comparing
+// one path against another. Two spellings of the same location must reduce to
+// one string or a path-keyed set counts them twice: on macOS /var is a symlink
+// to /private/var, so a path under either spelling has to resolve before it is
+// compared. [EvalSymlinks] resolves only paths that exist, so resolving the
+// longest existing ancestor and rejoining the remaining components keeps an
+// absent path comparable with a resolved one instead of leaving it merely
+// cleaned.
+func ResolveForCompare(fsys FS, path string) string {
+	path = filepath.Clean(path)
+
+	if resolved, err := EvalSymlinks(fsys, path); err == nil {
+		return resolved
+	}
+
+	if parent := filepath.Dir(path); parent != path {
+		return filepath.Join(ResolveForCompare(fsys, parent), filepath.Base(path))
+	}
+
+	return path
+}
+
+// Within reports whether path is dir or a descendant of it, comparing both
+// through [ResolveForCompare] so a symlink that leaves dir is caught rather
+// than counted as inside it.
+func Within(fsys FS, dir, path string) bool {
+	rel, err := filepath.Rel(ResolveForCompare(fsys, dir), ResolveForCompare(fsys, path))
+	if err != nil {
+		return false
+	}
+
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
 // ParentPathHasSymlink reports whether rel cannot be safely traversed under rootDir.
 // It returns true when rel is empty, ".", absolute, escapes rootDir with "..", or has a symlink in a parent component.
 // The final path component is not checked, so callers can safely remove a leaf symlink.
@@ -320,7 +354,7 @@ func ParentPathHasSymlink(fsys FS, rootDir, rel string) (bool, error) {
 		current = filepath.Join(current, part)
 
 		info, err := Lstat(fsys, current)
-		if errors.Is(err, fs.ErrNotExist) {
+		if errors.Is(err, iofs.ErrNotExist) {
 			return false, nil
 		}
 
@@ -339,22 +373,22 @@ func ParentPathHasSymlink(fsys FS, rootDir, rel string) (bool, error) {
 // MkdirTemp creates a temporary directory on the given filesystem. Unlike
 // [os.MkdirTemp], prefix is always literal: the random component is appended and
 // a "*" in prefix is not treated as a placeholder.
-func MkdirTemp(fs FS, dir, prefix string) (string, error) {
-	return afero.TempDir(fs, dir, prefix)
+func MkdirTemp(fsys FS, dir, prefix string) (string, error) {
+	return afero.TempDir(fsys, dir, prefix)
 }
 
 // CreateTemp creates a temporary file on the given filesystem, following the
 // same rule as [os.CreateTemp]: the last "*" in pattern is replaced by the
 // random component, or, when pattern has no "*", the random component is
 // appended.
-func CreateTemp(fs FS, dir, pattern string) (File, error) {
-	return afero.TempFile(fs, dir, pattern)
+func CreateTemp(fsys FS, dir, pattern string) (File, error) {
+	return afero.TempFile(fsys, dir, pattern)
 }
 
 // Link creates a hard link. It delegates to LinkIfPossible for filesystems
 // that implement the HardLinker interface.
-func Link(fs FS, oldname, newname string) error {
-	linker, ok := fs.(HardLinker)
+func Link(fsys FS, oldname, newname string) error {
+	linker, ok := fsys.(HardLinker)
 	if !ok {
 		return &os.LinkError{Op: "link", Old: oldname, New: newname, Err: ErrNoHardLink}
 	}
@@ -364,8 +398,8 @@ func Link(fs FS, oldname, newname string) error {
 
 // Symlink creates a symbolic link. It uses afero's SymlinkIfPossible
 // which is supported by OsFs and any FS implementing afero.Linker.
-func Symlink(fs FS, oldname, newname string) error {
-	linker, ok := fs.(afero.Linker)
+func Symlink(fsys FS, oldname, newname string) error {
+	linker, ok := fsys.(afero.Linker)
 	if !ok {
 		return &os.LinkError{Op: "symlink", Old: oldname, New: newname, Err: afero.ErrNoSymlink}
 	}
@@ -376,8 +410,8 @@ func Symlink(fs FS, oldname, newname string) error {
 // Readlink reads the target of a symbolic link. It uses afero's
 // ReadlinkIfPossible which is supported by OsFs and any FS implementing
 // afero.Symlinker.
-func Readlink(fs FS, name string) (string, error) {
-	reader, ok := fs.(afero.Symlinker)
+func Readlink(fsys FS, name string) (string, error) {
+	reader, ok := fsys.(afero.Symlinker)
 	if !ok {
 		return "", &os.PathError{Op: "readlink", Path: name, Err: afero.ErrNoSymlink}
 	}
@@ -386,8 +420,8 @@ func Readlink(fs FS, name string) (string, error) {
 }
 
 // Lock acquires a blocking lock for the given name on the filesystem.
-func Lock(fs FS, name string) (Unlocker, error) {
-	locker, ok := fs.(Locker)
+func Lock(fsys FS, name string) (Unlocker, error) {
+	locker, ok := fsys.(Locker)
 	if !ok {
 		return nil, ErrNoLock
 	}
@@ -396,8 +430,8 @@ func Lock(fs FS, name string) (Unlocker, error) {
 }
 
 // TryLock attempts a non-blocking lock for the given name on the filesystem.
-func TryLock(fs FS, name string) (Unlocker, bool, error) {
-	locker, ok := fs.(Locker)
+func TryLock(fsys FS, name string) (Unlocker, bool, error) {
+	locker, ok := fsys.(Locker)
 	if !ok {
 		return nil, false, ErrNoLock
 	}
@@ -414,12 +448,12 @@ func TryLock(fs FS, name string) (Unlocker, bool, error) {
 // call returns after that bound elapses even when ctx is never canceled.
 // Callers that want a shorter deadline should pass a ctx with their own
 // timeout.
-func LockContext(ctx context.Context, fs FS, name string) (Unlocker, error) {
-	if cl, ok := fs.(ContextLocker); ok {
+func LockContext(ctx context.Context, fsys FS, name string) (Unlocker, error) {
+	if cl, ok := fsys.(ContextLocker); ok {
 		return cl.LockContext(ctx, name)
 	}
 
-	return Lock(fs, name)
+	return Lock(fsys, name)
 }
 
 // WalkDirParallelOption configures a [WalkDirParallel] call.
@@ -436,7 +470,7 @@ type walkDirParallelConfig struct {
 // guarded by fastwalk's ancestor-cycle detection.
 //
 // Without this option, symlinked directories are visited as single
-// entries with `d.IsDir() == false`, matching stdlib [fs.WalkDir].
+// entries with `d.IsDir() == false`, matching stdlib [iofs.WalkDir].
 func WithFollowSymlinks() WalkDirParallelOption {
 	return func(c *walkDirParallelConfig) {
 		c.followSymlinks = true
@@ -452,7 +486,7 @@ func WithFollowSymlinks() WalkDirParallelOption {
 // gives no ordering guarantee across directories. Callers that depend
 // on deterministic order, or that write to shared state from fn, must
 // use [WalkDir] or serialize access themselves.
-func WalkDirParallel(fsys FS, root string, fn fs.WalkDirFunc, opts ...WalkDirParallelOption) error {
+func WalkDirParallel(fsys FS, root string, fn iofs.WalkDirFunc, opts ...WalkDirParallelOption) error {
 	if _, ok := fsys.(*osFS); !ok {
 		return WalkDir(fsys, root, fn)
 	}
@@ -477,19 +511,19 @@ func WalkDirParallel(fsys FS, root string, fn fs.WalkDirFunc, opts ...WalkDirPar
 }
 
 // WalkDir walks the file tree rooted at root, calling fn for each file or
-// directory in the tree, including root. The fn callback receives an fs.DirEntry
+// directory in the tree, including root. The fn callback receives an iofs.DirEntry
 // instead of os.FileInfo, which can be more efficient since it does not require
 // a stat call for every visited file.
 //
 // All errors that arise visiting files and directories are filtered by fn:
-// see the fs.WalkDirFunc documentation for details.
+// see the iofs.WalkDirFunc documentation for details.
 //
 // The files are walked in lexical order, which makes the output deterministic
 // but means that for very large directories WalkDir can be inefficient.
 // WalkDir does not follow symbolic links.
 //
 // Adapted from spf13/afero#571; replace with afero.WalkDir once merged.
-func WalkDir(fsys FS, root string, fn fs.WalkDirFunc) error {
+func WalkDir(fsys FS, root string, fn iofs.WalkDirFunc) error {
 	info, err := lstatIfPossible(fsys, root)
 	if err != nil {
 		err = fn(root, nil, err)
@@ -513,7 +547,7 @@ func WalkDir(fsys FS, root string, fn fs.WalkDirFunc) error {
 // Each logical path is reported once, so a directory reachable through several
 // links is visited once, and a link pointing back at an ancestor terminates
 // instead of looping.
-func WalkDirWithSymlinks(fsys FS, root string, fn fs.WalkDirFunc) error {
+func WalkDirWithSymlinks(fsys FS, root string, fn iofs.WalkDirFunc) error {
 	w := &symlinkWalker{
 		fsys:           fsys,
 		fn:             fn,
@@ -533,14 +567,14 @@ func WalkDirWithSymlinks(fsys FS, root string, fn fs.WalkDirFunc) error {
 // nested walks it starts for each followed link.
 type symlinkWalker struct {
 	fsys           FS
-	fn             fs.WalkDirFunc
+	fn             iofs.WalkDirFunc
 	visited        map[string]bool
 	visitedLogical map[string]bool
 }
 
 // walk traverses the tree at physical, reporting entries under logical.
 func (w *symlinkWalker) walk(physical, logical string) error {
-	return WalkDir(w.fsys, physical, func(current string, d fs.DirEntry, err error) error {
+	return WalkDir(w.fsys, physical, func(current string, d iofs.DirEntry, err error) error {
 		if err != nil {
 			return w.fn(current, d, err)
 		}
@@ -565,7 +599,7 @@ func (w *symlinkWalker) walk(physical, logical string) error {
 			}
 		}
 
-		if d.Type()&fs.ModeSymlink == 0 {
+		if d.Type()&iofs.ModeSymlink == 0 {
 			return nil
 		}
 
@@ -604,19 +638,19 @@ type osFS struct {
 	afero.Fs
 }
 
-func (fs *osFS) LinkIfPossible(oldname, newname string) error {
+func (fsys *osFS) LinkIfPossible(oldname, newname string) error {
 	return os.Link(oldname, newname)
 }
 
-func (fs *osFS) SymlinkIfPossible(oldname, newname string) error {
+func (fsys *osFS) SymlinkIfPossible(oldname, newname string) error {
 	return os.Symlink(oldname, newname)
 }
 
-func (fs *osFS) ReadlinkIfPossible(name string) (string, error) {
+func (fsys *osFS) ReadlinkIfPossible(name string) (string, error) {
 	return os.Readlink(name)
 }
 
-func (fs *osFS) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+func (fsys *osFS) LstatIfPossible(name string) (os.FileInfo, bool, error) {
 	info, err := os.Lstat(name)
 
 	return info, true, err
@@ -628,7 +662,7 @@ func (*osFS) EvalSymlinksIfPossible(name string) (string, bool, error) {
 	return resolved, true, err
 }
 
-func (fs *osFS) Lock(name string) (Unlocker, error) {
+func (fsys *osFS) Lock(name string) (Unlocker, error) {
 	l := flock.New(name)
 	if err := l.Lock(); err != nil {
 		return nil, err
@@ -637,7 +671,7 @@ func (fs *osFS) Lock(name string) (Unlocker, error) {
 	return l, nil
 }
 
-func (fs *osFS) TryLock(name string) (Unlocker, bool, error) {
+func (fsys *osFS) TryLock(name string) (Unlocker, bool, error) {
 	l := flock.New(name)
 
 	acquired, err := l.TryLock()
@@ -671,7 +705,7 @@ const (
 	maxLockWait = 30 * time.Minute
 )
 
-func (fs *osFS) LockContext(ctx context.Context, name string) (Unlocker, error) {
+func (fsys *osFS) LockContext(ctx context.Context, name string) (Unlocker, error) {
 	ctx, cancel := context.WithTimeout(ctx, maxLockWait)
 	defer cancel()
 
@@ -697,36 +731,36 @@ type memMapFS struct {
 	locksMu  sync.Mutex
 }
 
-func (fs *memMapFS) SymlinkIfPossible(oldname, newname string) error {
-	if _, exists := fs.symlinks[newname]; exists {
+func (fsys *memMapFS) SymlinkIfPossible(oldname, newname string) error {
+	if _, exists := fsys.symlinks[newname]; exists {
 		return &os.LinkError{Op: "symlink", Old: oldname, New: newname, Err: os.ErrExist}
 	}
 
-	fs.symlinks[newname] = oldname
+	fsys.symlinks[newname] = oldname
 
 	return nil
 }
 
-func (fs *memMapFS) LinkIfPossible(oldname, newname string) error {
-	if _, err := fs.Fs.Stat(newname); err == nil {
+func (fsys *memMapFS) LinkIfPossible(oldname, newname string) error {
+	if _, err := fsys.Fs.Stat(newname); err == nil {
 		return &os.LinkError{Op: "link", Old: oldname, New: newname, Err: os.ErrExist}
 	}
 
-	data, err := afero.ReadFile(fs.Fs, oldname)
+	data, err := afero.ReadFile(fsys.Fs, oldname)
 	if err != nil {
 		return &os.LinkError{Op: "link", Old: oldname, New: newname, Err: err}
 	}
 
-	info, err := fs.Fs.Stat(oldname)
+	info, err := fsys.Fs.Stat(oldname)
 	if err != nil {
 		return &os.LinkError{Op: "link", Old: oldname, New: newname, Err: err}
 	}
 
-	return afero.WriteFile(fs.Fs, newname, data, info.Mode())
+	return afero.WriteFile(fsys.Fs, newname, data, info.Mode())
 }
 
-func (fs *memMapFS) ReadlinkIfPossible(name string) (string, error) {
-	target, ok := fs.symlinks[name]
+func (fsys *memMapFS) ReadlinkIfPossible(name string) (string, error) {
+	target, ok := fsys.symlinks[name]
 	if !ok {
 		return "", &os.PathError{Op: "readlink", Path: name, Err: os.ErrInvalid}
 	}
@@ -734,12 +768,12 @@ func (fs *memMapFS) ReadlinkIfPossible(name string) (string, error) {
 	return target, nil
 }
 
-func (fs *memMapFS) LstatIfPossible(name string) (os.FileInfo, bool, error) {
-	if _, ok := fs.symlinks[name]; ok {
+func (fsys *memMapFS) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	if _, ok := fsys.symlinks[name]; ok {
 		return symlinkFileInfo{name: filepath.Base(name)}, true, nil
 	}
 
-	info, err := fs.Fs.Stat(name)
+	info, err := fsys.Fs.Stat(name)
 
 	return info, false, err
 }
@@ -747,25 +781,25 @@ func (fs *memMapFS) LstatIfPossible(name string) (os.FileInfo, bool, error) {
 // Remove deletes the file or symlink at name. Symlinks live in a side table
 // that the embedded afero.MemMapFs does not see, so they are handled here
 // before delegating to the underlying filesystem.
-func (fs *memMapFS) Remove(name string) error {
-	if _, ok := fs.symlinks[name]; ok {
-		delete(fs.symlinks, name)
+func (fsys *memMapFS) Remove(name string) error {
+	if _, ok := fsys.symlinks[name]; ok {
+		delete(fsys.symlinks, name)
 		return nil
 	}
 
-	return fs.Fs.Remove(name)
+	return fsys.Fs.Remove(name)
 }
 
 // RemoveAll deletes path and any children it contains. Symlinks live in a
 // side table that the embedded afero.MemMapFs does not see, so they are
 // handled here before delegating to the underlying filesystem.
-func (fs *memMapFS) RemoveAll(path string) error {
-	if _, ok := fs.symlinks[path]; ok {
-		delete(fs.symlinks, path)
+func (fsys *memMapFS) RemoveAll(path string) error {
+	if _, ok := fsys.symlinks[path]; ok {
+		delete(fsys.symlinks, path)
 		return nil
 	}
 
-	return fs.Fs.RemoveAll(path)
+	return fsys.Fs.RemoveAll(path)
 }
 
 // symlinkFileInfo reports symlink metadata for links stored in memMapFS's side table.
@@ -780,15 +814,15 @@ func (info symlinkFileInfo) ModTime() time.Time { return time.Time{} }
 func (info symlinkFileInfo) IsDir() bool        { return false }
 func (info symlinkFileInfo) Sys() any           { return nil }
 
-func (fs *memMapFS) Lock(name string) (Unlocker, error) {
-	l := fs.getOrCreateLock(name)
+func (fsys *memMapFS) Lock(name string) (Unlocker, error) {
+	l := fsys.getOrCreateLock(name)
 	l.mu.Lock()
 
 	return l, nil
 }
 
-func (fs *memMapFS) TryLock(name string) (Unlocker, bool, error) {
-	l := fs.getOrCreateLock(name)
+func (fsys *memMapFS) TryLock(name string) (Unlocker, bool, error) {
+	l := fsys.getOrCreateLock(name)
 
 	if !l.mu.TryLock() {
 		return nil, false, nil
@@ -797,11 +831,11 @@ func (fs *memMapFS) TryLock(name string) (Unlocker, bool, error) {
 	return l, true, nil
 }
 
-func (fs *memMapFS) LockContext(ctx context.Context, name string) (Unlocker, error) {
+func (fsys *memMapFS) LockContext(ctx context.Context, name string) (Unlocker, error) {
 	ctx, cancel := context.WithTimeout(ctx, maxLockWait)
 	defer cancel()
 
-	l := fs.getOrCreateLock(name)
+	l := fsys.getOrCreateLock(name)
 
 	for {
 		if l.mu.TryLock() {
@@ -816,14 +850,14 @@ func (fs *memMapFS) LockContext(ctx context.Context, name string) (Unlocker, err
 	}
 }
 
-func (fs *memMapFS) getOrCreateLock(name string) *memLock {
-	fs.locksMu.Lock()
-	defer fs.locksMu.Unlock()
+func (fsys *memMapFS) getOrCreateLock(name string) *memLock {
+	fsys.locksMu.Lock()
+	defer fsys.locksMu.Unlock()
 
-	l, ok := fs.locks[name]
+	l, ok := fsys.locks[name]
 	if !ok {
 		l = &memLock{}
-		fs.locks[name] = l
+		fsys.locks[name] = l
 	}
 
 	return l
@@ -884,8 +918,8 @@ func NewZipDecompressor(opts ...ZipDecompressorOption) *ZipDecompressor {
 
 // Unzip extracts a zip archive from src to dst directory on the given filesystem.
 // The umask parameter is applied to file permissions (use 0 to preserve original permissions).
-func (z *ZipDecompressor) Unzip(l log.Logger, fs FS, dst, src string, umask os.FileMode) error {
-	file, err := fs.Open(src)
+func (z *ZipDecompressor) Unzip(l log.Logger, fsys FS, dst, src string, umask os.FileMode) error {
+	file, err := fsys.Open(src)
 	if err != nil {
 		return fmt.Errorf("failed to open zip archive %q: %w", src, err)
 	}
@@ -921,7 +955,7 @@ func (z *ZipDecompressor) Unzip(l log.Logger, fs FS, dst, src string, umask os.F
 		return fmt.Errorf("failed to read zip archive %q: %w", src, err)
 	}
 
-	if err := fs.MkdirAll(dst, applyUmask(defaultZipDirMode, umask)); err != nil {
+	if err := fsys.MkdirAll(dst, applyUmask(defaultZipDirMode, umask)); err != nil {
 		return fmt.Errorf("failed to create directory %q: %w", dst, err)
 	}
 
@@ -936,7 +970,7 @@ func (z *ZipDecompressor) Unzip(l log.Logger, fs FS, dst, src string, umask os.F
 	var totalSize int64
 
 	for _, zipFile := range zipReader.File {
-		if err := z.extractZipFile(l, fs, dst, zipFile, umask, &totalSize); err != nil {
+		if err := z.extractZipFile(l, fsys, dst, zipFile, umask, &totalSize); err != nil {
 			return fmt.Errorf("failed to extract file %q: %w", zipFile.Name, err)
 		}
 	}
@@ -946,7 +980,7 @@ func (z *ZipDecompressor) Unzip(l log.Logger, fs FS, dst, src string, umask os.F
 
 // extractZipFile extracts a single file from a zip archive.
 func (z *ZipDecompressor) extractZipFile(
-	l log.Logger, fs FS, dst string, zipFile *zip.File, umask os.FileMode, totalSize *int64,
+	l log.Logger, fsys FS, dst string, zipFile *zip.File, umask os.FileMode, totalSize *int64,
 ) error {
 	destPath, err := sanitizeZipPath(dst, zipFile.Name)
 	if err != nil {
@@ -956,7 +990,7 @@ func (z *ZipDecompressor) extractZipFile(
 	fileInfo := zipFile.FileInfo()
 
 	if fileInfo.IsDir() {
-		if err := fs.MkdirAll(destPath, applyUmask(fileInfo.Mode(), umask)); err != nil {
+		if err := fsys.MkdirAll(destPath, applyUmask(fileInfo.Mode(), umask)); err != nil {
 			return fmt.Errorf("failed to create directory %q: %w", destPath, err)
 		}
 
@@ -964,22 +998,22 @@ func (z *ZipDecompressor) extractZipFile(
 	}
 
 	if fileInfo.Mode()&os.ModeSymlink != 0 {
-		return z.extractSymlink(l, fs, dst, destPath, zipFile, umask, totalSize)
+		return z.extractSymlink(l, fsys, dst, destPath, zipFile, umask, totalSize)
 	}
 
-	return z.extractRegularFile(l, fs, destPath, zipFile, umask, totalSize)
+	return z.extractRegularFile(l, fsys, destPath, zipFile, umask, totalSize)
 }
 
 // extractRegularFile extracts a regular file from a zip file.
 func (z *ZipDecompressor) extractRegularFile(
 	l log.Logger,
-	fs FS,
+	fsys FS,
 	destPath string,
 	zipFile *zip.File,
 	umask os.FileMode,
 	totalSize *int64,
 ) error {
-	if err := fs.MkdirAll(
+	if err := fsys.MkdirAll(
 		filepath.Dir(destPath),
 		applyUmask(defaultZipDirMode, umask),
 	); err != nil {
@@ -999,7 +1033,7 @@ func (z *ZipDecompressor) extractRegularFile(
 
 	mode := applyUmask(zipFile.FileInfo().Mode(), umask)
 
-	outFile, err := fs.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	outFile, err := fsys.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return fmt.Errorf("failed to create file %q: %w", destPath, err)
 	}
@@ -1022,7 +1056,7 @@ func (z *ZipDecompressor) extractRegularFile(
 			l.Warnf("Error closing file %q: %v", destPath, closeErr)
 		}
 
-		if removeErr := fs.Remove(destPath); removeErr != nil {
+		if removeErr := fsys.Remove(destPath); removeErr != nil {
 			l.Warnf("Error removing partial file %q: %v", destPath, removeErr)
 		}
 
@@ -1041,16 +1075,16 @@ func (z *ZipDecompressor) extractRegularFile(
 	return nil
 }
 
-// FileInfoDirEntry wraps os.FileInfo to implement fs.DirEntry.
+// FileInfoDirEntry wraps os.FileInfo to implement iofs.DirEntry.
 // Adapted from spf13/afero#571; replace with afero equivalent once merged.
 type FileInfoDirEntry struct {
 	FileInfo os.FileInfo
 }
 
-func (d FileInfoDirEntry) Name() string               { return d.FileInfo.Name() }
-func (d FileInfoDirEntry) IsDir() bool                { return d.FileInfo.IsDir() }
-func (d FileInfoDirEntry) Type() fs.FileMode          { return d.FileInfo.Mode().Type() }
-func (d FileInfoDirEntry) Info() (fs.FileInfo, error) { return d.FileInfo, nil }
+func (d FileInfoDirEntry) Name() string                 { return d.FileInfo.Name() }
+func (d FileInfoDirEntry) IsDir() bool                  { return d.FileInfo.IsDir() }
+func (d FileInfoDirEntry) Type() iofs.FileMode          { return d.FileInfo.Mode().Type() }
+func (d FileInfoDirEntry) Info() (iofs.FileInfo, error) { return d.FileInfo, nil }
 
 // limitedReader wraps a reader and enforces a size limit.
 type limitedReader struct {
@@ -1187,7 +1221,7 @@ func (state *symlinkWalkState) processComponent(fsys FS, part string, end int) (
 		return false, err
 	}
 
-	if info.Mode()&fs.ModeSymlink == 0 {
+	if info.Mode()&iofs.ModeSymlink == 0 {
 		return state.processRegularComponent(info, end)
 	}
 
@@ -1301,7 +1335,7 @@ func walkSymlinksLinkParent(dest string, vol string, volLen int) string {
 
 // walkDir recursively descends path, calling walkDirFn.
 // Adapted from https://go.dev/src/path/filepath/path.go
-func walkDir(fsys FS, path string, d fs.DirEntry, walkDirFn fs.WalkDirFunc) error {
+func walkDir(fsys FS, path string, d iofs.DirEntry, walkDirFn iofs.WalkDirFunc) error {
 	if err := walkDirFn(path, d, nil); err != nil || !d.IsDir() {
 		if errors.Is(err, filepath.SkipDir) && d.IsDir() {
 			err = nil
@@ -1337,11 +1371,11 @@ func walkDir(fsys FS, path string, d fs.DirEntry, walkDirFn fs.WalkDirFunc) erro
 }
 
 // ReadDirEntries reads the directory named by dirname and returns a sorted
-// list of directory entries. It prefers the fs.ReadDirFile fast path when the
+// list of directory entries. It prefers the iofs.ReadDirFile fast path when the
 // backing file supports it, and otherwise falls back to Readdir wrapped in
 // FileInfoDirEntry so backings that only expose the legacy os.File API still
 // work.
-func ReadDirEntries(fsys FS, dirname string) ([]fs.DirEntry, error) {
+func ReadDirEntries(fsys FS, dirname string) ([]iofs.DirEntry, error) {
 	f, err := fsys.Open(dirname)
 	if err != nil {
 		return nil, err
@@ -1351,7 +1385,7 @@ func ReadDirEntries(fsys FS, dirname string) ([]fs.DirEntry, error) {
 		_ = f.Close()
 	}()
 
-	if rdf, ok := f.(fs.ReadDirFile); ok {
+	if rdf, ok := f.(iofs.ReadDirFile); ok {
 		entries, err := rdf.ReadDir(-1)
 		if err != nil {
 			return nil, err
@@ -1359,7 +1393,7 @@ func ReadDirEntries(fsys FS, dirname string) ([]fs.DirEntry, error) {
 
 		slices.SortFunc(
 			entries,
-			func(a, b fs.DirEntry) int { return strings.Compare(a.Name(), b.Name()) },
+			func(a, b iofs.DirEntry) int { return strings.Compare(a.Name(), b.Name()) },
 		)
 
 		return entries, nil
@@ -1370,7 +1404,7 @@ func ReadDirEntries(fsys FS, dirname string) ([]fs.DirEntry, error) {
 		return nil, err
 	}
 
-	entries := make([]fs.DirEntry, len(infos))
+	entries := make([]iofs.DirEntry, len(infos))
 
 	for i, info := range infos {
 		entries[i] = FileInfoDirEntry{FileInfo: info}
@@ -1378,7 +1412,7 @@ func ReadDirEntries(fsys FS, dirname string) ([]fs.DirEntry, error) {
 
 	slices.SortFunc(
 		entries,
-		func(a, b fs.DirEntry) int { return strings.Compare(a.Name(), b.Name()) },
+		func(a, b iofs.DirEntry) int { return strings.Compare(a.Name(), b.Name()) },
 	)
 
 	return entries, nil
@@ -1473,7 +1507,7 @@ func ValidateResolvedSymlinkTarget(fsys FS, root, linkPath string) error {
 // extractSymlink extracts a symlink from a zip file.
 func (z *ZipDecompressor) extractSymlink(
 	l log.Logger,
-	fs FS,
+	fsys FS,
 	dst, destPath string,
 	zipFile *zip.File,
 	umask os.FileMode,
@@ -1522,14 +1556,14 @@ func (z *ZipDecompressor) extractSymlink(
 		return err
 	}
 
-	if err := fs.MkdirAll(
+	if err := fsys.MkdirAll(
 		filepath.Dir(destPath),
 		applyUmask(defaultZipDirMode, umask),
 	); err != nil {
 		return fmt.Errorf("failed to create directory %q: %w", filepath.Dir(destPath), err)
 	}
 
-	return Symlink(fs, target, destPath)
+	return Symlink(fsys, target, destPath)
 }
 
 // applyUmask applies a umask to a file mode.

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -55,35 +55,35 @@ func TestFileExists(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		setup    func(fs vfs.FS)
+		setup    func(fsys vfs.FS)
 		path     string
 		expected bool
 	}{
 		{
 			name: "file exists",
-			setup: func(fs vfs.FS) {
-				require.NoError(t, afero.WriteFile(fs, "/test.txt", []byte("content"), 0644))
+			setup: func(fsys vfs.FS) {
+				require.NoError(t, afero.WriteFile(fsys, "/test.txt", []byte("content"), 0644))
 			},
 			path:     "/test.txt",
 			expected: true,
 		},
 		{
 			name:     "file does not exist",
-			setup:    func(fs vfs.FS) {},
+			setup:    func(fsys vfs.FS) {},
 			path:     "/nonexistent.txt",
 			expected: false,
 		},
 		{
 			name: "directory exists",
-			setup: func(fs vfs.FS) {
-				require.NoError(t, fs.MkdirAll("/testdir", 0755))
+			setup: func(fsys vfs.FS) {
+				require.NoError(t, fsys.MkdirAll("/testdir", 0755))
 			},
 			path:     "/testdir",
 			expected: true,
 		},
 		{
 			name:     "parent does not exist",
-			setup:    func(fs vfs.FS) {},
+			setup:    func(fsys vfs.FS) {},
 			path:     "/nonexistent/file.txt",
 			expected: false,
 		},

--- a/internal/view/human_render.go
+++ b/internal/view/human_render.go
@@ -4,15 +4,14 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/view/diagnostic"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/mitchellh/go-wordwrap"
-	"golang.org/x/term"
 )
 
 const (
@@ -40,11 +39,13 @@ type HumanRender struct {
 	disableColor bool
 }
 
-func NewHumanRender(disableColor bool) Render {
-	disableColor = disableColor || !term.IsTerminal(int(os.Stderr.Fd()))
+func NewHumanRender(v *venv.Venv, disableColor bool) Render {
+	v.RequireTerminal()
 
-	width, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
+	disableColor = disableColor || !v.Terminal.StderrIsTTY()
+
+	width := v.Terminal.Width()
+	if width == 0 {
 		width = defaultWidth
 	}
 

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -427,6 +427,7 @@ func NewWorktrees(
 					paths, err := createGitWorktrees(
 						gitCmdCtx,
 						l,
+						v,
 						gitRunner,
 						gitRefs,
 						repoRemote,
@@ -635,6 +636,7 @@ func recordDiffTelemetry(ctx context.Context, diffs *git.Diffs) {
 func createGitWorktrees(
 	ctx context.Context,
 	l log.Logger,
+	v *venv.Venv,
 	gitRunner *git.GitRunner,
 	gitRefs []string,
 	repoRemote, repoBranch, repoCommit string,
@@ -682,7 +684,7 @@ func createGitWorktrees(
 					return util.NotifyIfSlow(
 						ctx,
 						l,
-						util.SpinnerWriter(),
+						util.SpinnerWriter(v),
 						time.Second,
 						util.SlowNotifyMsg{
 							Spinner: fmt.Sprintf("Creating Git worktree for reference %s...", ref),

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +34,7 @@ func TestNewWorktrees(t *testing.T) {
 	w, err := worktrees.NewWorktrees(
 		t.Context(),
 		logger.CreateLogger(),
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: filters.UniqueGitFilters()},
 	)
 	require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestNewWorktreesWithInvalidReference(t *testing.T) {
 	_, err = worktrees.NewWorktrees(
 		t.Context(),
 		logger.CreateLogger(),
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: filters.UniqueGitFilters()},
 	)
 	require.Error(t, err)
@@ -671,7 +671,7 @@ func TestWorktreeCleanup(t *testing.T) {
 	_, err = worktrees.NewWorktrees(
 		t.Context(),
 		logger.CreateLogger(),
-		venv.OSVenv(),
+		venvtest.NewOSWithEmptyEnv(),
 		worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: filters.UniqueGitFilters()},
 	)
 	require.Error(t, err)

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func run() (code int) {
 		log.WithFormatter(format.NewFormatter(format.NewPrettyFormatPlaceholders())),
 	)
 
-	reporter := panicreport.New(v.FS)
+	reporter := panicreport.New(v)
 	// Recover panics here so main owns os.Exit and any future main-level defers still run.
 	defer func() {
 		if reporter.PanicHandler(recover(), l, version.GetVersion, os.Args) {

--- a/pkg/config/autoinclude_test.go
+++ b/pkg/config/autoinclude_test.go
@@ -56,7 +56,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -120,7 +120,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -200,7 +200,7 @@ include "base" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -251,7 +251,7 @@ include "common" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -332,7 +332,7 @@ dependency "leak" {
 `), 0644),
 	)
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -385,7 +385,7 @@ exclude {
 
 	l := logger.CreateLogger()
 
-	ctxFull, pctxFull := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctxFull, pctxFull := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctxFull.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	parsedFull, err := config.ParseConfigFile(ctxFull, pctxFull, l, cfgPath, nil)
@@ -399,7 +399,7 @@ exclude {
 		"autoinclude exclude must win in full parse",
 	)
 
-	ctxPartial, pctxPartial := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctxPartial, pctxPartial := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctxPartial.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctxPartial = pctxPartial.WithDecodeList(config.ExcludeBlock).WithSkipOutputsResolution()
 
@@ -432,7 +432,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 
 	l := logger.CreateLogger()
 
@@ -471,7 +471,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 
 	l := logger.CreateLogger()
 
@@ -512,7 +512,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 
 	l := logger.CreateLogger()
 
@@ -560,7 +560,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx = pctx.WithDecodeList(config.DependencyBlock, config.RemoteStateBlock).
 		WithSkipOutputsResolution()
@@ -618,7 +618,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -662,7 +662,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), autoIncludePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), autoIncludePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -698,7 +698,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -758,7 +758,7 @@ inputs = {
 
 	l := logger.CreateLogger()
 
-	ctxFull, pctxFull := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctxFull, pctxFull := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctxFull.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	parsedFull, err := config.ParseConfigFile(ctxFull, pctxFull, l, cfgPath, nil)
@@ -779,7 +779,7 @@ inputs = {
 		"autoinclude terraform source must win in full parse",
 	)
 
-	ctxPartial, pctxPartial := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctxPartial, pctxPartial := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctxPartial.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctxPartial = pctxPartial.WithDecodeList(config.TerraformSource).WithSkipOutputsResolution()
 
@@ -836,7 +836,7 @@ errors {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx = pctx.WithDecodeList(
 		config.DependencyBlock,
@@ -903,7 +903,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx = pctx.WithDecodeList(config.DependencyBlock).WithSkipOutputsResolution()
 
@@ -968,7 +968,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), autoIncludePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), autoIncludePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 	pctx = pctx.WithDecodeList(config.DependencyBlock, config.RemoteStateBlock).
@@ -1007,7 +1007,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	// A shared config cache so the second parse can see (and would otherwise reuse) the first entry.
 	ctx = context.WithValue(
 		ctx,
@@ -1098,7 +1098,7 @@ remote_state {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	// A shared config cache so the second parse can see (and would otherwise reuse) the first entry.
 	ctx = context.WithValue(
 		ctx,
@@ -1182,7 +1182,7 @@ dependency "bar" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock, config.DependencyBlock).
 		WithSkipOutputsResolution()
@@ -1227,7 +1227,7 @@ stack "networking" {
 `), 0644))
 
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -1295,7 +1295,7 @@ inputs = {
 `), 0644))
 
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -1341,7 +1341,7 @@ unit "app" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), stackPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -1392,7 +1392,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()

--- a/pkg/config/catalog_test.go
+++ b/pkg/config/catalog_test.go
@@ -134,7 +134,7 @@ func TestCatalogParseConfigFile(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			_, catalogPctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tt.configPath)
+			_, catalogPctx := newTestParsingContext(t, venvtest.NewWithOSFS(), tt.configPath)
 			catalogPctx.ScaffoldRootFileName = filepath.Base(tt.configPath)
 			config, err := config.ReadCatalogConfig(t.Context(), l, catalogPctx)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/errorconfig"
 	inthclparse "github.com/gruntwork-io/terragrunt/internal/hclparse"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/writer"
 
@@ -99,7 +100,7 @@ var (
 		DefaultTerragruntConfigPath,
 	}
 
-	DefaultParserOptions = func(l log.Logger, strictControls strict.Controls) []hclparse.Option {
+	DefaultParserOptions = func(l log.Logger, v *venv.Venv, strictControls strict.Controls) []hclparse.Option {
 		writer := writer.New(
 			writer.WithLogger(l),
 			writer.WithDefaultLevel(log.ErrorLevel),
@@ -108,7 +109,7 @@ var (
 
 		parseOpts := make([]hclparse.Option, 0, 3) //nolint:mnd
 		parseOpts = append(parseOpts,
-			hclparse.WithDiagnosticsWriter(writer, l.Formatter().DisabledColors()),
+			hclparse.WithDiagnosticsWriter(v, writer, l.Formatter().DisabledColors()),
 			hclparse.WithLogger(l),
 		)
 

--- a/pkg/config/config_as_cty_test.go
+++ b/pkg/config/config_as_cty_test.go
@@ -1,6 +1,8 @@
 package config_test
 
 import (
+	"context"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -12,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/codegen"
 	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -306,7 +309,7 @@ func TestStackUnitCtyReading(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,
@@ -331,7 +334,18 @@ func TestStackLocalsCtyReading(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+
+	// The fixture calls get_repo_root, which shells out to git.
+	repoRoot, err := filepath.Abs("../..")
+	require.NoError(t, err)
+
+	v := venvtest.NewWithOSFS().WithHandler(
+		func(_ context.Context, _ vexec.Invocation) vexec.Result {
+			return vexec.Result{Stdout: []byte(repoRoot + "\n")}
+		},
+	)
+
+	ctx, pctx := newTestParsingContext(t, v, config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,

--- a/pkg/config/config_helpers_test.go
+++ b/pkg/config/config_helpers_test.go
@@ -142,7 +142,7 @@ func TestPathRelativeToInclude(t *testing.T) {
 	for _, tc := range testCases {
 		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params, tc.configPath)
 		l := logger.CreateLogger()
-		ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
+		ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), tc.configPath)
 		pctx = pctx.WithTrackInclude(trackInclude)
 		actualPath, actualErr := config.PathRelativeToInclude(ctx, pctx, l, tc.params)
 		require.NoError(
@@ -276,7 +276,7 @@ func TestPathRelativeFromInclude(t *testing.T) {
 	for _, tc := range testCases {
 		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params, tc.configPath)
 		l := logger.CreateLogger()
-		ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
+		ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), tc.configPath)
 		pctx = pctx.WithTrackInclude(trackInclude)
 		actualPath, actualErr := config.PathRelativeFromInclude(ctx, pctx, l, tc.params)
 		require.NoError(
@@ -529,7 +529,7 @@ func TestFindInParentFolders(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), tc.configPath)
 
 			if tc.maxFoldersToCheck != 0 {
 				pctx.MaxFoldersToCheck = tc.maxFoldersToCheck
@@ -579,7 +579,7 @@ unit "test" {
 	require.NoError(t, err)
 
 	l := logger.CreateLogger()
-	_, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackHclPath)
+	_, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), stackHclPath)
 	pctx.WorkingDir = tempDir
 
 	stackConfig, err := config.ReadStackConfigFile(t.Context(), l, pctx, stackHclPath, nil)
@@ -606,7 +606,7 @@ func TestFindInParentFoldersSharedRunContext(t *testing.T) {
 	}
 
 	l := logger.CreateLogger()
-	baseCtx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), first)
+	baseCtx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), first)
 	ctx := config.WithConfigValues(baseCtx)
 
 	firstPath, err := config.FindInParentFolders(ctx, pctx, l, []string{"root.hcl"})
@@ -655,7 +655,7 @@ func TestFindInParentFoldersSharedRunContextWithRacing(t *testing.T) {
 	}
 
 	l := logger.CreateLogger()
-	baseCtx, basePctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPaths[0])
+	baseCtx, basePctx := newTestParsingContext(t, venvtest.NewWithOSFS(), configPaths[0])
 	ctx := config.WithConfigValues(baseCtx)
 
 	group, groupCtx := errgroup.WithContext(ctx)
@@ -770,7 +770,7 @@ func TestResolveTerragruntInterpolation(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), tc.configPath)
 
 			if tc.maxFoldersToCheck != 0 {
 				pctx.MaxFoldersToCheck = tc.maxFoldersToCheck
@@ -867,7 +867,7 @@ func TestResolveEnvInterpolationConfigString(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), tc.configPath)
 
 			if tc.env != nil {
 				pctx.Venv.Env = tc.env
@@ -925,7 +925,7 @@ func TestResolveCommandsInterpolationConfigString(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), tc.configPath)
 			actualOut, actualErr := config.ParseConfigString(
 				ctx,
 				pctx,
@@ -983,7 +983,7 @@ func TestResolveCliArgsInterpolationConfigString(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 			pctx.TerraformCliArgs = iacargs.New(cliArgs...)
 
 			actualOut, actualErr := config.ParseConfigString(
@@ -1054,7 +1054,7 @@ func testGetTerragruntDir(t *testing.T, configPath string, expectedPath string) 
 	t.Helper()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), configPath)
 	actualPath, err := config.GetTerragruntDir(ctx, pctx, l)
 
 	require.NoError(t, err, "Unexpected error: %v", err)
@@ -1215,7 +1215,7 @@ func TestGetParentTerragruntDir(t *testing.T) {
 	for _, tc := range testCases {
 		trackInclude := getTrackIncludeFromTestData(tc.include, tc.params, tc.configPath)
 		l := logger.CreateLogger()
-		ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), tc.configPath)
+		ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), tc.configPath)
 		pctx = pctx.WithTrackInclude(trackInclude)
 		actualPath, actualErr := config.GetParentTerragruntDir(ctx, pctx, l, tc.params)
 		require.NoError(
@@ -1295,7 +1295,7 @@ func TestTerraformBuiltInFunctions(t *testing.T) {
 			)
 			configString := fmt.Sprintf("inputs = { test = %s }", tc.input)
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 			actual, err := config.ParseConfigString(ctx, pctx, l, cfgPath, configString, nil)
 			require.NoError(t, err, "For hcl '%s', unexpected error: %v", tc.input, err)
 
@@ -1428,7 +1428,7 @@ func TestTerragruntDeepMergeFunction(t *testing.T) {
 			cfgPath := "../../test/fixtures/config-terraform-functions/" + config.DefaultTerragruntConfigPath
 			configString := fmt.Sprintf("inputs = { test = %s }", tc.input)
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 			require.NoError(t, pctx.Experiments.EnableExperiment(experiment.DeepMerge))
 			actual, err := config.ParseConfigString(ctx, pctx, l, cfgPath, configString, nil)
 			require.NoError(t, err)
@@ -1448,7 +1448,7 @@ func TestTerragruntDeepMergeFunctionRequiresExperiment(t *testing.T) {
 	cfgPath := "../../test/fixtures/config-terraform-functions/" + config.DefaultTerragruntConfigPath
 	configString := `inputs = { test = deep_merge({ a = 1 }, { b = 2 }) }`
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	_, err := config.ParseConfigString(ctx, pctx, l, cfgPath, configString, nil)
 
 	require.Error(t, err)
@@ -1461,7 +1461,7 @@ func TestTerragruntDeepMergeFunctionInvalidType(t *testing.T) {
 	cfgPath := "../../test/fixtures/config-terraform-functions/" + config.DefaultTerragruntConfigPath
 	configString := `inputs = { test = deep_merge({ a = 1 }, "invalid") }`
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.DeepMerge))
 	_, err := config.ParseConfigString(ctx, pctx, l, cfgPath, configString, nil)
 
@@ -1482,7 +1482,7 @@ func TestTerragruntDeepMergeFunctionFilesetJSONEndToEnd(t *testing.T) {
 	require.NoError(t, err)
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.DeepMerge))
 
 	cfg, err := config.ParseConfigFile(ctx, pctx, l, cfgPath, nil)
@@ -1591,7 +1591,7 @@ func TestReadTerragruntConfigInputs(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,
@@ -1646,7 +1646,7 @@ func TestReadTerragruntConfigRemoteState(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,
@@ -1688,7 +1688,7 @@ func TestReadTerragruntConfigHooks(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,
@@ -1738,7 +1738,7 @@ func TestReadTerragruntConfigLocals(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,
@@ -1775,7 +1775,7 @@ func TestReadTerragruntConfigResolvesRelativeToOriginalTerragruntDir(t *testing.
 	require.NoError(t, err)
 
 	// correct original path: get_original_terragrunt_dir() resolves to the unit dir
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), unitFilename)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), unitFilename)
 	pctx.OriginalTerragruntConfigPath = unitFilename
 	pctx.SkipOutput = true
 
@@ -1790,7 +1790,7 @@ func TestReadTerragruntConfigResolvesRelativeToOriginalTerragruntDir(t *testing.
 		config.DefaultTerragruntConfigPath,
 	)
 
-	ctxWrong, pctxWrong := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), unitFilename)
+	ctxWrong, pctxWrong := newTestParsingContext(t, venvtest.NewWithOSFS(), unitFilename)
 	pctxWrong.OriginalTerragruntConfigPath = parentFilename
 	pctxWrong.SkipOutput = true
 
@@ -1891,7 +1891,7 @@ func TestStartsWith(t *testing.T) {
 		t.Run(fmt.Sprintf("%v %v", id, tc.args), func(t *testing.T) {
 			t.Parallel()
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "")
 			actual, err := config.StartsWith(ctx, pctx, tc.args)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, actual)
@@ -1921,7 +1921,7 @@ func TestEndsWith(t *testing.T) {
 		t.Run(fmt.Sprintf("%v %v", id, tc.args), func(t *testing.T) {
 			t.Parallel()
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "")
 			actual, err := config.EndsWith(ctx, pctx, tc.args)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, actual)
@@ -1974,7 +1974,7 @@ func TestTimeCmp(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "")
 
 			actual, err := config.TimeCmp(ctx, pctx, l, tc.args)
 			if tc.err != "" {
@@ -2017,7 +2017,7 @@ func TestStrContains(t *testing.T) {
 		t.Run(fmt.Sprintf("StrContains %v", tc.args), func(t *testing.T) {
 			t.Parallel()
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "")
 
 			actual, err := config.StrContains(ctx, pctx, tc.args)
 			if tc.err != "" {
@@ -2035,7 +2035,7 @@ func TestReadTFVarsFiles(t *testing.T) {
 	t.Parallel()
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	tgConfigCty, err := config.ParseTerragruntConfig(
 		ctx,
 		pctx,
@@ -2150,7 +2150,7 @@ func TestConstraintCheck(t *testing.T) {
 			func(t *testing.T) {
 				t.Parallel()
 
-				ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
+				ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "")
 
 				actual, err := config.ConstraintCheck(ctx, pctx, tc.args)
 				if tc.err != "" {
@@ -2182,7 +2182,7 @@ func TestStartsWithArityRegression(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "")
 
 			require.NotPanics(t, func() {
 				_, err := config.StartsWith(ctx, pctx, tc.args)
@@ -2210,7 +2210,7 @@ func TestEndsWithArityRegression(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "")
 
 			require.NotPanics(t, func() {
 				_, err := config.EndsWith(ctx, pctx, tc.args)
@@ -2238,7 +2238,7 @@ func TestStrContainsArityRegression(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "")
 
 			require.NotPanics(t, func() {
 				_, err := config.StrContains(ctx, pctx, tc.args)
@@ -2276,7 +2276,7 @@ func TestRunCommandOptionsOnlyArityRegression(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "")
 
 			require.NotPanics(t, func() {
 				_, err := config.RunCommand(ctx, pctx, l, tc.params)

--- a/pkg/config/config_partial_test.go
+++ b/pkg/config/config_partial_test.go
@@ -37,7 +37,7 @@ dependencies {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -75,7 +75,7 @@ prevent_destroy = false
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	_, err := config.PartialParseConfigString(
 		ctx,
 		pctx,
@@ -112,7 +112,7 @@ skip = true
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock, config.TerragruntFlags)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -142,7 +142,7 @@ func TestPartialParseOmittedItems(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock, config.TerragruntFlags)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -181,7 +181,7 @@ func TestPartialParseDoesNotResolveIgnoredBlockEvenInParent(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), configPath)
 	pctx = pctx.WithDecodeList(config.TerragruntFlags)
 	_, err = config.PartialParseConfigFile(ctx, pctx, l, configPath, nil)
 	require.NoError(t, err)
@@ -341,7 +341,7 @@ include "grandparent" {
 
 			l := logger.CreateLogger()
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), childPath)
 			pctx = pctx.WithDecodeList(config.TerragruntFlags)
 
 			_, err := config.PartialParseConfigFile(ctx, pctx, l, childPath, nil)
@@ -372,7 +372,7 @@ func TestPartialParseOnlyInheritsSelectedBlocksFlags(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), configPath)
 	pctx = pctx.WithDecodeList(config.TerragruntFlags)
 	terragruntConfig, err := config.PartialParseConfigFile(ctx, pctx, l, configPath, nil)
 	require.NoError(t, err)
@@ -404,7 +404,7 @@ func TestPartialParseOnlyInheritsSelectedBlocksDependencies(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), configPath)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 	terragruntConfig, err := config.PartialParseConfigFile(ctx, pctx, l, configPath, nil)
 	require.NoError(t, err)
@@ -433,7 +433,7 @@ dependency "vpc" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -467,7 +467,7 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -503,7 +503,7 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -540,7 +540,7 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock, config.DependencyBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -577,7 +577,7 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock, config.DependenciesBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -614,7 +614,7 @@ dependency "sql" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock, config.DependenciesBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -651,7 +651,7 @@ terraform {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.TerraformSource)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -684,7 +684,7 @@ dependency "ec2" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -720,7 +720,7 @@ func TestPartialParseSavesToHclCache(t *testing.T) {
 	// Setup cache and context
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	ctx = context.WithValue(ctx, config.HclCacheContextKey, hclCache)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
@@ -757,7 +757,7 @@ func TestPartialParseCacheHitOnSecondParse(t *testing.T) {
 
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	ctx = context.WithValue(ctx, config.HclCacheContextKey, hclCache)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
@@ -796,7 +796,7 @@ func TestPartialParseCacheInvalidationOnFileModification(t *testing.T) {
 
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	ctx = context.WithValue(ctx, config.HclCacheContextKey, hclCache)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
@@ -847,7 +847,7 @@ func TestPartialParseCacheWithInvalidFile(t *testing.T) {
 
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	ctx = context.WithValue(ctx, config.HclCacheContextKey, hclCache)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
@@ -884,7 +884,7 @@ func TestPartialParseCacheKeyFormat(t *testing.T) {
 
 	hclCache := cache.NewCache[*hclparse.File]("test-hcl-cache")
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	ctx = context.WithValue(ctx, config.HclCacheContextKey, hclCache)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock)
 
@@ -963,7 +963,7 @@ func TestPartialParseConfigCacheDifferentCallers(t *testing.T) {
 	l := logger.CreateLogger()
 
 	// Parse shared config from module A's context.
-	ctxA, pctxA := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), moduleAConfigPath)
+	ctxA, pctxA := newTestParsingContext(t, venvtest.NewWithOSFS(), moduleAConfigPath)
 	ctxA = context.WithValue(ctxA, config.HclCacheContextKey, hclCache)
 	ctxA = context.WithValue(ctxA, config.TerragruntConfigCacheContextKey, configCache)
 	pctxA.UsePartialParseConfigCache = true
@@ -974,7 +974,7 @@ func TestPartialParseConfigCacheDifferentCallers(t *testing.T) {
 	require.NotNil(t, configA)
 
 	// Parse shared config from module B's context (different TerragruntConfigPath).
-	ctxB, pctxB := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), moduleBConfigPath)
+	ctxB, pctxB := newTestParsingContext(t, venvtest.NewWithOSFS(), moduleBConfigPath)
 	ctxB = context.WithValue(ctxB, config.HclCacheContextKey, hclCache)
 	ctxB = context.WithValue(ctxB, config.TerragruntConfigCacheContextKey, configCache)
 	pctxB.UsePartialParseConfigCache = true
@@ -1021,7 +1021,7 @@ exclude {
 `
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.FeatureFlagsBlock, config.ExcludeBlock)
 
 	terragruntConfig, err := config.PartialParseConfigString(
@@ -1065,7 +1065,7 @@ exclude {
 `
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.TerragruntFlags)
 
 	_, err := config.PartialParseConfigString(
@@ -1101,7 +1101,7 @@ exclude {
 `
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.FeatureFlagsBlock, config.ExcludeBlock)
 
 	terragruntConfig, err := config.PartialParseConfigString(
@@ -1143,7 +1143,7 @@ terraform {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.TerraformExtraArgs)
 	terragruntConfig, err := config.PartialParseConfigString(
 		ctx,
@@ -1204,7 +1204,7 @@ dependency "upstream" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock, config.TerraformExtraArgs).
 		WithDiagnosticsSuppressed(l)
 	terragruntConfig, err := config.PartialParseConfigString(
@@ -1257,7 +1257,7 @@ dependency "upstream" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 
 	pctx = pctx.WithDecodeList(config.TerraformSource)
 
@@ -1297,7 +1297,7 @@ dependency "upstream" {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.TerraformSource)
 
 	_, err := config.PartialParseConfigString(
@@ -1333,7 +1333,7 @@ terraform {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.TerraformSource)
 	_, err := config.PartialParseConfigString(
 		ctx,
@@ -1469,7 +1469,7 @@ exclude {
 			require.NoError(t, os.WriteFile(childPath, []byte(tc.childHCL), 0644))
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), childPath)
 			pctx = pctx.WithDecodeList(config.FeatureFlagsBlock, config.ExcludeBlock)
 
 			for name, value := range tc.cliFlags {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -37,7 +37,7 @@ remote_state {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -71,7 +71,7 @@ remote_state = {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -114,7 +114,7 @@ remote_state = {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -164,7 +164,7 @@ remote_state {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -199,7 +199,7 @@ remote_state = {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 }
@@ -225,7 +225,7 @@ generate = {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -258,7 +258,7 @@ generate = {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 }
@@ -277,7 +277,7 @@ func TestParseTerragruntJsonConfigRemoteStateMinimalConfig(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -306,7 +306,7 @@ remote_state {}
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 	assert.Contains(
@@ -337,7 +337,7 @@ remote_state {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -392,7 +392,7 @@ func TestParseTerragruntJsonConfigRemoteStateFullConfig(t *testing.T) {
 `
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -434,7 +434,7 @@ retryable_errors = [".*Error.*"]
 `
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "retryable_errors")
@@ -452,7 +452,7 @@ func TestParseTerragruntJsonConfigRetryConfiguration(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	_, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -478,7 +478,7 @@ func TestParseIamRole(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -506,7 +506,7 @@ func TestParseIamAssumeRoleDuration(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -534,7 +534,7 @@ func TestParseIamAssumeRoleSessionName(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -568,7 +568,7 @@ func TestParseIamWebIdentity(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -600,7 +600,7 @@ dependencies {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -639,7 +639,7 @@ dependencies {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -697,7 +697,7 @@ dependencies {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -765,7 +765,7 @@ func TestParseTerragruntJsonConfigRemoteStateDynamoDbTerraformConfigAndDependenc
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -833,7 +833,7 @@ include {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 
 	terragruntConfig, parseErr := config.ParseConfigString(ctx, pctx, l, cfgPath, cfg, nil)
 	if assert.NoError(t, parseErr, "Unexpected error: %v", parseErr) {
@@ -880,7 +880,7 @@ include {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 
 	terragruntConfig, parseErr := config.ParseConfigString(ctx, pctx, l, cfgPath, cfg, nil)
 	if assert.NoError(t, parseErr, "Unexpected error: %v", parseErr) {
@@ -939,7 +939,7 @@ remote_state {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 
 	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, cfgPath, cfg, nil)
 	if assert.NoError(t, err, "Unexpected error: %v", err) {
@@ -989,7 +989,7 @@ dependencies {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), configPath)
 	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, configPath, cfg, nil)
 	require.NoError(t, err, "Unexpected error: %v", err)
 
@@ -1040,7 +1040,7 @@ func TestParseTerragruntJsonConfigIncludeOverrideAll(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), cfgPath)
 	terragruntConfig, err := config.ParseConfigString(ctx, pctx, l, cfgPath, cfg, nil)
 	require.NoError(t, err, "Unexpected error: %v", err)
 
@@ -1073,7 +1073,7 @@ func TestParseTerragruntConfigTwoLevels(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), configPath)
 
 	_, actualErr := config.ParseConfigString(ctx, pctx, l, configPath, cfg, nil)
 
@@ -1106,7 +1106,7 @@ func TestParseTerragruntConfigThreeLevels(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), configPath)
 
 	_, actualErr := config.ParseConfigString(ctx, pctx, l, configPath, cfg, nil)
 
@@ -1138,7 +1138,7 @@ func TestParseTerragruntConfigEmptyConfig(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -1164,7 +1164,7 @@ func TestParseTerragruntConfigEmptyConfigOldConfig(t *testing.T) {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	cfg, err := config.ParseConfigString(
 		ctx,
@@ -1190,7 +1190,7 @@ terraform {}
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -1222,7 +1222,7 @@ terraform {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -1264,7 +1264,7 @@ terraform {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -1334,7 +1334,7 @@ terraform {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -1416,7 +1416,7 @@ func TestParseTerragruntJsonConfigTerraformWithMultipleExtraArguments(t *testing
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -1740,7 +1740,7 @@ prevent_destroy = true
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -1769,7 +1769,7 @@ prevent_destroy = false
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -1798,7 +1798,7 @@ skip = true
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
@@ -1815,7 +1815,7 @@ skip = false
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	_, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, cfg, nil)
 	require.Error(t, err)
@@ -1849,7 +1849,7 @@ terraform {
 	)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), absConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), absConfigPath)
 	pctx.MaxFoldersToCheck = 5
 
 	terragruntConfig, err := config.ParseConfigString(
@@ -1981,7 +1981,7 @@ func BenchmarkReadTerragruntConfig(b *testing.B) {
 			require.NoError(b, err)
 
 			l := createLogger()
-			_, pctx := newTestParsingContext(b, venvtest.NewOSWithEmptyEnv(), workingDir)
+			_, pctx := newTestParsingContext(b, venvtest.NewWithOSFS(), workingDir)
 			pctx.UsePartialParseConfigCache = fixture.usePartialParseCache
 
 			b.ResetTimer()
@@ -1990,7 +1990,7 @@ func BenchmarkReadTerragruntConfig(b *testing.B) {
 				b.Context(),
 				l,
 				pctx,
-				config.DefaultParserOptions(l, pctx.StrictControls),
+				config.DefaultParserOptions(l, pctx.Venv, pctx.StrictControls),
 			)
 			b.StopTimer()
 			require.NoError(b, err)
@@ -2063,7 +2063,7 @@ func TestBestEffortParseConfigString(t *testing.T) {
 
 			l := createLogger()
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 			terragruntConfig, err := config.ParseConfigString(
 				ctx,
@@ -2096,7 +2096,7 @@ func TestParseConfigGenerateBlockWithHclFmt(t *testing.T) {
 }`
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -2129,7 +2129,7 @@ func TestParseConfigGenerateAttrWithHclFmt(t *testing.T) {
 }`
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -2161,7 +2161,7 @@ func TestParseConfigGenerateBlockWithMutable(t *testing.T) {
 }`
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MutableGenerate))
 
 	terragruntConfig, err := config.ParseConfigString(
@@ -2195,7 +2195,7 @@ func TestParseConfigGenerateAttrWithMutable(t *testing.T) {
 }`
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.MutableGenerate))
 
 	terragruntConfig, err := config.ParseConfigString(
@@ -2228,7 +2228,7 @@ func TestParseConfigGenerateBlockMutableRequiresExperiment(t *testing.T) {
 }`
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	_, err := config.ParseConfigString(
 		ctx,
@@ -2254,7 +2254,7 @@ func TestParseConfigWithMissingIfExists(t *testing.T) {
 }`
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
@@ -2312,7 +2312,7 @@ dependency "dep" {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 
 	pctx.WorkingDir = unitPath
 
@@ -2514,7 +2514,7 @@ inputs = {
 
 	l := createLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	terragruntConfig, err := config.ParseConfigString(
 		ctx,
 		pctx,
@@ -2679,7 +2679,7 @@ exclude {
 }
 `
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-exclude-no-run")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-exclude-no-run")
 	cfg, err := config.ParseConfigString(
 		ctx,
 		pctx,

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1454,7 +1454,7 @@ func resolveOutputJSON(
 	// we need to suspend logging diagnostic errors on this attempt
 	parseOptions := slices.Concat(
 		pctx.ParserOptions,
-		[]hclparse.Option{hclparse.WithDiagnosticsWriter(io.Discard, true)},
+		[]hclparse.Option{hclparse.WithDiagnosticsWriter(pctx.Venv, io.Discard, true)},
 	)
 
 	remoteStateTGConfig, err := PartialParseConfigFile(

--- a/pkg/config/dependency_internal_test.go
+++ b/pkg/config/dependency_internal_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -303,7 +303,7 @@ func TestApplyExtraArgsEnvVarsForOutput(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			pctx := &ParsingContext{Venv: venv.OSVenv().WithEnv(tc.initial)}
+			pctx := &ParsingContext{Venv: venvtest.NewOSWithEmptyEnv().WithEnv(tc.initial)}
 			applyExtraArgsEnvVarsForOutput(pctx, tc.terraform)
 			assert.Equal(t, tc.want, pctx.Venv.Env)
 		})

--- a/pkg/config/dependency_test.go
+++ b/pkg/config/dependency_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
-	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -129,11 +128,11 @@ func TestParseDependencyBlockMultiple(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), filename)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), filename)
 	err = pctx.Experiments.EnableExperiment(experiment.DependencyFetchOutputFromState)
 	require.NoError(t, err)
 
-	pctx.Venv.Env = venv.OSVenv().Env
+	pctx.Venv.Env = venvtest.NewOSWithEmptyEnv().Env
 	tfConfig, err := config.ParseConfigFile(ctx, pctx, logger.CreateLogger(), filename, nil)
 	require.NoError(t, err)
 	assert.Len(t, tfConfig.TerragruntDependencies, 2)
@@ -184,7 +183,7 @@ dependency "enabled" {
 }
 `
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock)
 
 	// Should not panic - disabled deps bypass config_path validation
@@ -225,7 +224,7 @@ func TestDependencyOriginalTerragruntDir(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), filename)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), filename)
 	pctx.OriginalTerragruntConfigPath = filename
 	pctx.SkipOutput = true
 
@@ -248,7 +247,7 @@ func TestDependencyOriginalTerragruntDir(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	ctxB, pctxB := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), unitBFilename)
+	ctxB, pctxB := newTestParsingContext(t, venvtest.NewWithOSFS(), unitBFilename)
 	pctxB.OriginalTerragruntConfigPath = unitBFilename
 
 	unitBConfig, err := config.ParseConfigFile(
@@ -279,7 +278,7 @@ dependency "enabled" {
 }
 `
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	pctx = pctx.WithDecodeList(config.DependencyBlock)
 
 	// Should not error - disabled deps bypass config_path validation

--- a/pkg/config/dependency_tf_test.go
+++ b/pkg/config/dependency_tf_test.go
@@ -7,11 +7,9 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/venv"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
-	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,9 +33,7 @@ func TestTFExposedIncludeFullParseSurfacesNoOutputsError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
-	pctx.Venv.Env = venv.OSVenv().Env
-	pctx.Venv.FS = vfs.NewOSFS()
+	ctx, pctx := newTestParsingContext(t, venv.OSVenv(), childPath)
 	pctx.TFPath = helpers.WrappedBinary(ctx)
 
 	_, err = config.ParseConfigFile(ctx, pctx, logger.CreateLogger(), childPath, nil)

--- a/pkg/config/early_stack_eval_test.go
+++ b/pkg/config/early_stack_eval_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	inthclparse "github.com/gruntwork-io/terragrunt/internal/hclparse"
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -68,7 +70,7 @@ var terragruntFuncNames = []string{
 func newStackParsePctx(t *testing.T, baseDir string) *config.ParsingContext {
 	t.Helper()
 
-	_, pctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), venvtest.NewOSWithEmptyEnv())
+	_, pctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), venvtest.NewWithOSFS())
 	pctx.TerragruntConfigPath = filepath.Join(baseDir, "terragrunt.hcl")
 	pctx.WorkingDir = baseDir
 	pctx.MaxFoldersToCheck = 100
@@ -316,6 +318,14 @@ unit "vpc" {
 `), 0644))
 
 	pctx := newStackParsePctx(t, stackDir)
+
+	// The unit's path attribute is whatever run_cmd prints.
+	pctx.Venv = pctx.Venv.WithHandler(
+		func(_ context.Context, inv vexec.Invocation) vexec.Result {
+			return vexec.Result{Stdout: []byte(strings.Join(inv.Args, " ") + "\n")}
+		},
+	)
+
 	funcsFor := func(dir string) (map[string]function.Function, error) {
 		return config.EarlyStackParseFunctions(t.Context(), logger.CreateLogger(), dir, pctx)
 	}

--- a/pkg/config/exclude_include_test.go
+++ b/pkg/config/exclude_include_test.go
@@ -62,7 +62,7 @@ include "root" {
 }
 `), 0644))
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), childPath)
 
 			l := logger.CreateLogger()
 
@@ -138,7 +138,7 @@ exclude {
 }
 `), 0644))
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), childPath)
 
 			l := logger.CreateLogger()
 
@@ -202,7 +202,7 @@ include "root" {
 }
 `), 0644))
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), childPath)
 
 			l := logger.CreateLogger()
 
@@ -261,7 +261,7 @@ include "root" {
 }
 `), 0644))
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), childPath)
 
 			l := logger.CreateLogger()
 
@@ -319,7 +319,7 @@ include "root" {
 }
 `), 0644))
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), childPath)
 
 			l := logger.CreateLogger()
 

--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -209,7 +209,7 @@ func TestParseConfigStringExpansionRequiresExperiment(t *testing.T) {
 	skipInExperimentMode(t)
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 
 	_, err := config.ParseConfigString(
 		ctx,
@@ -255,7 +255,7 @@ func TestReadStackConfigStringExpansionRequiresExperiment(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultStackFile)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultStackFile)
 
 			_, err := config.ReadStackConfigString(
 				ctx,
@@ -299,7 +299,7 @@ include "extra" {
 `), 0o644))
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), stackPath)
 	pctx.Venv.FS = fsys
 
 	_, err := config.ReadStackConfigFile(ctx, l, pctx, stackPath, nil)
@@ -1308,7 +1308,7 @@ func newExpansionParsingContext(
 ) (context.Context, *config.ParsingContext) {
 	tb.Helper()
 
-	ctx, pctx := newTestParsingContext(tb, venvtest.NewOSWithEmptyEnv(), configPath)
+	ctx, pctx := newTestParsingContext(tb, venvtest.NewWithOSFS(), configPath)
 	require.NoError(tb, pctx.Experiments.EnableExperiment(experiment.BlockIteration))
 
 	return ctx, pctx

--- a/pkg/config/find_in_parent_folders_bench_test.go
+++ b/pkg/config/find_in_parent_folders_bench_test.go
@@ -23,7 +23,7 @@ func BenchmarkFindInParentFolders(b *testing.B) {
 
 			b.Run("depth="+strconv.Itoa(depth)+"/units="+strconv.Itoa(units), func(b *testing.B) {
 				l := logger.CreateLogger()
-				baseCtx, pctx := newTestParsingContext(b, venvtest.NewOSWithEmptyEnv(), configPaths[0])
+				baseCtx, pctx := newTestParsingContext(b, venvtest.NewWithOSFS(), configPaths[0])
 				params := []string{benchRootFileName}
 
 				for b.Loop() {

--- a/pkg/config/fuzz_test.go
+++ b/pkg/config/fuzz_test.go
@@ -34,7 +34,7 @@ func FuzzHCLStringHelpers(f *testing.F) {
 	f.Fuzz(func(t *testing.T, raw string) {
 		args := strings.Split(raw, "\x00")
 
-		ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "")
+		ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "")
 
 		swOut, swErr := config.StartsWith(ctx, pctx, args)
 		ewOut, ewErr := config.EndsWith(ctx, pctx, args)

--- a/pkg/config/hclparse/file_test.go
+++ b/pkg/config/hclparse/file_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,12 +39,12 @@ func TestRebindRoutesDiagnosticsThroughNewWriter(t *testing.T) {
 		reboundBuf  bytes.Buffer
 	)
 
-	original := hclparse.NewParser(hclparse.WithDiagnosticsWriter(&originalBuf, true))
+	original := hclparse.NewParser(hclparse.WithDiagnosticsWriter(venvtest.New(), &originalBuf, true))
 
 	file, err := original.ParseFromString(hclWithUndefinedVar, fixturePath)
 	require.NoError(t, err)
 
-	rebound := file.Rebind(hclparse.NewParser(hclparse.WithDiagnosticsWriter(&reboundBuf, true)))
+	rebound := file.Rebind(hclparse.NewParser(hclparse.WithDiagnosticsWriter(venvtest.New(), &reboundBuf, true)))
 
 	var out fooOnly
 
@@ -66,12 +67,12 @@ func TestRebindLeavesOriginalFileUnaffected(t *testing.T) {
 		reboundBuf  bytes.Buffer
 	)
 
-	original := hclparse.NewParser(hclparse.WithDiagnosticsWriter(&originalBuf, true))
+	original := hclparse.NewParser(hclparse.WithDiagnosticsWriter(venvtest.New(), &originalBuf, true))
 
 	file, err := original.ParseFromString(hclWithUndefinedVar, fixturePath)
 	require.NoError(t, err)
 
-	rebound := file.Rebind(hclparse.NewParser(hclparse.WithDiagnosticsWriter(&reboundBuf, true)))
+	rebound := file.Rebind(hclparse.NewParser(hclparse.WithDiagnosticsWriter(venvtest.New(), &reboundBuf, true)))
 	require.NotNil(t, rebound, "Rebind must return a usable file wrapper")
 
 	var out fooOnly
@@ -94,12 +95,12 @@ func TestRebindRendersSourceSnippet(t *testing.T) {
 
 	var reboundBuf bytes.Buffer
 
-	original := hclparse.NewParser(hclparse.WithDiagnosticsWriter(io.Discard, true))
+	original := hclparse.NewParser(hclparse.WithDiagnosticsWriter(venvtest.New(), io.Discard, true))
 
 	file, err := original.ParseFromString(hclWithUndefinedVar, fixturePath)
 	require.NoError(t, err)
 
-	rebound := file.Rebind(hclparse.NewParser(hclparse.WithDiagnosticsWriter(&reboundBuf, true)))
+	rebound := file.Rebind(hclparse.NewParser(hclparse.WithDiagnosticsWriter(venvtest.New(), &reboundBuf, true)))
 
 	var out fooOnly
 
@@ -127,7 +128,7 @@ func TestRebindWithRacing(t *testing.T) {
 
 	const goroutines = 32
 
-	cached, err := hclparse.NewParser(hclparse.WithDiagnosticsWriter(io.Discard, true)).
+	cached, err := hclparse.NewParser(hclparse.WithDiagnosticsWriter(venvtest.New(), io.Discard, true)).
 		ParseFromString(hclWithUndefinedVar, fixturePath)
 	require.NoError(t, err)
 
@@ -144,7 +145,7 @@ func TestRebindWithRacing(t *testing.T) {
 
 			var buf bytes.Buffer
 
-			rebound := cached.Rebind(hclparse.NewParser(hclparse.WithDiagnosticsWriter(&buf, true)))
+			rebound := cached.Rebind(hclparse.NewParser(hclparse.WithDiagnosticsWriter(venvtest.New(), &buf, true)))
 
 			var out fooOnly
 

--- a/pkg/config/hclparse/options.go
+++ b/pkg/config/hclparse/options.go
@@ -3,6 +3,7 @@ package hclparse
 import (
 	"io"
 
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/hcl/v2"
 )
@@ -17,9 +18,9 @@ func WithLogger(logger log.Logger) Option {
 	}
 }
 
-func WithDiagnosticsWriter(writer io.Writer, disableColor bool) Option {
+func WithDiagnosticsWriter(v *venv.Venv, writer io.Writer, disableColor bool) Option {
 	return func(parser *Parser) *Parser {
-		diagsWriter := parser.GetDiagnosticsWriter(writer, disableColor)
+		diagsWriter := parser.GetDiagnosticsWriter(v, writer, disableColor)
 
 		parser.diagsWriterFunc = func(diags hcl.Diagnostics) error {
 			if !diags.HasErrors() {

--- a/pkg/config/hclparse/parser.go
+++ b/pkg/config/hclparse/parser.go
@@ -6,14 +6,13 @@ package hclparse
 
 import (
 	"io"
-	"os"
 	"path/filepath"
 
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
-	"golang.org/x/term"
 )
 
 type Parser struct {
@@ -92,23 +91,20 @@ func (parser *Parser) ParseFromBytes(content []byte, configPath string) (file *F
 	return file, nil
 }
 
-// GetDiagnosticsWriter returns a hcl2 parsing diagnostics emitter for the current terminal.
+// GetDiagnosticsWriter returns a hcl2 parsing diagnostics emitter for the
+// terminal v describes. A run with no terminal gets width 0, which disables
+// word-wrapping: wrapping there would split messages at positions that shift
+// with path lengths, which is awkward to read back and to test against.
 func (parser *Parser) GetDiagnosticsWriter(
+	v *venv.Venv,
 	writer io.Writer,
 	disableColor bool,
 ) hcl.DiagnosticWriter {
-	termColor := !disableColor && term.IsTerminal(int(os.Stderr.Fd()))
+	v.RequireTerminal()
 
-	termWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
-		// When not connected to a terminal (e.g., in CI, tests, or piped output),
-		// use width 0 to disable word-wrapping. This prevents error messages from
-		// being split at unpredictable positions based on path lengths, which can
-		// cause issues when parsing or testing error output.
-		termWidth = 0
-	}
+	termColor := !disableColor && v.Terminal.StderrIsTTY()
 
-	return hcl.NewDiagnosticTextWriter(writer, parser.Files(), uint(termWidth), termColor)
+	return hcl.NewDiagnosticTextWriter(writer, parser.Files(), uint(v.Terminal.Width()), termColor)
 }
 
 func (parser *Parser) handleDiagnostics(file *File, diags hcl.Diagnostics) error {

--- a/pkg/config/locals_test.go
+++ b/pkg/config/locals_test.go
@@ -23,7 +23,7 @@ func TestEvaluateLocalsBlock(t *testing.T) {
 		ParseFromString(LocalsTestConfig, config.DefaultTerragruntConfigPath)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	evaluatedLocals, err := config.EvaluateLocalsBlock(ctx, pctx, logger.CreateLogger(), file)
 	require.NoError(t, err)
 
@@ -66,7 +66,7 @@ func TestEvaluateLocalsBlockMultiDeepReference(t *testing.T) {
 		ParseFromString(LocalsTestMultiDeepReferenceConfig, config.DefaultTerragruntConfigPath)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	evaluatedLocals, err := config.EvaluateLocalsBlock(ctx, pctx, logger.CreateLogger(), file)
 	require.NoError(t, err)
 
@@ -103,7 +103,7 @@ func TestEvaluateLocalsBlockImpossibleWillFail(t *testing.T) {
 		ParseFromString(LocalsTestImpossibleConfig, config.DefaultTerragruntConfigPath)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	_, err = config.EvaluateLocalsBlock(ctx, pctx, logger.CreateLogger(), file)
 	require.Error(t, err)
 
@@ -120,7 +120,7 @@ func TestEvaluateLocalsBlockMultipleLocalsBlocksWillFail(t *testing.T) {
 		ParseFromString(MultipleLocalsBlockConfig, config.DefaultTerragruntConfigPath)
 	require.NoError(t, err)
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	_, err = config.EvaluateLocalsBlock(ctx, pctx, logger.CreateLogger(), file)
 	require.Error(t, err)
 }

--- a/pkg/config/parsing_context.go
+++ b/pkg/config/parsing_context.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"maps"
-	"os"
 	"path/filepath"
 	"slices"
 
@@ -143,7 +142,7 @@ func NewParsingContext(
 		opt(pctx)
 	}
 
-	pctx.ParserOptions = DefaultParserOptions(l, pctx.StrictControls)
+	pctx.ParserOptions = DefaultParserOptions(l, v, pctx.StrictControls)
 
 	return ctx, pctx
 }
@@ -233,13 +232,13 @@ func (ctx *ParsingContext) WithParseOption(parserOptions []hclparse.Option) *Par
 func (ctx *ParsingContext) WithDiagnosticsSuppressed(l log.Logger) *ParsingContext {
 	var diagWriter = io.Discard
 	if l.Level() >= log.DebugLevel {
-		diagWriter = os.Stderr
+		diagWriter = ctx.Venv.Writers.ErrWriter
 	}
 
 	c := ctx.Clone()
 	c.ParserOptions = slices.Concat(
 		ctx.ParserOptions,
-		[]hclparse.Option{hclparse.WithDiagnosticsWriter(diagWriter, true)},
+		[]hclparse.Option{hclparse.WithDiagnosticsWriter(ctx.Venv, diagWriter, true)},
 	)
 
 	return c

--- a/pkg/config/parsing_context_test.go
+++ b/pkg/config/parsing_context_test.go
@@ -30,7 +30,12 @@ func TestWithDependencyConfigPath_CustomDownloadDir_Preserved(t *testing.T) {
 	customDownloadDir := filepath.Join(tmpDir, "custom-cache")
 
 	l := logger.CreateLogger()
-	_, pctx := config.NewParsingContext(t.Context(), l, venvtest.NewOSWithEmptyEnv(), config.WithStrictControls(controls.New()))
+	_, pctx := config.NewParsingContext(
+		t.Context(),
+		l,
+		venvtest.NewWithOSFS(),
+		config.WithStrictControls(controls.New()),
+	)
 
 	_, callerDefaultDir := util.DefaultWorkingAndDownloadDirs(callerConfigPath)
 	pctx.TerragruntConfigPath = callerConfigPath
@@ -59,7 +64,12 @@ func TestWithDependencyConfigPath_DefaultDownloadDir_Updated(t *testing.T) {
 	depConfigPath := filepath.Join(tmpDir, "modules", "vpc", "terragrunt.hcl")
 
 	l := logger.CreateLogger()
-	_, pctx := config.NewParsingContext(t.Context(), l, venvtest.NewOSWithEmptyEnv(), config.WithStrictControls(controls.New()))
+	_, pctx := config.NewParsingContext(
+		t.Context(),
+		l,
+		venvtest.NewWithOSFS(),
+		config.WithStrictControls(controls.New()),
+	)
 
 	// Set DownloadDir to the caller's default (no TG_DOWNLOAD_DIR override).
 	_, callerDefaultDir := util.DefaultWorkingAndDownloadDirs(callerConfigPath)
@@ -93,7 +103,12 @@ func TestWithDependencyConfigPath_CustomDownloadDir_NotDefaultForAnyModule(t *te
 	customDownloadDir := filepath.Join(tmpDir, ".terragrunt-cache")
 
 	l := logger.CreateLogger()
-	_, pctx := config.NewParsingContext(t.Context(), l, venvtest.NewOSWithEmptyEnv(), config.WithStrictControls(controls.New()))
+	_, pctx := config.NewParsingContext(
+		t.Context(),
+		l,
+		venvtest.NewWithOSFS(),
+		config.WithStrictControls(controls.New()),
+	)
 
 	_, callerDefaultDir := util.DefaultWorkingAndDownloadDirs(callerConfigPath)
 	pctx.TerragruntConfigPath = callerConfigPath

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -365,10 +365,10 @@ func validateUpdateSourceWithCAS(
 // own terragrunt.hcl, which is only available once the source is materialized. Without this check
 // the relative source would be copied verbatim and silently fail to resolve from the generated
 // location, since the cas:: rewrite that gives it meaning never runs.
-func rejectTerraformUpdateSourceWithoutCAS(fs vfs.FS, dest string) error {
+func rejectTerraformUpdateSourceWithoutCAS(fsys vfs.FS, dest string) error {
 	unitFile := filepath.Join(dest, DefaultTerragruntConfigPath)
 
-	content, err := vfs.ReadFile(fs, unitFile)
+	content, err := vfs.ReadFile(fsys, unitFile)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil

--- a/pkg/config/stack_fs_error_test.go
+++ b/pkg/config/stack_fs_error_test.go
@@ -32,7 +32,7 @@ unit "app" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv().WithFS(statErrorFS{
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS().WithFS(statErrorFS{
 		FS:       vfs.NewOSFS(),
 		failPath: filepath.Join(tmpDir, inthclparse.AutoIncludeStackFile),
 	}), stackPath)
@@ -52,7 +52,7 @@ func TestReadValuesPropagatesStatError(t *testing.T) {
 
 	ctx, pctx := newTestParsingContext(
 		t,
-		venvtest.NewOSWithEmptyEnv().WithFS(statErrorFS{
+		venvtest.NewWithOSFS().WithFS(statErrorFS{
 			FS:       vfs.NewOSFS(),
 			failPath: filepath.Join(tmpDir, "terragrunt.values.hcl"),
 		}),

--- a/pkg/config/stack_test.go
+++ b/pkg/config/stack_test.go
@@ -33,7 +33,7 @@ stack "projects" {
 }
 
 `
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	terragruntStackConfig, err := config.ReadStackConfigString(
 		ctx,
 		logger.CreateLogger(),
@@ -112,7 +112,7 @@ stack "network" {
     no_dot_terragrunt_stack = true
 }
 `
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	terragruntStackConfig, err := config.ReadStackConfigString(
 		ctx,
 		logger.CreateLogger(),
@@ -176,7 +176,7 @@ locals {
 	project = "my-project
 }
 `
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
 	_, err := config.ReadStackConfigString(
 		ctx,
 		logger.CreateLogger(),

--- a/pkg/config/stack_validation_test.go
+++ b/pkg/config/stack_validation_test.go
@@ -420,7 +420,7 @@ unit "extra" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	_, err := config.ReadStackConfigFile(ctx, logger.CreateLogger(), pctx, stackFilePath, nil)
@@ -494,7 +494,7 @@ unit "extra" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	stackConfig, err := config.ReadStackConfigFile(
@@ -550,7 +550,7 @@ unit "added" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	stackConfig, err := config.ReadStackConfigFile(
@@ -643,7 +643,7 @@ stack "added" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	stackConfig, err := config.ReadStackConfigFile(
@@ -725,7 +725,7 @@ unit "extra" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	_, err := config.ReadStackConfigFile(ctx, logger.CreateLogger(), pctx, stackFilePath, nil)
@@ -766,7 +766,7 @@ unit "vpc" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	_, err := config.ReadStackConfigFile(ctx, logger.CreateLogger(), pctx, stackFilePath, nil)
@@ -814,7 +814,7 @@ unit "vpc" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	stackConfig, err := config.ReadStackConfigFile(
@@ -879,7 +879,7 @@ unit "vpc" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackFilePath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), stackFilePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	stackConfig, err := config.ReadStackConfigFile(

--- a/pkg/config/terraform_version_test.go
+++ b/pkg/config/terraform_version_test.go
@@ -27,7 +27,7 @@ terraform {
 
 	l := logger.CreateLogger()
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), "test-time-mock")
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), "test-time-mock")
 	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.VersionAttribute))
 
 	terragruntConfig, err := config.ParseConfigString(
@@ -145,7 +145,7 @@ include "root" {
 
 			l := logger.CreateLogger()
 
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
+			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), childPath)
 			require.NoError(t, pctx.Experiments.EnableExperiment(experiment.VersionAttribute))
 
 			terragruntConfig, err := config.ParseConfigFile(ctx, pctx, l, childPath, nil)

--- a/pkg/config/variable.go
+++ b/pkg/config/variable.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/strict"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -33,23 +34,23 @@ type ParsedVariable struct {
 // ParseVariables - parse variables from tf files.
 func ParseVariables(
 	l log.Logger,
-	fsys vfs.FS,
+	v *venv.Venv,
 	strictControls strict.Controls,
 	directoryPath string,
 ) ([]*ParsedVariable, error) {
 	// list all tf files
-	tfFiles, err := util.ListTfFiles(fsys, directoryPath)
+	tfFiles, err := util.ListTfFiles(v.FS, directoryPath)
 	if err != nil {
 		return nil, err
 	}
 
-	parser := hclparse.NewParser(DefaultParserOptions(l, strictControls)...)
+	parser := hclparse.NewParser(DefaultParserOptions(l, v, strictControls)...)
 
 	// iterate over files and parse variables.
 	var parsedInputs []*ParsedVariable
 
 	for _, tfFile := range tfFiles {
-		content, err := vfs.ReadFile(fsys, tfFile)
+		content, err := vfs.ReadFile(v.FS, tfFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/config/variable_test.go
+++ b/pkg/config/variable_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +18,7 @@ func TestScanVariables(t *testing.T) {
 
 	inputs, err := config.ParseVariables(
 		logger.CreateLogger(),
-		vfs.NewOSFS(),
+		venvtest.NewWithOSFS(),
 		controls.New(),
 		"../../test/fixtures/inputs",
 	)
@@ -74,7 +75,7 @@ func TestParseVariablesIgnoresSubdirectories(t *testing.T) {
 		),
 	)
 
-	inputs, err := config.ParseVariables(logger.CreateLogger(), fsys, controls.New(), moduleDir)
+	inputs, err := config.ParseVariables(logger.CreateLogger(), venvtest.New().WithFS(fsys), controls.New(), moduleDir)
 	require.NoError(t, err)
 
 	require.Len(t, inputs, 1)
@@ -86,7 +87,7 @@ func TestScanDefaultVariables(t *testing.T) {
 
 	inputs, err := config.ParseVariables(
 		logger.CreateLogger(),
-		vfs.NewOSFS(),
+		venvtest.NewWithOSFS(),
 		controls.New(),
 		"../../test/fixtures/inputs-defaults",
 	)

--- a/test/helpers/venvtest/venvtest.go
+++ b/test/helpers/venvtest/venvtest.go
@@ -5,8 +5,10 @@
 package venvtest
 
 import (
-	"bufio"
+	"context"
+	"errors"
 	"io"
+	"net"
 	"runtime"
 	"strings"
 
@@ -18,19 +20,35 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/writer"
 )
 
+// ErrNoListen is what the in-memory bundle's listener returns. A test whose
+// subject serves on a socket says so by supplying its own; until it does,
+// binding a port fails rather than quietly claiming one on the machine running
+// the suite.
+var ErrNoListen = errors.New("venvtest: listening is not permitted")
+
 // Cache and temp roots for the in-memory bundle. They sit under a name no real
 // machine uses, so a test that accidentally runs them against the OS filesystem
 // fails loudly instead of writing into the invoking user's directories.
 const (
 	memCacheDir = "/venvtest/cache"
 	memTempDir  = "/venvtest/tmp"
+	memWorkDir  = "/venvtest/work"
+
+	// memPID is a fixed process id, so a crash report or log line carrying it
+	// compares equal between runs.
+	memPID = 1
 )
 
 // New returns an in-memory venv: a fail-closed exec, an in-memory filesystem,
 // a fail-closed no-network HTTP client, a mem SOPS decrypter yielding empty
 // cleartext, an empty (non-nil) environment, deterministic platform handles,
-// an empty console reader, and both writers wired to [io.Discard]. Refine it
-// with venv.Venv's fluent With methods.
+// an empty console reader, a console that is no stream's terminal and has no
+// width, and both writers wired to [io.Discard]. Refine it with venv.Venv's
+// fluent With methods.
+//
+// Reporting no terminal is what a piped or captured run reports, so color and
+// wrapping stay off and output does not shift with the terminal the suite
+// happens to run under.
 //
 // A test whose subject runs a command supplies a handler through WithHandler.
 // Until it does, the command fails with [vexec.ErrNoSpawn] rather than
@@ -38,12 +56,15 @@ const (
 // stdout would take as a real answer.
 func New() *venv.Venv {
 	return &venv.Venv{
-		Exec:   vexec.NewNoSpawnExec(),
-		FS:     vfs.NewMemMapFS(),
-		HTTP:   vhttp.NewNoNetworkClient(),
-		Sops:   vsops.NewMemDecrypter(func(string, string) ([]byte, error) { return nil, nil }),
-		Reader: bufio.NewReader(strings.NewReader("")),
-		Env:    map[string]string{},
+		Exec: vexec.NewNoSpawnExec(),
+		FS:   vfs.NewMemMapFS(),
+		HTTP: vhttp.NewNoNetworkClient(),
+		Sops: vsops.NewMemDecrypter(func(string, string) ([]byte, error) { return nil, nil }),
+		Listen: func(context.Context, string, string) (net.Listener, error) {
+			return nil, ErrNoListen
+		},
+		Stdin: strings.NewReader(""),
+		Env:   map[string]string{},
 		Platform: &venv.Platform{
 			UserHomeDir: func() (string, error) {
 				return "", nil
@@ -54,7 +75,19 @@ func New() *venv.Venv {
 			TempDir: func() string {
 				return memTempDir
 			},
+			Getwd: func() (string, error) {
+				return memWorkDir, nil
+			},
+			GetPID: func() int {
+				return memPID
+			},
 			GOOS: runtime.GOOS,
+		},
+		Terminal: &venv.Terminal{
+			StdinIsTTY:  func() bool { return false },
+			StdoutIsTTY: func() bool { return false },
+			StderrIsTTY: func() bool { return false },
+			Width:       func() int { return 0 },
 		},
 		Writers: &writer.Writers{Writer: io.Discard, ErrWriter: io.Discard},
 	}

--- a/test/integration_azure_blob_test.go
+++ b/test/integration_azure_blob_test.go
@@ -40,8 +40,7 @@ func TestAzureBlobRoundTrip(t *testing.T) {
 			SubscriptionID:     sub,
 			StorageAccountName: account,
 		}).
-		WithVenv(venv.OSVenv()).
-		Build(log.New())
+		Build(log.New(), venv.OSVenv())
 	require.NoError(t, err, "Build config")
 
 	bc, err := azurehelper.NewBlobClient(cfg)

--- a/test/integration_azure_test.go
+++ b/test/integration_azure_test.go
@@ -262,8 +262,7 @@ func azureResourceGroup(ctx context.Context, t *testing.T, account string) strin
 			StorageAccountName: account,
 			UseAzureADAuth:     new(true),
 		}).
-		WithVenv(venv.OSVenv()).
-		Build(log.New())
+		Build(log.New(), venv.OSVenv())
 	require.NoError(t, err, "resolving Azure credentials")
 
 	lookupCtx, cancel := context.WithTimeout(ctx, azureLookupTimeout)
@@ -289,8 +288,7 @@ func azureTestConfig(ctx context.Context, t *testing.T, account string) *azurehe
 			StorageAccountName: account,
 			UseAzureADAuth:     new(true),
 		}).
-		WithVenv(venv.OSVenv()).
-		Build(log.New())
+		Build(log.New(), venv.OSVenv())
 	require.NoError(t, err, "resolving Azure credentials")
 
 	return cfg

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 const (
@@ -206,7 +207,7 @@ func readConfig(t *testing.T, opts *options.TerragruntOptions) *config.Terragrun
 		t.Context(),
 		l,
 		pctx,
-		config.DefaultParserOptions(l, opts.StrictControls),
+		config.DefaultParserOptions(l, venvtest.NewWithOSFS(), opts.StrictControls),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Improves coverage of venv.

As part of this, the name `fsys` has been used more consistently for the vfs parameter.

In addition, this switches over to venvtest where possible, improving hermiticity of tests. While doing this, a stdin leak was discovered, and patched by getting rid of Venv.Reader and replacing it with Venv.Stdin.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
