### PR TITLE
chore: Wiring expansion into the unit and stack parse

### DIFF
--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -38,7 +38,7 @@ unit "app" {
   }
 
   source = "./modules/app"
-  path   = "app"
+  path   = "app/${each.key}"
 }
 `
 
@@ -55,7 +55,7 @@ stack "team" {
   }
 
   source = "./stacks/team"
-  path   = "team"
+  path   = "team/${count.index}"
 }
 `
 
@@ -633,29 +633,31 @@ bogus "x" {
 	require.Error(t, err)
 }
 
-func TestUnitAndStackDecodeExpansionBlock(t *testing.T) {
+func TestUnitAndStackExpandPerIterationElement(t *testing.T) {
 	t.Parallel()
 
 	stackCfg, err := parseStackString(t, unitWithExpansionHCL+stackWithExpansionHCL)
 	require.NoError(t, err)
-	require.Len(t, stackCfg.Units, 1)
-	require.Len(t, stackCfg.Stacks, 1)
+	require.Len(t, stackCfg.Units, 2)
+	require.Len(t, stackCfg.Stacks, 2)
 
-	unitExpansion := stackCfg.Units[0].Expansion
-	require.NotNil(t, unitExpansion)
-	require.NotNil(t, unitExpansion.ForEach)
-	assert.Equal(
-		t,
-		cty.SetVal([]cty.Value{cty.StringVal("web"), cty.StringVal("api")}),
-		*unitExpansion.ForEach,
-	)
+	unitPaths := map[string]string{}
 
-	stackExpansion := stackCfg.Stacks[0].Expansion
-	require.NotNil(t, stackExpansion)
-	require.NotNil(t, stackExpansion.Count)
-	// Decoding and the literal build the number at different big.Float precisions,
-	// which assert.Equal reads as a diff.
-	assert.True(t, stackExpansion.Count.RawEquals(cty.NumberIntVal(2)))
+	for _, unit := range stackCfg.Units {
+		require.NotNil(t, unit.Expansion)
+		unitPaths[unit.Expansion.Key()] = unit.Path
+	}
+
+	assert.Equal(t, map[string]string{"web": "app/web", "api": "app/api"}, unitPaths)
+
+	stackPaths := map[string]string{}
+
+	for _, stack := range stackCfg.Stacks {
+		require.NotNil(t, stack.Expansion)
+		stackPaths[stack.Expansion.Key()] = stack.Path
+	}
+
+	assert.Equal(t, map[string]string{"0": "team/0", "1": "team/1"}, stackPaths)
 }
 
 func TestBlocksWithoutExpansionDecodeUnchanged(t *testing.T) {

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -48,10 +48,21 @@ const (
 
 // StackConfigFile represents the structure of terragrunt.stack.hcl stack file.
 type StackConfigFile struct {
-	Locals   *terragruntLocal    `hcl:"locals,block"`
-	Includes []*StackIncludeFile `hcl:"include,block"`
-	Stacks   []*Stack            `hcl:"stack,block"`
-	Units    []*Unit             `hcl:"unit,block"`
+	Locals      *terragruntLocal    `hcl:"locals,block"`
+	Includes    []*StackIncludeFile `hcl:"include,block"`
+	StackBlocks []componentHeader   `hcl:"stack,block"`
+	UnitBlocks  []componentHeader   `hcl:"unit,block"`
+	Stacks      []*Stack
+	Units       []*Unit
+}
+
+// componentHeader keeps `unit` and `stack` in the stack file's schema without evaluating the
+// block body. Source, path and values are attributes, so a whole-file decode resolves them
+// before expansion can bind each.*/count.index, and a block referencing either fails on an
+// undefined variable.
+type componentHeader struct {
+	Remain hcl.Body `hcl:",remain"`
+	Name   string   `hcl:",label"`
 }
 
 // StackIncludeFile represents an include block in a stack file.
@@ -466,6 +477,7 @@ func generateUnits(
 				sourceDir:    opts.sourceDir,
 				targetDir:    opts.targetDir,
 				name:         unit.Name,
+				displayName:  componentAddress(unit.Name, unit.Expansion),
 				path:         unit.Path,
 				source:       unit.Source,
 				values:       unit.Values,
@@ -477,7 +489,7 @@ func generateUnits(
 
 			l.Infof(
 				"Generating unit %s from %s",
-				unit.Name,
+				componentAddress(unit.Name, unit.Expansion),
 				util.RelPathForLog(opts.rootWorkingDir, opts.sourceFile, opts.logShowAbsPaths),
 			)
 
@@ -512,6 +524,7 @@ func generateStacks(
 				sourceDir:    opts.sourceDir,
 				targetDir:    opts.targetDir,
 				name:         stack.Name,
+				displayName:  componentAddress(stack.Name, stack.Expansion),
 				path:         stack.Path,
 				source:       stack.Source,
 				noStack:      stack.NoStack != nil && *stack.NoStack,
@@ -523,7 +536,7 @@ func generateStacks(
 
 			l.Infof(
 				"Generating stack %s from %s",
-				stack.Name,
+				componentAddress(stack.Name, stack.Expansion),
 				util.RelPathForLog(opts.rootWorkingDir, opts.sourceFile, opts.logShowAbsPaths),
 			)
 
@@ -557,6 +570,7 @@ type componentToGenerate struct {
 	sourceDir    string
 	targetDir    string
 	name         string
+	displayName  string
 	path         string
 	source       string
 	noStack      bool
@@ -723,7 +737,7 @@ func generateComponent(
 		kindStr = "stack"
 	}
 
-	l.Debugf("Generating: %s (%s) to %s", cmp.name, source, dest)
+	l.Debugf("Generating: %s (%s) to %s", cmp.displayName, source, dest)
 
 	if err := fetchComponentSource(ctx, l, v, opts, cmp, kindStr, source, dest); err != nil {
 		return err
@@ -1162,6 +1176,11 @@ func ParseStackConfig(
 		return nil, decodeErr
 	}
 
+	config.Units, config.Stacks, err = decodeComponents(file, evalParsingContext)
+	if err != nil {
+		return nil, err
+	}
+
 	// Process include blocks and merge any generated stack-level autoinclude file.
 	stackDir := filepath.Dir(file.ConfigPath)
 
@@ -1213,15 +1232,6 @@ func ParseStackConfig(
 	return stackConfig, nil
 }
 
-// stackComponentHeaders captures only the label and path of each unit/stack block
-// so component paths can be resolved before the full decode evaluates values.
-// source, values, and every other attribute are left in the block body, unevaluated.
-type stackComponentHeaders struct {
-	Remain hcl.Body                `hcl:",remain"`
-	Stacks []*stackComponentHeader `hcl:"stack,block"`
-	Units  []*stackComponentHeader `hcl:"unit,block"`
-}
-
 // stackComponentHeader is the path-only shape of a unit or stack block.
 type stackComponentHeader struct {
 	Remain  hcl.Body `hcl:",remain"`
@@ -1249,14 +1259,14 @@ func injectStackComponentRefs(
 	stackDir string,
 	parserOpts []hclparse.Option,
 ) error {
-	headers := &stackComponentHeaders{}
-	if err := file.Decode(headers, evalCtx); err != nil {
+	baseUnits, baseStacks, err := decodeComponentHeaders(file, evalCtx)
+	if err != nil {
 		return err
 	}
 
 	// Publish the base refs first so a sibling autoinclude block whose path references unit.<name>.path /
 	// stack.<name>.path can resolve against the base components, matching how the full decode resolves them.
-	setStackComponentRefVars(evalCtx, stackDir, headers.Units, headers.Stacks)
+	setStackComponentRefVars(evalCtx, stackDir, baseUnits, baseStacks)
 
 	autoUnits, autoStacks, err := stackAutoIncludeComponentHeaders(
 		fsys,
@@ -1269,8 +1279,8 @@ func injectStackComponentRefs(
 	}
 
 	// Republish so an overridden component's path reflects the override, not the base path it replaced.
-	units := util.MergeNamed(headers.Units, autoUnits, componentHeaderName)
-	stacks := util.MergeNamed(headers.Stacks, autoStacks, componentHeaderName)
+	units := util.MergeNamed(baseUnits, autoUnits, componentHeaderName)
+	stacks := util.MergeNamed(baseStacks, autoStacks, componentHeaderName)
 	setStackComponentRefVars(evalCtx, stackDir, units, stacks)
 
 	return nil
@@ -1336,8 +1346,8 @@ func stackAutoIncludeComponentHeaders(
 		return nil, nil, fmt.Errorf("failed to read stack autoinclude %q: %w", autoIncludePath, err)
 	}
 
-	headers := &stackComponentHeaders{}
-	if decodeErr := incFile.Decode(headers, evalCtx); decodeErr != nil {
+	autoUnits, autoStacks, decodeErr := decodeComponentHeaders(incFile, evalCtx)
+	if decodeErr != nil {
 		return nil, nil, fmt.Errorf(
 			"failed to decode stack autoinclude headers %q: %w",
 			autoIncludePath,
@@ -1345,7 +1355,60 @@ func stackAutoIncludeComponentHeaders(
 		)
 	}
 
-	return headers.Units, headers.Stacks, nil
+	return autoUnits, autoStacks, nil
+}
+
+// decodeComponentHeaders reads the label and path of each unit and stack block. Blocks are
+// expanded so that a path referencing each.*/count.index still decodes, and only unexpanded
+// components come back: a component reference names a whole block, which an expanded one has
+// no single path to answer for.
+func decodeComponentHeaders(
+	file *hclparse.File,
+	evalCtx *hcl.EvalContext,
+) ([]*stackComponentHeader, []*stackComponentHeader, error) {
+	units, err := expandComponentHeaders(file, MetadataUnit, evalCtx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stacks, err := expandComponentHeaders(file, MetadataStack, evalCtx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return units, stacks, nil
+}
+
+func expandComponentHeaders(
+	file *hclparse.File,
+	blockType string,
+	evalCtx *hcl.EvalContext,
+) ([]*stackComponentHeader, error) {
+	instances, err := file.ExpandBlocks(blockType, &stackComponentHeader{}, evalCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	headers := make([]*stackComponentHeader, 0, len(instances))
+
+	for _, instance := range instances {
+		if instance.Expanded() {
+			continue
+		}
+
+		header, ok := instance.Value.(*stackComponentHeader)
+		if !ok {
+			panic(fmt.Sprintf(
+				"ExpandBlocks returned %T for a %s block, but it decodes into the type it is given",
+				instance.Value,
+				blockType,
+			))
+		}
+
+		headers = append(headers, header)
+	}
+
+	return headers, nil
 }
 
 // componentHeaderName returns a header's block name, or an empty string for a nil entry so MergeNamed leaves it untouched.
@@ -1462,6 +1525,93 @@ func pruneOverriddenStackAutoIncludes(
 	return nil
 }
 
+// componentAddress identifies one instance of a unit or stack block. Every instance of an
+// expanded block carries its label, so the label alone would fold a whole set into one entry.
+func componentAddress(name string, expansion *hclparse.ExpansionBlock) string {
+	if expansion == nil || !expansion.Expanded() {
+		return name
+	}
+
+	return name + "[" + expansion.Key() + "]"
+}
+
+// decodeComponents decodes a stack file's unit and stack blocks, returning one value per
+// iteration element. A block that declares no expansion yields a single value.
+func decodeComponents(
+	file *hclparse.File,
+	evalCtx *hcl.EvalContext,
+) ([]*Unit, []*Stack, error) {
+	units, err := decodeUnitBlocks(file, evalCtx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stacks, err := decodeStackBlocks(file, evalCtx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return units, stacks, nil
+}
+
+// decodeUnitBlocks decodes a stack file's unit blocks, returning one Unit per iteration
+// element. A block that declares no expansion yields a single Unit.
+func decodeUnitBlocks(file *hclparse.File, evalContext *hcl.EvalContext) ([]*Unit, error) {
+	instances, err := file.ExpandBlocks(MetadataUnit, &Unit{}, evalContext)
+	if err != nil {
+		return nil, err
+	}
+
+	units := make([]*Unit, 0, len(instances))
+
+	for _, instance := range instances {
+		unit, ok := instance.Value.(*Unit)
+		if !ok {
+			panic(fmt.Sprintf(
+				"ExpandBlocks returned %T for a unit block, but it decodes into the type it is given",
+				instance.Value,
+			))
+		}
+
+		if unit.Expansion != nil {
+			unit.Expansion.InstanceKey = instance.InstanceKey
+		}
+
+		units = append(units, unit)
+	}
+
+	return units, nil
+}
+
+// decodeStackBlocks decodes a stack file's stack blocks, returning one Stack per iteration
+// element. A block that declares no expansion yields a single Stack.
+func decodeStackBlocks(file *hclparse.File, evalContext *hcl.EvalContext) ([]*Stack, error) {
+	instances, err := file.ExpandBlocks(MetadataStack, &Stack{}, evalContext)
+	if err != nil {
+		return nil, err
+	}
+
+	stacks := make([]*Stack, 0, len(instances))
+
+	for _, instance := range instances {
+		stack, ok := instance.Value.(*Stack)
+		if !ok {
+			panic(fmt.Sprintf(
+				"ExpandBlocks returned %T for a stack block, but it decodes into the type it is given",
+				instance.Value,
+			))
+		}
+
+		if stack.Expansion != nil {
+			stack.Expansion.InstanceKey = instance.InstanceKey
+		}
+
+		stacks = append(stacks, stack)
+	}
+
+	return stacks, nil
+}
+
 // processStackConfigIncludes resolves include blocks during stack file parsing.
 // It reads each included file, parses it with the same eval context, and merges
 // its units and stacks into the main config so generation sees all components,
@@ -1494,6 +1644,11 @@ func processStackConfigIncludes(
 			return fmt.Errorf("failed to decode include %q: %w", inc.Name, decodeErr)
 		}
 
+		included.Units, included.Stacks, err = decodeComponents(incFile, evalCtx)
+		if err != nil {
+			return fmt.Errorf("failed to decode include %q: %w", inc.Name, err)
+		}
+
 		if included.Locals != nil {
 			return fmt.Errorf("included stack file %q must not define locals", inc.Name)
 		}
@@ -1510,22 +1665,24 @@ func processStackConfigIncludes(
 	seen := make(map[string]struct{}, len(config.Units))
 
 	for _, u := range config.Units {
-		if _, exists := seen[u.Name]; exists {
+		address := componentAddress(u.Name, u.Expansion)
+		if _, exists := seen[address]; exists {
 			return inthclparse.DuplicateUnitNameError{Name: u.Name}
 		}
 
-		seen[u.Name] = struct{}{}
+		seen[address] = struct{}{}
 	}
 
 	// Validate no duplicate stack names after merge.
 	seen = make(map[string]struct{}, len(config.Stacks))
 
 	for _, s := range config.Stacks {
-		if _, exists := seen[s.Name]; exists {
+		address := componentAddress(s.Name, s.Expansion)
+		if _, exists := seen[address]; exists {
 			return inthclparse.DuplicateStackNameError{Name: s.Name}
 		}
 
-		seen[s.Name] = struct{}{}
+		seen[address] = struct{}{}
 	}
 
 	return nil
@@ -1588,6 +1745,11 @@ func mergeStackAutoIncludeFile(
 		return fmt.Errorf("failed to decode stack autoinclude %q: %w", autoIncludePath, decodeErr)
 	}
 
+	included.Units, included.Stacks, err = decodeComponents(incFile, evalCtx)
+	if err != nil {
+		return fmt.Errorf("failed to decode stack autoinclude %q: %w", autoIncludePath, err)
+	}
+
 	if included.Locals != nil {
 		return fmt.Errorf("stack autoinclude %q must not define locals", autoIncludePath)
 	}
@@ -1621,11 +1783,12 @@ func validateUniqueComponentNames(units []*Unit, stacks []*Stack) error {
 			continue
 		}
 
-		if _, dup := seenUnits[u.Name]; dup {
+		address := componentAddress(u.Name, u.Expansion)
+		if _, dup := seenUnits[address]; dup {
 			return inthclparse.DuplicateUnitNameError{Name: u.Name}
 		}
 
-		seenUnits[u.Name] = struct{}{}
+		seenUnits[address] = struct{}{}
 	}
 
 	seenStacks := make(map[string]struct{}, len(stacks))
@@ -1635,11 +1798,12 @@ func validateUniqueComponentNames(units []*Unit, stacks []*Stack) error {
 			continue
 		}
 
-		if _, dup := seenStacks[s.Name]; dup {
+		address := componentAddress(s.Name, s.Expansion)
+		if _, dup := seenStacks[address]; dup {
 			return inthclparse.DuplicateStackNameError{Name: s.Name}
 		}
 
-		seenStacks[s.Name] = struct{}{}
+		seenStacks[address] = struct{}{}
 	}
 
 	return nil

--- a/pkg/config/stack_validation.go
+++ b/pkg/config/stack_validation.go
@@ -105,7 +105,7 @@ func validateUnits(units []*Unit) error {
 		"unit",
 		func(element any, i int) (string, string, string) {
 			unit := element.(*Unit)
-			return unit.Name, unit.Path, unit.Source
+			return componentAddress(unit.Name, unit.Expansion), unit.Path, unit.Source
 		},
 	)
 }
@@ -117,7 +117,7 @@ func validateStacks(stacks []*Stack) error {
 		"stack",
 		func(element any, i int) (string, string, string) {
 			stack := element.(*Stack)
-			return stack.Name, stack.Path, stack.Source
+			return componentAddress(stack.Name, stack.Expansion), stack.Path, stack.Source
 		},
 	)
 }

--- a/test/fixtures/stacks/expansion/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/expansion/live/terragrunt.stack.hcl
@@ -1,0 +1,43 @@
+unit "aurora" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  source = "../units/app"
+  path   = "aurora/${each.key}"
+
+  values = {
+    role = each.key
+  }
+}
+
+unit "shard" {
+  expansion {
+    count = 2
+  }
+
+  source = "../units/app"
+  path   = "shard/${count.index}"
+
+  values = {
+    role = "shard-${count.index}"
+  }
+}
+
+unit "vpc" {
+  source = "../units/app"
+  path   = "vpc"
+
+  values = {
+    role = "vpc"
+  }
+}
+
+stack "team" {
+  expansion {
+    count = 2
+  }
+
+  source = "../stacks/team"
+  path   = "team/${count.index}"
+}

--- a/test/fixtures/stacks/expansion/stacks/team/app/main.tf
+++ b/test/fixtures/stacks/expansion/stacks/team/app/main.tf
@@ -1,0 +1,7 @@
+variable "role" {
+  type = string
+}
+
+output "role" {
+  value = var.role
+}

--- a/test/fixtures/stacks/expansion/stacks/team/app/terragrunt.hcl
+++ b/test/fixtures/stacks/expansion/stacks/team/app/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "."
+}
+
+inputs = {
+  role = values.role
+}

--- a/test/fixtures/stacks/expansion/stacks/team/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/expansion/stacks/team/terragrunt.stack.hcl
@@ -1,0 +1,8 @@
+unit "member" {
+  source = "./app"
+  path   = "member"
+
+  values = {
+    role = "member"
+  }
+}

--- a/test/fixtures/stacks/expansion/units/app/main.tf
+++ b/test/fixtures/stacks/expansion/units/app/main.tf
@@ -1,0 +1,7 @@
+variable "role" {
+  type = string
+}
+
+output "role" {
+  value = var.role
+}

--- a/test/fixtures/stacks/expansion/units/app/terragrunt.hcl
+++ b/test/fixtures/stacks/expansion/units/app/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "."
+}
+
+inputs = {
+  role = values.role
+}

--- a/test/integration_stack_expansion_test.go
+++ b/test/integration_stack_expansion_test.go
@@ -1,0 +1,100 @@
+package test_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+)
+
+const testFixtureStacksExpansion = "fixtures/stacks/expansion"
+
+// generateExpansionStack copies the fixture and generates, returning the generated
+// .terragrunt-stack directory.
+func generateExpansionStack(t *testing.T) string {
+	t.Helper()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksExpansion)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksExpansion)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStacksExpansion, "live")
+
+	helpers.RunTerragrunt(
+		t,
+		"terragrunt stack generate --experiment block-iteration --working-dir "+rootPath,
+	)
+
+	return filepath.Join(rootPath, ".terragrunt-stack")
+}
+
+func TestStackExpansionGeneratesOneDirectoryPerElement(t *testing.T) {
+	t.Parallel()
+
+	stackPath := generateExpansionStack(t)
+
+	for _, unit := range []string{
+		filepath.Join("aurora", "web"),
+		filepath.Join("aurora", "api"),
+		filepath.Join("shard", "0"),
+		filepath.Join("shard", "1"),
+		"vpc",
+	} {
+		assert.FileExists(t, filepath.Join(stackPath, unit, "terragrunt.hcl"))
+	}
+
+	// A nested stack generates its own .terragrunt-stack, so its units sit a level deeper.
+	for _, stack := range []string{"0", "1"} {
+		assert.FileExists(
+			t,
+			filepath.Join(stackPath, "team", stack, ".terragrunt-stack", "member", "terragrunt.hcl"),
+		)
+	}
+}
+
+func TestStackExpansionResolvesValuesPerInstance(t *testing.T) {
+	t.Parallel()
+
+	stackPath := generateExpansionStack(t)
+
+	roles := map[string]string{
+		filepath.Join("aurora", "web"): "web",
+		filepath.Join("aurora", "api"): "api",
+		filepath.Join("shard", "0"):    "shard-0",
+		filepath.Join("shard", "1"):    "shard-1",
+		"vpc":                          "vpc",
+	}
+
+	for unit, role := range roles {
+		values, err := os.ReadFile(filepath.Join(stackPath, unit, "terragrunt.values.hcl"))
+		require.NoError(t, err)
+
+		assert.Contains(t, string(values), `role = "`+role+`"`)
+	}
+}
+
+func TestStackExpansionRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsExperimentMode(t) {
+		t.Skip(
+			"Skipping: TG_EXPERIMENT_MODE forces all experiments on, opening the gate this test pins shut",
+		)
+	}
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksExpansion)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksExpansion)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStacksExpansion, "live")
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt stack generate --working-dir "+rootPath,
+	)
+
+	var expansionErr config.ExpansionRequiresExperimentError
+	require.ErrorAs(t, err, &expansionErr)
+	assert.Equal(t, "unit", expansionErr.BlockType)
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Wires expansion into unit and stack parsing.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Stack and unit expansions now create separate instances for each expansion element.
  - Generated instances receive distinct, expansion-specific addresses and paths.
  - Expanded units and nested stacks preserve per-instance configuration values.

- **Bug Fixes**
  - Duplicate detection now distinguishes expanded instances correctly.
  - Included and automatically included components resolve expanded blocks consistently.
  - Validation and generation now operate on each materialized expansion instance.

- **Tests**
  - Added coverage for expanded units, nested stacks, generated paths, instance values, and required feature enablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->