### PR TITLE
chore: Nesting the dependency cty map by iteration key

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1701,7 +1701,16 @@ func DetectInputsCtyUsage(file *hclparse.File) bool {
 				continue
 			}
 
-			attrTraversal, ok := traversal[2].(hcl.TraverseAttr)
+			rest := traversal[2:]
+			if _, indexed := rest[0].(hcl.TraverseIndex); indexed {
+				rest = rest[1:]
+			}
+
+			if len(rest) == 0 {
+				continue
+			}
+
+			attrTraversal, ok := rest[0].(hcl.TraverseAttr)
 			if !ok || attrTraversal.Name != MetadataInputs {
 				continue
 			}

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -204,16 +204,27 @@ func (dep *Dependency) isDisabled() bool {
 	return !dep.isEnabled()
 }
 
+// instanceKey returns the key of the expansion element this dependency came from. A declared
+// expansion is not proof of one: blocks decoded outside the expanding decoder (the autoinclude
+// decode) carry the declaration with no key, and callers must read those as whole blocks.
+func (dep *Dependency) instanceKey() (string, bool) {
+	if dep.Expansion == nil {
+		return "", false
+	}
+
+	return dep.Expansion.Key(), dep.Expansion.Expanded()
+}
+
 // mergeKey identifies a dependency when include merging matches blocks up. Every instance
 // of an expanded block carries the same label, so matching on the label alone would fold a
-// whole set into whichever instance came last. A block that declares an expansion but has
-// not been expanded yet still merges by label, since merging runs on declarations too.
+// whole set into whichever instance came last.
 func (dep *Dependency) mergeKey() string {
-	if dep.Expansion == nil || dep.Expansion.Key() == "" {
+	key, expanded := dep.instanceKey()
+	if !expanded {
 		return dep.Name
 	}
 
-	return dep.Name + "[" + dep.Expansion.Key() + "]"
+	return dep.Name + "[" + key + "]"
 }
 
 // Given a dependency config, we should only attempt to merge mocks outputs with the outputs if MockOutputsMergeWithState is not nil or true
@@ -690,6 +701,9 @@ func getDependencyBlockConfigPathsByFilepath(
 //   - outputs: The map of outputs of the corresponding terraform module that lives at the target config of the
 //     dependency.
 //
+// An expanded block instead maps its name to one such mapping per instance, keyed by the instance key, so that
+// `dependency.foo["bar"].outputs` addresses a single element of the set.
+//
 // This routine will go through the process of obtaining the outputs using `terragrunt output` from the target config.
 // The traceCtx parameter is the trace context from the parent span (parse_dependencies) to establish parent-child
 // relationship for individual dependency traces.
@@ -704,6 +718,7 @@ func dependencyBlocksToCtyValue(
 	// dependencyMap is the top level map that maps dependency block names to the encoded version, which includes
 	// various attributes for accessing information about the target config (including the module outputs).
 	dependencyMap := map[string]cty.Value{}
+	instanceMaps := map[string]map[string]cty.Value{}
 	lock := sync.Mutex{}
 	dependencyErrGroup, _ := errgroup.WithContext(traceCtx)
 
@@ -766,12 +781,21 @@ func dependencyBlocksToCtyValue(
 				return err
 			}
 
-			// Lock the map as only one goroutine should be writing to the map at a time
 			lock.Lock()
 			defer lock.Unlock()
 
-			// Finally, feed the encoded dependency into the higher order map under the block name
-			dependencyMap[dependencyConfig.Name] = dependencyEncodingMapEncoded
+			instanceKey, expanded := dependencyConfig.instanceKey()
+			if !expanded {
+				dependencyMap[dependencyConfig.Name] = dependencyEncodingMapEncoded
+
+				return nil
+			}
+
+			if instanceMaps[dependencyConfig.Name] == nil {
+				instanceMaps[dependencyConfig.Name] = map[string]cty.Value{}
+			}
+
+			instanceMaps[dependencyConfig.Name][instanceKey] = dependencyEncodingMapEncoded
 
 			return nil
 		})
@@ -779,6 +803,19 @@ func dependencyBlocksToCtyValue(
 
 	if err := dependencyErrGroup.Wait(); err != nil {
 		return nil, err
+	}
+
+	for name, instances := range instanceMaps {
+		if _, taken := dependencyMap[name]; taken {
+			return nil, DependencyLabelCollisionError{Name: name}
+		}
+
+		encodedInstances, err := gocty.ToCtyValue(instances, generateTypeFromValuesMap(instances))
+		if err != nil {
+			return nil, TerragruntOutputListEncodingError{Paths: paths, Err: err}
+		}
+
+		dependencyMap[name] = encodedInstances
 	}
 
 	// We need to convert the value map to a single cty.Value at the end so that it can be used in the execution ctx

--- a/pkg/config/dependency_inputs_test.go
+++ b/pkg/config/dependency_inputs_test.go
@@ -118,6 +118,24 @@ inputs = {
 `,
 			expected: true,
 		},
+		{
+			name: "expanded dependency inputs detected",
+			config: `
+inputs = {
+  value = dependency.dep["web"].inputs.some_value
+}
+`,
+			expected: true,
+		},
+		{
+			name: "expanded dependency outputs not detected",
+			config: `
+inputs = {
+  value = dependency.dep["web"].outputs.some_value
+}
+`,
+			expected: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -334,6 +334,19 @@ func (err StackMockOutputsTypeError) Error() string {
 	)
 }
 
+// DependencyLabelCollisionError is returned when one dependency label has to address both a
+// whole block and the instances of an expanded block.
+type DependencyLabelCollisionError struct {
+	Name string
+}
+
+func (err DependencyLabelCollisionError) Error() string {
+	return fmt.Sprintf(
+		"dependency %q is declared both with and without an expansion, so the block and its instances claim the same address; rename one of them",
+		err.Name,
+	)
+}
+
 type TerragruntOutputListEncodingError struct {
 	Err   error
 	Paths []string

--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -802,6 +804,438 @@ func TestDependencyCtyShapeExcludesExpansionMetadata(t *testing.T) {
 		"outputs",
 		"inputs",
 	}, attrs)
+}
+
+// TestDependencyOutputsAddressedByInstanceKey pins the address an expanded dependency answers to,
+// alongside an unexpanded block in the same config to hold its unkeyed address steady.
+func TestDependencyOutputsAddressedByInstanceKey(t *testing.T) {
+	t.Parallel()
+
+	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+
+	cfg, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		`
+dependency "vpc" {
+  config_path  = "../vpc"
+  skip_outputs = true
+
+  mock_outputs = {
+    id = "vpc-main"
+  }
+}
+
+dependency "aurora" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  config_path  = "../aurora-${each.key}"
+  skip_outputs = true
+
+  mock_outputs = {
+    id = "aurora-${each.key}"
+  }
+}
+
+dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  config_path  = "../shard-${count.index}"
+  skip_outputs = true
+
+  mock_outputs = {
+    id = "shard-${count.index}"
+  }
+}
+
+inputs = {
+  vpc_id      = dependency.vpc.outputs.id
+  vpc_outputs = dependency.vpc.outputs
+  web         = dependency.aurora["web"].outputs.id
+  api         = dependency.aurora["api"].outputs.id
+  first       = dependency.shard["0"].outputs.id
+  second      = dependency.shard["1"].outputs.id
+  unquoted    = dependency.shard[0].outputs.id
+}
+`,
+		nil,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{
+		"vpc_id":      "vpc-main",
+		"vpc_outputs": map[string]any{"id": "vpc-main"},
+		"web":         "aurora-web",
+		"api":         "aurora-api",
+		"first":       "shard-0",
+		"second":      "shard-1",
+		"unquoted":    "shard-0",
+	}, cfg.Inputs)
+}
+
+// TestDependencyOutputsRejectExpandedBlockWithoutKey holds the keyed level to being the only
+// address for an expanded block, since a config that reached past it would be reading an
+// arbitrary instance.
+func TestDependencyOutputsRejectExpandedBlockWithoutKey(t *testing.T) {
+	t.Parallel()
+
+	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+
+	_, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		`
+dependency "aurora" {
+  expansion {
+    for_each = toset(["web"])
+  }
+
+  config_path  = "../aurora-${each.key}"
+  skip_outputs = true
+
+  mock_outputs = {
+    id = "aurora-${each.key}"
+  }
+}
+
+inputs = {
+  id = dependency.aurora.outputs.id
+}
+`,
+		nil,
+	)
+
+	var diags hcl.Diagnostics
+	require.ErrorAs(t, err, &diags)
+	require.Len(t, diags, 1)
+	// Naming the diagnostic keeps the test from passing on any other evaluation failure the
+	// fixture might grow.
+	assert.Equal(t, "Unsupported attribute", diags[0].Summary)
+}
+
+// TestDependencyOutputsEncodeDivergentSchemasPerKey covers instances whose outputs share no
+// schema, so encoding cannot lean on the keys agreeing on a type.
+func TestDependencyOutputsEncodeDivergentSchemasPerKey(t *testing.T) {
+	t.Parallel()
+
+	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+
+	cfg, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		`
+dependency "mixed" {
+  expansion {
+    for_each = {
+      a = { id = "mixed-a" }
+      b = { name = "mixed-b", size = 3 }
+    }
+  }
+
+  config_path  = "../mixed-${each.key}"
+  skip_outputs = true
+
+  mock_outputs = each.value
+}
+
+inputs = {
+  a_id   = dependency.mixed["a"].outputs.id
+  b_name = dependency.mixed["b"].outputs.name
+  b_size = dependency.mixed["b"].outputs.size
+}
+`,
+		nil,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{
+		"a_id":   "mixed-a",
+		"b_name": "mixed-b",
+		"b_size": json.Number("3"),
+	}, cfg.Inputs)
+}
+
+// TestDependencyInstanceKeysMatchAddressableKeys ties the key the parser reports for an instance
+// to the key a config writes to reach it.
+func TestDependencyInstanceKeysMatchAddressableKeys(t *testing.T) {
+	t.Parallel()
+
+	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+
+	cfg, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		`
+dependency "numbered" {
+  expansion {
+    for_each = toset([1, 2])
+  }
+
+  config_path  = "../numbered-${each.key}"
+  skip_outputs = true
+
+  mock_outputs = {
+    engine_key = each.key
+  }
+}
+
+dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  config_path  = "../shard-${count.index}"
+  skip_outputs = true
+
+  mock_outputs = {
+    engine_key = tostring(count.index)
+  }
+}
+
+inputs = {
+  numbered = {
+    "1" = dependency.numbered["1"].outputs.engine_key
+    "2" = dependency.numbered["2"].outputs.engine_key
+  }
+
+  shard = {
+    "0" = dependency.shard["0"].outputs.engine_key
+    "1" = dependency.shard["1"].outputs.engine_key
+  }
+}
+`,
+		nil,
+	)
+	require.NoError(t, err)
+
+	addressed := map[string]map[string]any{}
+
+	for _, name := range []string{"numbered", "shard"} {
+		byKey, ok := cfg.Inputs[name].(map[string]any)
+		require.True(t, ok)
+
+		addressed[name] = byKey
+	}
+
+	reported := map[string][]string{}
+
+	for _, dep := range cfg.TerragruntDependencies {
+		require.NotNil(t, dep.Expansion)
+
+		key := dep.Expansion.Key()
+		reported[dep.Name] = append(reported[dep.Name], key)
+
+		// The instance recorded the key the expansion engine handed its body, so an address
+		// built from Key() only lands here if both agree on the stringification.
+		assert.Equal(t, key, addressed[dep.Name][key])
+	}
+
+	assert.Equal(t, map[string][]string{
+		"numbered": {"1", "2"},
+		"shard":    {"0", "1"},
+	}, reported)
+}
+
+// TestDependencyOutputsAddressEmptyEachKey covers an each.key that is itself the empty string,
+// which is a key like any other and must not read as an absent one.
+func TestDependencyOutputsAddressEmptyEachKey(t *testing.T) {
+	t.Parallel()
+
+	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+
+	cfg, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		`
+dependency "mixed" {
+  expansion {
+    for_each = toset(["", "web"])
+  }
+
+  config_path  = "../mixed-${each.key}"
+  skip_outputs = true
+
+  mock_outputs = {
+    id = "mixed-${each.key}"
+  }
+}
+
+inputs = {
+  blank = dependency.mixed[""].outputs.id
+  web   = dependency.mixed["web"].outputs.id
+}
+`,
+		nil,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{
+		"blank": "mixed-",
+		"web":   "mixed-web",
+	}, cfg.Inputs)
+}
+
+// TestDependencyLabelClaimedByBlockAndInstances covers a label that has to address both a whole
+// block and a set of instances, which include merging is free to produce.
+func TestDependencyLabelClaimedByBlockAndInstances(t *testing.T) {
+	t.Parallel()
+
+	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+
+	_, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		`
+dependency "aurora" {
+  config_path  = "../aurora"
+  skip_outputs = true
+
+  mock_outputs = {
+    id = "aurora-main"
+  }
+}
+
+dependency "aurora" {
+  expansion {
+    for_each = toset(["web"])
+  }
+
+  config_path  = "../aurora-${each.key}"
+  skip_outputs = true
+
+  mock_outputs = {
+    id = "aurora-${each.key}"
+  }
+}
+
+inputs = {
+  id = dependency.aurora["web"].outputs.id
+}
+`,
+		nil,
+	)
+
+	var collision config.DependencyLabelCollisionError
+	require.ErrorAs(t, err, &collision)
+	assert.Equal(t, "aurora", collision.Name)
+}
+
+// TestDependencyOutputsResolveUnknownWhenOutputsSkipped covers hcl validate, where the placeholder
+// standing in for unresolved outputs has to sit below the keyed level to be reachable.
+func TestDependencyOutputsResolveUnknownWhenOutputsSkipped(t *testing.T) {
+	t.Parallel()
+
+	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+	pctx.SkipOutput = true
+	pctx.SkipOutputsResolution = true
+
+	_, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		`
+dependency "aurora" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  config_path = "../does-not-exist-${each.key}"
+}
+
+inputs = {
+  web = dependency.aurora["web"].outputs.id
+  api = dependency.aurora["api"].outputs.id
+}
+`,
+		nil,
+	)
+	require.NoError(t, err)
+}
+
+// TestDependencyInstancesAccumulateWithRacing drives enough instances through the concurrent
+// output resolution to give the race detector something to catch.
+func TestDependencyInstancesAccumulateWithRacing(t *testing.T) {
+	t.Parallel()
+
+	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+
+	cfg, err := config.ParseConfigString(
+		ctx,
+		pctx,
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		`
+dependency "vpc" {
+  config_path  = "../vpc"
+  skip_outputs = true
+
+  mock_outputs = {
+    id = "vpc-main"
+  }
+}
+
+dependency "shard" {
+  expansion {
+    count = 40
+  }
+
+  config_path  = "../shard-${count.index}"
+  skip_outputs = true
+
+  mock_outputs = {
+    id = "shard-${count.index}"
+  }
+}
+
+dependency "region" {
+  expansion {
+    for_each = toset([for i in range(40) : "r${i}"])
+  }
+
+  config_path  = "../region-${each.key}"
+  skip_outputs = true
+
+  mock_outputs = {
+    id = "region-${each.key}"
+  }
+}
+
+inputs = {
+  vpc          = dependency.vpc.outputs.id
+  first_shard  = dependency.shard["0"].outputs.id
+  last_shard   = dependency.shard["39"].outputs.id
+  first_region = dependency.region["r0"].outputs.id
+  last_region  = dependency.region["r39"].outputs.id
+}
+`,
+		nil,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{
+		"vpc":          "vpc-main",
+		"first_shard":  "shard-0",
+		"last_shard":   "shard-39",
+		"first_region": "region-r0",
+		"last_region":  "region-r39",
+	}, cfg.Inputs)
 }
 
 func parseDependencyString(tb testing.TB, cfg string) (*config.TerragruntConfig, error) {

--- a/pkg/config/hclparse/expansion.go
+++ b/pkg/config/hclparse/expansion.go
@@ -86,6 +86,12 @@ func (key InstanceKey) Key() string {
 	}
 }
 
+// Expanded reports whether this key names one element of an expanded block. An each.key
+// can itself be the empty string, so [InstanceKey.Key] cannot stand in for this test.
+func (key InstanceKey) Expanded() bool {
+	return key.EachKey != nil || key.CountIndex != nil
+}
+
 // Instance is one decoded product of expanding a block. A block with no expansion
 // block yields a single Instance with both keys nil.
 type Instance struct {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Nesting the outputs cty map into the iteration key when dependency blocks use expansion.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dependency outputs from expanded instances can now be accessed using instance keys, including numeric and empty-string keys.
  * Expanded dependency inputs support bracket notation, such as `dependency["name"].inputs`.

* **Bug Fixes**
  * Improved handling of mixed expanded and unexpanded dependencies, including clear errors for label collisions.
  * Dependency outputs with different schemas are encoded correctly per instance.
  * Unknown and concurrently accumulated dependency instances are handled more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->