### PR TITLE
ci: Add weekly security scans

### DIFF
--- a/.github/scripts/coverage/resolve-commits.sh
+++ b/.github/scripts/coverage/resolve-commits.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Resolve the "current" and "previous" commits for the weekly coverage diff and
 # write them (plus their dates) to $GITHUB_OUTPUT.
+# Also used by the weekly security scan (.github/workflows/security-scan-weekly.yml).
 #
 # Current is HEAD. Previous walks the trunk (origin/main) back WINDOW_DAYS, up to
 # 2x that window, for the first commit that differs from HEAD. When none is found

--- a/.github/scripts/coverage/resolve-commits.sh
+++ b/.github/scripts/coverage/resolve-commits.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 # Resolve the "current" and "previous" commits for the weekly coverage diff and
 # write them (plus their dates) to $GITHUB_OUTPUT.
-# Also used by the weekly security scan (.github/workflows/security-scan-weekly.yml).
 #
 # Current is HEAD. Previous walks the trunk (origin/main) back WINDOW_DAYS, up to
 # 2x that window, for the first commit that differs from HEAD. When none is found

--- a/.github/scripts/security-scan/security-scan-report.sh
+++ b/.github/scripts/security-scan/security-scan-report.sh
@@ -52,16 +52,21 @@ jq_lib() {
 			else "UNKNOWN" end;
 		def sevrank: {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "UNKNOWN": 4}[.] // 9;
 		def counts_line: . as $c |
-			(["CRITICAL","HIGH","MEDIUM","LOW","UNKNOWN"]
+			(["CRITICAL","HIGH","MEDIUM","LOW"]
 				| map(. as $s | select(($c[$s] // 0) > 0) | "\($c[$s]) \($s)")
 				| join(", ")) as $by_sev |
 			"\($c.total // 0) total" + (if $by_sev != "" then " (\($by_sev))" else "" end);
+		def loc: .target + (if (.line // 0) > 0 then ":\(.line)" else "" end);
 		def finding_line:
-			"[\(.severity)] \(.class) \(.id)"
-			+ (if .pkg != "" then " \(.pkg)" else "" end)
-			+ (if .installed != "" then " \(.installed)" else "" end)
-			+ (if .fixed != "" then " -> \(.fixed)" else "" end)
-			+ " (\(.target))";
+			(if .severity != "UNKNOWN" then "[\(.severity)] " else "" end)
+			+ (if .class == "vuln" then
+				"\(.pkg) \(.installed)"
+				+ (if .fixed != "" then " -> \(.fixed)" else "" end)
+				+ " \(.id)"
+			else
+				.id + (if .title != "" then " \(.title)" else "" end)
+			end)
+			+ " (\(loc))";
 	JQ
 }
 
@@ -122,6 +127,7 @@ cmd_summary() {
 				id: (.VulnerabilityID // ""),
 				severity: (.Severity | sev),
 				target: ($r.Target // ""),
+				line: 0,
 				pkg: (.PkgName // ""),
 				installed: (.InstalledVersion // ""),
 				fixed: (.FixedVersion // ""),
@@ -132,6 +138,7 @@ cmd_summary() {
 				id: (.AVDID // .ID // ""),
 				severity: (.Severity | sev),
 				target: ($r.Target // ""),
+				line: (.CauseMetadata.StartLine // 0),
 				pkg: "",
 				installed: "",
 				fixed: "",
@@ -142,6 +149,7 @@ cmd_summary() {
 				id: (.RuleID // ""),
 				severity: (.Severity | sev),
 				target: ($r.Target // ""),
+				line: (.StartLine // 0),
 				pkg: "",
 				installed: "",
 				fixed: "",
@@ -222,9 +230,9 @@ cmd_render() {
 	write() { echo "$@" >>"$summary_file"; }
 
 	table() {
-		echo "| Severity | Class | ID | Target | Package | Installed | Fixed |"
-		echo "|----------|-------|----|--------|---------|-----------|-------|"
-		jq -r '.[] | "| \(.severity) | \(.class) | \(.id) | \(.target) | \(.pkg) | \(.installed) | \(.fixed) |"'
+		echo "| Severity | Class | ID | Location | Package | Installed | Fixed |"
+		echo "|----------|-------|----|----------|---------|-----------|-------|"
+		jq -r "$(jq_lib)"'.[] | "| \(.severity) | \(.class) | \(.id) | \(loc) | \(.pkg) | \(.installed) | \(.fixed) |"'
 	}
 
 	write "## Weekly Security Scan"

--- a/.github/scripts/security-scan/security-scan-report.sh
+++ b/.github/scripts/security-scan/security-scan-report.sh
@@ -44,16 +44,22 @@ usage() {
 now_utc() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 this_commit() { echo "${GITHUB_SHA:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"; }
 
-# Shared jq defs: severity normalization/ranking and the one-line finding format.
+# Shared jq defs: severity handling, the fields every finding class has in
+# common, and the count/finding/list output formats.
 jq_lib() {
 	cat <<-'JQ'
-		def sev: if . == null then "UNKNOWN"
-			elif (["CRITICAL","HIGH","MEDIUM","LOW","UNKNOWN"] | index(.)) then .
-			else "UNKNOWN" end;
-		def sevrank: {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "UNKNOWN": 4}[.] // 9;
+		def sev: if IN("CRITICAL", "HIGH", "MEDIUM", "LOW") then . else "UNKNOWN" end;
+		def sevrank: {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3}[.] // 4;
+		def base($r): {
+			id: "", pkg: "", installed: "", fixed: "", line: 0,
+			severity: (.Severity | sev), target: ($r.Target // ""), title: (.Title // "")
+		};
+		def counts: {CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0, UNKNOWN: 0}
+			+ (group_by(.severity) | map({(.[0].severity): length}) | add // {})
+			+ {total: length};
 		def counts_line: . as $c |
-			(["CRITICAL","HIGH","MEDIUM","LOW"]
-				| map(. as $s | select(($c[$s] // 0) > 0) | "\($c[$s]) \($s)")
+			(["CRITICAL", "HIGH", "MEDIUM", "LOW"]
+				| map(select(($c[.] // 0) > 0) | "\($c[.]) \(.)")
 				| join(", ")) as $by_sev |
 			"\($c.total // 0) total" + (if $by_sev != "" then " (\($by_sev))" else "" end);
 		def loc: .target + (if (.line // 0) > 0 then ":\(.line)" else "" end);
@@ -67,6 +73,12 @@ jq_lib() {
 				.id + (if .title != "" then " \(.title)" else "" end)
 			end)
 			+ " (\(loc))";
+		def listed($items; $label; $limit): if ($items | length) == 0 then "" else
+			"\($label) (\($items | length)):\n"
+			+ ([$items[:$limit][] | "  \(finding_line)"] | join("\n"))
+			+ (if ($items | length) > $limit
+				then "\n  ...and \(($items | length) - $limit) more" else "" end)
+		end;
 	JQ
 }
 
@@ -75,11 +87,6 @@ cmd_scan() {
 	local src="${1:?Usage: security-scan-report.sh scan <src-dir> <out.json> [trivy args...]}"
 	local out="${2:?Usage: security-scan-report.sh scan <src-dir> <out.json> [trivy args...]}"
 	shift 2
-
-	if ! command -v trivy >/dev/null 2>&1; then
-		echo "Error: trivy not found on PATH; install it (e.g. aquasecurity/setup-trivy) first." >&2
-		exit 1
-	fi
 
 	mkdir -p "$(dirname "$out")"
 
@@ -122,51 +129,28 @@ cmd_summary() {
 		--arg timestamp "$(now_utc)" \
 		"$(jq_lib)"'
 		[.Results[]? as $r |
-			(($r.Vulnerabilities // [])[] | {
+			(($r.Vulnerabilities // [])[] | base($r) + {
 				class: "vuln",
 				id: (.VulnerabilityID // ""),
-				severity: (.Severity | sev),
-				target: ($r.Target // ""),
-				line: 0,
 				pkg: (.PkgName // ""),
 				installed: (.InstalledVersion // ""),
-				fixed: (.FixedVersion // ""),
-				title: (.Title // "")
+				fixed: (.FixedVersion // "")
 			}),
-			(($r.Misconfigurations // [])[] | select((.Status // "FAIL") == "FAIL") | {
+			(($r.Misconfigurations // [])[] | select((.Status // "FAIL") == "FAIL") | base($r) + {
 				class: "misconfig",
 				id: (.AVDID // .ID // ""),
-				severity: (.Severity | sev),
-				target: ($r.Target // ""),
-				line: (.CauseMetadata.StartLine // 0),
-				pkg: "",
-				installed: "",
-				fixed: "",
-				title: (.Title // "")
+				line: (.CauseMetadata.StartLine // 0)
 			}),
-			(($r.Secrets // [])[] | {
+			(($r.Secrets // [])[] | base($r) + {
 				class: "secret",
 				id: (.RuleID // ""),
-				severity: (.Severity | sev),
-				target: ($r.Target // ""),
-				line: (.StartLine // 0),
-				pkg: "",
-				installed: "",
-				fixed: "",
-				title: (.Title // "")
+				line: (.StartLine // 0)
 			})
 		]
 		| map(. + {key: "\(.class)|\(.target)|\(.pkg)|\(.id)"})
 		| unique_by(.key)
 		| sort_by([(.severity | sevrank), .key])
-		| {
-			commit: $commit,
-			timestamp: $timestamp,
-			counts: (reduce .[] as $f (
-				{CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0, UNKNOWN: 0, total: 0};
-				.[$f.severity] += 1 | .total += 1)),
-			findings: .
-		}' "$input" >"$output"
+		| {commit: $commit, timestamp: $timestamp, counts: counts, findings: .}' "$input" >"$output"
 
 	echo "Summary: $output ($(jq -r '.counts.total' "$output") findings)"
 }
@@ -201,8 +185,8 @@ cmd_compare() {
 		--slurpfile prev "$previous" '
 		($cur[0]) as $c |
 		($prev[0]) as $p |
-		($c.findings | map({(.key): true}) | add // {}) as $ckeys |
-		($p.findings | map({(.key): true}) | add // {}) as $pkeys |
+		INDEX($c.findings[]; .key) as $ckeys |
+		INDEX($p.findings[]; .key) as $pkeys |
 		{
 			baseline: false,
 			current_counts: $c.counts,
@@ -322,12 +306,6 @@ cmd_payload() {
 		--argjson limit "$limit" \
 		--slurpfile rep "$report" \
 		"$(jq_lib)"'
-		def listed($items; $label): if ($items | length) > 0 then
-			"\($label) (\($items | length)):\n"
-			+ ([$items[:$limit][] | "  \(finding_line)"] | join("\n"))
-			+ (if ($items | length) > $limit then "\n  ...and \(($items | length) - $limit) more" else "" end)
-		else "" end;
-
 		($rep[0]) as $r |
 
 		(if $r.baseline then
@@ -336,25 +314,18 @@ cmd_payload() {
 			"Findings: \($r.current_counts | counts_line) (was \($r.previous_counts | counts_line))"
 		end) as $totals |
 
-		{
-			new: listed($r.new; "New this week"),
-			fixed: listed($r.fixed; "Fixed this week"),
-			current: listed($r.current_findings; "Current findings")
-		} as $lists |
+		listed($r.new; "New this week"; $limit) as $new |
+		(if ($r.baseline | not) and $new == "" then "No new findings this week." else "" end) as $none |
 
-		(if ($r.baseline | not) and $lists.new == "" then "No new findings this week." else "" end) as $none |
-
-		{
-			text: (
-				($header + "\n\n")
-				+ $totals
-				+ (if $lists.new != "" then "\n\n" + $lists.new else "" end)
-				+ (if $lists.fixed != "" then "\n\n" + $lists.fixed else "" end)
-				+ (if $none != "" then "\n\n" + $none else "" end)
-				+ (if $lists.current != "" then "\n\n" + $lists.current else "" end)
-				+ "\n\n<\($run_url)|View workflow run>"
-			)
-		}'
+		{text: ([
+			$header,
+			$totals,
+			$new,
+			listed($r.fixed; "Fixed this week"; $limit),
+			$none,
+			listed($r.current_findings; "Current findings"; $limit),
+			"<\($run_url)|View workflow run>"
+		] | map(select(. != "")) | join("\n\n"))}'
 }
 
 # Post the report to Slack
@@ -365,7 +336,8 @@ cmd_notify() {
 	local payload
 	payload=$(cmd_payload "$report")
 
-	curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d "$payload" "$webhook"
+	curl -sS --fail-with-body --connect-timeout 10 --max-time 30 \
+		-X POST -H "Content-Type: application/json" -d "$payload" "$webhook"
 	echo "Slack notification sent."
 }
 
@@ -379,22 +351,35 @@ cmd_notify_failure() {
 	payload=$(jq -n --arg run_url "$run_url" \
 		'{text: "*Weekly Security Scan: terragrunt*\nRun failed before producing a report.\n\n<\($run_url)|View workflow run>"}')
 
-	curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d "$payload" "$webhook"
+	curl -sS --fail-with-body --connect-timeout 10 --max-time 30 \
+		-X POST -H "Content-Type: application/json" -d "$payload" "$webhook"
 	echo "Slack failure notification sent."
 }
 
-# Route the subcommand to its handler
+# Fail before any work when a subcommand's tools are missing
+require_tools() {
+	local tool missing=()
+	for tool in "$@"; do
+		command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+	done
+	if [[ ${#missing[@]} -gt 0 ]]; then
+		echo "Error: not found on PATH: ${missing[*]}. Install them (e.g. aquasecurity/setup-trivy for trivy) first." >&2
+		exit 1
+	fi
+}
+
+# Route the subcommand to its handler, after checking its pre-reqs
 main() {
 	local cmd="${1:-}"
 	shift || true
 	case "$cmd" in
-	scan) cmd_scan "$@" ;;
-	summary) cmd_summary "$@" ;;
-	compare) cmd_compare "$@" ;;
-	render) cmd_render "$@" ;;
-	payload) cmd_payload "$@" ;;
-	notify) cmd_notify "$@" ;;
-	notify-failure) cmd_notify_failure "$@" ;;
+	scan) require_tools jq trivy && cmd_scan "$@" ;;
+	summary) require_tools jq && cmd_summary "$@" ;;
+	compare) require_tools jq && cmd_compare "$@" ;;
+	render) require_tools jq && cmd_render "$@" ;;
+	payload) require_tools jq && cmd_payload "$@" ;;
+	notify) require_tools jq curl && cmd_notify "$@" ;;
+	notify-failure) require_tools jq curl && cmd_notify_failure "$@" ;;
 	"" | -h | --help | help) usage ;;
 	*)
 		echo "Unknown subcommand: $cmd" >&2

--- a/.github/scripts/security-scan/security-scan-report.sh
+++ b/.github/scripts/security-scan/security-scan-report.sh
@@ -314,6 +314,12 @@ cmd_payload() {
 		--argjson limit "$limit" \
 		--slurpfile rep "$report" \
 		"$(jq_lib)"'
+		def listed($items; $label): if ($items | length) > 0 then
+			"\($label) (\($items | length)):\n"
+			+ ([$items[:$limit][] | "  \(finding_line)"] | join("\n"))
+			+ (if ($items | length) > $limit then "\n  ...and \(($items | length) - $limit) more" else "" end)
+		else "" end;
+
 		($rep[0]) as $r |
 
 		(if $r.baseline then
@@ -322,15 +328,11 @@ cmd_payload() {
 			"Findings: \($r.current_counts | counts_line) (was \($r.previous_counts | counts_line))"
 		end) as $totals |
 
-		(def listed($items; $label): if ($items | length) > 0 then
-			"\($label) (\($items | length)):\n"
-			+ ([$items[:$limit][] | "  \(finding_line)"] | join("\n"))
-			+ (if ($items | length) > $limit then "\n  ...and \(($items | length) - $limit) more" else "" end)
-		else "" end;
 		{
 			new: listed($r.new; "New this week"),
-			fixed: listed($r.fixed; "Fixed this week")
-		}) as $lists |
+			fixed: listed($r.fixed; "Fixed this week"),
+			current: listed($r.current_findings; "Current findings")
+		} as $lists |
 
 		(if ($r.baseline | not) and $lists.new == "" then "No new findings this week." else "" end) as $none |
 
@@ -341,6 +343,7 @@ cmd_payload() {
 				+ (if $lists.new != "" then "\n\n" + $lists.new else "" end)
 				+ (if $lists.fixed != "" then "\n\n" + $lists.fixed else "" end)
 				+ (if $none != "" then "\n\n" + $none else "" end)
+				+ (if $lists.current != "" then "\n\n" + $lists.current else "" end)
 				+ "\n\n<\($run_url)|View workflow run>"
 			)
 		}'

--- a/.github/scripts/security-scan/security-scan-report.sh
+++ b/.github/scripts/security-scan/security-scan-report.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Single entrypoint for the weekly security scan report. Only the `scan` and
+# `summary` subcommands know about the scanner (currently Trivy); the summary,
+# report, and notification formats are scanner-agnostic so the implementation
+# can be swapped without changing the workflow contract.
+#
+# Subcommands:
+#   scan <src-dir> <out.json> [trivy args...]  Run `trivy fs` over <src-dir> and write the
+#                                    raw JSON report to <out.json>. Extra args are passed
+#                                    through to trivy (e.g. --skip-db-update).
+#   summary <scan.json> <out.json>   Normalize a raw scan report into a flat findings
+#                                    summary keyed for diffing, with per-severity counts.
+#   compare <cur> <prev> [out]       Diff two summaries -> report JSON with new and fixed
+#                                    findings. A missing/empty previous summary yields a
+#                                    baseline (current-only) report.
+#   render <report.json>             Render the report as Markdown to $GITHUB_STEP_SUMMARY
+#                                    (or stdout).
+#   payload <report.json>            Print the Slack message payload JSON to stdout.
+#   notify <report.json>             Post the report to Slack ($SECURITY_SCAN_SLACK_WEBHOOK_URL).
+#   notify-failure                   Post a run-failure notice to Slack so a broken scan
+#                                    is not a silent missed week.
+#
+# Env knobs — SECURITY_SCAN_* configure the scanner-agnostic reporting;
+# TRIVY_* configure the scanner itself (intentionally shadowing trivy's native
+# env config; the explicit flags passed by `scan` always win):
+#   SECURITY_SCAN_RENDER_LIMIT  Max current findings rendered in the step summary (default: 50).
+#   SECURITY_SCAN_NOTIFY_LIMIT  Max new/fixed findings listed in the Slack message (default: 10).
+#   TRIVY_SCANNERS      Scanners for `scan` (default: vuln,misconfig,secret).
+#   TRIVY_SKIP_DIRS     Comma-separated dirs `scan` skips (default: test and
+#                       docs/src/fixtures, whose intentionally-simple fixtures
+#                       would drown the report).
+#   TRIVY_TIMEOUT       Trivy scan timeout (default: 15m).
+#
+# Pass a missing-previous path as /nonexistent to `compare` to get a baseline report.
+
+SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+usage() {
+	sed -n '/^# Single entrypoint/,/to get a baseline report\.$/p' "$SELF"
+}
+
+now_utc() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+this_commit() { echo "${GITHUB_SHA:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"; }
+
+# Shared jq defs: severity normalization/ranking and the one-line finding format.
+jq_lib() {
+	cat <<-'JQ'
+		def sev: if . == null then "UNKNOWN"
+			elif (["CRITICAL","HIGH","MEDIUM","LOW","UNKNOWN"] | index(.)) then .
+			else "UNKNOWN" end;
+		def sevrank: {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "UNKNOWN": 4}[.] // 9;
+		def counts_line: . as $c |
+			(["CRITICAL","HIGH","MEDIUM","LOW","UNKNOWN"]
+				| map(. as $s | select(($c[$s] // 0) > 0) | "\($c[$s]) \($s)")
+				| join(", ")) as $by_sev |
+			"\($c.total // 0) total" + (if $by_sev != "" then " (\($by_sev))" else "" end);
+		def finding_line:
+			"[\(.severity)] \(.class) \(.id)"
+			+ (if .pkg != "" then " \(.pkg)" else "" end)
+			+ (if .installed != "" then " \(.installed)" else "" end)
+			+ (if .fixed != "" then " -> \(.fixed)" else "" end)
+			+ " (\(.target))";
+	JQ
+}
+
+# Run `trivy fs` over a source tree and write the raw JSON report
+cmd_scan() {
+	local src="${1:?Usage: security-scan-report.sh scan <src-dir> <out.json> [trivy args...]}"
+	local out="${2:?Usage: security-scan-report.sh scan <src-dir> <out.json> [trivy args...]}"
+	shift 2
+
+	if ! command -v trivy >/dev/null 2>&1; then
+		echo "Error: trivy not found on PATH; install it (e.g. aquasecurity/setup-trivy) first." >&2
+		exit 1
+	fi
+
+	mkdir -p "$(dirname "$out")"
+
+	# Findings never fail the scan (--exit-code 0): the diff report is the deliverable.
+	trivy fs \
+		--scanners "${TRIVY_SCANNERS:-vuln,misconfig,secret}" \
+		--skip-dirs "${TRIVY_SKIP_DIRS:-test,docs/src/fixtures}" \
+		--timeout "${TRIVY_TIMEOUT:-15m}" \
+		--format json \
+		--output "$out" \
+		--exit-code 0 \
+		--no-progress \
+		"$@" \
+		"$src"
+
+	echo "Scan:  $src"
+	echo "Report: $out ($(jq '[.Results[]? | ((.Vulnerabilities // []) + (.Misconfigurations // []) + (.Secrets // []))] | flatten | length' "$out") raw findings)"
+}
+
+# Normalize a raw Trivy report into a flat, diffable findings summary
+cmd_summary() {
+	local input="${1:?Usage: security-scan-report.sh summary <trivy.json> <out.json>}"
+	local output="${2:?Usage: security-scan-report.sh summary <trivy.json> <out.json>}"
+
+	if [[ ! -f "$input" ]]; then
+		echo "Error: trivy report '$input' not found" >&2
+		exit 1
+	fi
+
+	if ! jq empty "$input" 2>/dev/null; then
+		echo "Error: trivy report '$input' is not valid JSON" >&2
+		exit 1
+	fi
+
+	mkdir -p "$(dirname "$output")"
+
+	# One record per unique (class, target, pkg, id); passing misconfigurations are dropped.
+	jq \
+		--arg commit "$(this_commit)" \
+		--arg timestamp "$(now_utc)" \
+		"$(jq_lib)"'
+		[.Results[]? as $r |
+			(($r.Vulnerabilities // [])[] | {
+				class: "vuln",
+				id: (.VulnerabilityID // ""),
+				severity: (.Severity | sev),
+				target: ($r.Target // ""),
+				pkg: (.PkgName // ""),
+				installed: (.InstalledVersion // ""),
+				fixed: (.FixedVersion // ""),
+				title: (.Title // "")
+			}),
+			(($r.Misconfigurations // [])[] | select((.Status // "FAIL") == "FAIL") | {
+				class: "misconfig",
+				id: (.AVDID // .ID // ""),
+				severity: (.Severity | sev),
+				target: ($r.Target // ""),
+				pkg: "",
+				installed: "",
+				fixed: "",
+				title: (.Title // "")
+			}),
+			(($r.Secrets // [])[] | {
+				class: "secret",
+				id: (.RuleID // ""),
+				severity: (.Severity | sev),
+				target: ($r.Target // ""),
+				pkg: "",
+				installed: "",
+				fixed: "",
+				title: (.Title // "")
+			})
+		]
+		| map(. + {key: "\(.class)|\(.target)|\(.pkg)|\(.id)"})
+		| unique_by(.key)
+		| sort_by([(.severity | sevrank), .key])
+		| {
+			commit: $commit,
+			timestamp: $timestamp,
+			counts: (reduce .[] as $f (
+				{CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0, UNKNOWN: 0, total: 0};
+				.[$f.severity] += 1 | .total += 1)),
+			findings: .
+		}' "$input" >"$output"
+
+	echo "Summary: $output ($(jq -r '.counts.total' "$output") findings)"
+}
+
+# Diff two findings summaries into a new/fixed report
+cmd_compare() {
+	local current="${1:?Usage: security-scan-report.sh compare <current.json> <previous.json> [output.json]}"
+	local previous="${2:?Usage: security-scan-report.sh compare <current.json> <previous.json> [output.json]}"
+	local output="${3:-security-scan-report.json}"
+
+	if [[ ! -f "$current" ]]; then
+		echo "Error: current summary '$current' not found" >&2
+		exit 1
+	fi
+
+	if [[ ! -s "$previous" ]]; then
+		echo "No previous scan data found: establishing baseline."
+		jq '{
+			baseline: true,
+			current_counts: .counts,
+			previous_counts: null,
+			new: [],
+			fixed: [],
+			unchanged: null,
+			current_findings: .findings
+		}' "$current" >"$output"
+		return 0
+	fi
+
+	jq -n \
+		--slurpfile cur "$current" \
+		--slurpfile prev "$previous" '
+		($cur[0]) as $c |
+		($prev[0]) as $p |
+		($c.findings | map({(.key): true}) | add // {}) as $ckeys |
+		($p.findings | map({(.key): true}) | add // {}) as $pkeys |
+		{
+			baseline: false,
+			current_counts: $c.counts,
+			previous_counts: $p.counts,
+			new: [$c.findings[] | select($pkeys[.key] | not)],
+			fixed: [$p.findings[] | select($ckeys[.key] | not)],
+			unchanged: ([$c.findings[] | select($pkeys[.key])] | length),
+			current_findings: $c.findings
+		}' >"$output"
+
+	echo "Report: $output ($(jq -r '.new | length' "$output") new, $(jq -r '.fixed | length' "$output") fixed)"
+}
+
+# Render the report as Markdown to $GITHUB_STEP_SUMMARY (or stdout)
+cmd_render() {
+	local report="${1:?Usage: security-scan-report.sh render <report.json>}"
+	local summary_file="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+	local limit="${SECURITY_SCAN_RENDER_LIMIT:-50}"
+
+	if [[ ! -f "$report" ]]; then
+		echo "No trivy report at '$report'; skipping summary." >&2
+		return 0
+	fi
+
+	write() { echo "$@" >>"$summary_file"; }
+
+	table() {
+		echo "| Severity | Class | ID | Target | Package | Installed | Fixed |"
+		echo "|----------|-------|----|--------|---------|-----------|-------|"
+		jq -r '.[] | "| \(.severity) | \(.class) | \(.id) | \(.target) | \(.pkg) | \(.installed) | \(.fixed) |"'
+	}
+
+	write "## Weekly Security Scan"
+	write ""
+
+	local baseline
+	baseline=$(jq -r '.baseline' "$report")
+	if [[ "$baseline" == "true" ]]; then
+		write "Baseline established: $(jq -r "$(jq_lib)"'.current_counts | counts_line' "$report")"
+	else
+		write "| Severity | Current | Previous |"
+		write "|----------|---------|----------|"
+		jq -r '["CRITICAL","HIGH","MEDIUM","LOW","UNKNOWN","total"][] as $s |
+			"| \($s) | \(.current_counts[$s] // 0) | \(.previous_counts[$s] // 0) |"' "$report" >>"$summary_file"
+		write ""
+
+		local new_count fixed_count
+		new_count=$(jq -r '.new | length' "$report")
+		fixed_count=$(jq -r '.fixed | length' "$report")
+
+		write "### New findings ($new_count)"
+		write ""
+		if [[ "$new_count" -gt 0 ]]; then
+			jq -c '.new' "$report" | table >>"$summary_file"
+		else
+			write "No new findings this week."
+		fi
+		write ""
+
+		write "### Fixed findings ($fixed_count)"
+		write ""
+		if [[ "$fixed_count" -gt 0 ]]; then
+			jq -c '.fixed' "$report" | table >>"$summary_file"
+		else
+			write "No fixed findings this week."
+		fi
+	fi
+	write ""
+
+	local total shown
+	total=$(jq -r '.current_findings | length' "$report")
+	shown=$((total < limit ? total : limit))
+
+	write "### All current findings ($total)"
+	write ""
+	if [[ "$total" -gt 0 ]]; then
+		write "<details><summary>Showing $shown of $total</summary>"
+		write ""
+		jq -c --argjson limit "$limit" '.current_findings[:$limit]' "$report" | table >>"$summary_file"
+		if [[ "$total" -gt "$limit" ]]; then
+			write ""
+			write "...and $((total - limit)) more; see the security-scan-report.json artifact."
+		fi
+		write ""
+		write "</details>"
+	else
+		write "No findings."
+	fi
+}
+
+# Print the Slack message payload for the report to stdout
+cmd_payload() {
+	local report="${1:?Usage: security-scan-report.sh payload <report.json>}"
+	local limit="${SECURITY_SCAN_NOTIFY_LIMIT:-10}"
+	local repo="${REPO:-gruntwork-io/terragrunt}"
+	local run_url="${GITHUB_SERVER_URL:-https://github.com}/${repo}/actions/runs/${GITHUB_RUN_ID:-0}"
+
+	if [[ ! -f "$report" ]]; then
+		echo "Error: trivy report '$report' not found" >&2
+		exit 1
+	fi
+
+	# Header: one dated line per endpoint, matching the weekly coverage report.
+	local cur_sha="${CURRENT_SHA:-}" cur_date="${CURRENT_DATE:-unknown}"
+	local prev_sha="${PREVIOUS_SHA:-}" prev_date="${PREVIOUS_DATE:-unknown}"
+	local header="*Weekly Security Scan: terragrunt*"
+	if [[ -n "$cur_sha" && -n "$prev_sha" ]]; then
+		header+=$'\n'"From: ${prev_date} ${prev_sha}"
+		header+=$'\n'"To: ${cur_date} ${cur_sha}"
+	elif [[ -n "$cur_sha" ]]; then
+		header+=$'\n'"At: ${cur_date} ${cur_sha}"
+	fi
+
+	jq -n \
+		--arg header "$header" \
+		--arg run_url "$run_url" \
+		--argjson limit "$limit" \
+		--slurpfile rep "$report" \
+		"$(jq_lib)"'
+		($rep[0]) as $r |
+
+		(if $r.baseline then
+			"Findings baseline: \($r.current_counts | counts_line)"
+		else
+			"Findings: \($r.current_counts | counts_line) (was \($r.previous_counts | counts_line))"
+		end) as $totals |
+
+		(def listed($items; $label): if ($items | length) > 0 then
+			"\($label) (\($items | length)):\n"
+			+ ([$items[:$limit][] | "  \(finding_line)"] | join("\n"))
+			+ (if ($items | length) > $limit then "\n  ...and \(($items | length) - $limit) more" else "" end)
+		else "" end;
+		{
+			new: listed($r.new; "New this week"),
+			fixed: listed($r.fixed; "Fixed this week")
+		}) as $lists |
+
+		(if ($r.baseline | not) and $lists.new == "" then "No new findings this week." else "" end) as $none |
+
+		{
+			text: (
+				($header + "\n\n")
+				+ $totals
+				+ (if $lists.new != "" then "\n\n" + $lists.new else "" end)
+				+ (if $lists.fixed != "" then "\n\n" + $lists.fixed else "" end)
+				+ (if $none != "" then "\n\n" + $none else "" end)
+				+ "\n\n<\($run_url)|View workflow run>"
+			)
+		}'
+}
+
+# Post the report to Slack
+cmd_notify() {
+	local webhook="${SECURITY_SCAN_SLACK_WEBHOOK_URL:?Required environment variable SECURITY_SCAN_SLACK_WEBHOOK_URL}"
+	local report="${1:?Usage: security-scan-report.sh notify <report.json>}"
+
+	local payload
+	payload=$(cmd_payload "$report")
+
+	curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d "$payload" "$webhook"
+	echo "Slack notification sent."
+}
+
+# Post a run-failure notice to Slack
+cmd_notify_failure() {
+	local webhook="${SECURITY_SCAN_SLACK_WEBHOOK_URL:?Required environment variable SECURITY_SCAN_SLACK_WEBHOOK_URL}"
+	local repo="${REPO:-gruntwork-io/terragrunt}"
+	local run_url="${GITHUB_SERVER_URL:-https://github.com}/${repo}/actions/runs/${GITHUB_RUN_ID:-0}"
+
+	local payload
+	payload=$(jq -n --arg run_url "$run_url" \
+		'{text: "*Weekly Security Scan: terragrunt*\nRun failed before producing a report.\n\n<\($run_url)|View workflow run>"}')
+
+	curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d "$payload" "$webhook"
+	echo "Slack failure notification sent."
+}
+
+# Route the subcommand to its handler
+main() {
+	local cmd="${1:-}"
+	shift || true
+	case "$cmd" in
+	scan) cmd_scan "$@" ;;
+	summary) cmd_summary "$@" ;;
+	compare) cmd_compare "$@" ;;
+	render) cmd_render "$@" ;;
+	payload) cmd_payload "$@" ;;
+	notify) cmd_notify "$@" ;;
+	notify-failure) cmd_notify_failure "$@" ;;
+	"" | -h | --help | help) usage ;;
+	*)
+		echo "Unknown subcommand: $cmd" >&2
+		usage >&2
+		exit 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.github/scripts/security-scan/tests/security-scan-report.bats
+++ b/.github/scripts/security-scan/tests/security-scan-report.bats
@@ -1,0 +1,232 @@
+#!/usr/bin/env bats
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../security-scan-report.sh"
+  CURRENT_RAW="${BATS_TEST_TMPDIR}/current-raw.json"
+  PREVIOUS_RAW="${BATS_TEST_TMPDIR}/previous-raw.json"
+  CURRENT="${BATS_TEST_TMPDIR}/current-summary.json"
+  PREVIOUS="${BATS_TEST_TMPDIR}/previous-summary.json"
+  REPORT="${BATS_TEST_TMPDIR}/report.json"
+
+  # Current scan: a duplicated HIGH vuln, a severity-less vuln, a failing and a
+  # passing misconfiguration, and a CRITICAL secret.
+  cat >"$CURRENT_RAW" <<'EOF'
+{
+  "SchemaVersion": 2,
+  "Results": [
+    {
+      "Target": "go.mod",
+      "Class": "lang-pkgs",
+      "Type": "gomod",
+      "Vulnerabilities": [
+        {"VulnerabilityID": "CVE-2026-1111", "PkgName": "golang.org/x/foo", "InstalledVersion": "1.0.0", "FixedVersion": "1.0.1", "Severity": "HIGH", "Title": "foo before 1.0.1 allows RCE"},
+        {"VulnerabilityID": "CVE-2026-1111", "PkgName": "golang.org/x/foo", "InstalledVersion": "1.0.0", "FixedVersion": "1.0.1", "Severity": "HIGH", "Title": "foo before 1.0.1 allows RCE"},
+        {"VulnerabilityID": "GO-2026-9999", "PkgName": "golang.org/x/bar", "InstalledVersion": "0.2.0", "Title": "bar is unmaintained"}
+      ]
+    },
+    {
+      "Target": "Dockerfile",
+      "Class": "config",
+      "Type": "dockerfile",
+      "Misconfigurations": [
+        {"ID": "DS002", "AVDID": "AVD-DS-0002", "Title": "Image user should not be root", "Severity": "MEDIUM", "Status": "FAIL"},
+        {"ID": "DS999", "AVDID": "AVD-DS-0999", "Title": "Passing check", "Severity": "LOW", "Status": "PASS"}
+      ]
+    },
+    {
+      "Target": "config/creds.txt",
+      "Class": "secret",
+      "Secrets": [
+        {"RuleID": "github-pat", "Category": "GitHub", "Severity": "CRITICAL", "Title": "GitHub Personal Access Token"}
+      ]
+    }
+  ]
+}
+EOF
+
+  # Previous scan: shares GO-2026-9999 and AVD-DS-0002 with current, lacks the
+  # HIGH vuln and the secret (new this week), and has one LOW vuln fixed since.
+  cat >"$PREVIOUS_RAW" <<'EOF'
+{
+  "SchemaVersion": 2,
+  "Results": [
+    {
+      "Target": "go.mod",
+      "Class": "lang-pkgs",
+      "Type": "gomod",
+      "Vulnerabilities": [
+        {"VulnerabilityID": "GO-2026-9999", "PkgName": "golang.org/x/bar", "InstalledVersion": "0.2.0", "Title": "bar is unmaintained"},
+        {"VulnerabilityID": "CVE-2020-0001", "PkgName": "example.com/old", "InstalledVersion": "2.0.0", "FixedVersion": "2.0.1", "Severity": "LOW", "Title": "old bug"}
+      ]
+    },
+    {
+      "Target": "Dockerfile",
+      "Class": "config",
+      "Type": "dockerfile",
+      "Misconfigurations": [
+        {"ID": "DS002", "AVDID": "AVD-DS-0002", "Title": "Image user should not be root", "Severity": "MEDIUM", "Status": "FAIL"}
+      ]
+    }
+  ]
+}
+EOF
+
+  "$SCRIPT" summary "$CURRENT_RAW" "$CURRENT"
+  "$SCRIPT" summary "$PREVIOUS_RAW" "$PREVIOUS"
+  "$SCRIPT" compare "$CURRENT" "$PREVIOUS" "$REPORT"
+}
+
+@test "summary counts findings by severity" {
+  run jq -c '.counts' "$CURRENT"
+  [ "$output" == '{"CRITICAL":1,"HIGH":1,"MEDIUM":1,"LOW":0,"UNKNOWN":1,"total":4}' ]
+}
+
+@test "summary dedupes repeated findings" {
+  run jq -r '[.findings[] | select(.id == "CVE-2026-1111")] | length' "$CURRENT"
+  [ "$output" == "1" ]
+}
+
+@test "summary drops passing misconfigurations" {
+  run jq -r '.findings[].id' "$CURRENT"
+  [[ "$output" == *"AVD-DS-0002"* ]]
+  [[ "$output" != *"AVD-DS-0999"* ]]
+}
+
+@test "summary defaults a missing severity to UNKNOWN" {
+  run jq -r '.findings[] | select(.id == "GO-2026-9999") | .severity' "$CURRENT"
+  [ "$output" == "UNKNOWN" ]
+}
+
+@test "summary orders findings most severe first" {
+  run jq -r '[.findings[].severity] | join(",")' "$CURRENT"
+  [ "$output" == "CRITICAL,HIGH,MEDIUM,UNKNOWN" ]
+}
+
+@test "summary tolerates a scan with no results" {
+  echo '{"SchemaVersion": 2}' >"${BATS_TEST_TMPDIR}/empty-raw.json"
+  run "$SCRIPT" summary "${BATS_TEST_TMPDIR}/empty-raw.json" "${BATS_TEST_TMPDIR}/empty-summary.json"
+  [ "$status" -eq 0 ]
+  run jq -r '.counts.total' "${BATS_TEST_TMPDIR}/empty-summary.json"
+  [ "$output" == "0" ]
+}
+
+@test "summary fails on malformed scan JSON" {
+  echo 'not json' >"${BATS_TEST_TMPDIR}/broken.json"
+  run "$SCRIPT" summary "${BATS_TEST_TMPDIR}/broken.json" "${BATS_TEST_TMPDIR}/out.json"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not valid JSON"* ]]
+}
+
+@test "summary fails on a missing scan file" {
+  run "$SCRIPT" summary "${BATS_TEST_TMPDIR}/nonexistent.json" "${BATS_TEST_TMPDIR}/out.json"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "compare reports new and fixed findings" {
+  run jq -r '[.new[].id] | join(",")' "$REPORT"
+  [ "$output" == "github-pat,CVE-2026-1111" ]
+  run jq -r '[.fixed[].id] | join(",")' "$REPORT"
+  [ "$output" == "CVE-2020-0001" ]
+  run jq -r '.unchanged' "$REPORT"
+  [ "$output" == "2" ]
+}
+
+@test "compare reports a baseline when the previous summary is missing" {
+  run "$SCRIPT" compare "$CURRENT" /nonexistent "${BATS_TEST_TMPDIR}/baseline.json"
+  [ "$status" -eq 0 ]
+  run jq -c '{baseline, new: (.new | length), findings: (.current_findings | length)}' "${BATS_TEST_TMPDIR}/baseline.json"
+  [ "$output" == '{"baseline":true,"new":0,"findings":4}' ]
+}
+
+@test "compare treats an empty previous summary as a baseline" {
+  : >"${BATS_TEST_TMPDIR}/empty-prev.json"
+  run "$SCRIPT" compare "$CURRENT" "${BATS_TEST_TMPDIR}/empty-prev.json" "${BATS_TEST_TMPDIR}/baseline.json"
+  [ "$status" -eq 0 ]
+  run jq -r '.baseline' "${BATS_TEST_TMPDIR}/baseline.json"
+  [ "$output" == "true" ]
+}
+
+@test "compare fails on a missing current summary" {
+  run "$SCRIPT" compare "${BATS_TEST_TMPDIR}/nonexistent.json" "$PREVIOUS" "${BATS_TEST_TMPDIR}/out.json"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "render writes the report to the step summary" {
+  GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/summary.md" run "$SCRIPT" render "$REPORT"
+  [ "$status" -eq 0 ]
+  run cat "${BATS_TEST_TMPDIR}/summary.md"
+  [[ "$output" == *"New findings (2)"* ]]
+  [[ "$output" == *"Fixed findings (1)"* ]]
+  [[ "$output" == *"CVE-2026-1111"* ]]
+}
+
+@test "render caps the current findings table" {
+  GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/summary.md" SECURITY_SCAN_RENDER_LIMIT=1 run "$SCRIPT" render "$REPORT"
+  run cat "${BATS_TEST_TMPDIR}/summary.md"
+  [[ "$output" == *"and 3 more"* ]]
+}
+
+@test "render tolerates a missing report" {
+  run "$SCRIPT" render "${BATS_TEST_TMPDIR}/nonexistent.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipping summary"* ]]
+}
+
+@test "payload lists new and fixed findings" {
+  run "$SCRIPT" payload "$REPORT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"New this week (2)"* ]]
+  [[ "$output" == *"Fixed this week (1)"* ]]
+  [[ "$output" == *"github-pat"* ]]
+}
+
+@test "payload caps the listed findings" {
+  SECURITY_SCAN_NOTIFY_LIMIT=1 run "$SCRIPT" payload "$REPORT"
+  [[ "$output" == *"...and 1 more"* ]]
+}
+
+@test "payload reports when nothing is new" {
+  run "$SCRIPT" compare "$CURRENT" "$CURRENT" "${BATS_TEST_TMPDIR}/same.json"
+  [ "$status" -eq 0 ]
+  run "$SCRIPT" payload "${BATS_TEST_TMPDIR}/same.json"
+  [[ "$output" == *"No new findings this week."* ]]
+}
+
+@test "notify requires the webhook env" {
+  SECURITY_SCAN_SLACK_WEBHOOK_URL="" run "$SCRIPT" notify "$REPORT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SECURITY_SCAN_SLACK_WEBHOOK_URL"* ]]
+}
+
+@test "notify-failure requires the webhook env" {
+  SECURITY_SCAN_SLACK_WEBHOOK_URL="" run "$SCRIPT" notify-failure
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SECURITY_SCAN_SLACK_WEBHOOK_URL"* ]]
+}
+
+@test "render reports a baseline" {
+  run "$SCRIPT" compare "$CURRENT" /nonexistent "${BATS_TEST_TMPDIR}/baseline.json"
+  [ "$status" -eq 0 ]
+  GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/summary.md" run "$SCRIPT" render "${BATS_TEST_TMPDIR}/baseline.json"
+  [ "$status" -eq 0 ]
+  run cat "${BATS_TEST_TMPDIR}/summary.md"
+  [[ "$output" == *"Baseline established: 4 total"* ]]
+  [[ "$output" != *"New findings"* ]]
+}
+
+@test "payload reports a baseline" {
+  run "$SCRIPT" compare "$CURRENT" /nonexistent "${BATS_TEST_TMPDIR}/baseline.json"
+  [ "$status" -eq 0 ]
+  CURRENT_SHA=abc123 CURRENT_DATE=2026-08-17 run "$SCRIPT" payload "${BATS_TEST_TMPDIR}/baseline.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Findings baseline: 4 total"* ]]
+  [[ "$output" == *"At: 2026-08-17 abc123"* ]]
+}
+
+@test "fails on an unknown subcommand" {
+  run "$SCRIPT" bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown subcommand: bogus"* ]]
+}

--- a/.github/scripts/security-scan/tests/security-scan-report.bats
+++ b/.github/scripts/security-scan/tests/security-scan-report.bats
@@ -97,6 +97,15 @@ EOF
   [ "$output" == "UNKNOWN" ]
 }
 
+@test "summary maps an unsupported severity to UNKNOWN" {
+  jq '(.Results[0].Vulnerabilities[] | select(.VulnerabilityID == "CVE-2026-1111") | .Severity) = "BOGUS"' \
+    "$CURRENT_RAW" >"${BATS_TEST_TMPDIR}/bogus-raw.json"
+  run "$SCRIPT" summary "${BATS_TEST_TMPDIR}/bogus-raw.json" "${BATS_TEST_TMPDIR}/bogus-summary.json"
+  [ "$status" -eq 0 ]
+  run jq -r '.findings[] | select(.id == "CVE-2026-1111") | .severity' "${BATS_TEST_TMPDIR}/bogus-summary.json"
+  [ "$output" == "UNKNOWN" ]
+}
+
 @test "summary orders findings most severe first" {
   run jq -r '[.findings[].severity] | join(",")' "$CURRENT"
   [ "$output" == "CRITICAL,HIGH,MEDIUM,UNKNOWN" ]
@@ -236,6 +245,16 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"Findings baseline: 4 total"* ]]
   [[ "$output" == *"At: 2026-08-17 abc123"* ]]
+}
+
+@test "scan checks its tools before doing any work" {
+  SHIMS="${BATS_TEST_TMPDIR}/shims"
+  mkdir -p "$SHIMS"
+  for tool in bash dirname basename jq; do ln -s "$(command -v "$tool")" "$SHIMS/$tool"; done
+  PATH="$SHIMS" run "$SCRIPT" scan . "${BATS_TEST_TMPDIR}/scan/out.json"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"trivy"* ]]
+  [ ! -d "${BATS_TEST_TMPDIR}/scan" ]
 }
 
 @test "fails on an unknown subcommand" {

--- a/.github/scripts/security-scan/tests/security-scan-report.bats
+++ b/.github/scripts/security-scan/tests/security-scan-report.bats
@@ -29,7 +29,7 @@ setup() {
       "Class": "config",
       "Type": "dockerfile",
       "Misconfigurations": [
-        {"ID": "DS002", "AVDID": "AVD-DS-0002", "Title": "Image user should not be root", "Severity": "MEDIUM", "Status": "FAIL"},
+        {"ID": "DS002", "AVDID": "AVD-DS-0002", "Title": "Image user should not be root", "Severity": "MEDIUM", "Status": "FAIL", "CauseMetadata": {"StartLine": 5}},
         {"ID": "DS999", "AVDID": "AVD-DS-0999", "Title": "Passing check", "Severity": "LOW", "Status": "PASS"}
       ]
     },
@@ -37,7 +37,7 @@ setup() {
       "Target": "config/creds.txt",
       "Class": "secret",
       "Secrets": [
-        {"RuleID": "github-pat", "Category": "GitHub", "Severity": "CRITICAL", "Title": "GitHub Personal Access Token"}
+        {"RuleID": "github-pat", "Category": "GitHub", "Severity": "CRITICAL", "Title": "GitHub Personal Access Token", "StartLine": 10}
       ]
     }
   ]
@@ -179,14 +179,20 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"New this week (2)"* ]]
   [[ "$output" == *"Fixed this week (1)"* ]]
-  [[ "$output" == *"github-pat"* ]]
+  [[ "$output" == *"[CRITICAL] github-pat GitHub Personal Access Token (config/creds.txt:10)"* ]]
+  [[ "$output" == *"[LOW] example.com/old 2.0.0 -> 2.0.1 CVE-2020-0001 (go.mod)"* ]]
 }
 
 @test "payload lists the current findings" {
   run "$SCRIPT" payload "$REPORT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Current findings (4)"* ]]
-  [[ "$output" == *"[UNKNOWN] vuln GO-2026-9999 golang.org/x/bar 0.2.0 (go.mod)"* ]]
+  [[ "$output" == *"golang.org/x/bar 0.2.0 GO-2026-9999 (go.mod)"* ]]
+}
+
+@test "payload omits the UNKNOWN severity tag" {
+  run "$SCRIPT" payload "$REPORT"
+  [[ "$output" != *"[UNKNOWN]"* ]]
 }
 
 @test "payload caps the listed findings" {

--- a/.github/scripts/security-scan/tests/security-scan-report.bats
+++ b/.github/scripts/security-scan/tests/security-scan-report.bats
@@ -182,6 +182,13 @@ EOF
   [[ "$output" == *"github-pat"* ]]
 }
 
+@test "payload lists the current findings" {
+  run "$SCRIPT" payload "$REPORT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Current findings (4)"* ]]
+  [[ "$output" == *"[UNKNOWN] vuln GO-2026-9999 golang.org/x/bar 0.2.0 (go.mod)"* ]]
+}
+
 @test "payload caps the listed findings" {
   SECURITY_SCAN_NOTIFY_LIMIT=1 run "$SCRIPT" payload "$REPORT"
   [[ "$output" == *"...and 1 more"* ]]

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -57,7 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: bats
-        run: mise x bats -- bats --print-output-on-failure .github/scripts/release/tests/ .github/scripts/coverage/tests/
+        run: mise x bats -- bats --print-output-on-failure .github/scripts/release/tests/ .github/scripts/coverage/tests/ .github/scripts/security-scan/tests/
 
   test-js:
     name: Test JS scripts

--- a/.github/workflows/security-scan-weekly.yml
+++ b/.github/workflows/security-scan-weekly.yml
@@ -1,0 +1,138 @@
+name: Weekly Security Scan
+
+on:
+  schedule:
+    # Every Monday at 09:17 UTC, shortly after the coverage report
+    - cron: '17 9 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: security-scan-weekly-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  weekly:
+    name: Weekly Security Diff
+    runs-on: ubuntu-latest
+    env:
+      WINDOW_DAYS: "7"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          # The trunk commit that triggered the scheduled run.
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Use mise to install dependencies
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.5.12
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          version: v0.74.0
+          cache: true
+
+      - name: Resolve commits
+        id: refs
+        # Reuses the coverage scripts' resolver; keep in sync with coverage-weekly.yml.
+        run: ./.github/scripts/coverage/resolve-commits.sh
+
+      - name: Scan current
+        env:
+          GITHUB_SHA: ${{ steps.refs.outputs.current_sha }}
+        run: |
+          ./.github/scripts/security-scan/security-scan-report.sh scan . current/scan.json
+          ./.github/scripts/security-scan/security-scan-report.sh summary current/scan.json current/scan-summary.json
+
+      - name: Prepare previous checkout
+        if: steps.refs.outputs.same_commit != 'true'
+        env:
+          PREV_SHA: ${{ steps.refs.outputs.previous_sha }}
+        run: git worktree add --detach "../prev" "$PREV_SHA"
+
+      - name: Scan previous
+        if: steps.refs.outputs.same_commit != 'true'
+        env:
+          GITHUB_SHA: ${{ steps.refs.outputs.previous_sha }}
+        # Skip DB/check updates so both scans diff code changes against the same databases.
+        run: |
+          ./.github/scripts/security-scan/security-scan-report.sh scan ../prev previous/scan.json --skip-db-update --skip-check-update
+          ./.github/scripts/security-scan/security-scan-report.sh summary previous/scan.json previous/scan-summary.json
+
+      - name: Compare findings
+        # A missing/empty previous summary yields a baseline (current-only) report.
+        run: ./.github/scripts/security-scan/security-scan-report.sh compare current/scan-summary.json previous/scan-summary.json security-scan-report.json
+
+      - name: Write step summary
+        if: always()
+        run: ./.github/scripts/security-scan/security-scan-report.sh render security-scan-report.json
+
+      - name: Upload raw scan (current)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scan-current.json
+          path: current/scan.json
+          retention-days: 90
+
+      - name: Upload raw scan (previous)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scan-previous.json
+          path: previous/scan.json
+          retention-days: 90
+          if-no-files-found: ignore
+
+      - name: Upload scan summary (current)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scan-summary-current.json
+          path: current/scan-summary.json
+          retention-days: 90
+
+      - name: Upload scan summary (previous)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scan-summary-previous.json
+          path: previous/scan-summary.json
+          retention-days: 90
+          if-no-files-found: ignore
+
+      - name: Upload security-scan-report.json
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: security-scan-report.json
+          path: security-scan-report.json
+          retention-days: 90
+
+      - name: Notify Slack
+        if: always() && hashFiles('security-scan-report.json') != '' && env.SECURITY_SCAN_SLACK_WEBHOOK_URL != ''
+        env:
+          SECURITY_SCAN_SLACK_WEBHOOK_URL: ${{ secrets.SECURITY_SCAN_SLACK_WEBHOOK_URL || secrets.COVERAGE_SLACK_WEBHOOK_URL }}
+          CURRENT_SHA: ${{ steps.refs.outputs.current_sha }}
+          CURRENT_DATE: ${{ steps.refs.outputs.current_date }}
+          PREVIOUS_SHA: ${{ steps.refs.outputs.previous_sha }}
+          PREVIOUS_DATE: ${{ steps.refs.outputs.previous_date }}
+          REPO: ${{ github.repository }}
+        run: ./.github/scripts/security-scan/security-scan-report.sh notify security-scan-report.json
+
+      - name: Notify Slack (run failed)
+        # A failed scan would otherwise be a silent missed week.
+        if: failure() && hashFiles('security-scan-report.json') == '' && env.SECURITY_SCAN_SLACK_WEBHOOK_URL != ''
+        env:
+          SECURITY_SCAN_SLACK_WEBHOOK_URL: ${{ secrets.SECURITY_SCAN_SLACK_WEBHOOK_URL || secrets.COVERAGE_SLACK_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+        run: ./.github/scripts/security-scan/security-scan-report.sh notify-failure

--- a/.github/workflows/security-scan-weekly.yml
+++ b/.github/workflows/security-scan-weekly.yml
@@ -53,6 +53,14 @@ jobs:
           ./.github/scripts/security-scan/security-scan-report.sh scan . current/scan.json
           ./.github/scripts/security-scan/security-scan-report.sh summary current/scan.json current/scan-summary.json
 
+      - name: Reuse the current summary as previous
+        # No distinct previous commit: the diff is against the same tree, so the
+        # week reports zero new and zero fixed rather than a fresh baseline.
+        if: steps.refs.outputs.same_commit == 'true'
+        run: |
+          mkdir -p previous
+          cp current/scan-summary.json previous/scan-summary.json
+
       - name: Prepare previous checkout
         if: steps.refs.outputs.same_commit != 'true'
         env:


### PR DESCRIPTION

<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Add weekly security scan (Trivy) with week-over-week diff and Slack report 

Close: #6682

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated weekly security scans with manual run support.
  - Scans detect vulnerabilities, configuration issues, and exposed secrets.
  - Reports compare current and previous results, highlighting new, fixed, and unchanged findings.
  - Markdown summaries are available as downloadable artifacts.
  - Slack notifications report completed scans and scan failures.
- **Tests**
  - Added comprehensive automated coverage for reporting, comparisons, rendering, notifications, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->