### PR TITLE
fix: Strip credentials before local CLI config write

### DIFF
--- a/docs/src/data/changelog/v1.1.4/generated-cli-config-credentials.mdx
+++ b/docs/src/data/changelog/v1.1.4/generated-cli-config-credentials.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.4"
+category: "bug-fixes"
+---
+
+#### Registry credentials are no longer copied into the generated CLI config
+
+When the [Provider Cache Server](/features/caching/provider-cache-server) is enabled, Terragrunt writes a CLI config for OpenTofu/Terraform into each unit's working directory, based on your own CLI config. That generated file used to include a copy of every `credentials` block from your config, including the ones for registries Terragrunt routes through the cache server.
+
+Those copies were never read. For a routed registry, Terragrunt sets the matching `TF_TOKEN_<hostname>` environment variable, which takes precedence over a `credentials` block, and the cache server presents your real credentials when it contacts the registry on your behalf. The generated file now leaves the block out for those registries, so your token stays in the CLI config you put it in instead of being duplicated somewhere it had no effect.
+
+Credentials for hosts the cache server does not route are unchanged, since OpenTofu/Terraform contacts those directly and still reads them from the generated config.

--- a/internal/providercache/local_cli_config_test.go
+++ b/internal/providercache/local_cli_config_test.go
@@ -1,0 +1,70 @@
+package providercache_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/providercache"
+	pcoptions "github.com/gruntwork-io/terragrunt/internal/providercache/options"
+	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateLocalCLIConfigStripsProxiedCredentials pins the wiring, not the stripping: drop
+// the call to [providercache.StripProxiedCredentials] and no other test notices the real
+// token returning to disk.
+func TestCreateLocalCLIConfigStripsProxiedCredentials(t *testing.T) {
+	const (
+		registry      = "registry.example.test"
+		realToken     = "REAL-REGISTRY-TOKEN"
+		cacheToken    = "11111111-2222-3333-4444-555555555555"
+		userCLIConfig = `
+credentials "` + registry + `" {
+  token = "` + realToken + `"
+}
+
+host "` + registry + `" {
+  services = {
+    "providers.v1" = "https://` + registry + `/v1/providers/"
+  }
+}
+`
+	)
+
+	rootDir := t.TempDir()
+
+	v := venv.OSVenv().WithHTTP(vhttp.NewNoNetworkClient())
+
+	userCfgPath := filepath.Join(rootDir, "user.tfrc")
+	require.NoError(t, vfs.WriteFile(v.FS, userCfgPath, []byte(userCLIConfig), 0o600))
+
+	// Both the user config Init reads and the registry list are scoped to the fake host, so
+	// resolving it never leaves the process.
+	t.Setenv("TF_CLI_CONFIG_FILE", userCfgPath)
+
+	pc := providercache.NewProviderCache()
+	require.NoError(t, pc.Init(
+		logger.CreateLogger(),
+		v,
+		&pcoptions.ProviderCacheOptions{
+			Dir:           filepath.Join(rootDir, "providers"),
+			Token:         cacheToken,
+			RegistryNames: []string{registry},
+		},
+		rootDir,
+	))
+
+	generated := filepath.Join(t.TempDir(), ".terraformrc")
+	require.NoError(t, pc.CreateLocalCLIConfig(t.Context(), v, tfimpl.OpenTofu, generated, ""))
+
+	written, err := vfs.ReadFile(v.FS, generated)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(written), realToken)
+	assert.NotContains(t, string(written), `credentials "`+registry+`"`)
+}

--- a/internal/providercache/providercache.go
+++ b/internal/providercache/providercache.go
@@ -306,7 +306,7 @@ func (pc *ProviderCache) warmUpCache(
 	)
 
 	// Create terraform cli config file that enables provider caching and does not use provider cache dir
-	if err := pc.createLocalCLIConfig(
+	if err := pc.CreateLocalCLIConfig(
 		ctx,
 		v,
 		tfOpts.TofuImplementation,
@@ -419,7 +419,7 @@ func (pc *ProviderCache) runTerraformWithCache(
 	args clihelper.Args,
 ) (*util.CmdOutput, error) {
 	// Create terraform cli config file that uses provider cache dir
-	if err := pc.createLocalCLIConfig(
+	if err := pc.CreateLocalCLIConfig(
 		ctx,
 		v,
 		tfOpts.TofuImplementation,
@@ -485,7 +485,7 @@ func argsRequestReadonlyLockfile(args []string) bool {
 	return false
 }
 
-// createLocalCLIConfig creates a local CLI config that merges the default/user configuration with our Provider Cache configuration.
+// CreateLocalCLIConfig creates a local CLI config that merges the default/user configuration with our Provider Cache configuration.
 // We don't want to use Terraform's `plugin_cache_dir` feature because the cache is populated by our Terragrunt Provider cache server, and to make sure that no Terraform process ever overwrites the global cache, we clear this value.
 // In order to force Terraform to queries our cache server instead of the original one, we use the section below.
 // https://github.com/hashicorp/terraform/issues/28309 (officially undocumented)
@@ -514,7 +514,7 @@ func argsRequestReadonlyLockfile(args []string) bool {
 // It creates two types of configuration depending on the `cacheRequestID` variable set.
 // 1. If `cacheRequestID` is set, `terraform init` does _not_ use the provider cache directory, the cache server creates a cache for requested providers and returns HTTP status 423. Since for each module we create the CLI config, using `cacheRequestID` we have the opportunity later retrieve from the cache server exactly those cached providers that were requested by `terraform init` using this configuration.
 // 2. If `cacheRequestID` is empty, 'terraform init` uses provider cache directory, the cache server acts as a proxy.
-func (pc *ProviderCache) createLocalCLIConfig(
+func (pc *ProviderCache) CreateLocalCLIConfig(
 	ctx context.Context,
 	v *venv.Venv,
 	implementation tfimpl.Type,
@@ -526,6 +526,8 @@ func (pc *ProviderCache) createLocalCLIConfig(
 
 	filteredRegistryNames := FilterRegistriesByImplementation(pc.opts.RegistryNames, implementation)
 	filteredRegistryNames = AppendCustomHostRegistries(pc.cliCfg.Hosts, filteredRegistryNames)
+
+	cfg.Credentials = StripProxiedCredentials(cfg.Credentials, filteredRegistryNames)
 
 	providerInstallationIncludes, err := pc.configureRegistryHosts(
 		ctx,
@@ -839,6 +841,30 @@ func ConvertToMultipleCommandsByPlatforms(args []string) [][]string {
 	}
 
 	return commandsArgs
+}
+
+// StripProxiedCredentials returns creds without the entries whose host is routed through the
+// cache server, keeping real registry tokens out of the generated CLI config. Those hosts
+// authenticate with the TF_TOKEN_<host> variable Terragrunt sets for exactly this set, and
+// the cache server supplies the real upstream credentials from memory. Unrouted hosts keep
+// their entry, since OpenTofu reaches them directly and no variable stands in for them.
+func StripProxiedCredentials(
+	creds []cliconfig.ConfigCredentials,
+	proxiedHosts []string,
+) []cliconfig.ConfigCredentials {
+	out := make([]cliconfig.ConfigCredentials, 0, len(creds))
+
+	for _, cred := range creds {
+		if slices.ContainsFunc(proxiedHosts, func(host string) bool {
+			return strings.EqualFold(host, cred.Name)
+		}) {
+			continue
+		}
+
+		out = append(out, cred)
+	}
+
+	return out
 }
 
 // AppendCustomHostRegistries adds custom host names from user config to the registry list

--- a/internal/providercache/strip_credentials_test.go
+++ b/internal/providercache/strip_credentials_test.go
@@ -1,0 +1,70 @@
+package providercache_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/providercache"
+	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStripProxiedCredentials pins which entries survive, in both directions: dropping an
+// unrouted host silently breaks its auth, and keeping a routed one puts a real token on disk.
+func TestStripProxiedCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		creds        []cliconfig.ConfigCredentials
+		proxiedHosts []string
+		want         []cliconfig.ConfigCredentials
+	}{
+		{
+			name:         "proxied host is dropped",
+			creds:        []cliconfig.ConfigCredentials{{Name: "registry.opentofu.org", Token: "real-token"}},
+			proxiedHosts: []string{"registry.opentofu.org"},
+			want:         []cliconfig.ConfigCredentials{},
+		},
+		{
+			name:         "unproxied host is kept",
+			creds:        []cliconfig.ConfigCredentials{{Name: "private.example.com", Token: "real-token"}},
+			proxiedHosts: []string{"registry.opentofu.org"},
+			want:         []cliconfig.ConfigCredentials{{Name: "private.example.com", Token: "real-token"}},
+		},
+		{
+			name: "only the proxied entry is dropped",
+			creds: []cliconfig.ConfigCredentials{
+				{Name: "registry.opentofu.org", Token: "registry-token"},
+				{Name: "private.example.com", Token: "private-token"},
+			},
+			proxiedHosts: []string{"registry.opentofu.org"},
+			want:         []cliconfig.ConfigCredentials{{Name: "private.example.com", Token: "private-token"}},
+		},
+		{
+			name:         "host match ignores case",
+			creds:        []cliconfig.ConfigCredentials{{Name: "Registry.OpenTofu.org", Token: "real-token"}},
+			proxiedHosts: []string{"registry.opentofu.org"},
+			want:         []cliconfig.ConfigCredentials{},
+		},
+		{
+			name:         "no proxied hosts keeps every entry",
+			creds:        []cliconfig.ConfigCredentials{{Name: "registry.opentofu.org", Token: "real-token"}},
+			proxiedHosts: nil,
+			want:         []cliconfig.ConfigCredentials{{Name: "registry.opentofu.org", Token: "real-token"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			unchanged := slices.Clone(tt.creds)
+
+			got := providercache.StripProxiedCredentials(tt.creds, tt.proxiedHosts)
+
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, unchanged, tt.creds, "the caller's slice must not be mutated")
+		})
+	}
+}

--- a/internal/tf/cliconfig/config.go
+++ b/internal/tf/cliconfig/config.go
@@ -3,6 +3,7 @@ package cliconfig
 
 import (
 	"maps"
+	"slices"
 
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -137,7 +138,7 @@ func (cfg *Config) Clone() *Config {
 		PluginCacheDir:             cfg.PluginCacheDir,
 		DisableCheckpoint:          cfg.DisableCheckpoint,
 		DisableCheckpointSignature: cfg.DisableCheckpointSignature,
-		Credentials:                cfg.Credentials,
+		Credentials:                slices.Clone(cfg.Credentials),
 		CredentialsHelpers:         cfg.CredentialsHelpers,
 		Hosts:                      hosts,
 		ProviderInstallation:       providerInstallation,

--- a/internal/tf/cliconfig/config_test.go
+++ b/internal/tf/cliconfig/config_test.go
@@ -210,3 +210,21 @@ disable_checkpoint_signature = false
 		})
 	}
 }
+
+// TestCloneCredentialsAreIndependent pins that rewriting a clone's tokens leaves the source
+// config untouched. That source is what the cache server reads to authenticate upstream, so
+// sharing the backing array would swap the real token out from under it.
+func TestCloneCredentialsAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	original := cliconfig.NewConfig(vfs.NewOSFS())
+	original.Credentials = []cliconfig.ConfigCredentials{
+		{Name: "registry.opentofu.org", Token: "real-token"},
+	}
+
+	clone := original.Clone()
+	clone.Credentials[0].Token = "substituted-token"
+
+	assert.Equal(t, "real-token", original.Credentials[0].Token)
+	assert.Equal(t, "substituted-token", clone.Credentials[0].Token)
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Strips unread tokens from the generated CLI configs for unit runs with the provider cache server active.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated Terraform/OpenTofu CLI configurations no longer include registry credentials for providers routed through the Provider Cache Server.
  * Routed registries now rely on cache-server authentication, while credentials for non-routed registries remain unchanged.
  * Improved configuration cloning to prevent credential changes from affecting the original configuration.

* **Documentation**
  * Added a v1.1.4 changelog entry describing the credential-handling fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->