### PR TITLE
docs: give each environment its own state backup path in the Terralith guide

### DIFF
--- a/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/09-step-6-breaking-the-terralith-further.mdx
+++ b/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/09-step-6-breaking-the-terralith-further.mdx
@@ -105,21 +105,29 @@ We should now have a file tree that looks like the following (we'll be getting r
 
 It's time to engage in our favorite solution for IaC refactoring, state manipulation!
 
-We're going to use the tools we've learned so far, and *pull* state from those two top-level units, then *push* them into the constituent units we've broken the megamodule down into. We expect to need to both move resource addresses in state, and forget particular resources to avoid accidentally destroying anything.
+We're going to *pull* state from those two top-level units, then *push* it into the constituent units we've broken the megamodule down into. These are two commands we haven't used yet: `terragrunt state pull` writes the current state of a unit to standard output, and `terragrunt state push` replaces the state of a unit with the contents of a file.
 
-<Code title="live/dev" lang="bash" frame="terminal" code={`terragrunt state pull > /tmp/tofu.tfstate
-cd ddb && terragrunt state push /tmp/tofu.tfstate
-cd ../iam && terragrunt state push /tmp/tofu.tfstate
-cd ../lambda && terragrunt state push /tmp/tofu.tfstate
-cd ../s3 && terragrunt state push /tmp/tofu.tfstate
+Each environment gets its own file so that the `dev` and `prod` pulls don't clobber each other.
+
+<Code title="live/dev" lang="bash" frame="terminal" code={`terragrunt state pull > /tmp/tofu-dev.tfstate
+cd ddb && terragrunt state push /tmp/tofu-dev.tfstate
+cd ../iam && terragrunt state push /tmp/tofu-dev.tfstate
+cd ../lambda && terragrunt state push /tmp/tofu-dev.tfstate
+cd ../s3 && terragrunt state push /tmp/tofu-dev.tfstate
 `} />
 
-<Code title="live/prod" lang="bash" frame="terminal" code={`terragrunt state pull > /tmp/tofu.tfstate
-cd ddb && terragrunt state push /tmp/tofu.tfstate
-cd ../iam && terragrunt state push /tmp/tofu.tfstate
-cd ../lambda && terragrunt state push /tmp/tofu.tfstate
-cd ../s3 && terragrunt state push /tmp/tofu.tfstate
+<Code title="live/prod" lang="bash" frame="terminal" code={`terragrunt state pull > /tmp/tofu-prod.tfstate
+cd ddb && terragrunt state push /tmp/tofu-prod.tfstate
+cd ../iam && terragrunt state push /tmp/tofu-prod.tfstate
+cd ../lambda && terragrunt state push /tmp/tofu-prod.tfstate
+cd ../s3 && terragrunt state push /tmp/tofu-prod.tfstate
 `} />
+
+Every unit now has a complete copy of its environment's state. We expect to need to both move resource addresses in state, and forget particular resources to avoid accidentally destroying anything.
+
+<Aside type="note">
+Those two files hold each environment's state as it was before the migration, so hold on to them until you've confirmed that the migration worked. Pushing one back into a unit rewinds that unit to the environment state you started with, which is how you'd retry if you get one of the moves or removes wrong. OpenTofu refuses to push a state file older than the one already in the backend, so you'll want to pass `-force` when you do.
+</Aside>
 
 We can now clean up the extraneous files mentioned earlier at the root of the environments.
 

--- a/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/11-step-8-refactoring-state-with-terragrunt-stacks.mdx
+++ b/docs/src/content/docs/02-guides/01-terralith-to-terragrunt/11-step-8-refactoring-state-with-terragrunt-stacks.mdx
@@ -180,40 +180,42 @@ To migrate state from the old unit paths to the new paths, we can run the follow
 
 <Code title="live" lang="bash" frame="terminal" code={`# Migrate dev state
 cd dev/ddb
-terragrunt state pull > /tmp/tofu.tfstate
+terragrunt state pull > /tmp/tofu-dev-ddb.tfstate
 cd ../.terragrunt-stack/ddb
-terragrunt state push /tmp/tofu.tfstate
+terragrunt state push /tmp/tofu-dev-ddb.tfstate
 cd ../../s3
-terragrunt state pull > /tmp/tofu.tfstate
+terragrunt state pull > /tmp/tofu-dev-s3.tfstate
 cd ../.terragrunt-stack/s3
-terragrunt state push /tmp/tofu.tfstate
+terragrunt state push /tmp/tofu-dev-s3.tfstate
 cd ../../iam
-terragrunt state pull > /tmp/tofu.tfstate
+terragrunt state pull > /tmp/tofu-dev-iam.tfstate
 cd ../.terragrunt-stack/iam
-terragrunt state push /tmp/tofu.tfstate
+terragrunt state push /tmp/tofu-dev-iam.tfstate
 cd ../../lambda
-terragrunt state pull > /tmp/tofu.tfstate
+terragrunt state pull > /tmp/tofu-dev-lambda.tfstate
 cd ../.terragrunt-stack/lambda
-terragrunt state push /tmp/tofu.tfstate
+terragrunt state push /tmp/tofu-dev-lambda.tfstate
 
 # Migrate prod state
 cd ../../../prod/ddb
-terragrunt state pull > /tmp/tofu.tfstate
+terragrunt state pull > /tmp/tofu-prod-ddb.tfstate
 cd ../.terragrunt-stack/ddb
-terragrunt state push /tmp/tofu.tfstate
+terragrunt state push /tmp/tofu-prod-ddb.tfstate
 cd ../../s3
-terragrunt state pull > /tmp/tofu.tfstate
+terragrunt state pull > /tmp/tofu-prod-s3.tfstate
 cd ../.terragrunt-stack/s3
-terragrunt state push /tmp/tofu.tfstate
+terragrunt state push /tmp/tofu-prod-s3.tfstate
 cd ../../iam
-terragrunt state pull > /tmp/tofu.tfstate
+terragrunt state pull > /tmp/tofu-prod-iam.tfstate
 cd ../.terragrunt-stack/iam
-terragrunt state push /tmp/tofu.tfstate
+terragrunt state push /tmp/tofu-prod-iam.tfstate
 cd ../../lambda
-terragrunt state pull > /tmp/tofu.tfstate
+terragrunt state pull > /tmp/tofu-prod-lambda.tfstate
 cd ../.terragrunt-stack/lambda
-terragrunt state push /tmp/tofu.tfstate
+terragrunt state push /tmp/tofu-prod-lambda.tfstate
 `} />
+
+Each unit's state goes to a file of its own, so you're left with a local copy of every unit's state from before the migration.
 
 We can now remove the `.gitignore` files, and prove to ourselves that state has migrated successfully!
 

--- a/test/integration_docs_aws_tofu_test.go
+++ b/test/integration_docs_aws_tofu_test.go
@@ -1625,12 +1625,12 @@ EOF
 
 		// Migrate state from old unit paths to new .terragrunt-stack paths
 		tmpDir := helpers.TmpDirWOSymlinks(t)
-		tempStateFile := filepath.Join(tmpDir, "tofu.tfstate")
 
 		for _, env := range environments {
 			for _, component := range components {
 				oldUnitDir := filepath.Join(liveDir, env, component)
 				newUnitDir := filepath.Join(liveDir, env, ".terragrunt-stack", component)
+				tempStateFile := filepath.Join(tmpDir, "tofu-"+env+"-"+component+".tfstate")
 
 				// Pull state from old location
 				stateContent, _ := helpers.ExecWithMiseAndCaptureOutput(


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #5912.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated state migration guidance to use separate temporary state files for development and production environments.
  - Clarified state pull and push commands, complete state copies, rollback procedures, and restoring older state snapshots.
  - Documented that each migrated unit retains its own pre-migration state copy.

- **Tests**
  - Updated migration coverage to verify distinct state files are used for each environment and component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->