### PR TITLE
fix: Fixing local copies when symlinks exist from provider caching

### DIFF
--- a/docs/src/data/changelog/v1.1.4/cas-local-source-cache-dirs.mdx
+++ b/docs/src/data/changelog/v1.1.4/cas-local-source-cache-dirs.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.4"
+category: "bug-fixes"
+---
+
+#### CAS no longer falls back on sources that have been initialized
+
+With CAS enabled, reading a local source that had already been initialized failed and fell back to the slower standard copy. Generating a stack from such a unit logged `CAS processing failed ... source escapes repository root`. Provider caching, whether through the [provider cache server](/features/caching/provider-cache-server) or the [automatic provider cache dir](/features/caching/auto-provider-cache-dir), leaves the plugins under `.terraform` pointing into a shared cache outside the source, and CAS read those links as the source reaching outside itself.
+
+CAS now leaves `.terraform` and `.terragrunt-cache` out of local sources, keeping `.terraform.lock.hcl` and everything else. Both directories hold working state that OpenTofu, Terraform, and Terragrunt rebuild on demand, so units and stacks stop being handed a stale copy of either, and running `tofu init` in a source directory stops changing the CAS key of source that hasn't changed.

--- a/internal/cas/local.go
+++ b/internal/cas/local.go
@@ -8,9 +8,11 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -23,6 +25,35 @@ const gitSymlinkMode = "120000"
 // trees. It is chosen independently of any git repository's object format because
 // local sources have no repository to inherit a format from.
 const DefaultLocalHashAlgorithm = HashSHA256
+
+// ignoredSourceDirs names directories left out of every tree CAS builds by
+// walking a source directory. Both hold working state rather than source:
+// OpenTofu/Terraform puts provider plugins in .terraform, which a provider
+// cache fills with links into a shared cache outside the source tree, and
+// .terragrunt-cache holds Terragrunt's own working copies. Taking either in
+// would tie the content hash to state that changes on every init and store
+// links resolving outside the tree they are materialized into.
+var ignoredSourceDirs = []string{util.TerraformCacheDir, util.TerragruntCacheDir}
+
+// ignoredSourceEntry reports whether the entry at path, reached by a walk rooted
+// at root, is one of [ignoredSourceDirs]. The root is exempt, because a
+// source directory carrying one of these names is the content the caller asked
+// for and dropping it would leave nothing behind.
+func ignoredSourceEntry(root, path string, d fs.DirEntry) bool {
+	return path != root && slices.Contains(ignoredSourceDirs, d.Name())
+}
+
+// dropIgnoredSourceEntry returns the walk result that drops an entry
+// [ignoredSourceEntry] matched. A link standing in for a cache directory is
+// dropped on its own, since filepath.SkipDir from a non-directory would skip
+// the rest of the entries beside it.
+func dropIgnoredSourceEntry(d fs.DirEntry) error {
+	if d.IsDir() {
+		return filepath.SkipDir
+	}
+
+	return nil
+}
 
 // StoreLocalDirectory persists all content from a local source directory into the CAS
 // and then links the persisted files to the target directory.
@@ -94,6 +125,10 @@ func (c *CAS) buildLocalTree(v *venv.Venv, dir string, alg HashAlgorithm) (strin
 	err := vfs.WalkDir(v.FS, dir, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+
+		if ignoredSourceEntry(dir, path, d) {
+			return dropIgnoredSourceEntry(d)
 		}
 
 		if d.IsDir() {

--- a/internal/cas/local_test.go
+++ b/internal/cas/local_test.go
@@ -244,6 +244,77 @@ func TestStoreLocalDirectoryRejectsEscapingSymlink(t *testing.T) {
 	assert.Contains(t, err.Error(), "symlink target escapes")
 }
 
+// TestStoreLocalDirectoryIgnoresCacheDirs covers a local source that has been
+// initialized in place: the plugins under .terraform are links into a shared
+// provider cache outside the source, and ingesting them would have to be
+// refused. Both cache directories are left out instead, so the source stores
+// cleanly and the target gets source alone.
+func TestStoreLocalDirectoryIgnoresCacheDirs(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == osWindows {
+		t.Skip("os.Symlink on Windows requires special permissions; covered by Unix CI")
+	}
+
+	c, v := newCAS(t)
+	l := logger.CreateLogger()
+
+	pluginCache := filepath.Join(helpers.TmpDirWOSymlinks(t), "hashicorp", "aws", "5.0.0")
+	require.NoError(t, os.MkdirAll(pluginCache, 0o755))
+
+	src := writeLocalFixture(t, map[string]string{
+		"main.tf":             "ok",
+		".terraform.lock.hcl": `provider "registry.opentofu.org/hashicorp/aws" {}`,
+		".terraform/providers/hashicorp/aws/5.0.0/keep.txt": "",
+		".terragrunt-cache/aBc123/dEf456/main.tf":           "stale",
+	})
+	require.NoError(t, os.Symlink(
+		pluginCache,
+		filepath.Join(src, ".terraform", "providers", "hashicorp", "aws", "darwin_arm64"),
+	))
+
+	dst := filepath.Join(t.TempDir(), "dst")
+	require.NoError(t, c.StoreLocalDirectory(t.Context(), l, v, src, dst))
+
+	assert.FileExists(t, filepath.Join(dst, "main.tf"))
+	assert.FileExists(
+		t,
+		filepath.Join(dst, ".terraform.lock.hcl"),
+		"the lock file is source and must survive the .terraform exclusion",
+	)
+	assert.NoDirExists(t, filepath.Join(dst, ".terraform"))
+	assert.NoDirExists(t, filepath.Join(dst, ".terragrunt-cache"))
+}
+
+// TestComputeLocalRootHashIgnoresCacheDirs pins the cache-key half of the
+// exclusion: initializing a source in place must not change the hash that
+// identifies it.
+func TestComputeLocalRootHashIgnoresCacheDirs(t *testing.T) {
+	t.Parallel()
+
+	c, v := newCAS(t)
+
+	clean := writeLocalFixture(t, map[string]string{"main.tf": "ok"})
+	initialized := writeLocalFixture(t, map[string]string{
+		"main.tf":                                 "ok",
+		".terraform/modules/modules.json":         `{"Modules":[]}`,
+		".terragrunt-cache/aBc123/dEf456/main.tf": "stale",
+	})
+
+	cleanHash, err := c.ComputeLocalRootHash(v, clean, cas.HashSHA256)
+	require.NoError(t, err)
+
+	initializedHash, err := c.ComputeLocalRootHash(v, initialized, cas.HashSHA256)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		cleanHash,
+		initializedHash,
+		"working state must not change the hash of unchanged source",
+	)
+}
+
 // TestComputeLocalRootHashIncludesSymlinks pins that swapping a symlink's
 // target changes the root hash. The pre-symlink-support buildLocalTree
 // silently skipped symlinks, so two trees that differed only in link target

--- a/internal/cas/source.go
+++ b/internal/cas/source.go
@@ -317,6 +317,10 @@ func (c *CAS) storeFetchedContent(
 			return err
 		}
 
+		if ignoredSourceEntry(sourceDir, path, d) {
+			return dropIgnoredSourceEntry(d)
+		}
+
 		if d.IsDir() {
 			return nil
 		}

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -683,11 +683,16 @@ func (c *CAS) processLocalStackComponent(
 
 // copyTree copies the directory tree rooted at src into dst using v.FS for all
 // reads and writes, preserving file permissions. Regular files, directories,
-// and symlinks are copied; other special files are skipped.
+// and symlinks are copied; other special files and [ignoredSourceDirs]
+// are skipped.
 func (c *CAS) copyTree(v *venv.Venv, src, dst string) error {
 	return vfs.WalkDir(v.FS, src, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+
+		if ignoredSourceEntry(src, path, d) {
+			return dropIgnoredSourceEntry(d)
 		}
 
 		rel, err := filepath.Rel(src, path)

--- a/internal/cas/stacks_local_test.go
+++ b/internal/cas/stacks_local_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"testing/synctest"
@@ -21,6 +22,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
+
+// serviceUnitName is the unit block that buildLocalStackFixture wires up with
+// update_source_with_cas, so it is the block whose source gets rewritten.
+const serviceUnitName = "service"
 
 func TestProcessStackComponent_LocalSource_RewritesStackSources(t *testing.T) {
 	t.Parallel()
@@ -189,41 +194,8 @@ func TestProcessStackComponent_LocalSource_ContentAddressedCacheKey(t *testing.T
 }
 `), 0o644))
 
-	l := logger.CreateLogger()
-
-	v := venv.OSVenv()
-
-	runAndExtractServiceRef := func(root string) string {
-		storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
-		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
-		require.NoError(t, err)
-
-		source := root + "//stacks/my-stack"
-
-		result, err := c.ProcessStackComponent(t.Context(), l, v, source, "stack")
-		require.NoError(t, err)
-
-		defer result.Cleanup()
-
-		content, err := os.ReadFile(filepath.Join(result.ContentDir, "terragrunt.stack.hcl"))
-		require.NoError(t, err)
-
-		blocks, err := cas.ReadStackBlocks(content)
-		require.NoError(t, err)
-
-		for _, b := range blocks {
-			if b.Name == "service" {
-				return b.Source
-			}
-		}
-
-		t.Fatal("service block not found")
-
-		return ""
-	}
-
-	refA := runAndExtractServiceRef(rootA)
-	refB := runAndExtractServiceRef(rootB)
+	refA := serviceUnitCASRef(t, rootA)
+	refB := serviceUnitCASRef(t, rootB)
 
 	require.True(t, strings.HasPrefix(refA, "cas::sha256:"))
 	require.True(t, strings.HasPrefix(refB, "cas::sha256:"))
@@ -231,7 +203,7 @@ func TestProcessStackComponent_LocalSource_ContentAddressedCacheKey(t *testing.T
 
 	// And identical content at a fresh path must re-hash to the same ref.
 	rootC := buildLocalStackFixture(t)
-	refC := runAndExtractServiceRef(rootC)
+	refC := serviceUnitCASRef(t, rootC)
 	assert.Equal(
 		t,
 		refA,
@@ -310,6 +282,221 @@ func TestProcessStackComponent_LocalSource_SymlinkEscapesRepo(t *testing.T) {
 	_, err := c.ProcessStackComponent(t.Context(), l, v, root+"//stacks/my-stack", "stack")
 	require.Error(t, err, "symlink pointing outside the source root must be rejected")
 	require.ErrorIs(t, err, cas.ErrSourceEscapesRepo)
+}
+
+// TestProcessStackComponent_LocalSource_ProviderCacheDirIgnored covers a unit
+// that has already been initialized with the provider cache enabled: the
+// plugins under .terraform are links into a shared cache directory outside the
+// unit, and the snapshot has to drop that directory instead of reading the
+// links as an attempt to escape.
+func TestProcessStackComponent_LocalSource_ProviderCacheDirIgnored(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == osWindows {
+		t.Skip("os.Symlink on Windows requires special permissions; covered by Unix CI")
+	}
+
+	c, v := newCAS(t)
+	l := logger.CreateLogger()
+
+	tmp := helpers.TmpDirWOSymlinks(t)
+
+	pluginCache := filepath.Join(
+		tmp, "plugin-cache", "registry.opentofu.org", "hashicorp", "aws", "5.0.0", "darwin_arm64",
+	)
+	require.NoError(t, os.MkdirAll(pluginCache, 0o755))
+
+	root := filepath.Join(tmp, "repo")
+	unit := filepath.Join(root, "units", "my-service")
+	require.NoError(t, os.MkdirAll(unit, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(unit, "terragrunt.hcl"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(unit, ".terraform.lock.hcl"),
+		[]byte(`provider "registry.opentofu.org/hashicorp/aws" {
+  version = "5.0.0"
+}
+`),
+		0o644,
+	))
+
+	providers := filepath.Join(
+		unit, ".terraform", "providers", "registry.opentofu.org", "hashicorp", "aws", "5.0.0",
+	)
+	require.NoError(t, os.MkdirAll(providers, 0o755))
+	require.NoError(t, os.Symlink(pluginCache, filepath.Join(providers, "darwin_arm64")))
+
+	result, err := c.ProcessStackComponent(t.Context(), l, v, root+"//units/my-service", "unit")
+	require.NoError(t, err)
+
+	defer result.Cleanup()
+
+	assert.FileExists(t, filepath.Join(result.ContentDir, "terragrunt.hcl"))
+	assert.FileExists(
+		t,
+		filepath.Join(result.ContentDir, ".terraform.lock.hcl"),
+		"the lock file is source and must survive the .terraform exclusion",
+	)
+	assert.NoDirExists(t, filepath.Join(result.ContentDir, ".terraform"))
+}
+
+// TestProcessStackComponent_LocalSource_TerragruntCacheDirIgnored covers a unit
+// that has been run in place, leaving a .terragrunt-cache working copy that
+// carries its own initialized .terraform directory.
+func TestProcessStackComponent_LocalSource_TerragruntCacheDirIgnored(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == osWindows {
+		t.Skip("os.Symlink on Windows requires special permissions; covered by Unix CI")
+	}
+
+	c, v := newCAS(t)
+	l := logger.CreateLogger()
+
+	tmp := helpers.TmpDirWOSymlinks(t)
+
+	pluginCache := filepath.Join(tmp, "plugin-cache", "hashicorp", "aws", "5.0.0", "darwin_arm64")
+	require.NoError(t, os.MkdirAll(pluginCache, 0o755))
+
+	root := filepath.Join(tmp, "repo")
+	unit := filepath.Join(root, "units", "my-service")
+	require.NoError(t, os.MkdirAll(unit, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(unit, "terragrunt.hcl"), []byte(""), 0o644))
+
+	workingCopy := filepath.Join(unit, ".terragrunt-cache", "aBc123", "dEf456")
+	providers := filepath.Join(workingCopy, ".terraform", "providers", "hashicorp", "aws", "5.0.0")
+	require.NoError(t, os.MkdirAll(providers, 0o755))
+	require.NoError(t, os.Symlink(pluginCache, filepath.Join(providers, "darwin_arm64")))
+
+	result, err := c.ProcessStackComponent(t.Context(), l, v, root+"//units/my-service", "unit")
+	require.NoError(t, err)
+
+	defer result.Cleanup()
+
+	assert.FileExists(t, filepath.Join(result.ContentDir, "terragrunt.hcl"))
+	assert.NoDirExists(t, filepath.Join(result.ContentDir, ".terragrunt-cache"))
+}
+
+// TestProcessStackComponent_LocalSource_SymlinkedCacheDirIgnored covers the
+// cache directory itself being a link to storage elsewhere, which the walk sees
+// as a symlink rather than a directory.
+func TestProcessStackComponent_LocalSource_SymlinkedCacheDirIgnored(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == osWindows {
+		t.Skip("os.Symlink on Windows requires special permissions; covered by Unix CI")
+	}
+
+	c, v := newCAS(t)
+	l := logger.CreateLogger()
+
+	tmp := helpers.TmpDirWOSymlinks(t)
+
+	elsewhere := filepath.Join(tmp, "scratch", "terraform-dir")
+	require.NoError(t, os.MkdirAll(elsewhere, 0o755))
+
+	root := filepath.Join(tmp, "repo")
+	unit := filepath.Join(root, "units", "my-service")
+	require.NoError(t, os.MkdirAll(unit, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(unit, "terragrunt.hcl"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(unit, "main.tf"), []byte(""), 0o644))
+	require.NoError(t, os.Symlink(elsewhere, filepath.Join(unit, ".terraform")))
+
+	result, err := c.ProcessStackComponent(t.Context(), l, v, root+"//units/my-service", "unit")
+	require.NoError(t, err)
+
+	defer result.Cleanup()
+
+	assert.FileExists(
+		t,
+		filepath.Join(result.ContentDir, "main.tf"),
+		"skipping the link must not cut the walk short for its siblings",
+	)
+	assert.NoFileExists(t, filepath.Join(result.ContentDir, ".terraform"))
+}
+
+// TestProcessStackComponent_LocalSource_CacheDirNamedSourceCopied covers a
+// source that carries a cache directory's name. Dropping it would leave the
+// component with nothing at all, so the exclusion stops at the source itself.
+func TestProcessStackComponent_LocalSource_CacheDirNamedSourceCopied(t *testing.T) {
+	t.Parallel()
+
+	c, v := newCAS(t)
+	l := logger.CreateLogger()
+
+	root := filepath.Join(helpers.TmpDirWOSymlinks(t), ".terragrunt-cache")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(""), 0o644))
+
+	result, err := c.ProcessStackComponent(t.Context(), l, v, root, "unit")
+	require.NoError(t, err)
+
+	defer result.Cleanup()
+
+	assert.FileExists(t, filepath.Join(result.ContentDir, "main.tf"))
+}
+
+// TestProcessStackComponent_LocalSource_CacheDirsDoNotAffectCASRefs pins the
+// cache-key half of the exclusion: local working state changes on every init,
+// so a snapshot that included it would hand out a different CAS ref for source
+// that never changed.
+func TestProcessStackComponent_LocalSource_CacheDirsDoNotAffectCASRefs(t *testing.T) {
+	t.Parallel()
+
+	clean := buildLocalStackFixture(t)
+	initialized := buildLocalStackFixture(t)
+
+	for _, dir := range []string{
+		filepath.Join(initialized, "modules", "vpc", ".terraform", "modules"),
+		filepath.Join(initialized, "units", "my-service", ".terragrunt-cache", "aBc123"),
+	} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "state.json"), []byte("{}"), 0o644))
+	}
+
+	assert.Equal(
+		t,
+		serviceUnitCASRef(t, clean),
+		serviceUnitCASRef(t, initialized),
+		"local working state must not change the CAS ref of unchanged source",
+	)
+}
+
+// serviceUnitCASRef processes the stack in a fixture built by
+// buildLocalStackFixture and returns the rewritten source of its "service"
+// unit, using a store of its own so nothing is read from an earlier run.
+func serviceUnitCASRef(t *testing.T, root string) string {
+	t.Helper()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	result, err := c.ProcessStackComponent(
+		t.Context(),
+		logger.CreateLogger(),
+		venv.OSVenv(),
+		root+"//stacks/my-stack",
+		"stack",
+	)
+	require.NoError(t, err)
+
+	defer result.Cleanup()
+
+	content, err := os.ReadFile(filepath.Join(result.ContentDir, "terragrunt.stack.hcl"))
+	require.NoError(t, err)
+
+	blocks, err := cas.ReadStackBlocks(content)
+	require.NoError(t, err)
+
+	for _, b := range blocks {
+		if b.Name == serviceUnitName {
+			return b.Source
+		}
+	}
+
+	t.Fatalf("no %q unit in the processed stack file", serviceUnitName)
+
+	return ""
 }
 
 // TestProcessStackComponent_EmptySourceFails exercises the empty-string
@@ -449,7 +636,7 @@ func TestProcessStackComponent_LocalSource_MaterializeSynthTree(t *testing.T) {
 	var serviceSource string
 
 	for _, b := range blocks {
-		if b.Name == "service" {
+		if b.Name == serviceUnitName {
 			serviceSource = b.Source
 
 			break


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6541.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Local source processing now excludes `.terraform` and `.terragrunt-cache` directories, including symlinked cache directories.
  - Terraform lock files and other sibling files remain included.
  - Changes inside generated cache directories no longer affect source hashes or references.
  - Sources with cache directories now process consistently without fallback failures.

- **Documentation**
  - Added a changelog entry describing the local source cache exclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->