### PR TITLE
chore: Wire expansion into dependency parse

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -767,10 +767,11 @@ type terragruntConfigFile struct {
 	IamAssumeRoleDuration    *int64              `hcl:"iam_assume_role_duration,attr"`
 	IamAssumeRoleSessionName *string             `hcl:"iam_assume_role_session_name,attr"`
 	IamWebIdentityToken      *string             `hcl:"iam_web_identity_token,attr"`
-	TerragruntDependencies   []Dependency        `hcl:"dependency,block"`
-	FeatureFlags             []*FeatureFlag      `hcl:"feature,block"`
-	Exclude                  *ExcludeConfig      `hcl:"exclude,block"`
-	Errors                   *ErrorsConfig       `hcl:"errors,block"`
+	DependencyBlocks         []dependencyHeader  `hcl:"dependency,block"`
+	TerragruntDependencies   []Dependency
+	FeatureFlags             []*FeatureFlag `hcl:"feature,block"`
+	Exclude                  *ExcludeConfig `hcl:"exclude,block"`
+	Errors                   *ErrorsConfig  `hcl:"errors,block"`
 
 	// We allow users to configure code generation via blocks:
 	//
@@ -803,6 +804,14 @@ type terragruntConfigFile struct {
 // routine that allows references to the other locals in the same block.
 type terragruntLocal struct {
 	Remain hcl.Body `hcl:",remain"`
+}
+
+// dependencyHeader keeps `dependency` in the config file's schema without evaluating the
+// block body. A block that expands has to be decoded once per element with
+// each.*/count.index bound, which a single whole-file decode cannot express.
+type dependencyHeader struct {
+	Remain hcl.Body `hcl:",remain"`
+	Name   string   `hcl:",label"`
 }
 
 type terragruntIncludeIgnore struct {
@@ -1828,6 +1837,13 @@ func decodeAsTerragruntConfigFile(
 
 		l.Debugf("Deferred attribute access error to autoinclude merge: %v", diagErr)
 	}
+
+	dependencies, err := decodeDependencyBlocks(file, evalContext, pctx.Experiments)
+	if err != nil {
+		return &terragruntConfig, err
+	}
+
+	terragruntConfig.TerragruntDependencies = dependencies
 
 	if terragruntConfig.Inputs != nil {
 		inputs, err := ctyhelper.UpdateUnknownCtyValValues(*terragruntConfig.Inputs)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -807,8 +807,7 @@ type terragruntLocal struct {
 }
 
 // dependencyHeader keeps `dependency` in the config file's schema without evaluating the
-// block body. A block that expands has to be decoded once per element with
-// each.*/count.index bound, which a single whole-file decode cannot express.
+// block body.
 type dependencyHeader struct {
 	Remain hcl.Body `hcl:",remain"`
 	Name   string   `hcl:",label"`

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -735,12 +735,16 @@ func PartialParseConfig(
 			}
 
 		case DependencyBlock:
-			decoded := TerragruntDependency{}
-
-			err := file.Decode(&decoded, evalParsingContext)
+			decodedDeps, err := decodeDependencyBlocks(
+				file,
+				evalParsingContext,
+				pctx.Experiments,
+			)
 			if err != nil {
 				return nil, err
 			}
+
+			decoded := TerragruntDependency{Dependencies: decodedDeps}
 
 			// In normal operation, if a dependency block does not have a `config_path` attribute, decoding returns an error since this attribute is required, but the `hclvalidate` command suppresses decoding errors and this causes a cycle between modules, so we need to filter out dependencies without a defined `config_path`.
 			decoded.Dependencies = decoded.Dependencies.FilteredWithoutConfigPath()

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -269,8 +269,6 @@ func decodeDependencyBlocks(
 		return nil, err
 	}
 
-	// A config with no dependency blocks keeps the nil slice the whole-file decode used to
-	// leave behind, which callers compare against.
 	if len(instances) == 0 {
 		return nil, nil
 	}

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -28,6 +28,7 @@ import (
 	s3backend "github.com/gruntwork-io/terragrunt/internal/remotestate/backend/s3"
 
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
@@ -203,6 +204,18 @@ func (dep *Dependency) isDisabled() bool {
 	return !dep.isEnabled()
 }
 
+// mergeKey identifies a dependency when include merging matches blocks up. Every instance
+// of an expanded block carries the same label, so matching on the label alone would fold a
+// whole set into whichever instance came last. A block that declares an expansion but has
+// not been expanded yet still merges by label, since merging runs on declarations too.
+func (dep *Dependency) mergeKey() string {
+	if dep.Expansion == nil || dep.Expansion.Key() == "" {
+		return dep.Name
+	}
+
+	return dep.Name + "[" + dep.Expansion.Key() + "]"
+}
+
 // Given a dependency config, we should only attempt to merge mocks outputs with the outputs if MockOutputsMergeWithState is not nil or true
 func (dep *Dependency) shouldMergeMockOutputsWithState(ctx *ParsingContext) bool {
 	allowedCommand :=
@@ -244,6 +257,46 @@ func outputLocksFromContext(ctx context.Context) *util.KeyLocks {
 	return util.NewKeyLocks()
 }
 
+// decodeDependencyBlocks decodes a config's dependency blocks, returning one Dependency
+// per iteration element. A block that declares no expansion yields a single Dependency.
+func decodeDependencyBlocks(
+	file *hclparse.File,
+	evalContext *hcl.EvalContext,
+	experiments experiment.Experiments,
+) (Dependencies, error) {
+	instances, err := file.ExpandBlocks(MetadataDependency, &Dependency{}, evalContext)
+	if err != nil {
+		return nil, err
+	}
+
+	// A config with no dependency blocks keeps the nil slice the whole-file decode used to
+	// leave behind, which callers compare against.
+	if len(instances) == 0 {
+		return nil, nil
+	}
+
+	dependencies := make(Dependencies, 0, len(instances))
+
+	for _, instance := range instances {
+		dep := instance.Value.(*Dependency)
+		if dep.Expansion != nil {
+			if !experiments.Evaluate(experiment.BlockIteration) {
+				return nil, ExpansionRequiresExperimentError{
+					ConfigPath: file.ConfigPath,
+					BlockType:  MetadataDependency,
+					BlockLabel: dep.Name,
+				}
+			}
+
+			dep.Expansion.InstanceKey = instance.InstanceKey
+		}
+
+		dependencies = append(dependencies, *dep)
+	}
+
+	return dependencies, nil
+}
+
 // Decode the dependency blocks from the file, and then retrieve all the outputs from the remote state. Then encode the
 // resulting map as a cty.Value object.
 // TODO: In the future, consider allowing importing dependency blocks from included config
@@ -261,10 +314,12 @@ func decodeAndRetrieveOutputs(
 		return nil, err
 	}
 
-	decodedDependency := TerragruntDependency{}
-	if err := file.Decode(&decodedDependency, evalParsingContext); err != nil {
+	dependencies, err := decodeDependencyBlocks(file, evalParsingContext, pctx.Experiments)
+	if err != nil {
 		return nil, err
 	}
+
+	decodedDependency := TerragruntDependency{Dependencies: dependencies}
 
 	// In normal operation, if a dependency block does not have a `config_path` attribute, decoding returns an error since this attribute is required, but the `hclvalidate` command suppresses decoding errors and this causes a cycle between modules, so we need to filter out dependencies without a defined `config_path`.
 	decodedDependency.Dependencies = decodedDependency.Dependencies.FilteredWithoutConfigPath()

--- a/pkg/config/expansion.go
+++ b/pkg/config/expansion.go
@@ -20,8 +20,7 @@ var expansionCapableBlocks = []string{MetadataDependency, MetadataUnit, Metadata
 // instead of rejecting it. Without this pass a user who writes expansion without the
 // experiment watches the block silently do nothing.
 //
-// JSON configs parse into a body this cannot walk, so they fall through to the decoder's
-// own unsupported-block error rather than the message naming the flag.
+// JSON configs parse into a body this cannot walk, so this pass does not cover them.
 func ValidateExpansionExperiment(experiments experiment.Experiments, file *hclparse.File) error {
 	if experiments.Evaluate(experiment.BlockIteration) {
 		return nil

--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -2,7 +2,9 @@ package config_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
@@ -36,6 +38,12 @@ unit "app" {
   source = "./modules/app"
   path   = "app"
 }
+`
+
+const jsonConfigPath = "terragrunt.hcl.json"
+
+const jsonDependencyWithExpansion = `
+{"dependency": {"aurora": {"expansion": {"count": 2}, "config_path": "../aurora-${count.index}"}}}
 `
 
 const stackWithExpansionHCL = `
@@ -320,23 +328,315 @@ func TestExpansionRequiresExperimentErrorNamesTheFlag(t *testing.T) {
 	assert.NotContains(t, unlabeled.Error(), `""`)
 }
 
-func TestDependencyDecodesExpansionBlock(t *testing.T) {
+func TestDependencyExpandsForEach(t *testing.T) {
 	t.Parallel()
 
-	cfg, err := parseDependencyString(t, dependencyWithExpansionHCL)
+	cfg, err := parseDependencyString(t, `
+dependency "aurora" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  config_path = "../${each.value}/aurora"
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, cfg.TerragruntDependencies, 2)
+
+	keys := make([]string, 0, len(cfg.TerragruntDependencies))
+	paths := make([]string, 0, len(cfg.TerragruntDependencies))
+
+	for _, dep := range cfg.TerragruntDependencies {
+		require.NotNil(t, dep.Expansion)
+		assert.Equal(t, "aurora", dep.Name)
+
+		keys = append(keys, dep.Expansion.Key())
+		paths = append(paths, dep.ConfigPath.AsString())
+	}
+
+	assert.ElementsMatch(t, []string{"web", "api"}, keys)
+	assert.ElementsMatch(t, []string{"../web/aurora", "../api/aurora"}, paths)
+}
+
+func TestDependencyExpandsCount(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyString(t, `
+dependency "shard" {
+  expansion {
+    count = 3
+  }
+
+  config_path = "../shard-${count.index}"
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, cfg.TerragruntDependencies, 3)
+
+	for index, dep := range cfg.TerragruntDependencies {
+		require.NotNil(t, dep.Expansion)
+		assert.Equal(t, strconv.Itoa(index), dep.Expansion.Key())
+		assert.Equal(t, "../shard-"+strconv.Itoa(index), dep.ConfigPath.AsString())
+	}
+}
+
+// TestDependencyExpansionResolvesPerInstance covers attributes other than config_path
+// resolving separately per element.
+func TestDependencyExpansionResolvesPerInstance(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyString(t, `
+locals {
+  regions = {
+    use1 = true
+    usw2 = false
+  }
+}
+
+dependency "vpc" {
+  expansion {
+    for_each = local.regions
+  }
+
+  config_path = "../${each.key}/vpc"
+  enabled     = each.value
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, cfg.TerragruntDependencies, 2)
+
+	enabled := map[string]bool{}
+
+	for _, dep := range cfg.TerragruntDependencies {
+		require.NotNil(t, dep.Enabled)
+		enabled[dep.Expansion.Key()] = *dep.Enabled
+	}
+
+	assert.Equal(t, map[string]bool{"use1": true, "usw2": false}, enabled)
+}
+
+// TestDisabledExpandedDependencySkipsOutputRetrieval covers a whole disabled set: every
+// instance points at a directory that does not exist, so the parse only succeeds if none
+// of them went looking for outputs.
+func TestDisabledExpandedDependencySkipsOutputRetrieval(t *testing.T) {
+	t.Parallel()
+
+	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+
+	cfg, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		`
+dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  enabled     = false
+  config_path = "../no-such-unit-${count.index}"
+}
+`,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, cfg.TerragruntDependencies, 2)
+
+	for _, dep := range cfg.TerragruntDependencies {
+		require.NotNil(t, dep.Enabled)
+		assert.False(t, *dep.Enabled)
+		assert.Nil(t, dep.RenderedOutputs)
+	}
+}
+
+// TestIncludeMergeKeepsEveryExpandedInstance covers an expanded set surviving an include
+// merge, which matches dependencies up by label.
+func TestIncludeMergeKeepsEveryExpandedInstance(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		mergeStrategy string
+	}{
+		{name: "shallow merge"},
+		{name: "deep merge", mergeStrategy: `merge_strategy = "deep"`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+
+			require.NoError(t, os.MkdirAll(filepath.Join(dir, "network"), 0o755))
+			require.NoError(t, os.MkdirAll(filepath.Join(dir, "logging"), 0o755))
+
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "root.hcl"), []byte(`
+dependencies {
+  paths = ["./network"]
+}
+
+dependency "vpc" {
+  enabled     = false
+  config_path = "../vpc"
+}
+`), 0o644))
+
+			configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
+			require.NoError(t, os.WriteFile(configPath, []byte(`
+include "root" {
+  path = "root.hcl"
+  `+tc.mergeStrategy+`
+}
+
+dependencies {
+  paths = ["./logging"]
+}
+
+dependency "shard" {
+  expansion {
+    count = 3
+  }
+
+  enabled     = false
+  config_path = "../shard-${count.index}"
+}
+`), 0o644))
+
+			ctx, pctx := newExpansionParsingContext(t, configPath)
+
+			cfg, err := config.ParseConfigFile(ctx, pctx, logger.CreateLogger(), configPath, nil)
+			require.NoError(t, err)
+
+			keys := make([]string, 0, len(cfg.TerragruntDependencies))
+
+			for _, dep := range cfg.TerragruntDependencies {
+				if dep.Name == "shard" {
+					keys = append(keys, dep.Expansion.Key())
+				}
+			}
+
+			assert.Equal(t, []string{"0", "1", "2"}, keys)
+		})
+	}
+}
+
+// TestExpandedDependencyCarriesItsOwnOutputConfig covers each instance resolving its own
+// mock outputs. Retrieved outputs cannot be told apart per instance yet: the cty map they
+// land in is still keyed by label alone.
+func TestExpandedDependencyCarriesItsOwnOutputConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+
+	cfg, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		`
+dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  config_path  = "../shard-${count.index}"
+  skip_outputs = true
+
+  mock_outputs = {
+    id = "shard-${count.index}"
+  }
+}
+`,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, cfg.TerragruntDependencies, 2)
+
+	outputs := map[string]string{}
+
+	for _, dep := range cfg.TerragruntDependencies {
+		require.NotNil(t, dep.MockOutputs)
+		outputs[dep.Expansion.Key()] = dep.MockOutputs.GetAttr("id").AsString()
+	}
+
+	assert.Equal(t, map[string]string{"0": "shard-0", "1": "shard-1"}, outputs)
+}
+
+// TestJSONConfigDecodesDependencies covers the JSON syntax the expansion-aware decode has
+// to keep serving.
+func TestJSONConfigDecodesDependencies(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyJSONString(t, `
+{"dependency": {"vpc": {"config_path": "../vpc", "enabled": false}}}
+`)
 	require.NoError(t, err)
 	require.Len(t, cfg.TerragruntDependencies, 1)
 
-	dep := cfg.TerragruntDependencies[0]
-	require.NotNil(t, dep.Expansion)
-	require.NotNil(t, dep.Expansion.ForEach)
+	assert.Equal(t, "vpc", cfg.TerragruntDependencies[0].Name)
+	assert.Equal(t, cty.StringVal("../vpc"), cfg.TerragruntDependencies[0].ConfigPath)
+	assert.Nil(t, cfg.TerragruntDependencies[0].Expansion)
+}
 
-	assert.Equal(
-		t,
-		cty.SetVal([]cty.Value{cty.StringVal("web"), cty.StringVal("api")}),
-		*dep.Expansion.ForEach,
+func TestJSONConfigExpandsDependencies(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyJSONString(t, jsonDependencyWithExpansion)
+	require.NoError(t, err)
+	require.Len(t, cfg.TerragruntDependencies, 2)
+
+	paths := make([]string, 0, len(cfg.TerragruntDependencies))
+	for _, dep := range cfg.TerragruntDependencies {
+		paths = append(paths, dep.ConfigPath.AsString())
+	}
+
+	assert.Equal(t, []string{"../aurora-0", "../aurora-1"}, paths)
+}
+
+func TestJSONExpansionRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	skipInExperimentMode(t)
+
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), jsonConfigPath)
+
+	_, err := config.PartialParseConfigString(
+		ctx,
+		pctx.WithDecodeList(config.DependencyBlock),
+		logger.CreateLogger(),
+		jsonConfigPath,
+		jsonDependencyWithExpansion,
+		nil,
 	)
-	assert.Nil(t, dep.Expansion.Count)
+
+	var typed config.ExpansionRequiresExperimentError
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, "dependency", typed.BlockType)
+	assert.Equal(t, "aurora", typed.BlockLabel)
+}
+
+// TestUnknownBlockRemainsRejected guards against the header-only dependency decode
+// loosening the strict schema into absorbing unrecognized blocks as remainder.
+func TestUnknownBlockRemainsRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+
+	_, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		`
+bogus "x" {
+  foo = 1
+}
+`,
+		nil,
+	)
+	require.Error(t, err)
 }
 
 func TestUnitAndStackDecodeExpansionBlock(t *testing.T) {
@@ -533,6 +833,24 @@ func parseDependencyErr(tb testing.TB, cfg string) error {
 	_, err := parseDependencyString(tb, cfg)
 
 	return err
+}
+
+func parseDependencyJSONString(
+	tb testing.TB,
+	cfg string,
+) (*config.TerragruntConfig, error) {
+	tb.Helper()
+
+	ctx, pctx := newExpansionParsingContext(tb, jsonConfigPath)
+
+	return config.PartialParseConfigString(
+		ctx,
+		pctx.WithDecodeList(config.DependencyBlock),
+		logger.CreateLogger(),
+		jsonConfigPath,
+		cfg,
+		nil,
+	)
 }
 
 func parseStackString(tb testing.TB, cfg string) (*config.StackConfig, error) {

--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -415,9 +415,8 @@ dependency "vpc" {
 	assert.Equal(t, map[string]bool{"use1": true, "usw2": false}, enabled)
 }
 
-// TestDisabledExpandedDependencySkipsOutputRetrieval covers a whole disabled set: every
-// instance points at a directory that does not exist, so the parse only succeeds if none
-// of them went looking for outputs.
+// TestDisabledExpandedDependencySkipsOutputRetrieval points every instance at a directory
+// that does not exist, so the parse only succeeds if none of them went looking for outputs.
 func TestDisabledExpandedDependencySkipsOutputRetrieval(t *testing.T) {
 	t.Parallel()
 
@@ -450,8 +449,6 @@ dependency "shard" {
 	}
 }
 
-// TestIncludeMergeKeepsEveryExpandedInstance covers an expanded set surviving an include
-// merge, which matches dependencies up by label.
 func TestIncludeMergeKeepsEveryExpandedInstance(t *testing.T) {
 	t.Parallel()
 
@@ -523,8 +520,7 @@ dependency "shard" {
 }
 
 // TestExpandedDependencyCarriesItsOwnOutputConfig covers each instance resolving its own
-// mock outputs. Retrieved outputs cannot be told apart per instance yet: the cty map they
-// land in is still keyed by label alone.
+// mock outputs.
 func TestExpandedDependencyCarriesItsOwnOutputConfig(t *testing.T) {
 	t.Parallel()
 
@@ -564,8 +560,6 @@ dependency "shard" {
 	assert.Equal(t, map[string]string{"0": "shard-0", "1": "shard-1"}, outputs)
 }
 
-// TestJSONConfigDecodesDependencies covers the JSON syntax the expansion-aware decode has
-// to keep serving.
 func TestJSONConfigDecodesDependencies(t *testing.T) {
 	t.Parallel()
 
@@ -617,8 +611,6 @@ func TestJSONExpansionRequiresExperiment(t *testing.T) {
 	assert.Equal(t, "aurora", typed.BlockLabel)
 }
 
-// TestUnknownBlockRemainsRejected guards against the header-only dependency decode
-// loosening the strict schema into absorbing unrecognized blocks as remainder.
 func TestUnknownBlockRemainsRejected(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/hclparse/expansion.go
+++ b/pkg/config/hclparse/expansion.go
@@ -1,8 +1,10 @@
 package hclparse
 
 import (
+	"errors"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -26,6 +28,8 @@ const (
 	countIndexAttrName = "index"
 
 	forEachElementLabel = forEachAttrName + " element"
+
+	labelTagKind = "label"
 )
 
 // DefaultMaxInstances bounds how many instances a single block may expand into,
@@ -87,6 +91,60 @@ func (key InstanceKey) Key() string {
 type Instance struct {
 	Value any
 	InstanceKey
+}
+
+// ExpandBlocks decodes every blockType block in the file through [ExpandBlock],
+// returning the instances in file order.
+//
+// A block whose diagnostics the parser is configured to swallow (hclvalidate, the LSP)
+// is dropped from the result rather than failing the file, so those callers keep parsing
+// best-effort.
+func (file *File) ExpandBlocks(
+	blockType string,
+	out any,
+	ctx *hcl.EvalContext,
+	opts ...ExpandOption,
+) ([]Instance, error) {
+	if file.fileUpdateHandlerFunc != nil {
+		if err := file.fileUpdateHandlerFunc(file); err != nil {
+			return nil, err
+		}
+	}
+
+	labels := labelFields(reflect.TypeOf(out).Elem())
+	labelNames := make([]string, 0, len(labels))
+
+	for _, label := range labels {
+		labelNames = append(labelNames, label.name)
+	}
+
+	content, _, diags := file.Body.PartialContent(&hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{{Type: blockType, LabelNames: labelNames}},
+	})
+	if err := file.HandleDiagnostics(diags); err != nil {
+		return nil, err
+	}
+
+	instances := make([]Instance, 0, len(content.Blocks))
+
+	for _, block := range content.Blocks {
+		expanded, err := ExpandBlock(block, out, ctx, opts...)
+		if err == nil {
+			instances = append(instances, expanded...)
+			continue
+		}
+
+		var blockDiags hcl.Diagnostics
+		if !errors.As(err, &blockDiags) {
+			return nil, err
+		}
+
+		if err := file.HandleDiagnostics(blockDiags); err != nil {
+			return nil, err
+		}
+	}
+
+	return instances, nil
 }
 
 // ExpandBlock decodes block once per iteration element, returning one Instance per
@@ -360,11 +418,42 @@ func expansionKey(key cty.Value, subject *hcl.Range) (string, error) {
 // decodeInstance decodes the whole block body, expansion sub-block included, into a
 // fresh value of outType.
 func decodeInstance(block *hcl.Block, outType reflect.Type, ctx *hcl.EvalContext) (any, error) {
-	instance := reflect.New(outType.Elem()).Interface()
+	instance := reflect.New(outType.Elem())
 
-	if diags := gohcl.DecodeBody(block.Body, ctx, instance); diags.HasErrors() {
+	if diags := gohcl.DecodeBody(block.Body, ctx, instance.Interface()); diags.HasErrors() {
 		return nil, diags
 	}
 
-	return instance, nil
+	// gohcl fills label fields only when it reaches a block through its parent body.
+	// Expansion decodes the body directly, so labels are assigned here instead.
+	for i, field := range labelFields(outType.Elem()) {
+		if i >= len(block.Labels) {
+			break
+		}
+
+		instance.Elem().Field(field.index).SetString(block.Labels[i])
+	}
+
+	return instance.Interface(), nil
+}
+
+type labelField struct {
+	name  string
+	index int
+}
+
+// labelFields returns the `hcl:",label"` fields of a block struct, in declaration order.
+func labelFields(structType reflect.Type) []labelField {
+	fields := make([]labelField, 0, structType.NumField())
+
+	for i := range structType.NumField() {
+		name, kind, found := strings.Cut(structType.Field(i).Tag.Get("hcl"), ",")
+		if !found || kind != labelTagKind {
+			continue
+		}
+
+		fields = append(fields, labelField{name: name, index: i})
+	}
+
+	return fields
 }

--- a/pkg/config/hclparse/expansion.go
+++ b/pkg/config/hclparse/expansion.go
@@ -424,8 +424,7 @@ func decodeInstance(block *hcl.Block, outType reflect.Type, ctx *hcl.EvalContext
 		return nil, diags
 	}
 
-	// gohcl fills label fields only when it reaches a block through its parent body.
-	// Expansion decodes the body directly, so labels are assigned here instead.
+	// gohcl assigns label fields only when it decodes a block through its parent body.
 	for i, field := range labelFields(outType.Elem()) {
 		if i >= len(block.Labels) {
 			break

--- a/pkg/config/hclparse/expansion_test.go
+++ b/pkg/config/hclparse/expansion_test.go
@@ -13,6 +13,7 @@ import (
 
 type testBlock struct {
 	Expansion *hclparse.ExpansionBlock `hcl:"expansion,block"`
+	Name      string                   `hcl:",label"`
 	Path      string                   `hcl:"path,attr"`
 }
 
@@ -553,6 +554,90 @@ dependency "a" {
 			require.Error(t, err)
 		})
 	}
+}
+
+// TestExpandBlockAssignsLabels covers the label field that decoding a block body on its
+// own would otherwise leave empty.
+func TestExpandBlockAssignsLabels(t *testing.T) {
+	t.Parallel()
+
+	instances, err := expand(t, `
+dependency "aurora" {
+  expansion {
+    count = 2
+  }
+
+  path = "../${count.index}"
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, instances, 2)
+
+	for _, inst := range instances {
+		assert.Equal(t, "aurora", inst.Value.(*testBlock).Name)
+	}
+}
+
+func TestExpandBlocksReadsEveryBlockInAFile(t *testing.T) {
+	t.Parallel()
+
+	file, err := hclparse.NewParser().ParseFromString(`
+dependency "vpc" {
+  path = "../vpc"
+}
+
+dependency "aurora" {
+  expansion {
+    for_each = {
+      web = "frontend"
+      api = "backend"
+    }
+  }
+
+  path = "../${each.value}"
+}
+`, "terragrunt.hcl")
+	require.NoError(t, err)
+
+	instances, err := file.ExpandBlocks("dependency", new(testBlock), nil)
+	require.NoError(t, err)
+	require.Len(t, instances, 3)
+
+	assert.Equal(t, "vpc", instances[0].Value.(*testBlock).Name)
+	assert.Empty(t, instances[0].Key())
+
+	assert.ElementsMatch(t, []string{"web", "api"}, keysOf(instances[1:]))
+}
+
+// TestExpandBlocksDropsBlocksWithSwallowedDiagnostics covers a block the handler forgives
+// leaving the result instead of failing the whole file.
+func TestExpandBlocksDropsBlocksWithSwallowedDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	parser := hclparse.NewParser(
+		hclparse.WithDiagnosticsHandler(
+			func(_ *hcl.File, _ hcl.Diagnostics) (hcl.Diagnostics, error) {
+				return nil, nil
+			},
+		),
+	)
+
+	file, err := parser.ParseFromString(`
+dependency "broken" {
+  path = local.undefined
+}
+
+dependency "vpc" {
+  path = "../vpc"
+}
+`, "terragrunt.hcl")
+	require.NoError(t, err)
+
+	instances, err := file.ExpandBlocks("dependency", new(testBlock), nil)
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+
+	assert.Equal(t, "vpc", instances[0].Value.(*testBlock).Name)
 }
 
 func expand(

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -638,7 +638,8 @@ func (cfg *TerragruntConfig) DeepMerge(l log.Logger, sourceConfig *TerragruntCon
 	return nil
 }
 
-// fetchDependencyPaths - return from configuration map with dependency_name: path
+// fetchDependencyPaths returns each dependency's config path, keyed the way include
+// merging matches dependencies up.
 func fetchDependencyPaths(config *TerragruntConfig) map[string]string {
 	var m = make(map[string]string)
 	if config == nil {
@@ -646,7 +647,7 @@ func fetchDependencyPaths(config *TerragruntConfig) map[string]string {
 	}
 
 	for _, dependency := range config.TerragruntDependencies {
-		m[dependency.Name] = dependency.ConfigPath.AsString()
+		m[dependency.mergeKey()] = dependency.ConfigPath.AsString()
 	}
 
 	return m
@@ -697,17 +698,17 @@ func mergeDependencyBlocks(
 
 	dependencyBlocks := make(map[string]Dependency)
 	for _, dep := range targetDependencies {
-		dependencyBlocks[dep.Name] = dep
-		keys = append(keys, dep.Name)
+		dependencyBlocks[dep.mergeKey()] = dep
+		keys = append(keys, dep.mergeKey())
 	}
 
 	for _, dep := range sourceDependencies {
-		_, hasSameKey := dependencyBlocks[dep.Name]
+		_, hasSameKey := dependencyBlocks[dep.mergeKey()]
 		if !hasSameKey {
-			keys = append(keys, dep.Name)
+			keys = append(keys, dep.mergeKey())
 		}
 		// Regardless of what is in dependencyBlocks, we will always override the key with source
-		dependencyBlocks[dep.Name] = dep
+		dependencyBlocks[dep.mergeKey()] = dep
 	}
 	// Now convert the map to list and set target
 	combinedDeps := make([]Dependency, 0, len(keys))
@@ -731,22 +732,22 @@ func deepMergeDependencyBlocks(
 
 	dependencyBlocks := make(map[string]Dependency)
 	for _, dep := range targetDependencies {
-		dependencyBlocks[dep.Name] = dep
-		keys = append(keys, dep.Name)
+		dependencyBlocks[dep.mergeKey()] = dep
+		keys = append(keys, dep.mergeKey())
 	}
 
 	for _, dep := range sourceDependencies {
-		sameKeyDep, hasSameKey := dependencyBlocks[dep.Name]
+		sameKeyDep, hasSameKey := dependencyBlocks[dep.mergeKey()]
 		if hasSameKey {
 			sameKeyDepPtr := &sameKeyDep
 			if err := sameKeyDepPtr.DeepMerge(&dep); err != nil {
 				return nil, err
 			}
 
-			dependencyBlocks[dep.Name] = *sameKeyDepPtr
+			dependencyBlocks[dep.mergeKey()] = *sameKeyDepPtr
 		} else {
-			dependencyBlocks[dep.Name] = dep
-			keys = append(keys, dep.Name)
+			dependencyBlocks[dep.mergeKey()] = dep
+			keys = append(keys, dep.mergeKey())
 		}
 	}
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Updates the `block-expansion` experiment with `dependency` expansion.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dependency blocks can now be expanded with `for_each` and `count`.
  - Each expanded dependency instance resolves its own configuration and mock outputs.
  - JSON configuration files support dependency blocks and dependency expansion.
  - Include merging preserves and distinguishes expanded dependency instances.

- **Bug Fixes**
  - Disabled dependencies no longer attempt unnecessary output retrieval.
  - Invalid or unsupported dependency blocks continue to produce clear validation errors.
  - Expansion now handles diagnostics without discarding valid dependency blocks.
  - Dependency expansion requires the appropriate experiment setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->