### PR TITLE
chore: Completing venv abstraction

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -116,6 +116,15 @@ linters:
         - pattern: ^os\.(UserHomeDir|UserCacheDir|UserConfigDir)$
           pkg: ^os$
           msg: use the venv's Platform handles instead of reading the invoking user's directories
+        - pattern: ^os\.(Getpid|Executable|Hostname)$
+          pkg: ^os$
+          msg: use the venv's Platform handles instead of reading the running process
+        - pattern: ^os\.Args$
+          pkg: ^os$
+          msg: take the arguments the CLI was handed rather than reading the process arguments
+        - pattern: ^runtime\.(GOOS|GOARCH)$
+          pkg: ^runtime$
+          msg: take the platform from the venv's Platform.GOOS and Platform.GOARCH instead of the compiled-in constants
         - pattern: ^os\.(Stdin|Stdout|Stderr)$
           pkg: ^os$
           msg: read and write the venv's Reader and Writers, and ask its Terminal whether a stream is a tty
@@ -128,11 +137,6 @@ linters:
         - pattern: ^http\.Default(Client|Transport)$
           pkg: ^net/http$
           msg: send through the venv's vhttp.Client instead of the shared default client
-        # A composite literal builds a client without calling anything the rules
-        # above match, so it is the remaining way to reach the network past the
-        # venv. The two production sites that survive it are the GCS client
-        # constructors, whose nolint directives cover this rule as well; both
-        # wrap a transport derived from the venv's own client.
         - pattern: ^http\.Client$
           pkg: ^net/http$
           msg: take the client from the venv's vhttp.Client rather than building one
@@ -147,9 +151,6 @@ linters:
           msg: resolve links on the venv's vfs.FS via vfs.EvalSymlinks, or vfs.ResolveForCompare when the result is to be compared against another path
         - pattern: ^(vfs\.NewOSFS|vexec\.NewOSExec|vhttp\.NewOSClient|vsops\.NewOSDecrypter)$
           msg: take the handle from the venv already in scope rather than building a fresh OS-backed one
-        # Cloud SDKs build their own transport when handed no client, so these
-        # entry points leak past the venv without any net/http call of our own
-        # for the rules above to catch.
         - pattern: ^config\.LoadDefaultConfig$
           pkg: ^github.com/aws/aws-sdk-go-v2/config$
           msg: build AWS config via awshelper.NewAWSConfigBuilder so requests ride the venv's HTTP client
@@ -221,33 +222,39 @@ linters:
       - linters:
           - forbidigo
         path: ^(internal/view/tui/tty\.go|internal/tf/run_cmd\.go)$
+      # main is where the process arguments enter the program and become the
+      # arguments every layer below is handed, so it is the one place that has
+      # nothing to read them from.
+      - linters:
+          - forbidigo
+        text: use of `os.Args`
+        path: ^main\.go$
 
-      # Everything below are the call sites that predate the forbidigo
-      # rules above. They reach the real OS directly and still need porting to
-      # venv. Delete entries as they are ported.
+      # The vendored urfave/cli help renderer reads CLI_TEMPLATE_ERROR_DEBUG
+      # from the process with os.Getenv, so the only way to turn its template
+      # diagnostics on is to put the variable where it will look.
+      - linters:
+          - forbidigo
+        text: use of `os.Setenv`
+        path: ^internal/cli/commands/help/cli\.go$
 
+      # Pre-existing style debt in two paths, held back so it can be cleaned
+      # up on its own. The venv rules are deliberately absent from this list,
+      # so they still apply to both paths.
       - linters:
-          - forbidigo
-        path: ^(internal/cli/commands/browse/tui/model\.go|internal/cli/commands/catalog/cli\.go|internal/view/tui/form/form\.go|internal/cli/commands/catalog/tui/tags_layout\.go|internal/cli/commands/commands\.go|internal/cli/commands/hcl/validate/validate\.go|internal/cli/commands/help/cli\.go|internal/cli/commands/render/render\.go|internal/cli/commands/scaffold/cli\.go|internal/cli/commands/scaffold/scaffold\.go)$
-      - linters:
-          - forbidigo
-        path: ^(internal/tf/cache/handlers/filesystem_mirror_provider\.go|internal/tf/cache/helpers/http\.go|internal/tf/cliconfig/credentials\.go|internal/tf/getproviders/constraints\.go|internal/tf/getproviders/hash\.go|internal/tf/getproviders/lock\.go|internal/tf/getproviders/package_authentication\.go|internal/tf/source\.go|internal/tf/tf\.go)$
-      - linters:
-          - forbidigo
-        path: ^(internal/runner/common/unit_runner\.go|internal/runner/run/debug\.go|internal/runner/run/run\.go|internal/runner/runnerpool/runner\.go)$
-      - linters:
-          - forbidigo
-        path: ^(pkg/config/catalog\.go|pkg/config/config_helpers\.go|pkg/config/config_partial\.go|pkg/config/config\.go|pkg/config/dependency\.go|pkg/config/stack\.go)$
-      # DefaultWrappedPath is a package-level var, so it probes for `tofu` at
-      # init time, before any venv exists.
-      #
-      # TODO: Make the lookup lazy with a once so we can inject venv into this.
-      - linters:
-          - forbidigo
-        path: ^pkg/options/options\.go$
-      - linters:
-          - forbidigo
-        path: ^(internal/discovery/phase_worktree\.go|internal/engine/engine\.go|internal/engine/verification\.go|internal/getter/tfrhelpers\.go|internal/git/git\.go|internal/remotestate/remote_state\.go|internal/remotestate/terraform_state_file\.go|internal/report/writer\.go|internal/services/catalog/module/doc\.go|internal/services/catalog/module/module\.go|internal/shell/run_cmd\.go|internal/stacks/clean/clean\.go|internal/tfimpl/tfimpl\.go|internal/util/lockfile\.go|internal/worktrees/worktrees\.go)$
+          - errcheck
+          - govet
+          - mnd
+          - paralleltest
+          - perfsprint
+          - staticcheck
+          - testifylint
+          - thelper
+          - tparallel
+          - unused
+          - wsl_v5
+        path: ^(internal/github/|test/integration_docs_test\.go$)
+
       # We end up with duplicated content in this package to save us from duplicating code in other packages.
       - linters:
           - dupl
@@ -266,10 +273,10 @@ linters:
           - lll
         path-except: "^(internal/awshelper/|internal/cas/|internal/cli/commands/(backend/(delete|migrate)|browse|catalog/tui/command|dag/graph|exec|find|help|list|scaffold|stack)/|internal/cloner/|internal/codegen/|internal/configbridge/|internal/discovery/|internal/engine/|internal/errorconfig/|internal/errors/|internal/experiment/|internal/filter/|internal/gcphelper/|internal/getter/|internal/git/|internal/os/exec/|internal/prepare/|internal/queue/|internal/report/|internal/retry/|internal/runner/(common|graph|run/creds|runall|runcfg)/|internal/stacks/(generate|output)/|internal/telemetry/|internal/tf/cache/(controllers|middleware)/|internal/tflint/|internal/tips/|internal/vfs/|internal/worktrees/|pkg/log/(format/(options|placeholders)|writer)/|pkg/options/)"
     paths:
-      - docs
-      - _ci
-      - .github
-      - .circleci
+      - ^docs/
+      - ^_ci/
+      - ^\.github/
+      - ^\.circleci/
       - third_party$
       - builtin$
       - examples$
@@ -285,10 +292,10 @@ formatters:
   exclusions:
     generated: lax
     paths:
-      - docs
-      - _ci
-      - .github
-      - .circleci
+      - ^docs/
+      - ^_ci/
+      - ^\.github/
+      - ^\.circleci/
       - third_party$
       - builtin$
       - examples$

--- a/docs/src/data/changelog/v1.1.4/prompt-answer-without-newline.mdx
+++ b/docs/src/data/changelog/v1.1.4/prompt-answer-without-newline.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.4"
+category: "bug-fixes"
+---
+
+#### Prompts accept a piped answer that has no trailing newline
+
+Piping an answer to a confirmation prompt, as in `printf yes | terragrunt run --all destroy`, failed with an `EOF` error because Terragrunt discarded a final answer that ended without a newline. Terragrunt now reads that final answer, and only a prompt that gets no input at all reports `EOF`.

--- a/docs/src/data/changelog/v1.1.4/sops-decrypt-auth-provider-credentials.mdx
+++ b/docs/src/data/changelog/v1.1.4/sops-decrypt-auth-provider-credentials.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.4"
+category: "bug-fixes"
+---
+
+#### `sops_decrypt_file` now uses the credentials your auth provider supplies
+
+When a run obtained credentials from [`--auth-provider-cmd`](/reference/cli/commands/run#auth-provider-cmd), `sops_decrypt_file` ignored them for any variable already set in the environment Terragrunt started with. The rest of the run honored the auth provider, and correctly overrode any ambient environment variables. OpenTofu/Terraform received those credentials, and so did the AWS calls Terragrunt makes on a unit's behalf, such as `get_aws_account_id`.
+
+Decryption now runs as the identity Terragrunt resolved for the unit, the same one the rest of the run uses, regardless of ambient environment variables.

--- a/internal/cas/benchmark_test.go
+++ b/internal/cas/benchmark_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
@@ -140,7 +140,7 @@ func BenchmarkGitOperations(b *testing.B) {
 	// Clone the repo locally for tree operations
 	repoDir := b.TempDir()
 
-	g, err := git.NewGitRunner(vexec.NewOSExec())
+	g, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(b, err)
 
 	g = g.WithWorkDir(repoDir)
@@ -150,7 +150,7 @@ func BenchmarkGitOperations(b *testing.B) {
 	require.NoError(b, g.Clone(ctx, repoURL, false, 0, ""))
 
 	b.Run("ls-remote", func(b *testing.B) {
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		runner, err := git.NewGitRunner(venv.OSVenv())
 		require.NoError(b, err)
 
 		b.ResetTimer()

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"errors"
 
@@ -216,7 +215,7 @@ func (r *GitResolver) Probe(ctx context.Context, rawURL string) (string, error) 
 		}
 	}
 
-	runner, err := git.NewGitRunner(r.Venv.Exec)
+	runner, err := git.NewGitRunner(r.Venv)
 	if err != nil {
 		return "", err
 	}
@@ -337,7 +336,7 @@ func (c *CAS) populateTreeFromSymbolicRef(
 	opts *CloneOptions,
 	ref *symbolicRef,
 ) error {
-	gitRunner, err := git.NewGitRunner(v.Exec)
+	gitRunner, err := git.NewGitRunner(v)
 	if err != nil {
 		return err
 	}
@@ -387,7 +386,7 @@ func (c *CAS) populateTreeFromCommitRef(
 	opts *CloneOptions,
 	ref *commitRef,
 ) (string, error) {
-	gitRunner, err := git.NewGitRunner(v.Exec)
+	gitRunner, err := git.NewGitRunner(v)
 	if err != nil {
 		return "", err
 	}
@@ -804,6 +803,8 @@ func (c *CAS) ensureBlob(
 	hash string,
 	gitPerm os.FileMode,
 ) (err error) {
+	v.RequireGOOS()
+
 	needsWrite, lock, err := c.blobStore.EnsureWithWait(v, hash)
 	if err != nil {
 		return err
@@ -839,7 +840,7 @@ func (c *CAS) ensureBlob(
 		return err
 	}
 
-	if runtime.GOOS == "windows" {
+	if v.Platform.GOOS == WindowsOS {
 		if err = tmpHandle.Sync(); err != nil {
 			return err
 		}

--- a/internal/cas/content.go
+++ b/internal/cas/content.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
@@ -361,6 +360,8 @@ func (c *Content) Read(v *venv.Venv, hash string) ([]byte, error) {
 // writeContentToFile writes data to a temporary file, sets appropriate
 // permissions, and performs an atomic rename.
 func (c *Content) writeContentToFile(l log.Logger, v *venv.Venv, hash string, data []byte) error {
+	v.RequireGOOS()
+
 	path := c.getPath(hash)
 	tempPath := path + ".tmp"
 
@@ -411,7 +412,7 @@ func (c *Content) writeContentToFile(l log.Logger, v *venv.Venv, hash string, da
 		return fmt.Errorf("chmod temp %s: %w", tempPath, err)
 	}
 
-	if runtime.GOOS == WindowsOS {
+	if v.Platform.GOOS == WindowsOS {
 		if _, err := v.FS.Stat(path); err == nil {
 			if err := v.FS.Chmod(path, RegularFilePerms); err != nil {
 				l.Warnf("failed to make destination file writable %s: %v", path, err)
@@ -427,7 +428,7 @@ func (c *Content) writeContentToFile(l log.Logger, v *venv.Venv, hash string, da
 		return fmt.Errorf("finalize %s: %w", path, err)
 	}
 
-	if runtime.GOOS == WindowsOS {
+	if v.Platform.GOOS == WindowsOS {
 		if err := v.FS.Chmod(path, StoredFilePerms); err != nil {
 			return fmt.Errorf("chmod %s: %w", path, err)
 		}

--- a/internal/cas/gitstore.go
+++ b/internal/cas/gitstore.go
@@ -255,7 +255,7 @@ func (s *GitStore) ProbeCachedCommit(
 		return "", false
 	}
 
-	runner, err := git.NewGitRunner(v.Exec)
+	runner, err := git.NewGitRunner(v)
 	if err != nil {
 		return "", false
 	}
@@ -346,7 +346,7 @@ func (s *GitStore) acquire(
 		return nil, ErrGitStoreFSNotOS
 	}
 
-	runner, err := git.NewGitRunner(v.Exec)
+	runner, err := git.NewGitRunner(v)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cas/gitstore_test.go
+++ b/internal/cas/gitstore_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -234,7 +233,7 @@ func newTestGitStore(t *testing.T) (*cas.GitStore, *venv.Venv, string) {
 func resolveHead(t *testing.T, url string) string {
 	t.Helper()
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	results, err := runner.LsRemote(t.Context(), url, "HEAD")

--- a/internal/cas/integration_test.go
+++ b/internal/cas/integration_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -113,7 +113,7 @@ func TestIntegration_TreeStorage(t *testing.T) {
 			cas.WithDepth(-1)))
 
 		// Get the commit hash for HEAD
-		g, err := git.NewGitRunner(vexec.NewOSExec())
+		g, err := git.NewGitRunner(venv.OSVenv())
 		require.NoError(t, err)
 
 		results, err := g.LsRemote(ctx, repoURL, "HEAD")

--- a/internal/cas/resolver_git_test.go
+++ b/internal/cas/resolver_git_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
 
 func TestGitResolver_ProbeHEAD(t *testing.T) {
@@ -26,7 +27,7 @@ func TestGitResolver_ProbeHEAD(t *testing.T) {
 	url, err := srv.Start(t.Context())
 	require.NoError(t, err)
 
-	r := &cas.GitResolver{Venv: &venv.Venv{Exec: vexec.NewOSExec()}}
+	r := &cas.GitResolver{Venv: venv.OSVenv()}
 
 	// Empty Branch → resolver queries HEAD.
 	got, err := r.Probe(t.Context(), url)
@@ -47,7 +48,7 @@ func TestGitResolver_ProbeBranch(t *testing.T) {
 	url, err := srv.Start(t.Context())
 	require.NoError(t, err)
 
-	r := &cas.GitResolver{Venv: &venv.Venv{Exec: vexec.NewOSExec()}, Branch: "feature"}
+	r := &cas.GitResolver{Venv: venv.OSVenv(), Branch: "feature"}
 
 	got, err := r.Probe(t.Context(), url)
 	require.NoError(t, err)
@@ -64,7 +65,7 @@ func TestGitResolver_ProbeTag(t *testing.T) {
 	url, err := srv.Start(t.Context())
 	require.NoError(t, err)
 
-	r := &cas.GitResolver{Venv: &venv.Venv{Exec: vexec.NewOSExec()}, Branch: "v1.0.0"}
+	r := &cas.GitResolver{Venv: venv.OSVenv(), Branch: "v1.0.0"}
 
 	// Annotated-tag ls-remote returns the tag object's hash, not the
 	// commit it points to. We just assert the resolver returns a
@@ -86,7 +87,7 @@ func TestGitResolver_CommitFormRefReturnsErrNoVersionMetadata(t *testing.T) {
 	url, err := srv.Start(t.Context())
 	require.NoError(t, err)
 
-	r := &cas.GitResolver{Venv: &venv.Venv{Exec: vexec.NewOSExec()}, Branch: commitSHA}
+	r := &cas.GitResolver{Venv: venv.OSVenv(), Branch: commitSHA}
 
 	// ls-remote does not resolve raw SHAs as refs; the caller passes
 	// a commit-form ref directly. Probe must surface this as
@@ -104,7 +105,7 @@ func TestGitResolver_UnknownRefReturnsErrNoVersionMetadata(t *testing.T) {
 	url, err := srv.Start(t.Context())
 	require.NoError(t, err)
 
-	r := &cas.GitResolver{Venv: &venv.Venv{Exec: vexec.NewOSExec()}, Branch: "does-not-exist"}
+	r := &cas.GitResolver{Venv: venv.OSVenv(), Branch: "does-not-exist"}
 
 	_, err = r.Probe(t.Context(), url)
 	require.ErrorIs(t, err, cas.ErrNoVersionMetadata)
@@ -122,7 +123,7 @@ func TestGitResolver_TokenIsCacheKeyVerbatim(t *testing.T) {
 	url, err := srv.Start(t.Context())
 	require.NoError(t, err)
 
-	r := &cas.GitResolver{Venv: &venv.Venv{Exec: vexec.NewOSExec()}}
+	r := &cas.GitResolver{Venv: venv.OSVenv()}
 
 	got, err := r.Probe(t.Context(), url)
 	require.NoError(t, err)
@@ -186,7 +187,7 @@ func TestGitResolver_ProbeSCPURLWithBranchUsesSeparateArgs(t *testing.T) {
 		}
 	})
 
-	r := &cas.GitResolver{Venv: &venv.Venv{Exec: stub}, Branch: "main"}
+	r := &cas.GitResolver{Venv: venvtest.New().WithExec(stub), Branch: "main"}
 
 	_, err := r.Probe(t.Context(), "git@github.com:org/repo.git")
 	require.NoError(t, err)
@@ -214,7 +215,7 @@ func TestGitResolver_ProbeHTTPURLWithBranchUsesSeparateArgs(t *testing.T) {
 		}
 	})
 
-	r := &cas.GitResolver{Venv: &venv.Venv{Exec: stub}, Branch: "main"}
+	r := &cas.GitResolver{Venv: venvtest.New().WithExec(stub), Branch: "main"}
 
 	_, err := r.Probe(t.Context(), "https://example.com/org/repo.git")
 	require.NoError(t, err)
@@ -231,7 +232,7 @@ func TestGitResolver_ProbeHTTPURLWithBranchUsesSeparateArgs(t *testing.T) {
 func newGitRunner(t *testing.T) *git.GitRunner {
 	t.Helper()
 
-	r, err := git.NewGitRunner(vexec.NewOSExec())
+	r, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	return r

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -239,7 +239,7 @@ func detectRepoHashAlgorithm(
 	v *venv.Venv,
 	repoDir string,
 ) (HashAlgorithm, error) {
-	runner, err := git.NewGitRunner(v.Exec)
+	runner, err := git.NewGitRunner(v)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -15,6 +15,7 @@ import (
 	awsproviderpatch "github.com/gruntwork-io/terragrunt/internal/cli/commands/aws-provider-patch"
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/hcl"
 	hclformat "github.com/gruntwork-io/terragrunt/internal/cli/commands/hcl/format"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
@@ -43,10 +44,8 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		t.Skip("Skipping test on Windows")
 	}
 
-	workingDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
+	workingDir, err := venvtest.New().Platform.Getwd()
+	require.NoError(t, err)
 
 	testCases := []struct {
 		expectedErr     error
@@ -450,7 +449,7 @@ func TestParseTerragruntOptionsFromArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
 			t.Parallel()
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 			l := log.New(
 				log.WithOutput(os.Stderr),
@@ -725,7 +724,7 @@ func TestFilterTerragruntArgs(t *testing.T) {
 		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
 			t.Parallel()
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			l := log.New(
 				log.WithOutput(os.Stderr),
 				log.WithLevel(defaultLogLevel),
@@ -802,7 +801,7 @@ func TestParseMultiStringArg(t *testing.T) {
 		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
 			t.Parallel()
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			l := log.New(
 				log.WithOutput(os.Stderr),
 				log.WithLevel(defaultLogLevel),
@@ -879,7 +878,7 @@ func TestParseMutliStringKeyValueArg(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		opts := options.NewTerragruntOptions()
+		opts := options.NewTerragruntOptions(vexec.NewOSExec())
 		opts.AwsProviderPatchOverrides = tc.defaultValue
 		l := log.New(
 			log.WithOutput(os.Stderr),
@@ -918,7 +917,7 @@ func TestTerragruntVersion(t *testing.T) {
 
 	for _, tc := range testCases {
 		output := &bytes.Buffer{}
-		opts := options.NewTerragruntOptions()
+		opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 		testV := venvtest.New()
 
@@ -941,7 +940,7 @@ func TestTerragruntHelp(t *testing.T) {
 
 	terragruntPrefix := flags.Prefix{flags.TerragruntPrefix}
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	app := cli.NewApp(logger.CreateLogger(), opts, venvtest.New())
 
 	testCases := []struct {
@@ -980,7 +979,7 @@ func TestTerragruntHelp(t *testing.T) {
 			t.Parallel()
 
 			output := &bytes.Buffer{}
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 			testV := venvtest.New()
 
@@ -1006,7 +1005,7 @@ func TestTerraformHelp_wrongHelpFlag(t *testing.T) {
 
 	output := &bytes.Buffer{}
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 	testV := venvtest.New()
 
@@ -1077,7 +1076,9 @@ func (err argMissingValueError) Error() string {
 	return "flag needs an argument: -" + string(err)
 }
 
-func TestAutocomplete(t *testing.T) { //nolint:paralleltest
+func TestAutocomplete(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		compLine          string
 		expectedCompletes []string
@@ -1102,7 +1103,7 @@ func TestAutocomplete(t *testing.T) { //nolint:paralleltest
 
 	for _, tc := range testCases {
 		output := &bytes.Buffer{}
-		opts := options.NewTerragruntOptions()
+		opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 		// Autocomplete reads COMP_LINE from the venv's environment, so the
 		// completion request is handed over rather than exported to the process.

--- a/internal/cli/app_tf_test.go
+++ b/internal/cli/app_tf_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
@@ -41,7 +42,7 @@ func TestTFTerraformHelp(t *testing.T) {
 
 	for _, tc := range testCases {
 		output := &bytes.Buffer{}
-		opts := options.NewTerragruntOptions()
+		opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 		testV := venv.OSVenv()
 

--- a/internal/cli/commands/backend/bootstrap/bootstrap.go
+++ b/internal/cli/commands/backend/bootstrap/bootstrap.go
@@ -43,7 +43,7 @@ func runBootstrap(
 			return err
 		}
 
-		return remoteState.Bootstrap(ctx, l, v, configbridge.RemoteStateOptsFromOpts(opts))
+		return remoteState.Bootstrap(ctx, l, v, configbridge.RemoteStateOptsFromOpts(v.Env, opts))
 	})
 }
 

--- a/internal/cli/commands/backend/delete/delete.go
+++ b/internal/cli/commands/backend/delete/delete.go
@@ -44,7 +44,7 @@ func runDelete(
 			ctx,
 			l,
 			v,
-			configbridge.RemoteStateOptsFromOpts(opts),
+			configbridge.RemoteStateOptsFromOpts(v.Env, opts),
 		)
 		if err != nil && !errors.As(err, new(backend.BucketDoesNotExistError)) {
 			return err
@@ -63,7 +63,7 @@ func runDelete(
 		return fmt.Errorf("flag -%s is not supported yet", BucketFlagName)
 	}
 
-	return remoteState.Delete(ctx, l, v, configbridge.RemoteStateOptsFromOpts(opts))
+	return remoteState.Delete(ctx, l, v, configbridge.RemoteStateOptsFromOpts(v.Env, opts))
 }
 
 func runAll(

--- a/internal/cli/commands/backend/migrate/migrate.go
+++ b/internal/cli/commands/backend/migrate/migrate.go
@@ -113,7 +113,7 @@ func Run(
 			ctx,
 			l,
 			srcV,
-			configbridge.RemoteStateOptsFromOpts(srcOpts),
+			configbridge.RemoteStateOptsFromOpts(v.Env, srcOpts),
 		)
 		if err != nil && !errors.As(err, new(backend.BucketDoesNotExistError)) {
 			return err
@@ -130,8 +130,8 @@ func Run(
 	return srcRemoteState.Migrate(
 		ctx, l,
 		srcV, dstV,
-		configbridge.RemoteStateOptsFromOpts(srcOpts),
-		configbridge.RemoteStateOptsFromOpts(dstOpts),
+		configbridge.RemoteStateOptsFromOpts(v.Env, srcOpts),
+		configbridge.RemoteStateOptsFromOpts(v.Env, dstOpts),
 		dstRemoteState,
 	)
 }

--- a/internal/cli/commands/browse/browse.go
+++ b/internal/cli/commands/browse/browse.go
@@ -73,7 +73,9 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *Options) error {
 		color = tui.ColorEnabled
 	}
 
-	err = tui.Run(ctx, l, v.FS, root, color, resultCh, warnCh)
+	v.RequireUserHomeDir()
+
+	err = tui.Run(ctx, l, v.FS, v.Platform.UserHomeDir, root, color, resultCh, warnCh)
 
 	cancel()
 	<-done

--- a/internal/cli/commands/browse/browse_test.go
+++ b/internal/cli/commands/browse/browse_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/browse"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -55,7 +56,11 @@ func TestRunUnwindsCleanlyWhenContextCancelledWithRacing(t *testing.T) {
 func TestNewCommandIsNamedBrowse(t *testing.T) {
 	t.Parallel()
 
-	cmd := browse.NewCommand(logger.CreateLogger(), options.NewTerragruntOptions(), venvtest.NewOSWithEmptyEnv())
+	cmd := browse.NewCommand(
+		logger.CreateLogger(),
+		options.NewTerragruntOptions(vexec.NewOSExec()),
+		venvtest.NewOSWithEmptyEnv(),
+	)
 
 	require.NotNil(t, cmd)
 	assert.Equal(t, browse.CommandName, cmd.Name)

--- a/internal/cli/commands/browse/tui/helpers_test.go
+++ b/internal/cli/commands/browse/tui/helpers_test.go
@@ -22,13 +22,19 @@ const (
 // models are driven through Update directly and never call Init, so the required
 // channels are wired but never read; tests that stream discovery inject a
 // [tui.DiscoveryResult] as a message instead.
+// stubHomeDir pins the home directory the path bar abbreviates against, so a
+// rendered path does not change with whoever runs the suite.
+func stubHomeDir() (string, error) {
+	return "/home/tester", nil
+}
+
 func newModel(t *testing.T, fsys vfs.FS, root *tui.Node, color tui.ColorMode, opts ...tui.Option) tui.Model {
 	t.Helper()
 
 	resultCh := make(chan tui.DiscoveryResult, 1)
 	warnCh := make(chan viewtui.Warning)
 
-	m := tui.NewModel(logger.CreateLogger(), fsys, root, color, resultCh, warnCh, opts...)
+	m := tui.NewModel(logger.CreateLogger(), fsys, stubHomeDir, root, color, resultCh, warnCh, opts...)
 
 	return update(t, m, tea.WindowSizeMsg{Width: testWidth, Height: testHeight})
 }

--- a/internal/cli/commands/browse/tui/init_test.go
+++ b/internal/cli/commands/browse/tui/init_test.go
@@ -25,7 +25,15 @@ func TestInitDeliversDiscoveryResultWithRacing(t *testing.T) {
 	warnCh := make(chan viewtui.Warning)
 	close(warnCh)
 
-	m := tui.NewModel(logger.CreateLogger(), vfs.NewMemMapFS(), tui.NewRoot("/repo"), tui.ColorDisabled, resultCh, warnCh)
+	m := tui.NewModel(
+		logger.CreateLogger(),
+		vfs.NewMemMapFS(),
+		stubHomeDir,
+		tui.NewRoot("/repo"),
+		tui.ColorDisabled,
+		resultCh,
+		warnCh,
+	)
 
 	want := tui.DiscoveryResult{Components: component.Components{component.NewUnit("/repo/vpc")}}
 

--- a/internal/cli/commands/browse/tui/model.go
+++ b/internal/cli/commands/browse/tui/model.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"errors"
-	"os"
 	"slices"
 	"strings"
 
@@ -75,6 +74,7 @@ var ErrChannelsRequired = errors.New("browse: result and warning channels must n
 func NewModel(
 	l log.Logger,
 	fsys vfs.FS,
+	userHomeDir func() (string, error),
 	root *Node,
 	color ColorMode,
 	resultCh <-chan DiscoveryResult,
@@ -90,7 +90,7 @@ func NewModel(
 
 	// Resolve the home directory once; the path bar abbreviates against it on
 	// every render. An error leaves it empty, which disables abbreviation.
-	home, err := os.UserHomeDir()
+	home, err := userHomeDir()
 	if err != nil {
 		l.Debugf("Could not resolve home directory for path abbreviation: %v", err)
 	}

--- a/internal/cli/commands/browse/tui/model_test.go
+++ b/internal/cli/commands/browse/tui/model_test.go
@@ -23,9 +23,9 @@ func TestNewModelPanicsOnNilChannels(t *testing.T) {
 	warnCh := make(chan viewtui.Warning)
 
 	assert.PanicsWithValue(t, tui.ErrChannelsRequired, func() {
-		tui.NewModel(l, fs, root, tui.ColorDisabled, nil, warnCh)
+		tui.NewModel(l, fs, stubHomeDir, root, tui.ColorDisabled, nil, warnCh)
 	})
 	assert.PanicsWithValue(t, tui.ErrChannelsRequired, func() {
-		tui.NewModel(l, fs, root, tui.ColorDisabled, resultCh, nil)
+		tui.NewModel(l, fs, stubHomeDir, root, tui.ColorDisabled, resultCh, nil)
 	})
 }

--- a/internal/cli/commands/browse/tui/run_test.go
+++ b/internal/cli/commands/browse/tui/run_test.go
@@ -31,6 +31,6 @@ func TestRunTreatsCancelledContextAsCleanExit(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	err := tui.Run(ctx, l, vfs.NewMemMapFS(), tui.NewRoot("/repo"), tui.ColorDisabled, resultCh, warnCh)
+	err := tui.Run(ctx, l, vfs.NewMemMapFS(), stubHomeDir, tui.NewRoot("/repo"), tui.ColorDisabled, resultCh, warnCh)
 	require.NoError(t, err)
 }

--- a/internal/cli/commands/browse/tui/tree.go
+++ b/internal/cli/commands/browse/tui/tree.go
@@ -180,7 +180,7 @@ func (m *Model) loadDir(n *Node) {
 
 	n.othersLoaded = true
 
-	entries, err := vfs.ReadDirEntries(m.fsys, n.absPath)
+	entries, err := vfs.ReadDir(m.fsys, n.absPath)
 	if err != nil {
 		return
 	}

--- a/internal/cli/commands/browse/tui/tui.go
+++ b/internal/cli/commands/browse/tui/tui.go
@@ -21,12 +21,16 @@ func Run(
 	ctx context.Context,
 	l log.Logger,
 	fsys vfs.FS,
+	userHomeDir func() (string, error),
 	root *Node,
 	color ColorMode,
 	resultCh <-chan DiscoveryResult,
 	warnCh <-chan viewtui.Warning,
 ) error {
-	_, err := tea.NewProgram(NewModel(l, fsys, root, color, resultCh, warnCh), tea.WithContext(ctx)).Run()
+	_, err := tea.NewProgram(
+		NewModel(l, fsys, userHomeDir, root, color, resultCh, warnCh),
+		tea.WithContext(ctx),
+	).Run()
 	if err == nil {
 		return nil
 	}

--- a/internal/cli/commands/catalog/catalog_test.go
+++ b/internal/cli/commands/catalog/catalog_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -236,7 +237,7 @@ func TestRunRejectsAnUnknownFormat(t *testing.T) {
 func newOptions(t *testing.T, workDir, outputFormat string) *catalog.Options {
 	t.Helper()
 
-	tgOpts := options.NewTerragruntOptions()
+	tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 	tgOpts.WorkingDir = workDir
 	tgOpts.RootWorkingDir = workDir
 	tgOpts.TerragruntConfigPath = filepath.Join(workDir, "terragrunt.hcl")

--- a/internal/cli/commands/catalog/cli.go
+++ b/internal/cli/commands/catalog/cli.go
@@ -4,7 +4,6 @@ package catalog
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/scaffold"
@@ -13,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
@@ -24,7 +24,7 @@ const (
 	FormatFlagName     = "format"
 )
 
-func NewFlags(opts *Options, prefix flags.Prefix) clihelper.Flags {
+func NewFlags(fsys vfs.FS, opts *Options, prefix flags.Prefix) clihelper.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
 
 	catalogFlags := clihelper.Flags{
@@ -57,7 +57,7 @@ func NewFlags(opts *Options, prefix flags.Prefix) clihelper.Flags {
 					}
 				}
 
-				info, err := os.Stat(resolved)
+				info, err := fsys.Stat(resolved)
 				if err != nil {
 					return clihelper.NewExitError(err, clihelper.ExitCodeGeneralError)
 				}
@@ -87,7 +87,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 	return &clihelper.Command{
 		Name:  CommandName,
 		Usage: "Launch the user interface for searching and managing your module catalog.",
-		Flags: NewFlags(cmdOpts, nil),
+		Flags: NewFlags(v.FS, cmdOpts, nil),
 		Before: func(_ context.Context, _ *clihelper.Context) error {
 			if err := cmdOpts.Validate(); err != nil {
 				return clihelper.NewExitError(err, clihelper.ExitCodeGeneralError)
@@ -114,7 +114,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 			}
 
 			if opts.ScaffoldRootFileName == "" {
-				opts.ScaffoldRootFileName = scaffold.GetDefaultRootFileName(ctx, opts)
+				opts.ScaffoldRootFileName = scaffold.GetDefaultRootFileName(ctx, v.FS, opts)
 			}
 
 			runOpts := *cmdOpts

--- a/internal/cli/commands/catalog/cli_test.go
+++ b/internal/cli/commands/catalog/cli_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -27,7 +29,7 @@ func TestNewCommandExposesTheCatalogFlags(t *testing.T) {
 	t.Parallel()
 
 	cmd := catalog.NewCommand(
-		logger.CreateLogger(), options.NewTerragruntOptions(), venvtest.New(),
+		logger.CreateLogger(), options.NewTerragruntOptions(vexec.NewOSExec()), venvtest.New(),
 	)
 
 	assert.Equal(t, catalog.CommandName, cmd.Name)
@@ -74,7 +76,7 @@ func TestNewCommandBeforeGatesNonInteractiveFormats(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 			if tc.withExperiment {
 				require.NoError(t, opts.Experiments.EnableExperiment(experiment.CatalogFormat))
@@ -115,7 +117,7 @@ func TestNewCommandActionLoadsThePositionalSource(t *testing.T) {
 
 	writeLocalRepo(t, v, repoDir)
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.CatalogFormat))
 
 	cmd := catalog.NewCommand(logger.CreateLogger(), opts, v)
@@ -184,14 +186,14 @@ func TestNewFlagsIgnoreFileAction(t *testing.T) {
 			dir := t.TempDir()
 			require.NoError(t, os.WriteFile(filepath.Join(dir, ignoreFileName), []byte("vendor\n"), 0o644))
 
-			opts := catalog.NewOptions(options.NewTerragruntOptions())
+			opts := catalog.NewOptions(options.NewTerragruntOptions(vexec.NewOSExec()))
 			opts.RootWorkingDir = dir
 
 			if !tc.noWorkingDir {
 				opts.WorkingDir = dir
 			}
 
-			flags := catalog.NewFlags(opts, nil)
+			flags := catalog.NewFlags(vfs.NewOSFS(), opts, nil)
 			require.NoError(t, flags.Parse(
 				clihelper.Args{"--" + catalog.IgnoreFileFlagName, tc.value(dir)},
 				map[string]string{},

--- a/internal/cli/commands/catalog/options_test.go
+++ b/internal/cli/commands/catalog/options_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
 func TestOptionsDefaultToTheTUI(t *testing.T) {
 	t.Parallel()
 
-	opts := catalog.NewOptions(options.NewTerragruntOptions())
+	opts := catalog.NewOptions(options.NewTerragruntOptions(vexec.NewOSExec()))
 
 	assert.Equal(t, catalog.FormatTUI, opts.Format)
 	require.NoError(t, opts.Validate())
@@ -38,7 +39,7 @@ func TestOptionsValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts := catalog.NewOptions(options.NewTerragruntOptions())
+			opts := catalog.NewOptions(options.NewTerragruntOptions(vexec.NewOSExec()))
 			opts.Format = tc.format
 
 			err := opts.Validate()

--- a/internal/cli/commands/catalog/tui/component_doc.go
+++ b/internal/cli/commands/catalog/tui/component_doc.go
@@ -132,7 +132,7 @@ func NewComponentDoc(rawContent, fileExt string) *ComponentDoc {
 // returns a populated ComponentDoc. Returns a zero-value *ComponentDoc
 // (non-nil) when no README is present.
 func FindComponentDoc(fsys vfs.FS, dir string) (*ComponentDoc, error) {
-	files, err := vfs.ReadDirEntries(fsys, dir)
+	files, err := vfs.ReadDir(fsys, dir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/commands/catalog/tui/copy_test.go
+++ b/internal/cli/commands/catalog/tui/copy_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/component"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -37,7 +38,7 @@ func TestCopyCmdScaffoldsDiscoveredComponent(t *testing.T) {
 	workingDir := testWorkingDir
 	require.NoError(t, fsys.MkdirAll(workingDir, 0o755))
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = workingDir
 
 	cmd := tui.NewCopyCmd(logger.CreateLogger(), opts, components[0])
@@ -57,7 +58,7 @@ func TestCopyCmdScaffoldsDiscoveredComponent(t *testing.T) {
 func TestCopyCmdPanicsWithoutFS(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = t.TempDir()
 
 	assert.Panics(t, func() {
@@ -69,7 +70,7 @@ func TestCopyCmdPanicsWithoutFS(t *testing.T) {
 func TestCopyCmdRejectsNilComponent(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = t.TempDir()
 
 	err := tui.NewCopyCmd(logger.CreateLogger(), opts, nil).WithFS(vfs.NewMemMapFS()).Run()
@@ -89,7 +90,7 @@ func TestCopyCmdRejectsEmptyWorkingDir(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, components, 1)
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = ""
 
 	err = tui.NewCopyCmd(logger.CreateLogger(), opts, components[0]).WithFS(fsys).Run()
@@ -101,7 +102,7 @@ func TestCopyCmdRejectsEmptyWorkingDir(t *testing.T) {
 func TestCopyCmdResultZeroValueBeforeRun(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = t.TempDir()
 
 	cmd := tui.NewCopyCmd(logger.CreateLogger(), opts, nil)
@@ -120,7 +121,7 @@ func TestCopyCmdResultZeroValueBeforeRun(t *testing.T) {
 func TestCopyCmdStdioSettersAreNoops(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = t.TempDir()
 
 	cmd := tui.NewCopyCmd(logger.CreateLogger(), opts, nil)

--- a/internal/cli/commands/catalog/tui/delegate.go
+++ b/internal/cli/commands/catalog/tui/delegate.go
@@ -79,7 +79,7 @@ type catalogDelegate struct {
 	tagsLayout TagsListLayout
 }
 
-func newCatalogDelegate(keys *DelegateKeyMap) catalogDelegate {
+func newCatalogDelegate(env map[string]string, keys *DelegateKeyMap) catalogDelegate {
 	// Use the same default item styles as the production delegate, with our color overrides.
 	styles := list.NewDefaultItemStyles(true)
 
@@ -110,7 +110,7 @@ func newCatalogDelegate(keys *DelegateKeyMap) catalogDelegate {
 		fullHelp: func() [][]key.Binding {
 			return [][]key.Binding{help}
 		},
-		tagsLayout: ResolveTagsListLayout(),
+		tagsLayout: ResolveTagsListLayout(env),
 	}
 }
 

--- a/internal/cli/commands/catalog/tui/load.go
+++ b/internal/cli/commands/catalog/tui/load.go
@@ -108,7 +108,7 @@ func LoadURL(
 
 	// Resolve the latest release tag once per repo. All components from the
 	// same repo share the Repo, so the tag is set for everyone.
-	repo.ResolveLatestTag(ctx, l, v.Exec)
+	repo.ResolveLatestTag(ctx, l, v)
 
 	source := ExtractRepoURL(repo.SourceURL())
 

--- a/internal/cli/commands/catalog/tui/model.go
+++ b/internal/cli/commands/catalog/tui/model.go
@@ -423,7 +423,7 @@ func newModelWithItems(
 	delegateKeys := NewDelegateKeyMap()
 	pagerKeys := NewPagerKeyMap()
 
-	delegate := newCatalogDelegate(delegateKeys)
+	delegate := newCatalogDelegate(v.Env, delegateKeys)
 
 	titleStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(viewtui.TitleForeground)).

--- a/internal/cli/commands/catalog/tui/scaffold.go
+++ b/internal/cli/commands/catalog/tui/scaffold.go
@@ -46,7 +46,7 @@ func (c *scaffoldCmd) WithPlan(plan *scaffold.Plan, values map[string]string) *s
 
 func (c *scaffoldCmd) Run() error {
 	if c.plan != nil {
-		defer c.plan.Cleanup()
+		defer c.plan.Cleanup(c.venv.FS)
 
 		c.logger.Debugf("Generating scaffolded component: %q", c.component.TerraformSourcePath())
 

--- a/internal/cli/commands/catalog/tui/tag_pills_test.go
+++ b/internal/cli/commands/catalog/tui/tag_pills_test.go
@@ -220,26 +220,28 @@ func TestTagsMarkdownSection(t *testing.T) {
 }
 
 func TestEnvTagsListLayoutToggle(t *testing.T) {
-	t.Setenv(tui.EnvTagsListLayout, "row")
-	assert.True(t, (tui.ResolveTagsListLayout() == tui.TagsListLayoutRow))
+	t.Parallel()
 
-	t.Setenv(tui.EnvTagsListLayout, "META")
-	assert.True(t, (tui.ResolveTagsListLayout() == tui.TagsListLayoutMeta))
+	layoutFor := func(value string) tui.TagsListLayout {
+		return tui.ResolveTagsListLayout(map[string]string{tui.EnvTagsListLayout: value})
+	}
 
-	t.Setenv(tui.EnvTagsListLayout, "")
-	assert.True(t, (tui.ResolveTagsListLayout() == tui.TagsListLayoutMeta))
-
-	t.Setenv(tui.EnvTagsListLayout, "garbage")
-	assert.True(t, (tui.ResolveTagsListLayout() == tui.TagsListLayoutMeta))
+	assert.Equal(t, tui.TagsListLayoutRow, layoutFor("row"))
+	assert.Equal(t, tui.TagsListLayoutMeta, layoutFor("META"))
+	assert.Equal(t, tui.TagsListLayoutMeta, layoutFor(""))
+	assert.Equal(t, tui.TagsListLayoutMeta, layoutFor("garbage"))
+	assert.Equal(t, tui.TagsListLayoutMeta, tui.ResolveTagsListLayout(map[string]string{}))
 }
 
 func TestEnvTagsDetailStyleToggle(t *testing.T) {
-	t.Setenv(tui.EnvTagsDetailStyle, "section")
-	assert.True(t, (tui.ResolveTagsDetailStyle() == tui.TagsDetailStyleSection))
+	t.Parallel()
 
-	t.Setenv(tui.EnvTagsDetailStyle, "")
-	assert.True(t, (tui.ResolveTagsDetailStyle() == tui.TagsDetailStylePills))
+	styleFor := func(value string) tui.TagsDetailStyle {
+		return tui.ResolveTagsDetailStyle(map[string]string{tui.EnvTagsDetailStyle: value})
+	}
 
-	t.Setenv(tui.EnvTagsDetailStyle, "garbage")
-	assert.True(t, (tui.ResolveTagsDetailStyle() == tui.TagsDetailStylePills))
+	assert.Equal(t, tui.TagsDetailStyleSection, styleFor("section"))
+	assert.Equal(t, tui.TagsDetailStylePills, styleFor(""))
+	assert.Equal(t, tui.TagsDetailStylePills, styleFor("garbage"))
+	assert.Equal(t, tui.TagsDetailStylePills, tui.ResolveTagsDetailStyle(map[string]string{}))
 }

--- a/internal/cli/commands/catalog/tui/tags_layout.go
+++ b/internal/cli/commands/catalog/tui/tags_layout.go
@@ -1,8 +1,9 @@
 package tui
 
 import (
-	"os"
 	"strings"
+
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 )
 
 // TagsListLayout selects how tag pills appear in the catalog list view.
@@ -43,8 +44,10 @@ const EnvTagsDetailStyle = "TG_TMP_CATALOG_TAGS_DETAIL"
 
 // ResolveTagsListLayout reads EnvTagsListLayout and returns the selected
 // layout. Unknown values fall back silently to the default (meta).
-func ResolveTagsListLayout() TagsListLayout {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvTagsListLayout))) {
+func ResolveTagsListLayout(env map[string]string) TagsListLayout {
+	venv.RequireEnvMap(env)
+
+	switch strings.ToLower(strings.TrimSpace(env[EnvTagsListLayout])) {
 	case "row":
 		return TagsListLayoutRow
 	default:
@@ -54,8 +57,10 @@ func ResolveTagsListLayout() TagsListLayout {
 
 // ResolveTagsDetailStyle reads EnvTagsDetailStyle and returns the selected
 // style. Unknown values fall back silently to the default (pills).
-func ResolveTagsDetailStyle() TagsDetailStyle {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvTagsDetailStyle))) {
+func ResolveTagsDetailStyle(env map[string]string) TagsDetailStyle {
+	venv.RequireEnvMap(env)
+
+	switch strings.ToLower(strings.TrimSpace(env[EnvTagsDetailStyle])) {
 	case "section":
 		return TagsDetailStyleSection
 	default:

--- a/internal/cli/commands/catalog/tui/update.go
+++ b/internal/cli/commands/catalog/tui/update.go
@@ -69,7 +69,7 @@ func updateList(msg tea.Msg, m Model) (tea.Model, tea.Cmd) {
 
 			switch {
 			case key.Matches(msg, m.delegateKeys.Choose):
-				tagsStyle := ResolveTagsDetailStyle()
+				tagsStyle := ResolveTagsDetailStyle(m.venv.Env)
 				tags := selectedComponent.Tags()
 
 				var (
@@ -162,7 +162,7 @@ func updatePager(msg tea.Msg, m Model) (tea.Model, tea.Cmd) {
 			if m.selectedComponent != nil {
 				updated, content, err := m.renderComponentContent(
 					m.selectedComponent,
-					ResolveTagsDetailStyle(),
+					ResolveTagsDetailStyle(m.venv.Env),
 					m.selectedComponent.Tags(),
 				)
 				if err != nil {
@@ -784,7 +784,7 @@ func (m Model) handleFormSubmit(values map[string]string) (tea.Model, tea.Cmd) {
 // the temp dir Prepare allocated.
 func (m *Model) abandonForm() {
 	if m.scaffoldPlan != nil {
-		m.scaffoldPlan.Cleanup()
+		m.scaffoldPlan.Cleanup(m.venv.FS)
 		m.scaffoldPlan = nil
 	}
 

--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -4,9 +4,7 @@ package commands
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"runtime"
 	"runtime/debug"
 	"slices"
 	"strings"
@@ -308,10 +306,12 @@ func RunAction(
 		}
 	}
 
+	v.RequireGOOS()
+
 	GiveWindowsSymlinksTip(
 		l,
 		v.FS,
-		runtime.GOOS,
+		v.Platform.GOOS,
 		opts.Tips,
 		v.Env,
 		opts.ProviderCacheOptions.Enabled,
@@ -403,7 +403,7 @@ func setupAutoProviderCacheDir(
 
 	if opts.TerraformVersion == nil {
 		_, ver, impl, err := run.PopulateTFVersion(ctx, l, v, run.PopulateTFVersionInput{
-			TFOpts:       configbridge.TFRunOptsFromOpts(opts),
+			TFOpts:       configbridge.TFRunOptsFromOpts(v.Env, opts),
 			WorkingDir:   opts.WorkingDir,
 			VersionFiles: opts.VersionManagerFileName,
 		})
@@ -464,7 +464,7 @@ func setupAutoProviderCacheDir(
 	const cacheDirMode = 0755
 
 	// Create the cache directory if it doesn't exist
-	if err := os.MkdirAll(providerCacheDir, cacheDirMode); err != nil {
+	if err := v.FS.MkdirAll(providerCacheDir, cacheDirMode); err != nil {
 		return fmt.Errorf("failed to create provider cache directory: %w", err)
 	}
 
@@ -516,7 +516,7 @@ func initialSetup(
 
 	// --- Working Dir
 	if opts.WorkingDir == "" {
-		currentDir, err := os.Getwd()
+		currentDir, err := v.Platform.Getwd()
 		if err != nil {
 			return err
 		}
@@ -556,7 +556,7 @@ func initialSetup(
 
 	// --- Terragrunt ConfigPath
 	if opts.TerragruntConfigPath == "" {
-		opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
+		opts.TerragruntConfigPath = config.GetDefaultConfigPath(v.FS, opts.WorkingDir)
 	} else if !filepath.IsAbs(opts.TerragruntConfigPath) &&
 		(cliCtx.Command.Name == runcmd.CommandName || slices.Contains(tf.CommandNames, cliCtx.Command.Name)) {
 		opts.TerragruntConfigPath = filepath.Join(opts.WorkingDir, opts.TerragruntConfigPath)

--- a/internal/cli/commands/discoverysetup/discoverysetup.go
+++ b/internal/cli/commands/discoverysetup/discoverysetup.go
@@ -39,7 +39,7 @@ func Worktrees(
 	}
 
 	cleanup := func(ctx context.Context) {
-		if cleanupErr := wts.Cleanup(ctx, l); cleanupErr != nil {
+		if cleanupErr := wts.Cleanup(ctx, l, v.FS); cleanupErr != nil {
 			l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 		}
 	}

--- a/internal/cli/commands/discoverysetup/discoverysetup_test.go
+++ b/internal/cli/commands/discoverysetup/discoverysetup_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/discoverysetup"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -23,7 +24,7 @@ func TestWorktreesNoGitFilters(t *testing.T) {
 	v := venvtest.NewOSWithEmptyEnv()
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 
 	d, err := discovery.NewForDiscoveryCommand(l, v.FS, &discovery.DiscoveryCommandOptions{
@@ -51,7 +52,7 @@ func TestWorktreesCreationFailure(t *testing.T) {
 	filters, err := filter.ParseFilterQueries(l, []string{"[main...HEAD]"})
 	require.NoError(t, err)
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.Filters = filters
 
@@ -95,7 +96,7 @@ func TestWorktreesStackGenerationFailure(t *testing.T) {
 	filters, err := filter.ParseFilterQueries(l, []string{"[HEAD~1...HEAD]"})
 	require.NoError(t, err)
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.Filters = filters
 

--- a/internal/cli/commands/exec/exec.go
+++ b/internal/cli/commands/exec/exec.go
@@ -96,7 +96,7 @@ func runTargetCommand(
 				ctx,
 				l,
 				v,
-				configbridge.ShellRunOptsFromOpts(opts),
+				configbridge.ShellRunOptsFromOpts(v.Env, opts),
 				dir,
 				false,
 				false,

--- a/internal/cli/commands/find/cli_test.go
+++ b/internal/cli/commands/find/cli_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/find"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -34,7 +35,7 @@ func TestNewCommandExposesTheFindFlags(t *testing.T) {
 	t.Parallel()
 
 	cmd := find.NewCommand(
-		logger.CreateLogger(), options.NewTerragruntOptions(), venvtest.New(),
+		logger.CreateLogger(), options.NewTerragruntOptions(vexec.NewOSExec()), venvtest.New(),
 	)
 
 	assert.Equal(t, find.CommandName, cmd.Name)
@@ -129,7 +130,7 @@ func TestNewCommandBeforeResolvesFormatAndMode(t *testing.T) {
 			root := "/find-cli"
 			v := venvtest.New().WithFS(newUnitsFS(t, root, findCLIUnits)).WithWriter(&buf)
 
-			tgOpts := options.NewTerragruntOptions()
+			tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 			tgOpts.WorkingDir = root
 			tgOpts.RootWorkingDir = root
 
@@ -183,7 +184,7 @@ func TestNewFlagsHiddenFlagRunsTheStrictControl(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			tgOpts := options.NewTerragruntOptions()
+			tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 			if tc.strictMode {
 				require.NoError(
 					t,
@@ -231,7 +232,7 @@ func TestNewFlagsExternalFlagAddsAGraphFilter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts := find.NewOptions(options.NewTerragruntOptions())
+			opts := find.NewOptions(options.NewTerragruntOptions(vexec.NewOSExec()))
 
 			flags := find.NewFlags(newTestLogger(t), opts, venvtest.New(), nil)
 			require.NoError(t, flags.Parse(clihelper.Args(tc.args), map[string]string{}))

--- a/internal/cli/commands/find/find_test.go
+++ b/internal/cli/commands/find/find_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/find"
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -501,7 +502,7 @@ locals {
 			// Setup test directory
 			tmpDir := tt.setup(t)
 
-			tgOpts := options.NewTerragruntOptions()
+			tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 			tgOpts.WorkingDir = tmpDir
 
 			l := logger.CreateLogger()
@@ -565,7 +566,7 @@ dependency "target" {
 		require.NoError(t, err)
 	}
 
-	tgOpts := options.NewTerragruntOptions()
+	tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 	tgOpts.WorkingDir = tmpDir
 	tgOpts.RootWorkingDir = tmpDir
 
@@ -684,7 +685,7 @@ exclude {
 `,
 	})
 
-	tgOpts := options.NewTerragruntOptions()
+	tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 	tgOpts.WorkingDir = root
 	tgOpts.RootWorkingDir = root
 
@@ -727,7 +728,7 @@ func TestRunFailsWhenTheWriterFails(t *testing.T) {
 			root := "/find-writer"
 			fsys := newUnitsFS(t, root, map[string]string{"unit1/terragrunt.hcl": ""})
 
-			tgOpts := options.NewTerragruntOptions()
+			tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 			tgOpts.WorkingDir = root
 			tgOpts.RootWorkingDir = root
 
@@ -767,7 +768,7 @@ func TestRunRejectsUnsupportedOptions(t *testing.T) {
 			root := "/find-invalid"
 			fsys := newUnitsFS(t, root, map[string]string{"unit1/terragrunt.hcl": ""})
 
-			tgOpts := options.NewTerragruntOptions()
+			tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 			tgOpts.WorkingDir = root
 			tgOpts.RootWorkingDir = root
 

--- a/internal/cli/commands/find/options_test.go
+++ b/internal/cli/commands/find/options_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/find"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,7 +14,7 @@ import (
 func TestNewOptionsDefaultsValidate(t *testing.T) {
 	t.Parallel()
 
-	opts := find.NewOptions(options.NewTerragruntOptions())
+	opts := find.NewOptions(options.NewTerragruntOptions(vexec.NewOSExec()))
 
 	assert.Equal(t, find.FormatText, opts.Format)
 	assert.Equal(t, find.ModeNormal, opts.Mode)
@@ -59,7 +60,7 @@ func TestOptionsValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts := find.NewOptions(options.NewTerragruntOptions())
+			opts := find.NewOptions(options.NewTerragruntOptions(vexec.NewOSExec()))
 			opts.Format = tc.format
 			opts.Mode = tc.mode
 

--- a/internal/cli/commands/hcl/validate/validate.go
+++ b/internal/cli/commands/hcl/validate/validate.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -133,7 +133,7 @@ func RunValidate(
 	}
 
 	defer func() {
-		cleanupErr := worktrees.Cleanup(ctx, l)
+		cleanupErr := worktrees.Cleanup(ctx, l, v.FS)
 		if cleanupErr != nil {
 			l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 		}
@@ -328,7 +328,7 @@ func RunValidateInputs(
 	}
 
 	defer func() {
-		cleanupErr := worktrees.Cleanup(ctx, l)
+		cleanupErr := worktrees.Cleanup(ctx, l, v.FS)
 		if cleanupErr != nil {
 			l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 		}
@@ -503,7 +503,7 @@ func getDefinedTerragruntInputs(
 		return nil, err
 	}
 
-	cliArgsTFVars, err := getTerraformInputNamesFromCLIArgs(l, opts, cfg)
+	cliArgsTFVars, err := getTerraformInputNamesFromCLIArgs(l, v.FS, opts, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -607,7 +607,7 @@ func getTerraformInputNamesFromVarFiles(
 		varFiles = append(varFiles, arg.GetVarFiles(l, fsys)...)
 	}
 
-	return getVarNamesFromVarFiles(l, varFiles)
+	return getVarNamesFromVarFiles(l, fsys, varFiles)
 }
 
 // getTerraformInputNamesFromCLIArgs will return the list of names of variables configured by -var and -var-file CLI
@@ -615,6 +615,7 @@ func getTerraformInputNamesFromVarFiles(
 // config and those that are directly passed in via the CLI.
 func getTerraformInputNamesFromCLIArgs(
 	l log.Logger,
+	fsys vfs.FS,
 	opts *options.TerragruntOptions,
 	terragruntConfig *config.TerragruntConfig,
 ) ([]string, error) {
@@ -637,7 +638,7 @@ func getTerraformInputNamesFromCLIArgs(
 		}
 	}
 
-	fileVars, err := getVarNamesFromVarFiles(l, varFiles)
+	fileVars, err := getVarNamesFromVarFiles(l, fsys, varFiles)
 	if err != nil {
 		return inputNames, err
 	}
@@ -654,42 +655,39 @@ func getTerraformInputNamesFromAutomaticVarFiles(
 	opts *options.TerragruntOptions,
 ) ([]string, error) {
 	base := opts.WorkingDir
-	automaticVarFiles := []string{}
 
-	tfTFVarsFile := filepath.Join(base, "terraform.tfvars")
-	if vfs.Exists(fsys, tfTFVarsFile) {
-		automaticVarFiles = append(automaticVarFiles, tfTFVarsFile)
-	}
-
-	tfTFVarsJSONFile := filepath.Join(base, "terraform.tfvars.json")
-	if vfs.Exists(fsys, tfTFVarsJSONFile) {
-		automaticVarFiles = append(automaticVarFiles, tfTFVarsJSONFile)
-	}
-
-	varFiles, err := filepath.Glob(filepath.Join(base, "*.auto.tfvars"))
-	if err != nil {
+	entries, err := vfs.ReadDir(fsys, base)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}
 
-	automaticVarFiles = append(automaticVarFiles, varFiles...)
+	automaticVarFiles := make([]string, 0, len(entries))
 
-	jsonVarFiles, err := filepath.Glob(filepath.Join(base, "*.auto.tfvars.json"))
-	if err != nil {
-		return nil, err
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+
+		named := name == "terraform.tfvars" || name == "terraform.tfvars.json"
+		automatic := strings.HasSuffix(name, ".auto.tfvars") || strings.HasSuffix(name, ".auto.tfvars.json")
+
+		if named || automatic {
+			automaticVarFiles = append(automaticVarFiles, filepath.Join(base, name))
+		}
 	}
 
-	automaticVarFiles = append(automaticVarFiles, jsonVarFiles...)
-
-	return getVarNamesFromVarFiles(l, automaticVarFiles)
+	return getVarNamesFromVarFiles(l, fsys, automaticVarFiles)
 }
 
 // getVarNamesFromVarFiles will parse all the given var files and returns a list of names of variables that are
 // configured in all of them combined together.
-func getVarNamesFromVarFiles(l log.Logger, varFiles []string) ([]string, error) {
+func getVarNamesFromVarFiles(l log.Logger, fsys vfs.FS, varFiles []string) ([]string, error) {
 	inputNames := []string{}
 
 	for _, varFile := range varFiles {
-		fileVars, err := getVarNamesFromVarFile(l, varFile)
+		fileVars, err := getVarNamesFromVarFile(l, fsys, varFile)
 		if err != nil {
 			return inputNames, err
 		}
@@ -702,8 +700,8 @@ func getVarNamesFromVarFiles(l log.Logger, varFiles []string) ([]string, error) 
 
 // getVarNamesFromVarFile will parse the given terraform var file and return a list of names of variables that are
 // configured in that var file.
-func getVarNamesFromVarFile(l log.Logger, varFile string) ([]string, error) {
-	fileContents, err := os.ReadFile(varFile)
+func getVarNamesFromVarFile(l log.Logger, fsys vfs.FS, varFile string) ([]string, error) {
+	fileContents, err := vfs.ReadFile(fsys, varFile)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/commands/list/cli_test.go
+++ b/internal/cli/commands/list/cli_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/list"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -34,7 +35,7 @@ func TestNewCommandExposesTheListFlags(t *testing.T) {
 	t.Parallel()
 
 	cmd := list.NewCommand(
-		logger.CreateLogger(), options.NewTerragruntOptions(), venvtest.New(),
+		logger.CreateLogger(), options.NewTerragruntOptions(vexec.NewOSExec()), venvtest.New(),
 	)
 
 	assert.Equal(t, list.CommandName, cmd.Name)
@@ -220,7 +221,7 @@ func TestNewFlagsHiddenFlagRunsTheStrictControl(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			tgOpts := options.NewTerragruntOptions()
+			tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 			if tc.strictMode {
 				require.NoError(
 					t,
@@ -268,7 +269,7 @@ func TestNewFlagsExternalFlagAddsAGraphFilter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts := list.NewOptions(options.NewTerragruntOptions())
+			opts := list.NewOptions(options.NewTerragruntOptions(vexec.NewOSExec()))
 
 			flags := list.NewFlags(newTestLogger(t), opts, venvtest.New(), nil)
 			require.NoError(t, flags.Parse(clihelper.Args(tc.args), map[string]string{}))
@@ -285,7 +286,7 @@ func newListCommand(t *testing.T, w *strings.Builder) *clihelper.Command {
 	root := "/list-cli"
 	v := venvtest.New().WithFS(newUnitsFS(t, root, listCLIUnits)).WithWriter(w)
 
-	tgOpts := options.NewTerragruntOptions()
+	tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 	tgOpts.WorkingDir = root
 	tgOpts.RootWorkingDir = root
 

--- a/internal/cli/commands/list/list_test.go
+++ b/internal/cli/commands/list/list_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/list"
 	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/view/dag"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -56,7 +57,7 @@ func TestBasicDiscovery(t *testing.T) {
 
 	expectedPaths := []string{"unit1", "unit2", filepath.Join("nested", "unit4"), "stack1"}
 
-	tgOpts := options.NewTerragruntOptions()
+	tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 	tgOpts.WorkingDir = tmpDir
 
 	// Create options
@@ -139,7 +140,7 @@ func TestHiddenDiscovery(t *testing.T) {
 		"stack1", filepath.Join(".hidden", "unit3"),
 	}
 
-	tgOpts := options.NewTerragruntOptions()
+	tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 	tgOpts.WorkingDir = tmpDir
 
 	l := logger.CreateLogger()
@@ -212,7 +213,7 @@ dependency "unit2" {
 
 	expectedPaths := []string{"unit1", "unit2", "unit3"}
 
-	tgOpts := options.NewTerragruntOptions()
+	tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 	tgOpts.WorkingDir = tmpDir
 
 	l := logger.CreateLogger()
@@ -287,7 +288,7 @@ dependency "unit3" {
 
 	expectedPaths := []string{"unit3", "unit2", "unit1"}
 
-	tgOpts := options.NewTerragruntOptions()
+	tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 	tgOpts.WorkingDir = tmpDir
 
 	l := logger.CreateLogger()
@@ -400,7 +401,7 @@ dependency "C" {
 
 	expectedPaths := []string{"A", "B", "C", "D", "E", "F"}
 
-	tgOpts := options.NewTerragruntOptions()
+	tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 	tgOpts.WorkingDir = tmpDir
 
 	l := logger.CreateLogger()
@@ -1048,7 +1049,7 @@ dependency "zulu" {
 				"zulu/terragrunt.hcl": "",
 			})
 
-			tgOpts := options.NewTerragruntOptions()
+			tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 			tgOpts.WorkingDir = root
 			tgOpts.RootWorkingDir = root
 
@@ -1107,7 +1108,7 @@ dependency "zulu" {
 				"nested/zulu/terragrunt.hcl": "",
 			})
 
-			tgOpts := options.NewTerragruntOptions()
+			tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 			tgOpts.WorkingDir = root
 			tgOpts.RootWorkingDir = root
 
@@ -1136,7 +1137,7 @@ func TestTextFormatGivesAWidePathItsOwnLine(t *testing.T) {
 		filepath.Join(widePathPrefix, "two", "terragrunt.hcl"): "",
 	})
 
-	tgOpts := options.NewTerragruntOptions()
+	tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 	tgOpts.WorkingDir = root
 	tgOpts.RootWorkingDir = root
 
@@ -1185,7 +1186,7 @@ func TestRunRejectsUnsupportedOptions(t *testing.T) {
 			root := "/list-invalid"
 			fsys := newUnitsFS(t, root, map[string]string{"unit1/terragrunt.hcl": ""})
 
-			tgOpts := options.NewTerragruntOptions()
+			tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 			tgOpts.WorkingDir = root
 			tgOpts.RootWorkingDir = root
 
@@ -1225,7 +1226,7 @@ func TestRunFailsWhenTheWriterFails(t *testing.T) {
 			root := "/list-writer"
 			fsys := newUnitsFS(t, root, map[string]string{"unit1/terragrunt.hcl": ""})
 
-			tgOpts := options.NewTerragruntOptions()
+			tgOpts := options.NewTerragruntOptions(vexec.NewOSExec())
 			tgOpts.WorkingDir = root
 			tgOpts.RootWorkingDir = root
 

--- a/internal/cli/commands/list/options_test.go
+++ b/internal/cli/commands/list/options_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/list"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,7 +14,7 @@ import (
 func TestNewOptionsDefaultsValidate(t *testing.T) {
 	t.Parallel()
 
-	opts := list.NewOptions(options.NewTerragruntOptions())
+	opts := list.NewOptions(options.NewTerragruntOptions(vexec.NewOSExec()))
 
 	assert.Equal(t, list.FormatText, opts.Format)
 	assert.Equal(t, list.ModeNormal, opts.Mode)
@@ -63,7 +64,7 @@ func TestOptionsValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts := list.NewOptions(options.NewTerragruntOptions())
+			opts := list.NewOptions(options.NewTerragruntOptions(vexec.NewOSExec()))
 			opts.Format = tc.format
 			opts.Mode = tc.mode
 

--- a/internal/cli/commands/profiling_test.go
+++ b/internal/cli/commands/profiling_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -22,7 +23,7 @@ func TestWrapWithProfilingRequiresExperiment(t *testing.T) {
 
 	v := venvtest.New()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.ProfileCPU = filepath.Join(t.TempDir(), "cpu.prof")
 
 	called := false
@@ -45,7 +46,7 @@ func TestWrapWithProfilingNoFlagsRunsAction(t *testing.T) {
 
 	v := venvtest.New()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 	called := false
 	wrapped := commands.WrapWithProfiling(logger.CreateLogger(), opts, v)
@@ -64,7 +65,7 @@ func TestWrapWithProfilingWritesProfile(t *testing.T) {
 
 	v := venvtest.New()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.ProfileGoroutine = filepath.Join(t.TempDir(), "goroutine.prof")
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.Profiling))
 
@@ -85,7 +86,7 @@ func TestWrapWithProfilingTightensExistingFilePermissions(t *testing.T) {
 
 	v := venvtest.New()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.ProfileGoroutine = filepath.Join(t.TempDir(), "goroutine.prof")
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.Profiling))
 

--- a/internal/cli/commands/run/flags_test.go
+++ b/internal/cli/commands/run/flags_test.go
@@ -7,6 +7,7 @@ import (
 	runcommand "github.com/gruntwork-io/terragrunt/internal/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -17,7 +18,7 @@ import (
 func TestNoHooksFlagRequiresExperiment(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	flags := runcommand.NewFlags(logger.CreateLogger(), opts, venvtest.New(), nil)
 
 	require.NoError(t, flags.Parse(clihelper.Args{"--no-hooks"}, map[string]string{}))
@@ -31,7 +32,7 @@ func TestNoHooksFlagRequiresExperiment(t *testing.T) {
 func TestNoHooksFlagAllowedWithExperiment(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.OptionalHooks))
 	flags := runcommand.NewFlags(logger.CreateLogger(), opts, venvtest.New(), nil)
 
@@ -43,7 +44,7 @@ func TestNoHooksFlagAllowedWithExperiment(t *testing.T) {
 func TestNoDependencyOutputsFlagRequiresExperiment(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	flags := runcommand.NewFlags(logger.CreateLogger(), opts, venvtest.New(), nil)
 
 	require.NoError(t, flags.Parse(clihelper.Args{"--no-dependency-outputs"}, map[string]string{}))
@@ -57,7 +58,7 @@ func TestNoDependencyOutputsFlagRequiresExperiment(t *testing.T) {
 func TestNoDependencyOutputsFlagAllowedWithExperiment(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.OptionalDependencyOutputs))
 	flags := runcommand.NewFlags(logger.CreateLogger(), opts, venvtest.New(), nil)
 

--- a/internal/cli/commands/run/help.go
+++ b/internal/cli/commands/run/help.go
@@ -74,7 +74,7 @@ func runTFHelp(
 		ctx,
 		l,
 		helpV,
-		configbridge.TFRunOptsFromOpts(opts),
+		configbridge.TFRunOptsFromOpts(v.Env, opts),
 		terraformHelpCmd...)
 	if err != nil {
 		var processError util.ProcessExecutionError

--- a/internal/cli/commands/run/run.go
+++ b/internal/cli/commands/run/run.go
@@ -86,7 +86,7 @@ func Run(ctx context.Context, l log.Logger, opts *options.TerragruntOptions, v *
 	// since the locals block may contain `get_aws_account_id()` func.
 	credsGetter := creds.NewGetter()
 	if err := credsGetter.ObtainAndUpdateEnvIfNecessary(ctx, l, v,
-		externalcmd.NewProvider(l, opts.AuthProviderCmd, configbridge.ShellRunOptsFromOpts(opts)),
+		externalcmd.NewProvider(l, opts.AuthProviderCmd, configbridge.ShellRunOptsFromOpts(v.Env, opts)),
 	); err != nil {
 		return err
 	}
@@ -175,7 +175,7 @@ func runVersionCommand(
 		ctx,
 		l,
 		v,
-		configbridge.TFRunOptsFromOpts(opts),
+		configbridge.TFRunOptsFromOpts(v.Env, opts),
 		opts.TerraformCliArgs.Slice()...)
 }
 
@@ -221,7 +221,7 @@ func checkVersionConstraints(
 	}
 
 	l, ver, impl, err := run.PopulateTFVersion(ctx, l, v, run.PopulateTFVersionInput{
-		TFOpts:       configbridge.TFRunOptsFromOpts(opts),
+		TFOpts:       configbridge.TFRunOptsFromOpts(v.Env, opts),
 		WorkingDir:   opts.WorkingDir,
 		VersionFiles: opts.VersionManagerFileName,
 	})

--- a/internal/cli/commands/run_action_test.go
+++ b/internal/cli/commands/run_action_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/panicreport"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -34,7 +35,7 @@ func TestRunActionInstallsRunScopedCache(t *testing.T) {
 		return nil
 	}
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.NoAutoProviderCacheDir = true
 
 	l := logger.CreateLogger()
@@ -51,7 +52,7 @@ func TestRunActionReturnsReportableErrorOnActionPanic(t *testing.T) {
 		panic("action panic")
 	}
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.NoAutoProviderCacheDir = true
 
 	err := commands.RunAction(t.Context(), nil, logger.CreateLogger(), opts, venvtest.New(), action)

--- a/internal/cli/commands/scaffold/cli.go
+++ b/internal/cli/commands/scaffold/cli.go
@@ -3,7 +3,6 @@ package scaffold
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
@@ -11,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -86,7 +86,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 			}
 
 			if opts.ScaffoldRootFileName == "" {
-				opts.ScaffoldRootFileName = GetDefaultRootFileName(ctx, opts)
+				opts.ScaffoldRootFileName = GetDefaultRootFileName(ctx, v.FS, opts)
 			}
 
 			return RunInteractive(ctx, l, v, opts.OptionsFromContext(ctx), moduleURL, templateURL)
@@ -94,7 +94,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 	}
 }
 
-func GetDefaultRootFileName(ctx context.Context, opts *options.TerragruntOptions) string {
+func GetDefaultRootFileName(ctx context.Context, fsys vfs.FS, opts *options.TerragruntOptions) string {
 	if err := opts.StrictControls.FilterByNames(controls.RootTerragruntHCL).
 		SuppressWarning().
 		Evaluate(ctx); err != nil {
@@ -109,7 +109,7 @@ func GetDefaultRootFileName(ctx context.Context, opts *options.TerragruntOptions
 	for foldersToCheck := opts.MaxFoldersToCheck; dir != prevDir && dir != "" && foldersToCheck > 0; foldersToCheck-- {
 		prevDir = dir
 
-		_, err := os.Stat(filepath.Join(dir, config.RecommendedParentConfigName))
+		_, err := fsys.Stat(filepath.Join(dir, config.RecommendedParentConfigName))
 		if err == nil {
 			return config.RecommendedParentConfigName
 		}

--- a/internal/cli/commands/scaffold/interactive.go
+++ b/internal/cli/commands/scaffold/interactive.go
@@ -32,7 +32,7 @@ func RunInteractive(
 		return err
 	}
 
-	defer plan.Cleanup()
+	defer plan.Cleanup(v.FS)
 
 	values, err := promptForValues(ctx, l, opts, plan, moduleURL)
 

--- a/internal/cli/commands/scaffold/interactive_test.go
+++ b/internal/cli/commands/scaffold/interactive_test.go
@@ -40,12 +40,14 @@ func prepare(t *testing.T, source string) *scaffold.Plan {
 	opts.WorkingDir = outputDir
 	opts.NonInteractive = true
 
+	v := venv.OSVenv()
+
 	plan, err := scaffold.Prepare(
-		t.Context(), logger.CreateLogger(), venv.OSVenv(), opts, source, "",
+		t.Context(), logger.CreateLogger(), v, opts, source, "",
 	)
 	require.NoError(t, err)
 
-	t.Cleanup(plan.Cleanup)
+	t.Cleanup(func() { plan.Cleanup(v.FS) })
 
 	return plan
 }

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/fs"
 	"net/url"
-	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -175,9 +174,9 @@ func (p *Plan) FormFields() []form.Field {
 
 // Cleanup removes the temporary directories allocated during Prepare.
 // Safe to call more than once; subsequent calls are no-ops.
-func (p *Plan) Cleanup() {
+func (p *Plan) Cleanup(fsys vfs.FS) {
 	for _, dir := range p.tempDirs {
-		if err := os.RemoveAll(dir); err != nil {
+		if err := fsys.RemoveAll(dir); err != nil {
 			p.logger.Warnf("Failed to clean up dir %s: %v", dir, err)
 		}
 	}
@@ -186,11 +185,10 @@ func (p *Plan) Cleanup() {
 }
 
 // Prepare downloads the source module and template, parses the module's
-// variable blocks, and returns a Plan ready for rendering. The caller is
-// responsible for invoking Plan.Cleanup() (typically via defer) once it has
-// either rendered the result via Generate or decided to abandon the work.
-// v is the virtualized environment threaded through the module download and
-// boilerplate preparation.
+// variable blocks, and returns a [Plan] ready for rendering. The caller is
+// responsible for invoking [Plan.Cleanup] (typically via defer) once it has
+// either rendered the result via [Plan.Generate] or decided to abandon the
+// work.
 func Prepare(
 	ctx context.Context,
 	l log.Logger,
@@ -223,7 +221,7 @@ func Prepare(
 	templateURL = tf.RewriteLegacyGCSPublicSource(ctx, l, templateURL, opts.StrictControls)
 
 	// create temporary directory where to download module
-	tempDir, err := os.MkdirTemp("", "scaffold")
+	tempDir, err := vfs.MkdirTemp(v.FS, v.Platform.TempDir(), "scaffold")
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +238,7 @@ func Prepare(
 
 	defer func() {
 		if !success {
-			plan.Cleanup()
+			plan.Cleanup(v.FS)
 		}
 	}()
 
@@ -518,7 +516,7 @@ func Run(
 		return err
 	}
 
-	defer plan.Cleanup()
+	defer plan.Cleanup(v.FS)
 
 	return plan.Generate(ctx, l, v, opts, nil)
 }
@@ -616,9 +614,10 @@ func applyCatalogConfigToScaffold(
 }
 
 // generateDefaultTemplate - write default template to provided dir
-func generateDefaultTemplate(boilerplateDir string) (string, error) {
+func generateDefaultTemplate(fsys vfs.FS, boilerplateDir string) (string, error) {
 	const ownerWriteGlobalReadPerms = 0o644
-	if err := os.WriteFile(
+	if err := vfs.WriteFile(
+		fsys,
 		filepath.Join(
 			boilerplateDir,
 			config.DefaultTerragruntConfigPath,
@@ -629,7 +628,8 @@ func generateDefaultTemplate(boilerplateDir string) (string, error) {
 		return "", err
 	}
 
-	if err := os.WriteFile(
+	if err := vfs.WriteFile(
+		fsys,
 		filepath.Join(
 			boilerplateDir,
 			"boilerplate.yml",
@@ -658,7 +658,7 @@ func downloadTemplate(
 	}
 
 	// Split the processed URL to get the base URL and subfolder
-	baseURL, subFolder, err := tf.SplitSourceURL(l, parsedTemplateURL)
+	baseURL, subFolder, err := tf.SplitSourceURL(l, v.FS, parsedTemplateURL)
 	if err != nil {
 		return "", err
 	}
@@ -673,7 +673,7 @@ func downloadTemplate(
 		return "", err
 	}
 
-	templateDir, err := os.MkdirTemp(tempDir, "template")
+	templateDir, err := vfs.MkdirTemp(v.FS, tempDir, "template")
 	if err != nil {
 		return "", err
 	}
@@ -703,7 +703,7 @@ func downloadTemplate(
 		subFolder = strings.TrimPrefix(subFolder, "/")
 		templateDir = filepath.Join(templateDir, subFolder)
 		// Verify that subfolder exists
-		if _, err := os.Stat(templateDir); errors.Is(err, fs.ErrNotExist) {
+		if _, err := v.FS.Stat(templateDir); errors.Is(err, fs.ErrNotExist) {
 			return "", fmt.Errorf(
 				"subfolder \"//%s\" not found in downloaded template from %s",
 				subFolder,
@@ -763,14 +763,14 @@ func prepareBoilerplateFiles(
 
 			boilerplateDir = tempTemplateDir
 		} else {
-			defaultTempDir, err := os.MkdirTemp(tempDir, "boilerplate")
+			defaultTempDir, err := vfs.MkdirTemp(v.FS, tempDir, "boilerplate")
 			if err != nil {
 				return "", err
 			}
 
 			boilerplateDir = defaultTempDir
 
-			boilerplateDir, err = generateDefaultTemplate(boilerplateDir)
+			boilerplateDir, err = generateDefaultTemplate(v.FS, boilerplateDir)
 			if err != nil {
 				return "", err
 			}
@@ -908,7 +908,7 @@ func rewriteTemplateURL(
 
 	ref := templateParams.Get(refParam)
 	if ref == "" {
-		rootSourceURL, _, err := tf.SplitSourceURL(l, updatedTemplateURL)
+		rootSourceURL, _, err := tf.SplitSourceURL(l, v.FS, updatedTemplateURL)
 		if err != nil {
 			return nil, err
 		}
@@ -957,7 +957,7 @@ func addRefToModuleURL(
 		// if ref is not passed, find last release tag
 		// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs =>
 		// git::https://github.com/gruntwork-io/terragrunt.git//test/fixtures/inputs?ref=v0.53.8
-		rootSourceURL, _, err := tf.SplitSourceURL(l, moduleURL)
+		rootSourceURL, _, err := tf.SplitSourceURL(l, v.FS, moduleURL)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/commands/scaffold/scaffold_test.go
+++ b/internal/cli/commands/scaffold/scaffold_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/boilerplate/variables"
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/scaffold"
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -434,7 +435,7 @@ catalog {
 			err = os.WriteFile(terragruntConfigPath, []byte(tc.terragruntConfig), 0644)
 			require.NoError(t, err)
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			// Set CLI flags if specified in test case
 			if tc.cliNoShell != nil {
 				opts.NoShell = *tc.cliNoShell
@@ -541,7 +542,7 @@ catalog {
 	err := os.WriteFile(terragruntConfigPath, []byte(terragruntConfig), 0644)
 	require.NoError(t, err)
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.TerragruntConfigPath = terragruntConfigPath
 	opts.WorkingDir = workDir
 	opts.ScaffoldRootFileName = "terragrunt.hcl"
@@ -580,7 +581,7 @@ catalog {
 	err := os.WriteFile(terragruntConfigPath, []byte(terragruntConfig), 0644)
 	require.NoError(t, err)
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.TerragruntConfigPath = terragruntConfigPath
 	opts.WorkingDir = workDir
 	opts.ScaffoldRootFileName = "terragrunt.hcl"

--- a/internal/cli/commands/stack/cli.go
+++ b/internal/cli/commands/stack/cli.go
@@ -68,7 +68,7 @@ func NewCommand(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) *cl
 				Name:  cleanCommandName,
 				Usage: "Clean the stack generated from the current directory",
 				Action: func(ctx context.Context, _ *clihelper.Context) error {
-					return RunClean(ctx, l, opts.OptionsFromContext(ctx))
+					return RunClean(ctx, l, v, opts.OptionsFromContext(ctx))
 				},
 			},
 		},

--- a/internal/cli/commands/stack/stack.go
+++ b/internal/cli/commands/stack/stack.go
@@ -48,7 +48,7 @@ func RunGenerate(
 			"working_dir":       opts.WorkingDir,
 		}, func(ctx context.Context, l log.Logger) error {
 			l.Debugf("Running stack clean for %s, as part of generate command", opts.WorkingDir)
-			return clean.CleanStacks(l, opts)
+			return clean.CleanStacks(l, v.FS, opts)
 		})
 		if err != nil {
 			return fmt.Errorf(
@@ -79,7 +79,7 @@ func RunGenerate(
 		}
 
 		defer func() {
-			cleanupErr := wts.Cleanup(ctx, l)
+			cleanupErr := wts.Cleanup(ctx, l, v.FS)
 			if cleanupErr != nil {
 				l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 			}
@@ -219,14 +219,14 @@ func FilterOutputs(outputs cty.Value, index string) cty.Value {
 }
 
 // RunClean recursively removes all stack directories under the specified WorkingDir.
-func RunClean(ctx context.Context, l log.Logger, opts *options.TerragruntOptions) error {
+func RunClean(ctx context.Context, l log.Logger, v *venv.Venv, opts *options.TerragruntOptions) error {
 	telemeter := telemetry.TelemeterFromContext(ctx)
 
 	err := telemeter.Collect(ctx, l, "stack_clean", map[string]any{
 		"stack_config_path": opts.TerragruntStackConfigPath,
 		"working_dir":       opts.WorkingDir,
 	}, func(ctx context.Context, l log.Logger) error {
-		return clean.CleanStacks(l, opts)
+		return clean.CleanStacks(l, v.FS, opts)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to clean stack directories under %q: %w", opts.WorkingDir, err)

--- a/internal/cli/flags/global/flags_test.go
+++ b/internal/cli/flags/global/flags_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags/global"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,7 +13,7 @@ import (
 func TestProfileFlagsRegistration(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	profileFlags := global.NewProfileFlags(opts, nil)
 
 	testCases := []struct {
@@ -35,7 +36,7 @@ func TestProfileFlagsRegistration(t *testing.T) {
 func TestProfileFlagsParse(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 	err := global.NewProfileFlags(opts, nil).Parse([]string{
 		"--profile-cpu=cpu.prof",
@@ -54,7 +55,7 @@ func TestProfileFlagsParse(t *testing.T) {
 func TestProfileFlagsParseSpaceForm(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 	err := global.NewProfileFlags(opts, nil).Parse([]string{"--profile-cpu", "cpu.prof"}, map[string]string{})
 	require.NoError(t, err)

--- a/internal/cli/flags/shared/filter.go
+++ b/internal/cli/flags/shared/filter.go
@@ -78,7 +78,7 @@ func NewFilterFlags(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv)
 					}
 
 					// Check for uncommitted changes
-					gitRunner, err := git.NewGitRunner(v.Exec)
+					gitRunner, err := git.NewGitRunner(v)
 					if err != nil {
 						return clihelper.NewExitError(err, clihelper.ExitCodeGeneralError)
 					}

--- a/internal/cli/flags/shared/filter_test.go
+++ b/internal/cli/flags/shared/filter_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags/shared"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -16,7 +17,7 @@ import (
 func TestDiscoveryBoundaryFlagRequiresExperiment(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	flags := shared.NewFilterFlags(logger.CreateLogger(), opts, venvtest.New())
 
 	require.NoError(t, flags.Parse(clihelper.Args{"--discovery-boundary", "."}, map[string]string{}))
@@ -29,7 +30,7 @@ func TestDiscoveryBoundaryFlagRequiresExperiment(t *testing.T) {
 func TestDiscoveryBoundaryFlagAllowedWithExperiment(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.BoundedDiscovery))
 	flags := shared.NewFilterFlags(logger.CreateLogger(), opts, venvtest.New())
 

--- a/internal/clihelper/autocomplete.go
+++ b/internal/clihelper/autocomplete.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"unicode/utf8"
 
@@ -72,10 +71,10 @@ func defaultComplete(cliCtx *Context) error {
 
 	if strings.HasPrefix(arg, "-") {
 		if cmd := cliCtx.Command; cmd != nil {
-			return printFlagSuggestions(arg, cmd.Flags, cliCtx.Writer)
+			return printFlagSuggestions(arg, cmd.Flags, cliCtx.Args(), cliCtx.Writer)
 		}
 
-		return printFlagSuggestions(arg, cliCtx.Flags, cliCtx.Writer)
+		return printFlagSuggestions(arg, cliCtx.Flags, cliCtx.Args(), cliCtx.Writer)
 	}
 
 	if cmd := cliCtx.Command; cmd != nil {
@@ -108,7 +107,7 @@ func printCommandSuggestions(arg string, commands []*Command, writer io.Writer) 
 	return nil
 }
 
-func printFlagSuggestions(arg string, flags []Flag, writer io.Writer) error {
+func printFlagSuggestions(arg string, flags []Flag, args Args, writer io.Writer) error {
 	cur := strings.TrimLeft(arg, "-")
 
 	errs := []error{}
@@ -124,7 +123,7 @@ func printFlagSuggestions(arg string, flags []Flag, writer io.Writer) error {
 				continue
 			}
 			// match if last argument matches this flag and it is not repeated
-			if strings.HasPrefix(name, cur) && cur != name && !cliArgContains(name) {
+			if strings.HasPrefix(name, cur) && cur != name && !argsContainFlag(args, name) {
 				flagCompletion := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
 
 				_, err := fmt.Fprintln(writer, flagCompletion)
@@ -140,14 +139,16 @@ func printFlagSuggestions(arg string, flags []Flag, writer io.Writer) error {
 	return nil
 }
 
-func cliArgContains(flagName string) bool {
+// argsContainFlag reports whether any spelling of flagName is already present
+// in args, so a flag the user has typed is not suggested again.
+func argsContainFlag(args Args, flagName string) bool {
 	for name := range strings.SplitSeq(flagName, ",") {
 		name = strings.TrimSpace(name)
 
 		count := min(utf8.RuneCountInString(name), maxDashesInFlag)
 
 		flag := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
-		if slices.Contains(os.Args, flag) {
+		if slices.Contains(args, flag) {
 			return true
 		}
 	}

--- a/internal/configbridge/bridge.go
+++ b/internal/configbridge/bridge.go
@@ -94,8 +94,8 @@ func populateFromOpts(pctx *config.ParsingContext, opts *options.TerragruntOptio
 }
 
 // ShellRunOptsFromOpts constructs shell.ShellOptions from TerragruntOptions.
-func ShellRunOptsFromOpts(opts *options.TerragruntOptions) *shell.ShellOptions {
-	s := shell.NewShellOptions().
+func ShellRunOptsFromOpts(env map[string]string, opts *options.TerragruntOptions) *shell.ShellOptions {
+	s := shell.NewShellOptions(env).
 		WithWorkingDir(opts.WorkingDir).
 		WithTelemetry(opts.Telemetry).
 		WithEngine(opts.EngineConfig, opts.EngineOptions).
@@ -121,23 +121,23 @@ func BackendOptsFromOpts(opts *options.TerragruntOptions) *backend.Options {
 }
 
 // RemoteStateOptsFromOpts constructs remotestate.Options from TerragruntOptions.
-func RemoteStateOptsFromOpts(opts *options.TerragruntOptions) *remotestate.Options {
+func RemoteStateOptsFromOpts(env map[string]string, opts *options.TerragruntOptions) *remotestate.Options {
 	return &remotestate.Options{
 		Options:             *BackendOptsFromOpts(opts),
 		DisableBucketUpdate: opts.DisableBucketUpdate,
-		TFRunOpts:           TFRunOptsFromOpts(opts),
+		TFRunOpts:           TFRunOptsFromOpts(env, opts),
 	}
 }
 
 // TFRunOptsFromOpts constructs tf.TFOptions from TerragruntOptions.
-func TFRunOptsFromOpts(opts *options.TerragruntOptions) *tf.TFOptions {
+func TFRunOptsFromOpts(env map[string]string, opts *options.TerragruntOptions) *tf.TFOptions {
 	return &tf.TFOptions{
 		JSONLogFormat:                opts.JSONLogFormat,
 		OriginalTerragruntConfigPath: opts.OriginalTerragruntConfigPath,
 		TerragruntConfigPath:         opts.TerragruntConfigPath,
 		TofuImplementation:           opts.TofuImplementation,
 		TerraformCliArgs:             opts.TerraformCliArgs,
-		ShellOptions:                 ShellRunOptsFromOpts(opts),
+		ShellOptions:                 ShellRunOptsFromOpts(env, opts),
 	}
 }
 

--- a/internal/configbridge/bridge_test.go
+++ b/internal/configbridge/bridge_test.go
@@ -39,7 +39,7 @@ func TestRemoteStateOptsFromOpts_CarriesBackendOptions(t *testing.T) {
 	opts.DisableBucketUpdate = true
 	opts.TerragruntConfigPath = "/work/terragrunt.hcl"
 
-	got := configbridge.RemoteStateOptsFromOpts(opts)
+	got := configbridge.RemoteStateOptsFromOpts(map[string]string{}, opts)
 
 	assert.True(t, got.Experiments.Evaluate(experiment.AzureBackend), "experiments must reach remote state options")
 	assert.True(t, got.DisableBucketUpdate)

--- a/internal/configbridge/copy_test.go
+++ b/internal/configbridge/copy_test.go
@@ -183,7 +183,7 @@ func TestShellRunOptsFromOptsCopiesEveryOption(t *testing.T) {
 
 	opts := optionsWithDistinctValues(t)
 
-	shellOpts := configbridge.ShellRunOptsFromOpts(opts)
+	shellOpts := configbridge.ShellRunOptsFromOpts(map[string]string{}, opts)
 	require.NotNil(t, shellOpts)
 
 	assert.Equal(t, opts.WorkingDir, shellOpts.WorkingDir, "commands run in the working dir of the unit")
@@ -205,7 +205,7 @@ func TestTFRunOptsFromOptsCopiesEveryOption(t *testing.T) {
 
 	opts := optionsWithDistinctValues(t)
 
-	tfOpts := configbridge.TFRunOptsFromOpts(opts)
+	tfOpts := configbridge.TFRunOptsFromOpts(map[string]string{}, opts)
 	require.NotNil(t, tfOpts)
 
 	assert.True(t, tfOpts.JSONLogFormat)

--- a/internal/discovery/discovery_boundary_test.go
+++ b/internal/discovery/discovery_boundary_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
@@ -79,7 +80,7 @@ dependency "external" {
 func (f *boundaryFixture) discover(t *testing.T, v *venv.Venv, query, boundary string) (component.Components, error) {
 	t.Helper()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = f.stagingDir
 	opts.RootWorkingDir = f.stagingDir
 
@@ -330,7 +331,7 @@ func TestDiscoveryBoundary_SurvivesFilterEvaluationWithRelationships(t *testing.
 				paths[i] = byName[n]
 			}
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			opts.WorkingDir = f.stagingDir
 			opts.RootWorkingDir = f.stagingDir
 
@@ -395,7 +396,7 @@ func TestDiscoveryBoundary_WithholdingAcrossFilterShapes(t *testing.T) {
 				paths[i] = byName[n]
 			}
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			opts.WorkingDir = f.stagingDir
 			opts.RootWorkingDir = f.stagingDir
 
@@ -470,7 +471,7 @@ func TestDiscoveryBoundary_UnfilteredRunWithholdsOnlyWhatTraversalReached(t *tes
 
 	f, v := newBoundaryFixture(t)
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = f.stagingDir
 	opts.RootWorkingDir = f.stagingDir
 
@@ -547,7 +548,7 @@ func TestDiscoveryBoundary_ExcludedDependencyStaysLinked(t *testing.T) {
 				expected[i] = byName[n]
 			}
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			opts.WorkingDir = f.stagingDir
 			opts.RootWorkingDir = f.stagingDir
 

--- a/internal/discovery/filter_test.go
+++ b/internal/discovery/filter_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -25,7 +25,7 @@ func TestDiscovery_GraphExpressionFilters(t *testing.T) {
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	// To speed up this test, make the temporary directory a git repository.
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpDir)
@@ -116,7 +116,7 @@ func TestDiscovery_GraphExpressionFilters_ComplexGraph(t *testing.T) {
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	// To speed up this test, make the temporary directory a git repository.
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpDir)
@@ -1031,7 +1031,7 @@ func TestDiscovery_DependentDiscovery_Standalone(t *testing.T) {
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	// To speed up this test, make the temporary directory a git repository.
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpDir)
@@ -1103,7 +1103,7 @@ func TestDiscovery_DependentDiscovery_ExcludeTarget(t *testing.T) {
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	// To speed up this test, make the temporary directory a git repository.
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpDir)
@@ -1174,7 +1174,7 @@ func TestDiscovery_DependencyDiscovery_ExcludeTarget(t *testing.T) {
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	// To speed up this test, make the temporary directory a git repository.
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpDir)
@@ -1249,7 +1249,7 @@ func TestDiscovery_DependentDiscovery_Bidirectional(t *testing.T) {
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	// To speed up this test, make the temporary directory a git repository.
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpDir)
@@ -1322,7 +1322,7 @@ func TestDiscovery_DependentDiscovery_OutsideWorkingDir(t *testing.T) {
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	// Initialize git repository at the root
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpDir)
@@ -1408,7 +1408,7 @@ func TestDiscovery_DependentDiscovery_OutsideWorkingDir_MultipleLevels(t *testin
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	// Initialize git repository at the root
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpDir)
@@ -1507,7 +1507,7 @@ func TestDiscovery_DependentDiscovery_DirectDependentOnly(t *testing.T) {
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	// To speed up this test, make the temporary directory a git repository.
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpDir)
@@ -1626,7 +1626,7 @@ func TestDiscovery_NegatedGraphFilters(t *testing.T) {
 
 			tmpDir := helpers.TmpDirWOSymlinks(t)
 
-			runner, err := git.NewGitRunner(vexec.NewOSExec())
+			runner, err := git.NewGitRunner(venv.OSVenv())
 			require.NoError(t, err)
 
 			runner = runner.WithWorkDir(tmpDir)

--- a/internal/discovery/graph_boundary_test.go
+++ b/internal/discovery/graph_boundary_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
@@ -75,7 +76,7 @@ dependency "external" {
 func (f *graphBoundaryFixture) discover(t *testing.T, v *venv.Venv, query string) component.Components {
 	t.Helper()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = f.stagingDir
 	opts.RootWorkingDir = f.stagingDir
 
@@ -162,7 +163,7 @@ func TestDiscoveryGraphBoundary_ValidatesBoundary(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			opts.WorkingDir = f.stagingDir
 			opts.RootWorkingDir = f.stagingDir
 
@@ -204,7 +205,7 @@ dependency "vpc" {
 	discover := func(query string) component.Components {
 		t.Helper()
 
-		opts := options.NewTerragruntOptions()
+		opts := options.NewTerragruntOptions(vexec.NewOSExec())
 		opts.WorkingDir = repoRoot
 		opts.RootWorkingDir = repoRoot
 

--- a/internal/discovery/graph_target_test.go
+++ b/internal/discovery/graph_target_test.go
@@ -47,7 +47,7 @@ dependency "db" {
 `,
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -97,7 +97,7 @@ dependency "db" {
 `,
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -150,7 +150,7 @@ func TestDiscoveryWithGraphTarget_NoDependents(t *testing.T) {
 		appDir: ``,
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -192,7 +192,7 @@ dependency "vpc" {
 `,
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	iofs "io/fs"
+	"io/fs"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -47,7 +47,7 @@ var DefaultConfigFilenames = []string{config.DefaultTerragruntConfigPath, config
 func walkDirFunc(
 	v *venv.Venv,
 	opts *options.TerragruntOptions,
-) func(string, iofs.WalkDirFunc) error {
+) func(string, fs.WalkDirFunc) error {
 	v.RequireFS()
 
 	if opts == nil {
@@ -55,12 +55,12 @@ func walkDirFunc(
 	}
 
 	if opts.Experiments.Evaluate(experiment.Symlinks) {
-		return func(root string, fn iofs.WalkDirFunc) error {
+		return func(root string, fn fs.WalkDirFunc) error {
 			return vfs.WalkDirWithSymlinks(v.FS, root, fn)
 		}
 	}
 
-	return func(root string, fn iofs.WalkDirFunc) error {
+	return func(root string, fn fs.WalkDirFunc) error {
 		return vfs.WalkDir(v.FS, root, fn)
 	}
 }
@@ -392,7 +392,7 @@ func stackDependencyPaths(
 		info, statErr := v.FS.Stat(depPath)
 		// Real I/O errors (permission denied, etc.) must surface so a malformed DAG isn't silently
 		// produced; only ENOENT is treated as "keep the raw path".
-		if statErr != nil && !errors.Is(statErr, iofs.ErrNotExist) {
+		if statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
 			return nil, NewStackDependencyExpansionError(depPath, statErr)
 		}
 

--- a/internal/discovery/phase_parse.go
+++ b/internal/discovery/phase_parse.go
@@ -364,7 +364,7 @@ func parseComponent(
 			// ObtainCredsForParsing writes auth-provider-cmd output into it.
 			parseV := v.WithEnvCloned().WithWriter(io.Discard).WithErrWriter(io.Discard)
 
-			shellOpts := configbridge.ShellRunOptsFromOpts(parseOpts)
+			shellOpts := configbridge.ShellRunOptsFromOpts(v.Env, parseOpts)
 
 			if parseOpts.DiscoveryAuthProviderCmd {
 				if _, err := creds.ObtainCredsForParsing(

--- a/internal/discovery/phase_worktree.go
+++ b/internal/discovery/phase_worktree.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -20,6 +19,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"golang.org/x/sync/errgroup"
@@ -89,7 +89,7 @@ func (p *WorktreePhase) Run(
 
 	for _, pair := range w.WorktreePairs {
 		discoveryGroup.Go(func() error {
-			fromFilters, toFilters, err := pair.Expand()
+			fromFilters, toFilters, err := pair.Expand(v.FS)
 			if err != nil {
 				return err
 			}
@@ -543,7 +543,7 @@ func (p *WorktreePhase) walkChangedStack(
 		shaGroup.Go(func() error {
 			var localErr error
 
-			fromSHA, localErr = GenerateDirSHA256(pair.FromComponent.Path())
+			fromSHA, localErr = GenerateDirSHA256(v.FS, pair.FromComponent.Path())
 
 			return localErr
 		})
@@ -551,7 +551,7 @@ func (p *WorktreePhase) walkChangedStack(
 		shaGroup.Go(func() error {
 			var localErr error
 
-			toSHA, localErr = GenerateDirSHA256(pair.ToComponent.Path())
+			toSHA, localErr = GenerateDirSHA256(v.FS, pair.ToComponent.Path())
 
 			return localErr
 		})
@@ -673,10 +673,10 @@ func TranslateDiscoveryContextArgsForWorktree(
 }
 
 // GenerateDirSHA256 calculates a single SHA256 checksum for all files in a directory.
-func GenerateDirSHA256(rootDir string) (string, error) {
+func GenerateDirSHA256(fsys vfs.FS, rootDir string) (string, error) {
 	var filePaths []string
 
-	err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
+	err := vfs.WalkDir(fsys, rootDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -715,7 +715,7 @@ func GenerateDirSHA256(rootDir string) (string, error) {
 		_, _ = hash.Write([]byte(normalizedPath))
 		_, _ = hash.Write([]byte{0})
 
-		f, err := os.Open(path)
+		f, err := fsys.Open(path)
 		if err != nil {
 			return "", fmt.Errorf("could not open file %s: %w", path, err)
 		}

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -479,11 +481,11 @@ func TestWorktreePhase_Integration_CommandArgs(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 				require.NoError(t, cleanupErr)
 			})
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			opts.WorkingDir = tmpDir
 			opts.RootWorkingDir = tmpDir
 
@@ -765,12 +767,12 @@ unit "unit_to_be_untouched" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
 	// Generate stacks in worktrees
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 	parsedFilters, parseErr := filter.ParseFilterQueries(l, []string{"[HEAD~1...HEAD]"})
@@ -920,11 +922,11 @@ func TestWorktreePhase_Integration_StackSourceOnlyInOneRef(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 	parsedFilters, parseErr := filter.ParseFilterQueries(l, []string{"[HEAD~1...HEAD]"})
@@ -1223,11 +1225,11 @@ locals {
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 				require.NoError(t, cleanupErr)
 			})
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			opts.WorkingDir = tmpDir
 			opts.RootWorkingDir = tmpDir
 
@@ -1321,11 +1323,11 @@ locals {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = basicDir
 	opts.RootWorkingDir = basicDir
 
@@ -1598,11 +1600,11 @@ locals {
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 				require.NoError(t, cleanupErr)
 			})
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			opts.WorkingDir = tmpDir
 			opts.RootWorkingDir = tmpDir
 
@@ -1706,11 +1708,11 @@ func TestWorktreePhase_Integration_FromSubdirectory_MultipleCommits(t *testing.T
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 				require.NoError(t, cleanupErr)
 			})
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			opts.WorkingDir = basicDir
 			opts.RootWorkingDir = basicDir
 
@@ -1895,12 +1897,12 @@ unit "app" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
 	// Generate stacks in worktrees
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -2089,11 +2091,11 @@ unit "app" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -2273,11 +2275,11 @@ unit "app" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -2441,11 +2443,11 @@ unit "myapp" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -2582,11 +2584,11 @@ unit "myapp" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -2708,11 +2710,11 @@ unit "myapp" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -2762,11 +2764,11 @@ func runWorktreeDiscovery(
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -2878,11 +2880,11 @@ unit "myapp" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -3032,10 +3034,10 @@ unit "app" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l))
+		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS()))
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -3157,10 +3159,10 @@ unit "app" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l))
+		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS()))
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -3257,11 +3259,11 @@ locals {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -3340,11 +3342,11 @@ locals {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -3446,11 +3448,11 @@ unit "myapp" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -3551,11 +3553,11 @@ unit "app" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l)
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 

--- a/internal/discovery/phase_worktree_test.go
+++ b/internal/discovery/phase_worktree_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -67,10 +68,10 @@ func TestGenerateDirSHA256(t *testing.T) {
 
 		tmpDir := t.TempDir()
 
-		hash1, err := discovery.GenerateDirSHA256(tmpDir)
+		hash1, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir)
 		require.NoError(t, err)
 
-		hash2, err := discovery.GenerateDirSHA256(tmpDir)
+		hash2, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir)
 		require.NoError(t, err)
 
 		assert.Equal(t, hash1, hash2, "Same empty directory should produce same hash")
@@ -86,10 +87,10 @@ func TestGenerateDirSHA256(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(tmpDir1, "file.txt"), content, 0644))
 		require.NoError(t, os.WriteFile(filepath.Join(tmpDir2, "file.txt"), content, 0644))
 
-		hash1, err := discovery.GenerateDirSHA256(tmpDir1)
+		hash1, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir1)
 		require.NoError(t, err)
 
-		hash2, err := discovery.GenerateDirSHA256(tmpDir2)
+		hash2, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir2)
 		require.NoError(t, err)
 
 		assert.Equal(t, hash1, hash2, "Directories with same files should produce same hash")
@@ -105,7 +106,7 @@ func TestGenerateDirSHA256(t *testing.T) {
 			os.WriteFile(filepath.Join(tmpDir, "file.txt"), []byte("content1"), 0644),
 		)
 
-		hash1, err := discovery.GenerateDirSHA256(tmpDir)
+		hash1, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir)
 		require.NoError(t, err)
 
 		require.NoError(
@@ -113,7 +114,7 @@ func TestGenerateDirSHA256(t *testing.T) {
 			os.WriteFile(filepath.Join(tmpDir, "file.txt"), []byte("content2"), 0644),
 		)
 
-		hash2, err := discovery.GenerateDirSHA256(tmpDir)
+		hash2, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir)
 		require.NoError(t, err)
 
 		assert.NotEqual(t, hash1, hash2, "Modified file should produce different hash")
@@ -129,10 +130,10 @@ func TestGenerateDirSHA256(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(tmpDir1, "original.txt"), content, 0644))
 		require.NoError(t, os.WriteFile(filepath.Join(tmpDir2, "renamed.txt"), content, 0644))
 
-		hash1, err := discovery.GenerateDirSHA256(tmpDir1)
+		hash1, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir1)
 		require.NoError(t, err)
 
-		hash2, err := discovery.GenerateDirSHA256(tmpDir2)
+		hash2, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir2)
 		require.NoError(t, err)
 
 		assert.NotEqual(
@@ -156,10 +157,10 @@ func TestGenerateDirSHA256(t *testing.T) {
 		require.NoError(t, os.MkdirAll(subDir, 0755))
 		require.NoError(t, os.WriteFile(filepath.Join(subDir, "file.txt"), content, 0644))
 
-		hash1, err := discovery.GenerateDirSHA256(tmpDir1)
+		hash1, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir1)
 		require.NoError(t, err)
 
-		hash2, err := discovery.GenerateDirSHA256(tmpDir2)
+		hash2, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir2)
 		require.NoError(t, err)
 
 		assert.NotEqual(t, hash1, hash2, "File move to subdirectory should produce different hash")
@@ -186,10 +187,10 @@ func TestGenerateDirSHA256(t *testing.T) {
 			),
 		)
 
-		hash1, err := discovery.GenerateDirSHA256(tmpDir1)
+		hash1, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir1)
 		require.NoError(t, err)
 
-		hash2, err := discovery.GenerateDirSHA256(tmpDir2)
+		hash2, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir2)
 		require.NoError(t, err)
 
 		assert.Equal(
@@ -213,10 +214,10 @@ func TestGenerateDirSHA256(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(tmpDir2, "b.txt"), []byte("b"), 0644))
 		require.NoError(t, os.WriteFile(filepath.Join(tmpDir2, "a.txt"), []byte("a"), 0644))
 
-		hash1, err := discovery.GenerateDirSHA256(tmpDir1)
+		hash1, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir1)
 		require.NoError(t, err)
 
-		hash2, err := discovery.GenerateDirSHA256(tmpDir2)
+		hash2, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir2)
 		require.NoError(t, err)
 
 		assert.Equal(t, hash1, hash2, "File creation order should not affect hash")
@@ -225,7 +226,7 @@ func TestGenerateDirSHA256(t *testing.T) {
 	t.Run("nonexistent_directory_returns_error", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := discovery.GenerateDirSHA256("/nonexistent/path/to/directory")
+		_, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), "/nonexistent/path/to/directory")
 		require.Error(t, err)
 	})
 
@@ -246,10 +247,10 @@ func TestGenerateDirSHA256(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(subDir1, "file.txt"), content, 0644))
 		require.NoError(t, os.WriteFile(filepath.Join(subDir2, "file.txt"), content, 0644))
 
-		hash1, err := discovery.GenerateDirSHA256(tmpDir1)
+		hash1, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir1)
 		require.NoError(t, err)
 
-		hash2, err := discovery.GenerateDirSHA256(tmpDir2)
+		hash2, err := discovery.GenerateDirSHA256(vfs.NewOSFS(), tmpDir2)
 		require.NoError(t, err)
 
 		assert.Equal(

--- a/internal/discovery/symlinks_test.go
+++ b/internal/discovery/symlinks_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -47,7 +48,7 @@ func TestDiscoverySymlinksExperiment(t *testing.T) {
 	discover := func(t *testing.T, experiments ...string) []string {
 		t.Helper()
 
-		opts := options.NewTerragruntOptions()
+		opts := options.NewTerragruntOptions(vexec.NewOSExec())
 		opts.WorkingDir = root
 		opts.RootWorkingDir = root
 

--- a/internal/engine/archive_internal_test.go
+++ b/internal/engine/archive_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +26,7 @@ func TestExtractArchiveWithLimitsAcceptsSmallArchive(t *testing.T) {
 		},
 	})
 
-	err := extractArchiveWithLimits(logger.CreateLogger(), archivePath, engineFile, 1024, 2)
+	err := extractArchiveWithLimits(logger.CreateLogger(), vfs.NewOSFS(), archivePath, engineFile, 1024, 2)
 	require.NoError(t, err)
 
 	content, err := os.ReadFile(engineFile)
@@ -47,7 +48,7 @@ func TestExtractArchiveWithLimitsAcceptsExactSizeLimit(t *testing.T) {
 		},
 	})
 
-	err := extractArchiveWithLimits(logger.CreateLogger(), archivePath, engineFile, 8, 2)
+	err := extractArchiveWithLimits(logger.CreateLogger(), vfs.NewOSFS(), archivePath, engineFile, 8, 2)
 	require.NoError(t, err)
 
 	content, err := os.ReadFile(engineFile)
@@ -77,7 +78,7 @@ func TestExtractArchiveWithLimitsRejectsTooManyFiles(t *testing.T) {
 		},
 	})
 
-	err := extractArchiveWithLimits(logger.CreateLogger(), archivePath, engineFile, 1024, 2)
+	err := extractArchiveWithLimits(logger.CreateLogger(), vfs.NewOSFS(), archivePath, engineFile, 1024, 2)
 
 	var extractionErr *archiveExtractionError
 	require.ErrorAs(t, err, &extractionErr)
@@ -102,7 +103,7 @@ func TestExtractArchiveWithLimitsRejectsOversizedContent(t *testing.T) {
 		},
 	})
 
-	err := extractArchiveWithLimits(logger.CreateLogger(), archivePath, engineFile, 8, 2)
+	err := extractArchiveWithLimits(logger.CreateLogger(), vfs.NewOSFS(), archivePath, engineFile, 8, 2)
 
 	var extractionErr *archiveExtractionError
 	require.ErrorAs(t, err, &extractionErr)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -332,7 +331,7 @@ func downloadEngine(
 			if !isDirectURL(e.Source) {
 				v.RequireHTTP()
 
-				tag, err := lastReleaseVersion(ctx, v.HTTP, execOptions)
+				tag, err := lastReleaseVersion(ctx, v, execOptions)
 				if err != nil {
 					return err
 				}
@@ -350,7 +349,7 @@ func downloadEngine(
 			return ensureErr
 		}
 
-		localEngineFile := filepath.Join(path, engineFileName(v.FS, e))
+		localEngineFile := filepath.Join(path, engineFileName(v, e))
 
 		// lock downloading process for only one instance
 		locks, err := downloadLocksFromContext(ctx)
@@ -366,7 +365,7 @@ func downloadEngine(
 			return nil
 		}
 
-		downloadFile := filepath.Join(path, enginePackageName(v.FS, e))
+		downloadFile := filepath.Join(path, enginePackageName(v, e))
 
 		// Prepare download assets
 		assets := &github.ReleaseAssets{
@@ -409,7 +408,7 @@ func downloadEngine(
 			l.Warnf("Skipping verification for %s", downloadFile)
 		}
 
-		if err := extractArchive(l, downloadFile, localEngineFile); err != nil {
+		if err := extractArchive(l, v.FS, downloadFile, localEngineFile); err != nil {
 			return err
 		}
 
@@ -421,7 +420,7 @@ func downloadEngine(
 
 func lastReleaseVersion(
 	ctx context.Context,
-	c vhttp.Client,
+	v *venv.Venv,
 	opts *ExecutionOptions,
 ) (string, error) {
 	repository := strings.TrimPrefix(opts.EngineConfig.Source, defaultEngineRepoRoot)
@@ -437,8 +436,8 @@ func lastReleaseVersion(
 	}
 
 	githubClient := github.NewGitHubAPIClient(
-		github.WithHTTPClient(vhttp.WithTimeout(c, engineReleaseLookupTimeout)),
-		github.WithGithubComDefaultAuth(),
+		github.WithHTTPClient(vhttp.WithTimeout(v.HTTP, engineReleaseLookupTimeout)),
+		github.WithGithubComDefaultAuth(v.Env),
 	)
 
 	tag, err := githubClient.GetLatestReleaseTag(ctx, repository)
@@ -451,9 +450,10 @@ func lastReleaseVersion(
 	return tag, nil
 }
 
-func extractArchive(l log.Logger, downloadFile string, engineFile string) error {
+func extractArchive(l log.Logger, fsys vfs.FS, downloadFile string, engineFile string) error {
 	return extractArchiveWithLimits(
 		l,
+		fsys,
 		downloadFile,
 		engineFile,
 		engineArchiveDecompressedSizeLimit,
@@ -463,15 +463,16 @@ func extractArchive(l log.Logger, downloadFile string, engineFile string) error 
 
 func extractArchiveWithLimits(
 	l log.Logger,
+	fsys vfs.FS,
 	downloadFile string,
 	engineFile string,
 	decompressedSizeLimit int64,
 	filesLimit int,
 ) error {
-	if !isArchiveByHeader(l, downloadFile) {
+	if !isArchiveByHeader(l, fsys, downloadFile) {
 		l.Info("Downloaded file is not an archive, no extraction needed")
 		// move file directly if it is not an archive
-		if err := os.Rename(downloadFile, engineFile); err != nil {
+		if err := fsys.Rename(downloadFile, engineFile); err != nil {
 			return err
 		}
 
@@ -480,13 +481,13 @@ func extractArchiveWithLimits(
 	// extract package and process files
 	path := filepath.Dir(engineFile)
 
-	tempDir, err := os.MkdirTemp(path, "temp-")
+	tempDir, err := vfs.MkdirTemp(fsys, path, "temp-")
 	if err != nil {
 		return err
 	}
 
 	defer func() {
-		if err = os.RemoveAll(tempDir); err != nil {
+		if err = fsys.RemoveAll(tempDir); err != nil {
 			l.Warnf("Failed to clean temp dir %s: %v", tempDir, err)
 		}
 	}()
@@ -494,12 +495,12 @@ func extractArchiveWithLimits(
 	if err = vfs.NewZipDecompressor(
 		vfs.WithFileSizeLimit(decompressedSizeLimit),
 		vfs.WithFilesLimit(filesLimit),
-	).Unzip(l, vfs.NewOSFS(), tempDir, downloadFile, 0); err != nil {
+	).Unzip(l, fsys, tempDir, downloadFile, 0); err != nil {
 		return newArchiveExtractionError(downloadFile, err)
 	}
 
 	// process files
-	files, err := os.ReadDir(tempDir)
+	files, err := vfs.ReadDir(fsys, tempDir)
 	if err != nil {
 		return err
 	}
@@ -509,7 +510,7 @@ func extractArchiveWithLimits(
 	if len(files) == 1 && !files[0].IsDir() {
 		// handle case where archive contains a single file, most of the cases
 		singleFile := filepath.Join(tempDir, files[0].Name())
-		if err := os.Rename(singleFile, engineFile); err != nil {
+		if err := fsys.Rename(singleFile, engineFile); err != nil {
 			return err
 		}
 
@@ -521,7 +522,7 @@ func extractArchiveWithLimits(
 		srcPath := filepath.Join(tempDir, file.Name())
 
 		dstPath := filepath.Join(path, file.Name())
-		if err := os.Rename(srcPath, dstPath); err != nil {
+		if err := fsys.Rename(srcPath, dstPath); err != nil {
 			return err
 		}
 	}
@@ -531,13 +532,16 @@ func extractArchiveWithLimits(
 
 // engineDir returns the directory path where engine files are stored.
 func engineDir(v *venv.Venv, opts *ExecutionOptions) (string, error) {
+	v.RequireGOOS()
+	v.RequireGOARCH()
+
 	engine := opts.EngineConfig
 	if vfs.Exists(v.FS, engine.Source) {
 		return filepath.Dir(engine.Source), nil
 	}
 
-	platform := runtime.GOOS
-	arch := runtime.GOARCH
+	platform := v.Platform.GOOS
+	arch := v.Platform.GOARCH
 
 	if cacheDir := opts.EngineOptions.CachePath; len(cacheDir) != 0 {
 		return filepath.Join(
@@ -569,15 +573,18 @@ func engineDir(v *venv.Venv, opts *ExecutionOptions) (string, error) {
 }
 
 // engineFileName returns the file name for the engine.
-func engineFileName(fsys vfs.FS, e *EngineConfig) string {
+func engineFileName(v *venv.Venv, e *EngineConfig) string {
+	v.RequireGOOS()
+	v.RequireGOARCH()
+
 	engineName := filepath.Base(e.Source)
-	if vfs.Exists(fsys, e.Source) {
+	if vfs.Exists(v.FS, e.Source) {
 		// return file name if source is absolute path
 		return engineName
 	}
 
-	platform := runtime.GOOS
-	arch := runtime.GOARCH
+	platform := v.Platform.GOOS
+	arch := v.Platform.GOARCH
 	engineName = strings.TrimPrefix(engineName, prefixTrim)
 
 	return fmt.Sprintf(fileNameFormat, engineName, e.Type, e.Version, platform, arch)
@@ -598,8 +605,8 @@ func engineChecksumSigName(e *EngineConfig) string {
 }
 
 // enginePackageName returns the package name for the engine.
-func enginePackageName(fsys vfs.FS, e *EngineConfig) string {
-	return engineFileName(fsys, e) + ".zip"
+func enginePackageName(v *venv.Venv, e *EngineConfig) string {
+	return engineFileName(v, e) + ".zip"
 }
 
 func isDirectURL(source string) bool {
@@ -607,8 +614,8 @@ func isDirectURL(source string) bool {
 }
 
 // isArchiveByHeader checks if a file is an archive by examining its header.
-func isArchiveByHeader(l log.Logger, filePath string) bool {
-	archiveType, err := detectFileType(l, filePath)
+func isArchiveByHeader(l log.Logger, fsys vfs.FS, filePath string) bool {
+	archiveType, err := detectFileType(l, fsys, filePath)
 
 	return err == nil && archiveType != ""
 }
@@ -824,7 +831,7 @@ func createEngine(
 			return err
 		}
 
-		localEnginePath := filepath.Join(path, engineFileName(v.FS, execOptions.EngineConfig))
+		localEnginePath := filepath.Join(path, engineFileName(v, execOptions.EngineConfig))
 		localChecksumFile := filepath.Join(path, engineChecksumName(execOptions.EngineConfig))
 		localChecksumSigFile := filepath.Join(path, engineChecksumSigName(execOptions.EngineConfig))
 
@@ -1351,8 +1358,8 @@ func ConvertMetaToProtobuf(meta map[string]any) (map[string]*anypb.Any, error) {
 }
 
 // detectFileType determines the type of file based on its magic bytes.
-func detectFileType(l log.Logger, filePath string) (string, error) {
-	file, err := os.Open(filePath)
+func detectFileType(l log.Logger, fsys vfs.FS, filePath string) (string, error) {
+	file, err := fsys.Open(filePath)
 	if err != nil {
 		return "", err
 	}

--- a/internal/engine/verification.go
+++ b/internal/engine/verification.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -16,12 +15,12 @@ import (
 
 // verifyFile verifies the checksums file and the signature file of the passed file
 func verifyFile(fsys vfs.FS, checkedFile, checksumsFile, signatureFile string) error {
-	checksums, err := os.ReadFile(checksumsFile)
+	checksums, err := vfs.ReadFile(fsys, checksumsFile)
 	if err != nil {
 		return err
 	}
 
-	checksumsSignature, err := os.ReadFile(signatureFile)
+	checksumsSignature, err := vfs.ReadFile(fsys, signatureFile)
 	if err != nil {
 		return err
 	}

--- a/internal/getter/oci_auth.go
+++ b/internal/getter/oci_auth.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	iofs "io/fs"
+	"io/fs"
 	"maps"
 	"net/http"
 	"path/filepath"
@@ -545,7 +545,7 @@ func loadOCIAmbientStores(l log.Logger, v *venv.Venv, tofu *ociTofuCredentials) 
 				return nil, OCIAmbientConfigFileError{Path: candidate, Err: err}
 			}
 
-			if !errors.Is(err, iofs.ErrNotExist) {
+			if !errors.Is(err, fs.ErrNotExist) {
 				l.Warnf("Skipping unparseable OCI credential file %s: %v", candidate, err)
 			}
 

--- a/internal/getter/oci_toforc.go
+++ b/internal/getter/oci_toforc.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	iofs "io/fs"
+	"io/fs"
 	"path/filepath"
 	"strings"
 
@@ -215,7 +215,7 @@ func ociTofuConfigFragments(l log.Logger, v *venv.Venv) ([]string, error) {
 	// tofu reads no fragments when the config directory is absent, unreadable, or not a directory.
 	info, err := v.FS.Stat(dir)
 	if err != nil {
-		if !errors.Is(err, iofs.ErrNotExist) {
+		if !errors.Is(err, fs.ErrNotExist) {
 			l.Warnf("Skipping unreadable OpenTofu CLI config directory %s: %v", dir, err)
 		}
 
@@ -226,7 +226,7 @@ func ociTofuConfigFragments(l log.Logger, v *venv.Venv) ([]string, error) {
 		return nil, nil
 	}
 
-	entries, err := vfs.ReadDirEntries(v.FS, dir)
+	entries, err := vfs.ReadDir(v.FS, dir)
 	if err != nil {
 		l.Warnf("Skipping unreadable OpenTofu CLI config directory %s: %v", dir, err)
 

--- a/internal/getter/resolver.go
+++ b/internal/getter/resolver.go
@@ -3,7 +3,6 @@ package getter
 import (
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 )
 
@@ -42,7 +41,7 @@ func DefaultSourceResolvers(
 
 	tfr := NewTFRResolver().
 		WithHTTPClient(vhttp.WithTimeout(v.HTTP, tfrResolverTimeout)).
-		WithAuth(RegistryAuth{Env: cfg.env, ReadUserConfig: vfs.IsOSFS(cfg.fsys)})
+		WithAuth(RegistryAuth{Env: cfg.env, FS: cfg.fsys})
 
 	if cfg.tfrEnabled {
 		requireLoggerFS(&cfg, SchemeTFR)

--- a/internal/getter/resolver_tfr.go
+++ b/internal/getter/resolver_tfr.go
@@ -92,7 +92,7 @@ func (r *TFRResolver) Probe(ctx context.Context, rawURL string) (string, error) 
 
 	registryDomain := srcURL.Host
 	if registryDomain == "" {
-		registryDomain = tfimpl.DefaultRegistryDomain(r.TofuImplementation)
+		registryDomain = tfimpl.DefaultRegistryDomain(r.Auth.Env, r.TofuImplementation)
 	}
 
 	versionList, hasVersion := srcURL.Query()[versionQueryKey]

--- a/internal/getter/tfr.go
+++ b/internal/getter/tfr.go
@@ -50,7 +50,7 @@ type RegistryGetter struct {
 // The user's CLI config lives on the real disk, so it is only consulted when
 // the getter is running against the OS filesystem.
 func (r *RegistryGetter) auth() RegistryAuth {
-	return RegistryAuth{Env: r.Venv.Env, ReadUserConfig: vfs.IsOSFS(r.Venv.FS)}
+	return RegistryAuth{Env: r.Venv.Env, FS: r.Venv.FS}
 }
 
 // NewRegistryGetter returns a [RegistryGetter] that issues registry-protocol
@@ -112,7 +112,7 @@ func (r *RegistryGetter) Get(ctx context.Context, req *getter.Request) error {
 
 	registryDomain := srcURL.Host
 	if registryDomain == "" {
-		registryDomain = tfimpl.DefaultRegistryDomain(r.TofuImplementation)
+		registryDomain = tfimpl.DefaultRegistryDomain(r.Venv.Env, r.TofuImplementation)
 	}
 
 	queryValues := srcURL.Query()

--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -336,7 +336,7 @@ func PinModuleVersion(
 
 	registryDomain := sourceURL.Host
 	if registryDomain == "" {
-		registryDomain = tfimpl.DefaultRegistryDomain(tofuImpl)
+		registryDomain = tfimpl.DefaultRegistryDomain(auth.Env, tofuImpl)
 	}
 
 	moduleRegistryBasePath, err := GetModuleRegistryURLBasePath(ctx, l, c, auth, registryDomain)
@@ -557,23 +557,23 @@ type moduleVersion struct {
 // RegistryAuth carries everything the registry protocol needs to authenticate
 // a request, so nothing on the path reaches for process state of its own.
 type RegistryAuth struct {
-	Env            map[string]string
-	ReadUserConfig bool
+	Env map[string]string
+	FS  vfs.FS
 }
 
 // applyHostToken adds an Authorization header to req based on the user's
 // OpenTofu/Terraform CLI config or the TG_TF_REGISTRY_TOKEN env var.
 func applyHostToken(req *http.Request, auth RegistryAuth) (*http.Request, error) {
-	// The CLI config lives in the invoking user's home directory, off any
-	// virtual filesystem, so a run that is not on the real disk skips it and
-	// authenticates from the env alone.
-	if auth.ReadUserConfig {
-		cliCfg, err := cliconfig.LoadUserConfig(vfs.NewOSFS())
+	// LoadUserConfig's vendored loader reads the invoking user's home directory
+	// directly, ignoring the filesystem it is handed, so it is only consulted
+	// when that filesystem is the real one.
+	if vfs.IsOSFS(auth.FS) {
+		cliCfg, err := cliconfig.LoadUserConfig(auth.FS)
 		if err != nil {
 			return nil, err
 		}
 
-		if creds := cliCfg.CredentialsSource().
+		if creds := cliCfg.CredentialsSource(auth.Env).
 			ForHost(svchost.Hostname(req.URL.Hostname())); creds != nil {
 			creds.PrepareRequest(req)
 			return req, nil

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -15,7 +15,9 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/os/signal"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/hashicorp/go-version"
 )
@@ -32,6 +34,7 @@ const (
 // GitRunner handles git command execution
 type GitRunner struct {
 	exec           vexec.Exec
+	env            map[string]string
 	repoRootMu     *sync.Mutex
 	GitPath        string
 	WorkDir        string
@@ -39,10 +42,15 @@ type GitRunner struct {
 	repoRootCached bool
 }
 
-// NewGitRunner creates a new GitRunner instance. The provided vexec.Exec is
-// used to resolve the `git` binary on PATH.
-func NewGitRunner(e vexec.Exec) (*GitRunner, error) {
-	gitPath, err := e.LookPath("git")
+// NewGitRunner creates a new GitRunner instance. It resolves the `git` binary
+// through the venv's exec handle. Every git command it prepares carries the
+// venv's environment, so a subprocess does not inherit the process
+// environment.
+func NewGitRunner(v *venv.Venv) (*GitRunner, error) {
+	v.RequireExec()
+	v.RequireEnv()
+
+	gitPath, err := v.Exec.LookPath("git")
 	if err != nil {
 		return nil, &WrappedError{
 			Op:      "git",
@@ -53,7 +61,8 @@ func NewGitRunner(e vexec.Exec) (*GitRunner, error) {
 
 	return &GitRunner{
 		GitPath:    gitPath,
-		exec:       e,
+		exec:       v.Exec,
+		env:        v.Env,
 		repoRootMu: &sync.Mutex{},
 	}, nil
 }
@@ -401,13 +410,16 @@ func (g *GitRunner) HasObject(ctx context.Context, hash string) (bool, error) {
 }
 
 // CreateTempDir creates a new temporary directory for git operations
-func (g *GitRunner) CreateTempDir() (string, func() error, error) {
+func (g *GitRunner) CreateTempDir(v *venv.Venv) (string, func() error, error) {
+	v.RequireFS()
+	v.RequireTempDir()
+
 	prefix := "terragrunt-cas-"
 
 	// Add a timestamp to the prefix to avoid conflicts
 	prefix += strconv.FormatInt(time.Now().UnixNano(), 10)
 
-	tempDir, err := os.MkdirTemp("", prefix+"*")
+	tempDir, err := vfs.MkdirTemp(v.FS, v.Platform.TempDir(), prefix)
 	if err != nil {
 		return "", nil, &WrappedError{
 			Op:      "create_temp_dir",
@@ -419,7 +431,7 @@ func (g *GitRunner) CreateTempDir() (string, func() error, error) {
 	g.WorkDir = tempDir
 
 	cleanup := func() error {
-		if err := os.RemoveAll(tempDir); err != nil {
+		if err := v.FS.RemoveAll(tempDir); err != nil {
 			return &WrappedError{
 				Op:      "cleanup_temp_dir",
 				Context: err.Error(),
@@ -970,6 +982,7 @@ func (g *GitRunner) ConfigSet(ctx context.Context, name, value string) error {
 
 func (g *GitRunner) prepareCommand(ctx context.Context, name string, args ...string) vexec.Cmd {
 	cmd := g.exec.Command(ctx, g.GitPath, append([]string{name}, args...)...)
+	cmd.SetEnv(venv.Environ(g.env))
 	cmd.SetCancel(func() error {
 		sig := signal.SignalFromContext(ctx)
 		if sig == nil {

--- a/internal/git/git_commands_test.go
+++ b/internal/git/git_commands_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,7 +27,7 @@ func TestNewGitRunner(t *testing.T) {
 			}),
 		)
 
-		runner, err := git.NewGitRunner(e)
+		runner, err := git.NewGitRunner(venvtest.New().WithExec(e))
 		require.NoError(t, err)
 		assert.Equal(t, "/usr/bin/git", runner.GitPath)
 	})
@@ -41,7 +42,7 @@ func TestNewGitRunner(t *testing.T) {
 			}),
 		)
 
-		runner, err := git.NewGitRunner(e)
+		runner, err := git.NewGitRunner(venvtest.New().WithExec(e))
 		require.ErrorIs(t, err, git.ErrCommandSpawn)
 		assert.Nil(t, runner)
 	})

--- a/internal/git/git_exec_test.go
+++ b/internal/git/git_exec_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,7 +28,7 @@ func TestExecGitRunner_LsRemote(t *testing.T) {
 
 	url := startCommittedServer(t)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	t.Run("valid repository", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestExecGitRunner_Clone(t *testing.T) {
 		t.Parallel()
 
 		cloneDir := helpers.TmpDirWOSymlinks(t)
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		runner, err := git.NewGitRunner(venv.OSVenv())
 		require.NoError(t, err)
 
 		runner = runner.WithWorkDir(cloneDir)
@@ -93,7 +93,7 @@ func TestExecGitRunner_Clone(t *testing.T) {
 		t.Parallel()
 
 		cloneDir := helpers.TmpDirWOSymlinks(t)
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		runner, err := git.NewGitRunner(venv.OSVenv())
 		require.NoError(t, err)
 
 		missing := "file://" + filepath.ToSlash(filepath.Join(t.TempDir(), "missing.git"))
@@ -119,7 +119,7 @@ func TestExecGitRunner_LsTree(t *testing.T) {
 	t.Run("valid repository", func(t *testing.T) {
 		t.Parallel()
 
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		runner, err := git.NewGitRunner(venv.OSVenv())
 		require.NoError(t, err)
 
 		tree, err := runner.WithWorkDir(cloneDir).LsTreeRecursive(ctx, "HEAD")
@@ -130,7 +130,7 @@ func TestExecGitRunner_LsTree(t *testing.T) {
 	t.Run("invalid reference", func(t *testing.T) {
 		t.Parallel()
 
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		runner, err := git.NewGitRunner(venv.OSVenv())
 		require.NoError(t, err)
 
 		_, err = runner.WithWorkDir(cloneDir).LsTreeRecursive(ctx, "nonexistent")
@@ -144,7 +144,7 @@ func TestExecGitRunner_LsTree(t *testing.T) {
 	t.Run("invalid repository", func(t *testing.T) {
 		t.Parallel()
 
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		runner, err := git.NewGitRunner(venv.OSVenv())
 		require.NoError(t, err)
 
 		// Try to ls-tree in an empty directory
@@ -162,7 +162,7 @@ func TestExecGitRunner_InitBare(t *testing.T) {
 
 	dir := helpers.TmpDirWOSymlinks(t)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(dir)
@@ -183,7 +183,7 @@ func TestExecGitRunner_FetchAndHasObject(t *testing.T) {
 
 	dir := helpers.TmpDirWOSymlinks(t)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(dir)
@@ -217,7 +217,7 @@ func TestExecGitRunner_FetchRejectsOptionInjectionRef(t *testing.T) {
 
 	bareDir := helpers.TmpDirWOSymlinks(t)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(bareDir)
@@ -243,7 +243,7 @@ func TestExecGitRunner_LsRemoteRejectsOptionInjectionRepo(t *testing.T) {
 
 	ctx := t.Context()
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	marker := filepath.Join(helpers.TmpDirWOSymlinks(t), "injected")
@@ -262,7 +262,7 @@ func TestExecGitRunner_HasObjectSurfacesNonMissingFailures(t *testing.T) {
 
 	dir := helpers.TmpDirWOSymlinks(t)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(dir)
@@ -286,7 +286,7 @@ func TestExecGitRunner_AddCommitCheckoutConfig(t *testing.T) {
 
 	dir := helpers.TmpDirWOSymlinks(t)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(dir)
@@ -334,7 +334,7 @@ func TestExecGitRunner_SubmoduleURLs(t *testing.T) {
 	url, err := srv.Start(ctx)
 	require.NoError(t, err)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(helpers.TmpDirWOSymlinks(t))
@@ -384,7 +384,7 @@ func cloneCommittedServer(t *testing.T) string {
 
 	cloneDir := helpers.TmpDirWOSymlinks(t)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	require.NoError(t, runner.WithWorkDir(cloneDir).Clone(t.Context(), url, true, 1, "main"))
@@ -400,7 +400,7 @@ func newCommittedRepo(t *testing.T) string {
 
 	dir := helpers.TmpDirWOSymlinks(t)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(dir)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -201,7 +202,7 @@ func TestCreateTempDir(t *testing.T) {
 
 	gitRunner := newMemRunner(t, staticResult(vexec.Result{}))
 
-	dir, cleanup, err := gitRunner.CreateTempDir()
+	dir, cleanup, err := gitRunner.CreateTempDir(venvtest.NewOSWithEmptyEnv())
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, cleanup())
@@ -452,7 +453,7 @@ func TestGitRunner_WithWorkDirGetRepoRootWithRacing(t *testing.T) {
 func newMemRunner(t *testing.T, h vexec.Handler) *git.GitRunner {
 	t.Helper()
 
-	r, err := git.NewGitRunner(vexec.NewMemExec(h))
+	r, err := git.NewGitRunner(venvtest.New().WithExec(vexec.NewMemExec(h)))
 	require.NoError(t, err)
 
 	return r
@@ -476,7 +477,7 @@ func newArgvCapturingRunner(t *testing.T, captured *[]string, stdout []byte) *gi
 		return vexec.Result{Stdout: stdout}
 	})
 
-	r, err := git.NewGitRunner(e)
+	r, err := git.NewGitRunner(venvtest.New().WithExec(e))
 	require.NoError(t, err)
 
 	return r

--- a/internal/git/server_test.go
+++ b/internal/git/server_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,7 +37,7 @@ func TestExecServer(t *testing.T) {
 		require.NoError(t, err)
 
 		cloneDir := helpers.TmpDirWOSymlinks(t)
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		runner, err := git.NewGitRunner(venv.OSVenv())
 		require.NoError(t, err)
 
 		runner = runner.WithWorkDir(cloneDir)
@@ -62,7 +62,7 @@ func TestExecServer(t *testing.T) {
 		url, err := srv.Start(t.Context())
 		require.NoError(t, err)
 
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		runner, err := git.NewGitRunner(venv.OSVenv())
 		require.NoError(t, err)
 
 		results, err := runner.LsRemote(t.Context(), url, "HEAD")
@@ -85,7 +85,7 @@ func TestExecServer(t *testing.T) {
 		require.NoError(t, err)
 
 		cloneDir := helpers.TmpDirWOSymlinks(t)
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		runner, err := git.NewGitRunner(venv.OSVenv())
 		require.NoError(t, err)
 
 		runner = runner.WithWorkDir(cloneDir)
@@ -115,7 +115,7 @@ func TestExecServer(t *testing.T) {
 		require.NoError(t, err)
 
 		cloneDir := helpers.TmpDirWOSymlinks(t)
-		runner, err := git.NewGitRunner(vexec.NewOSExec())
+		runner, err := git.NewGitRunner(venv.OSVenv())
 		require.NoError(t, err)
 
 		runner = runner.WithWorkDir(cloneDir)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -8,10 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -65,27 +63,24 @@ func WithGithubToken(token string) GitHubAPIClientOption {
 // WithGithubComDefaultAuth sets the authentication header based on the assumption
 // we're talking to github.com, and using the same logic as the gh cli:
 // https://cli.github.com/manual/gh_help_environment
-func WithGithubComDefaultAuth() GitHubAPIClientOption {
+func WithGithubComDefaultAuth(env map[string]string) GitHubAPIClientOption {
 	return func(c *GitHubAPIClient) {
-		if tok := getGithubTokenFromEnv(); tok != "" {
+		if tok := githubToken(env); tok != "" {
 			c.defaultHeaders.Set("Authorization", "Bearer "+tok)
 		}
 	}
 }
 
-// getGithubTokenFromEnv retrieves the GitHub token from environment
-// variables using the same logic as the gh cli:
-// https://cli.github.com/manual/gh_help_environment
-func getGithubTokenFromEnv() string {
-	if tok := os.Getenv("GH_TOKEN"); tok != "" {
+// githubToken retrieves the GitHub token, using the same order of preference
+// as the gh cli: https://cli.github.com/manual/gh_help_environment
+func githubToken(env map[string]string) string {
+	venv.RequireEnvMap(env)
+
+	if tok := env["GH_TOKEN"]; tok != "" {
 		return tok
 	}
 
-	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
-		return tok
-	}
-
-	return ""
+	return env["GITHUB_TOKEN"]
 }
 
 // NewGitHubAPIClient creates a new GitHub API client with optional configuration.
@@ -238,6 +233,8 @@ func (c *GitHubReleasesDownloadClient) DownloadReleaseAssets(
 	v *venv.Venv,
 	assets *ReleaseAssets,
 ) (*DownloadResult, error) {
+	v.RequireHTTP()
+
 	if assets.Repository == "" {
 		return nil, errors.New("repository cannot be empty")
 	}
@@ -297,24 +294,16 @@ func (c *GitHubReleasesDownloadClient) DownloadReleaseAssets(
 			}
 
 			opts := []getter.Option{
+				getter.WithHTTP(v.HTTP),
 				// Disable archive decompression: GitHub release assets are
 				// fetched verbatim, not unpacked.
 				getter.WithDecompressors(map[string]getter.Decompressor{}),
 			}
 
-			if tok := getGithubTokenFromEnv(); tok != "" {
-				header := http.Header{"Authorization": {"Bearer " + tok}}
-
-				if strings.HasPrefix(url, "https://") {
-					opts = append(opts, getter.WithHTTPSAuth(header))
-				}
-
-				// httptest.Server serves over plain HTTP, so tests need the
-				// header on the http getter too. In production we never send
-				// bearer tokens over plain HTTP.
-				if testing.Testing() {
-					opts = append(opts, getter.WithHTTPAuth(header))
-				}
+			// The token rides https only, so it cannot leak over an
+			// unencrypted redirect.
+			if tok := githubToken(v.Env); tok != "" && strings.HasPrefix(url, "https://") {
+				opts = append(opts, getter.WithHTTPSAuth(http.Header{"Authorization": {"Bearer " + tok}}))
 			}
 
 			if _, err := getter.GetFile(downloadCtx, v, localPath, url, opts...); err != nil {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -30,8 +30,11 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestGithubAuthPickupOrder(t *testing.T) {
+	t.Parallel()
 
 	t.Run("prefer GH_TOKEN", func(t *testing.T) {
+		t.Parallel()
+
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "Bearer goodtoken", r.Header.Get("Authorization"))
 
@@ -46,12 +49,12 @@ func TestGithubAuthPickupOrder(t *testing.T) {
 		}))
 		defer server.Close()
 
-		t.Setenv("GH_TOKEN", "goodtoken")
-		t.Setenv("GITHUB_TOKEN", "badtoken")
-
 		client := github.NewGitHubAPIClient(
 			github.WithBaseURL(server.URL),
-			github.WithGithubComDefaultAuth(),
+			github.WithGithubComDefaultAuth(map[string]string{
+				"GH_TOKEN":     "goodtoken",
+				"GITHUB_TOKEN": "badtoken",
+			}),
 		)
 
 		_, err := client.GetLatestRelease(t.Context(), "owner/repo")
@@ -59,6 +62,8 @@ func TestGithubAuthPickupOrder(t *testing.T) {
 	})
 
 	t.Run("use GITHUB_TOKEN", func(t *testing.T) {
+		t.Parallel()
+
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "Bearer goodtoken", r.Header.Get("Authorization"))
 
@@ -73,11 +78,12 @@ func TestGithubAuthPickupOrder(t *testing.T) {
 		}))
 		defer server.Close()
 
-		t.Setenv("GH_TOKEN", "")
-		t.Setenv("GITHUB_TOKEN", "goodtoken")
 		client := github.NewGitHubAPIClient(
 			github.WithBaseURL(server.URL),
-			github.WithGithubComDefaultAuth(),
+			github.WithGithubComDefaultAuth(map[string]string{
+				"GH_TOKEN":     "",
+				"GITHUB_TOKEN": "goodtoken",
+			}),
 		)
 
 		_, err := client.GetLatestRelease(t.Context(), "owner/repo")
@@ -343,7 +349,9 @@ func TestDownloadReleaseAssetsGitHubRelease(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	result, err := client.DownloadReleaseAssets(ctx, venvtest.NewWithOSFS(), assets)
+	v := venvtest.NewWithOSFS().WithHTTP(server.Client())
+
+	result, err := client.DownloadReleaseAssets(ctx, v, assets)
 	require.NoError(t, err)
 
 	// Verify result
@@ -356,7 +364,7 @@ func TestDownloadReleaseAssetsGitHubRelease(t *testing.T) {
 }
 
 func TestDownloadReleaseAssetsGitHubReleaseUsesToken(t *testing.T) {
-	tempDir := helpers.TmpDirWOSymlinks(t)
+	t.Parallel()
 
 	// shared logic for handlers
 	doResp := func(w http.ResponseWriter, r *http.Request) {
@@ -389,49 +397,56 @@ func TestDownloadReleaseAssetsGitHubReleaseUsesToken(t *testing.T) {
 	client := github.NewGitHubReleasesDownloadClient()
 
 	t.Run("prefer GH_TOKEN", func(t *testing.T) {
-		t.Setenv("GH_TOKEN", "goodtoken")
-		t.Setenv("GITHUB_TOKEN", "badtoken")
+		t.Parallel()
 
-		// Create mock server for GitHub releases
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The token only rides https, so the server has to speak TLS.
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "Bearer goodtoken", r.Header.Get("Authorization"))
 
 			doResp(w, r)
 		}))
 		defer server.Close()
 
+		v := venvtest.NewWithOSFS().WithHTTP(server.Client()).WithEnv(map[string]string{
+			"GH_TOKEN":     "goodtoken",
+			"GITHUB_TOKEN": "badtoken",
+		})
+
 		ctx := t.Context()
 
 		assets := &github.ReleaseAssets{
 			Repository:  server.URL + "/package.zip", // Direct URL
-			PackageFile: filepath.Join(tempDir, "package.zip"),
+			PackageFile: filepath.Join(helpers.TmpDirWOSymlinks(t), "package.zip"),
 			// Direct URLs don't use checksum files
 		}
 
-		_, err := client.DownloadReleaseAssets(ctx, venvtest.NewWithOSFS(), assets)
+		_, err := client.DownloadReleaseAssets(ctx, v, assets)
 		require.NoError(t, err)
 	})
 
 	t.Run("use GITHUB_TOKEN", func(t *testing.T) {
-		t.Setenv("GH_TOKEN", "")
-		t.Setenv("GITHUB_TOKEN", "goodtoken")
+		t.Parallel()
 
-		// Create mock server for GitHub releases
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "Bearer goodtoken", r.Header.Get("Authorization"))
 
 			doResp(w, r)
 		}))
 		defer server.Close()
 
+		v := venvtest.NewWithOSFS().WithHTTP(server.Client()).WithEnv(map[string]string{
+			"GH_TOKEN":     "",
+			"GITHUB_TOKEN": "goodtoken",
+		})
+
 		ctx := t.Context()
 
 		assets := &github.ReleaseAssets{
 			Repository:  server.URL + "/package.zip", // Direct URL
-			PackageFile: filepath.Join(tempDir, "package.zip"),
+			PackageFile: filepath.Join(helpers.TmpDirWOSymlinks(t), "package.zip"),
 			// Direct URLs don't use checksum files
 		}
-		_, err := client.DownloadReleaseAssets(ctx, venvtest.NewWithOSFS(), assets)
+		_, err := client.DownloadReleaseAssets(ctx, v, assets)
 		require.NoError(t, err)
 	})
 }
@@ -456,7 +471,9 @@ func TestDownloadReleaseAssetsDirectURL(t *testing.T) {
 		// Note: No Version, ChecksumFile, or ChecksumSigFile for direct URLs
 	}
 
-	result, err := client.DownloadReleaseAssets(t.Context(), venvtest.NewWithOSFS(), assets)
+	v := venvtest.NewWithOSFS().WithHTTP(server.Client())
+
+	result, err := client.DownloadReleaseAssets(t.Context(), v, assets)
 	require.NoError(t, err)
 
 	// Verify result

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -42,7 +42,7 @@ package glob
 import (
 	"errors"
 	"fmt"
-	iofs "io/fs"
+	"io/fs"
 	"path"
 	"path/filepath"
 	"strings"
@@ -121,7 +121,7 @@ func Expand(fsys vfs.FS, pattern string, opts ...ExpandOption) ([]string, error)
 	if !hasMeta {
 		info, err := fsys.Stat(root)
 		if err != nil {
-			if errors.Is(err, iofs.ErrNotExist) {
+			if errors.Is(err, fs.ErrNotExist) {
 				return nil, nil
 			}
 
@@ -142,10 +142,10 @@ func Expand(fsys vfs.FS, pattern string, opts ...ExpandOption) ([]string, error)
 
 	var matches []string
 
-	walkErr := vfs.WalkDir(fsys, root, func(entry string, d iofs.DirEntry, walkErr error) error {
+	walkErr := vfs.WalkDir(fsys, root, func(entry string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			if d != nil && d.IsDir() {
-				return iofs.SkipDir
+				return fs.SkipDir
 			}
 
 			return nil
@@ -163,19 +163,106 @@ func Expand(fsys vfs.FS, pattern string, opts ...ExpandOption) ([]string, error)
 
 		return nil
 	})
-	if walkErr != nil && !errors.Is(walkErr, iofs.ErrNotExist) {
+	if walkErr != nil && !errors.Is(walkErr, fs.ErrNotExist) {
 		return nil, walkErr
 	}
 
 	return matches, nil
 }
 
-// LegacyExpand returns the paths that match pattern using zglob semantics.
-// Prefer [Expand] for new code. LegacyExpand exists only for call sites that
-// interpret patterns written by users in configuration surface where a
-// behavior change between zglob and gobwas would be a breaking change.
-func LegacyExpand(pattern string) ([]string, error) {
-	return zglob.Glob(pattern)
+// LegacyExpand returns the paths on fsys that match pattern using zglob
+// semantics. Prefer [Expand] for new code. LegacyExpand exists only for call
+// sites that interpret patterns written by users in configuration surface
+// where a behavior change between zglob and gobwas would be a breaking change.
+//
+// zglob offers no way to walk anything but the real filesystem, so the walk is
+// reproduced here over fsys. Deciding whether a path matches is still zglob's
+// own matcher, built from the pattern by [zglob.New], which keeps the grammar
+// identical; fsys supplies nothing but the directory entries.
+// TestLegacyExpandMatchesZglob pins the two against each other over a corpus
+// of patterns.
+func LegacyExpand(fsys vfs.FS, pattern string) ([]string, error) {
+	root, hasMeta := legacyRoot(pattern)
+
+	// A pattern with no metacharacters names one path, and zglob reports a
+	// missing one as fs.ErrNotExist rather than as an empty result. Callers
+	// distinguish the two, so the distinction is preserved.
+	if !hasMeta {
+		if _, err := fsys.Stat(pattern); err != nil {
+			return nil, fs.ErrNotExist
+		}
+
+		return []string{pattern}, nil
+	}
+
+	matcher, err := zglob.New(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	matches := []string{}
+
+	// zglob surfaces a walk failure rather than treating it as an empty match,
+	// including the common case of a pattern rooted at a directory that does
+	// not exist, so the error is passed straight back here too.
+	walkErr := vfs.WalkDir(fsys, root, func(entry string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if matcher.Match(filepath.ToSlash(entry)) {
+			matches = append(matches, entry)
+		}
+
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	return matches, nil
+}
+
+// legacyRoot returns the deepest directory of pattern that zglob would start
+// its walk from, and reports whether pattern has anything to expand. It
+// reproduces zglob's rule, which treats only "*" and "{" as the markers that
+// end the literal prefix.
+//
+// zglob also expands a leading "~" and any whole segment of the form "$NAME"
+// from the process environment before choosing its root. That is not
+// reproduced here, so such a pattern roots its walk at a literal "$NAME"
+// directory and reports it missing, which the caller in internal/util already
+// reads as no matches. The matcher zglob builds still reads the environment,
+// so the walk root, not the grammar, is what keeps the expansion out.
+func legacyRoot(pattern string) (string, bool) {
+	var (
+		globmask string
+		root     string
+		found    bool
+	)
+
+	for segment := range strings.SplitSeq(filepath.ToSlash(pattern), "/") {
+		if !found && strings.ContainsAny(segment, "*{") {
+			found = true
+
+			root = globmask
+			if root == "" {
+				root = "."
+			}
+		}
+
+		globmask = path.Join(globmask, segment)
+
+		if globmask == "" {
+			globmask = "/"
+		}
+	}
+
+	if !found {
+		return "", false
+	}
+
+	return filepath.Clean(root), true
 }
 
 // splitRoot returns the longest leading directory of pattern that contains no

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -386,7 +386,7 @@ func TestLegacyExpandCollapsesGlobstar(t *testing.T) {
 
 	pattern := filepath.ToSlash(root) + "/**/*.tf"
 
-	got, err := glob.LegacyExpand(pattern)
+	got, err := glob.LegacyExpand(vfs.NewOSFS(), pattern)
 	require.NoError(t, err)
 
 	want := []string{

--- a/internal/glob/legacy_equivalence_test.go
+++ b/internal/glob/legacy_equivalence_test.go
@@ -1,0 +1,152 @@
+package glob_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/glob"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/mattn/go-zglob"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// legacyTree is the shape LegacyExpand is exercised against: nested
+// directories, several extensions, a dotfile, and a directory whose name is a
+// prefix of another so that a partial match cannot pass by accident.
+var legacyTree = []string{
+	"main.tf",
+	"README.md",
+	".hidden.tf",
+	"modules/a/main.tf",
+	"modules/a/vars.tf",
+	"modules/a/nested/deep.tf",
+	"modules/ab/main.tf",
+	"modules/b/main.tfvars",
+	"vendor/x/main.tf",
+}
+
+// legacyPatterns covers the grammar zglob accepts, including the "**"
+// collapsing that distinguishes it from [glob.Expand].
+var legacyPatterns = []string{
+	"*",
+	"*.tf",
+	"*.md",
+	"modules",
+	"modules/*",
+	"modules/*/main.tf",
+	"modules/**/*.tf",
+	"modules/**",
+	"**/*.tf",
+	"**/main.tf",
+	"modules/a/*",
+	"modules/a/**/*.tf",
+	"modules/{a,b}/*",
+	"modules/a?/main.tf",
+	"modules/[ab]/main.tf",
+	"vendor/**/*.tf",
+	"nothing-here/*",
+	"main.tf",
+	"missing.tf",
+	"modules/a/nested/deep.tf",
+}
+
+// TestLegacyExpandMatchesZglob pins LegacyExpand to the grammar it exists to
+// preserve: for every pattern in the corpus, walking the venv filesystem
+// returns exactly what zglob's own walk returns over the same tree on disk.
+//
+// The tree is written to disk precisely so the comparison is against real
+// zglob rather than against a second copy of our own logic.
+func TestLegacyExpandMatchesZglob(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	// macOS puts temp dirs behind a symlink, and zglob reports the path it
+	// walked rather than the one it was handed, so both sides have to start
+	// from the resolved spelling to be comparable.
+	root, err := filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+
+	for _, rel := range legacyTree {
+		full := filepath.Join(root, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(rel), 0o600))
+	}
+
+	fsys := vfs.NewOSFS()
+
+	for _, pattern := range legacyPatterns {
+		absolute := filepath.ToSlash(filepath.Join(root, pattern))
+
+		want, wantErr := zglob.Glob(absolute)
+		got, gotErr := glob.LegacyExpand(fsys, absolute)
+
+		if wantErr != nil {
+			require.Error(t, gotErr, "pattern %q: zglob failed but LegacyExpand did not", pattern)
+			require.ErrorIs(t, gotErr, os.ErrNotExist, "pattern %q", pattern)
+
+			continue
+		}
+
+		require.NoError(t, gotErr, "pattern %q", pattern)
+		assert.ElementsMatch(t, want, got, "pattern %q", pattern)
+	}
+}
+
+// TestLegacyExpandReportsMissingLiteralPath pins the error the caller in
+// internal/util depends on: a literal path that does not exist is reported as
+// fs.ErrNotExist, not as an empty match, because expandGlobPath treats those
+// two differently.
+func TestLegacyExpandReportsMissingLiteralPath(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fsys, "/src/main.tf", nil, 0o644))
+
+	got, err := glob.LegacyExpand(fsys, "/src/main.tf")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/src/main.tf"}, got)
+
+	_, err = glob.LegacyExpand(fsys, "/src/missing.tf")
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+// TestLegacyExpandRunsOnAnInMemoryFilesystem pins that the expansion resolves
+// entirely against the filesystem it is handed, never the real disk.
+func TestLegacyExpandRunsOnAnInMemoryFilesystem(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	for _, p := range []string{"/src/main.tf", "/src/modules/a/main.tf", "/src/README.md"} {
+		require.NoError(t, vfs.WriteFile(fsys, p, nil, 0o644))
+	}
+
+	got, err := glob.LegacyExpand(fsys, "/src/**/*.tf")
+	require.NoError(t, err)
+
+	// zglob collapses `**`, so the top-level file matches alongside the nested one.
+	assert.ElementsMatch(t, []string{"/src/main.tf", "/src/modules/a/main.tf"}, got)
+}
+
+// TestLegacyExpandDoesNotExpandEnvSegments pins the one place LegacyExpand
+// parts company with zglob. zglob expands a "$NAME" segment from the process
+// environment when choosing its walk root; the walk here roots at a literal
+// "$NAME" directory instead and reports it missing, which the caller in
+// internal/util reads as no matches.
+func TestLegacyExpandDoesNotExpandEnvSegments(t *testing.T) {
+	t.Setenv("LEGACY_EXPAND_PROBE", "real")
+
+	fsys := vfs.NewMemMapFS()
+	require.NoError(t, vfs.WriteFile(fsys, "/src/real/main.tf", nil, 0o644))
+
+	_, err := glob.LegacyExpand(fsys, "/src/$LEGACY_EXPAND_PROBE/*.tf")
+	require.ErrorIs(t, err, fs.ErrNotExist)
+
+	// The same tree is reachable when the segment is spelled literally.
+	got, err := glob.LegacyExpand(fsys, "/src/real/*.tf")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/src/real/main.tf"}, got)
+}

--- a/internal/hclparse/autoinclude.go
+++ b/internal/hclparse/autoinclude.go
@@ -2,7 +2,7 @@ package hclparse
 
 import (
 	"fmt"
-	iofs "io/fs"
+	"io/fs"
 	"path/filepath"
 	"strings"
 
@@ -313,7 +313,7 @@ func AutoIncludeDependencyPaths(fsys vfs.FS, unitDir string) ([]string, error) {
 // readAutoIncludeBody reads and parses an autoinclude file, returning (nil, nil) when the file does not exist.
 func readAutoIncludeBody(fsys vfs.FS, path string) (*hclsyntax.Body, error) {
 	data, err := vfs.ReadFile(fsys, path)
-	if errors.Is(err, iofs.ErrNotExist) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil, nil
 	}
 

--- a/internal/hclparse/stack.go
+++ b/internal/hclparse/stack.go
@@ -2,7 +2,7 @@ package hclparse
 
 import (
 	"fmt"
-	iofs "io/fs"
+	"io/fs"
 	"path/filepath"
 
 	"errors"
@@ -178,7 +178,7 @@ func ParseStackFileFromPath(fsys vfs.FS, stackDir string) (*ParseResult, error) 
 
 	data, err := vfs.ReadFile(fsys, stackFile)
 	if err != nil {
-		if errors.Is(err, iofs.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil, nil
 		}
 
@@ -374,7 +374,7 @@ func decodeDiscovery(
 ) ([]*unitPathOnlyHCL, []*stackPathOnlyHCL, error) {
 	data, err := vfs.ReadFile(fsys, stackFile)
 	if err != nil {
-		if errors.Is(err, iofs.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil, nil, nil
 		}
 
@@ -473,7 +473,7 @@ func readDiscoveryValues(
 
 	data, err := vfs.ReadFile(fsys, valuesPath)
 	if err != nil {
-		if errors.Is(err, iofs.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil, nil
 		}
 
@@ -518,7 +518,7 @@ func mergeDiscoveryStackAutoInclude(
 
 	data, err := vfs.ReadFile(fsys, autoIncludePath)
 	if err != nil {
-		if errors.Is(err, iofs.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 

--- a/internal/os/exec/opts.go
+++ b/internal/os/exec/opts.go
@@ -1,24 +1,10 @@
 package exec
 
 import (
-	"fmt"
-	"slices"
 	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 )
-
-const envVarsListFormat = "%s=%s"
-
-// envMapToSortedSlice formats env as "KEY=VALUE" strings sorted alphabetically.
-func envMapToSortedSlice(env map[string]string) []string {
-	out := make([]string, 0, len(env))
-	for k, v := range env {
-		out = append(out, fmt.Sprintf(envVarsListFormat, k, v))
-	}
-
-	slices.Sort(out)
-
-	return out
-}
 
 // Option is type for passing options to the Cmd.
 type Option func(*Cmd)
@@ -33,7 +19,7 @@ func WithUsePTY(state bool) Option {
 // WithEnv sets envs to the Cmd.
 func WithEnv(env map[string]string) Option {
 	return func(cmd *Cmd) {
-		cmd.SetEnv(envMapToSortedSlice(env))
+		cmd.SetEnv(venv.Environ(env))
 	}
 }
 

--- a/internal/panicreport/panicreport.go
+++ b/internal/panicreport/panicreport.go
@@ -115,6 +115,8 @@ type Reporter struct {
 	GetPID    func() int
 	TempDir   func() string
 	BuildInfo func() (commit string, modified bool)
+	GOOS      string
+	GOARCH    string
 }
 
 // RecoveredError carries a panic recovered outside the main goroutine.
@@ -127,12 +129,15 @@ type RecoveredError struct {
 // and takes the process details it records from v's platform handles.
 func New(v *venv.Venv) *Reporter {
 	v.RequireFS()
-	v.RequirePlatform()
+	v.RequireGOOS()
+	v.RequireGOARCH()
 
 	return &Reporter{
 		FS:     v.FS,
 		Getwd:  v.Platform.Getwd,
 		GetPID: v.Platform.GetPID,
+		GOOS:   v.Platform.GOOS,
+		GOARCH: v.Platform.GOARCH,
 		// TempDir is where the report lands when the working directory is not
 		// writable, so it is the last place a crash can still be recorded.
 		TempDir: v.Platform.TempDir,
@@ -423,8 +428,8 @@ func (r *Reporter) formatLog(
 		commit,
 		modified,
 		runtime.Version(),
-		runtime.GOOS,
-		runtime.GOARCH,
+		r.GOOS,
+		r.GOARCH,
 		runtime.NumCPU(),
 		runtime.GOMAXPROCS(0),
 		runtime.NumGoroutine(),

--- a/internal/panicreport/panicreport_test.go
+++ b/internal/panicreport/panicreport_test.go
@@ -64,7 +64,7 @@ func TestReportPanicWritesCrashLog(t *testing.T) {
 	assert.Contains(t, content, "Terragrunt version: 1.7.9")
 	assert.Contains(t, content, "Build commit: deadbeef")
 	assert.Contains(t, content, "Build modified: true")
-	assert.Contains(t, content, "GOOS/GOARCH: "+runtime.GOOS+"/"+runtime.GOARCH)
+	assert.Contains(t, content, "GOOS/GOARCH: "+stubGOOS+"/"+stubGOARCH)
 	assert.Contains(t, content, "NumCPU: ")
 	assert.Contains(t, content, "GOMAXPROCS: ")
 	assert.Contains(t, content, "NumGoroutine: ")
@@ -442,6 +442,11 @@ func newPanicLogger() (log.Logger, *bytes.Buffer) {
 	), buf
 }
 
+const (
+	stubGOOS   = "stub-goos"
+	stubGOARCH = "stub-goarch"
+)
+
 func newStubReporter(fsys vfs.FS, workDir string, now time.Time, pid int) *panicreport.Reporter {
 	return &panicreport.Reporter{
 		FS:        fsys,
@@ -450,5 +455,7 @@ func newStubReporter(fsys vfs.FS, workDir string, now time.Time, pid int) *panic
 		GetPID:    func() int { return pid },
 		TempDir:   func() string { return "/tmp" },
 		BuildInfo: func() (string, bool) { return "deadbeef", true },
+		GOOS:      stubGOOS,
+		GOARCH:    stubGOARCH,
 	}
 }

--- a/internal/prepare/prepare.go
+++ b/internal/prepare/prepare.go
@@ -50,7 +50,7 @@ func PrepareConfig(
 	provider := externalcmd.NewProvider(
 		l,
 		opts.AuthProviderCmd,
-		configbridge.ShellRunOptsFromOpts(opts),
+		configbridge.ShellRunOptsFromOpts(v.Env, opts),
 	)
 
 	if err := credsGetter.ObtainAndUpdateEnvIfNecessary(ctx, l, v, provider); err != nil {
@@ -107,7 +107,7 @@ func PrepareSource(
 
 	optsClone.TerraformCommand = run.CommandNameTerragruntReadConfig
 
-	if err = optsClone.RunWithErrorHandling(ctx, l, r, func() error {
+	if err = optsClone.RunWithErrorHandling(ctx, l, v.FS, r, func() error {
 		return run.ProcessHooks(ctx, l, v, run.ProcessHooksParams{
 			Hooks:    runCfg.Terraform.AfterHooks,
 			Opts:     configbridge.NewRunOptions(optsClone),
@@ -127,7 +127,7 @@ func PrepareSource(
 
 	credsGetter := creds.NewGetter()
 
-	if err = opts.RunWithErrorHandling(ctx, l, r, func() error {
+	if err = opts.RunWithErrorHandling(ctx, l, v.FS, r, func() error {
 		provider := amazonsts.NewProvider(l, opts.IAMRoleOptions, v.Env)
 		return credsGetter.ObtainAndUpdateEnvIfNecessary(ctx, l, v, provider)
 	}); err != nil {

--- a/internal/providercache/nested_modules_credentials_test.go
+++ b/internal/providercache/nested_modules_credentials_test.go
@@ -91,7 +91,7 @@ func TestNestedModuleCredentials(t *testing.T) {
 			{Name: "127.0.0.1", Token: realUserToken},
 		},
 	}
-	credsSource := cliCfg.CredentialsSource()
+	credsSource := cliCfg.CredentialsSource(map[string]string{})
 
 	// The fake discoverer returns the upstream's full URL as modules.v1, so the
 	// proxy targets the httptest server (HTTP, not HTTPS) without DNS lookups.

--- a/internal/providercache/providercache.go
+++ b/internal/providercache/providercache.go
@@ -153,11 +153,11 @@ func (pc *ProviderCache) Init(
 	providerService := services.NewProviderService(
 		pcOpts.Dir,
 		userProviderDir,
-		cliCfg.CredentialsSource(),
+		cliCfg.CredentialsSource(v.Env),
 		l,
 		v,
 	)
-	proxyProviderHandler := handlers.NewProxyProviderHandler(l, v.HTTP, cliCfg.CredentialsSource())
+	proxyProviderHandler := handlers.NewProxyProviderHandler(l, v.HTTP, cliCfg.CredentialsSource(v.Env))
 
 	// Custom hosts need handlers, but must not pollute pcOpts.RegistryNames — FilterRegistriesByImplementation
 	// relies on that slice containing only the standard registries to detect impl-based filtering.
@@ -168,6 +168,8 @@ func (pc *ProviderCache) Init(
 		cliCfg,
 		l,
 		v.HTTP,
+		v.FS,
+		v.Env,
 		registryNamesForHandlers,
 	)
 	if err != nil {
@@ -181,7 +183,7 @@ func (pc *ProviderCache) Init(
 	proxyModuleHandler := handlers.NewProxyModuleHandler(
 		l,
 		v.HTTP,
-		cliCfg.CredentialsSource(),
+		cliCfg.CredentialsSource(v.Env),
 		providerHandlers,
 		registryNamesForHandlers,
 	)
@@ -331,6 +333,8 @@ func (pc *ProviderCache) warmUpCache(
 	}
 
 	providerConstraints, err := getproviders.ParseProviderConstraints(
+		v.FS,
+		v.Env,
 		tfOpts.TofuImplementation,
 		filepath.Dir(tfOpts.TerragruntConfigPath),
 	)
@@ -386,7 +390,7 @@ func (pc *ProviderCache) warmUpCache(
 		}
 	}
 
-	err = getproviders.UpdateLockfile(ctx, tfOpts.ShellOptions.WorkingDir, caches)
+	err = getproviders.UpdateLockfile(ctx, v.FS, tfOpts.ShellOptions.WorkingDir, caches)
 	if err != nil {
 		return nil, err
 	}
@@ -400,6 +404,7 @@ func (pc *ProviderCache) warmUpCache(
 
 		err = getproviders.UpdateLockfileConstraints(
 			ctx,
+			v.FS,
 			tfOpts.ShellOptions.WorkingDir,
 			providerConstraints,
 		)

--- a/internal/remotestate/remote_state.go
+++ b/internal/remotestate/remote_state.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend/s3"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
@@ -148,7 +149,7 @@ func (remote *RemoteState) Migrate(
 	}
 
 	defer func() {
-		if err := os.Remove(stateFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := srcV.FS.Remove(stateFile); err != nil && !errors.Is(err, os.ErrNotExist) {
 			l.Warnf("Failed to remove temporary state file %s: %v", stateFile, err)
 		}
 	}()
@@ -247,7 +248,7 @@ func (remote *RemoteState) pullState(
 
 	l.Debugf("Creating temporary state file for migration")
 
-	file, err := os.CreateTemp("", "*.tfstate")
+	file, err := vfs.CreateTemp(v.FS, v.Platform.TempDir(), "*.tfstate")
 	if err != nil {
 		return "", err
 	}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -1724,7 +1725,7 @@ func TestParseJSONRunsFromFile(t *testing.T) {
 		err := os.WriteFile(reportFile, []byte(content), 0644)
 		require.NoError(t, err)
 
-		runs, err := report.ParseJSONRunsFromFile(reportFile)
+		runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 		require.NoError(t, err)
 		require.Len(t, runs, 1)
 		assert.Equal(t, "test-unit", runs[0].Name)
@@ -1733,7 +1734,7 @@ func TestParseJSONRunsFromFile(t *testing.T) {
 	t.Run("non-existent file", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := report.ParseJSONRunsFromFile(filepath.Join(tmp, "does-not-exist.json"))
+		_, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), filepath.Join(tmp, "does-not-exist.json"))
 		require.Error(t, err)
 	})
 }
@@ -1931,7 +1932,7 @@ func TestParseCSVRunsFromFile(t *testing.T) {
 		err := os.WriteFile(reportFile, []byte(content), 0644)
 		require.NoError(t, err)
 
-		runs, err := report.ParseCSVRunsFromFile(reportFile)
+		runs, err := report.ParseCSVRunsFromFile(vfs.NewOSFS(), reportFile)
 		require.NoError(t, err)
 		require.Len(t, runs, 1)
 		assert.Equal(t, "test-unit", runs[0].Name)
@@ -1940,7 +1941,7 @@ func TestParseCSVRunsFromFile(t *testing.T) {
 	t.Run("non-existent file", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := report.ParseCSVRunsFromFile(filepath.Join(tmp, "does-not-exist.csv"))
+		_, err := report.ParseCSVRunsFromFile(vfs.NewOSFS(), filepath.Join(tmp, "does-not-exist.csv"))
 		require.Error(t, err)
 	})
 }
@@ -2109,7 +2110,7 @@ func TestParseJSONRunsFromFileValidation(t *testing.T) {
 			err := os.WriteFile(reportFile, []byte(tt.input), 0644)
 			require.NoError(t, err)
 
-			_, err = report.ParseJSONRunsFromFile(reportFile)
+			_, err = report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -2128,7 +2129,7 @@ func TestParseJSONRunsFromFileValidation(t *testing.T) {
 		err := os.WriteFile(reportFile, []byte(content), 0644)
 		require.NoError(t, err)
 
-		_, err = report.ParseJSONRunsFromFile(reportFile)
+		_, err = report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 		require.Error(t, err)
 
 		var schemaErr *report.SchemaValidationError

--- a/internal/report/writer.go
+++ b/internal/report/writer.go
@@ -65,8 +65,8 @@ func ParseJSONRuns(data []byte) (JSONRuns, error) {
 // ParseJSONRunsFromFile reads and parses a JSON report from a file.
 // Returns a slice of JSONRun entries or an error if reading, validation, or parsing fails.
 // The report is validated against the JSON schema before parsing.
-func ParseJSONRunsFromFile(path string) (JSONRuns, error) {
-	data, err := os.ReadFile(path)
+func ParseJSONRunsFromFile(fsys vfs.FS, path string) (JSONRuns, error) {
+	data, err := vfs.ReadFile(fsys, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read report file %s: %w", path, err)
 	}
@@ -160,8 +160,8 @@ func ParseCSVRuns(data []byte) (CSVRuns, error) {
 
 // ParseCSVRunsFromFile reads and parses a CSV report from a file.
 // Returns a slice of CSVRun entries or an error if reading or parsing fails.
-func ParseCSVRunsFromFile(path string) (CSVRuns, error) {
-	data, err := os.ReadFile(path)
+func ParseCSVRunsFromFile(fsys vfs.FS, path string) (CSVRuns, error) {
+	data, err := vfs.ReadFile(fsys, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read report file %s: %w", path, err)
 	}

--- a/internal/runner/graph/graph.go
+++ b/internal/runner/graph/graph.go
@@ -33,7 +33,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *options.Terragru
 	// *Getter discarded: graph.Run only needs creds in v.Env for initial config parse.
 	// Per-unit creds are re-fetched in runnerpool task (intentional: each unit may have
 	// different opts after clone).
-	shellOpts := configbridge.ShellRunOptsFromOpts(opts)
+	shellOpts := configbridge.ShellRunOptsFromOpts(v.Env, opts)
 	if _, err := creds.ObtainCredsForParsing(
 		ctx,
 		l,

--- a/internal/runner/run/context.go
+++ b/internal/runner/run/context.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cache"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 )
 
 type configKey byte
@@ -48,5 +47,5 @@ func ModuleVersionResolverFromContext(ctx context.Context, v *venv.Venv) *getter
 
 func newModuleVersionResolver(v *venv.Venv) *getter.VersionResolver {
 	return getter.NewVersionResolver(v.HTTP).
-		WithAuth(getter.RegistryAuth{Env: v.Env, ReadUserConfig: vfs.IsOSFS(v.FS)})
+		WithAuth(getter.RegistryAuth{Env: v.Env, FS: v.FS})
 }

--- a/internal/runner/run/creds/getter_test.go
+++ b/internal/runner/run/creds/getter_test.go
@@ -152,7 +152,7 @@ func TestObtainCredsForParsingWithoutAuthProviderCmd(t *testing.T) {
 	})
 	v.Env["UNRELATED"] = "kept"
 
-	getter, err := creds.ObtainCredsForParsing(t.Context(), l, v, "", shell.NewShellOptions())
+	getter, err := creds.ObtainCredsForParsing(t.Context(), l, v, "", shell.NewShellOptions(map[string]string{}))
 	require.NoError(t, err)
 	assert.NotNil(t, getter)
 	assert.Zero(t, calls, "expected no subprocess invocations for an empty auth-provider command")
@@ -207,7 +207,7 @@ func TestObtainCredsForParsingPopulatesEnvBeforeParsing(t *testing.T) {
 				return vexec.Result{Stdout: []byte(tc.stdout)}
 			})
 
-			getter, err := creds.ObtainCredsForParsing(t.Context(), l, v, "auth-cmd", shell.NewShellOptions())
+			getter, err := creds.ObtainCredsForParsing(t.Context(), l, v, "auth-cmd", shell.NewShellOptions(map[string]string{}))
 			require.NoError(t, err)
 			assert.NotNil(t, getter)
 			assert.Equal(t, tc.wantEnv, v.Env)
@@ -226,7 +226,7 @@ func TestObtainCredsForParsingReportsCommandFailure(t *testing.T) {
 	})
 	v.Env["UNRELATED"] = "kept"
 
-	getter, err := creds.ObtainCredsForParsing(t.Context(), l, v, "auth-cmd", shell.NewShellOptions())
+	getter, err := creds.ObtainCredsForParsing(t.Context(), l, v, "auth-cmd", shell.NewShellOptions(map[string]string{}))
 	require.Error(t, err)
 	assert.Nil(t, getter)
 

--- a/internal/runner/run/creds/providers/externalcmd/provider_mem_test.go
+++ b/internal/runner/run/creds/providers/externalcmd/provider_mem_test.go
@@ -154,5 +154,5 @@ func TestProviderCommandShellwordsParsing(t *testing.T) {
 }
 
 func newRunOpts() *shell.ShellOptions {
-	return shell.NewShellOptions()
+	return shell.NewShellOptions(map[string]string{})
 }

--- a/internal/runner/run/creds/providers/externalcmd/provider_test.go
+++ b/internal/runner/run/creds/providers/externalcmd/provider_test.go
@@ -21,7 +21,7 @@ func TestGetCredentialsHandlesJSONNullResponse(t *testing.T) {
 	}
 
 	l := logger.CreateLogger()
-	opts := shell.NewShellOptions()
+	opts := shell.NewShellOptions(map[string]string{})
 
 	provider := externalcmd.NewProvider(l, "printf null", opts)
 

--- a/internal/runner/run/debug.go
+++ b/internal/runner/run/debug.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/runner/runcfg"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -23,8 +24,7 @@ const defaultPermissions = int(0600)
 // that terragrunt invokes the module, so that users can debug issues with the terragrunt config.
 func WriteTerragruntDebugFile(
 	l log.Logger,
-	fsys vfs.FS,
-	env map[string]string,
+	v *venv.Venv,
 	opts *Options,
 	cfg *runcfg.RunConfig,
 ) error {
@@ -34,7 +34,7 @@ func WriteTerragruntDebugFile(
 		opts.CacheDir,
 	)
 
-	declared, err := tf.ModuleVariables(fsys, opts.CacheDir)
+	declared, err := tf.ModuleVariables(v.FS, opts.CacheDir)
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func WriteTerragruntDebugFile(
 	l.Debugf("The following variables were detected in the %s module:", tofuImpl)
 	l.Debugf("%v", variables)
 
-	fileContents, err := terragruntDebugFileContents(l, env, cfg, variables)
+	fileContents, err := terragruntDebugFileContents(l, v.Env, cfg, variables)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func WriteTerragruntDebugFile(
 	configFolder := filepath.Dir(opts.TerragruntConfigPath)
 
 	fileName := filepath.Join(configFolder, TerragruntTFVarsFile)
-	if err := os.WriteFile(fileName, fileContents, os.FileMode(defaultPermissions)); err != nil {
+	if err := vfs.WriteFile(v.FS, fileName, fileContents, os.FileMode(defaultPermissions)); err != nil {
 		return err
 	}
 

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -77,6 +77,7 @@ func DownloadTerraformSource(
 
 	terraformSource, err := tf.NewSource(
 		l,
+		v.FS,
 		source,
 		opts.DownloadDir,
 		opts.UnitDir,
@@ -620,7 +621,7 @@ func tryCASDownload(
 		return false, nil
 	}
 
-	if _, err := git.NewGitRunner(v.Exec); err != nil {
+	if _, err := git.NewGitRunner(v); err != nil {
 		l.Warnf("Failed to initialize CAS environment: %v. Falling back to standard getter.", err)
 		cas.RecordFallback(
 			ctx,

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -689,7 +689,7 @@ func createConfig(
 		l,
 		versionV,
 		run.PopulateTFVersionInput{
-			TFOpts:       configbridge.TFRunOptsFromOpts(opts),
+			TFOpts:       configbridge.TFRunOptsFromOpts(map[string]string{}, opts),
 			WorkingDir:   opts.WorkingDir,
 			VersionFiles: opts.VersionManagerFileName,
 		},
@@ -1609,6 +1609,7 @@ func TestDownloadTerraformSourceIfNecessaryRejectsNonOSFilesystem(t *testing.T) 
 
 	src, err := tf.NewSource(
 		logger.CreateLogger(),
+		v.FS,
 		"git::https://github.com/gruntwork-io/terragrunt.git//foo",
 		t.TempDir(),
 		opts.WorkingDir,

--- a/internal/runner/run/hook.go
+++ b/internal/runner/run/hook.go
@@ -173,7 +173,7 @@ func ProcessErrorHooks(
 						ctx,
 						l,
 						hookV,
-						opts.shellRunOptions(),
+						opts.shellRunOptions(env),
 						curHook.WorkingDir,
 						curHook.SuppressStdout,
 						false,
@@ -281,7 +281,7 @@ func runHook(
 		ctx,
 		l,
 		hookV,
-		opts.shellRunOptions(),
+		opts.shellRunOptions(env),
 		workingDir,
 		suppressStdout,
 		false,
@@ -310,7 +310,7 @@ func executeTFLint(
 	actualLock.Lock()
 	defer actualLock.Unlock()
 
-	err := tflint.RunTflintWithOpts(ctx, l, v, opts.tflintRunOptions(), cfg, curHook)
+	err := tflint.RunTflintWithOpts(ctx, l, v, opts.tflintRunOptions(v.Env), cfg, curHook)
 	if err != nil {
 		l.Errorf("%s", hookErrorMessage(curHook.Name, err))
 		return err

--- a/internal/runner/run/options.go
+++ b/internal/runner/run/options.go
@@ -195,8 +195,8 @@ func (o *Options) DataDir(env map[string]string) string {
 }
 
 // shellRunOptions builds a *shell.ShellOptions from this Options.
-func (o *Options) shellRunOptions() *shell.ShellOptions {
-	s := shell.NewShellOptions().
+func (o *Options) shellRunOptions(env map[string]string) *shell.ShellOptions {
+	s := shell.NewShellOptions(env).
 		WithWorkingDir(o.CacheDir).
 		WithUnitDir(o.UnitDir).
 		WithTelemetry(o.Telemetry).
@@ -213,19 +213,19 @@ func (o *Options) shellRunOptions() *shell.ShellOptions {
 }
 
 // tfRunOptions builds a *tf.TFOptions from this Options.
-func (o *Options) tfRunOptions() *tf.TFOptions {
+func (o *Options) tfRunOptions(env map[string]string) *tf.TFOptions {
 	return &tf.TFOptions{
 		JSONLogFormat:                o.JSONLogFormat,
 		OriginalTerragruntConfigPath: o.OriginalTerragruntConfigPath,
 		TerragruntConfigPath:         o.TerragruntConfigPath,
 		TofuImplementation:           o.TofuImplementation,
 		TerraformCliArgs:             o.TerraformCliArgs,
-		ShellOptions:                 o.shellRunOptions(),
+		ShellOptions:                 o.shellRunOptions(env),
 	}
 }
 
 // remoteStateOpts builds a *remotestate.Options from this Options.
-func (o *Options) remoteStateOpts() *remotestate.Options {
+func (o *Options) remoteStateOpts(env map[string]string) *remotestate.Options {
 	return &remotestate.Options{
 		Options: backend.Options{
 			Experiments:                  o.Experiments,
@@ -233,15 +233,15 @@ func (o *Options) remoteStateOpts() *remotestate.Options {
 			NonInteractive:               o.NonInteractive,
 			FailIfBucketCreationRequired: o.FailIfBucketCreationRequired,
 		},
-		TFRunOpts:           o.tfRunOptions(),
+		TFRunOpts:           o.tfRunOptions(env),
 		DisableBucketUpdate: o.DisableBucketUpdate,
 	}
 }
 
 // tflintRunOptions builds a *tflint.TFLintOptions from this Options.
-func (o *Options) tflintRunOptions() *tflint.TFLintOptions {
+func (o *Options) tflintRunOptions(env map[string]string) *tflint.TFLintOptions {
 	return &tflint.TFLintOptions{
-		ShellOptions:         o.shellRunOptions(),
+		ShellOptions:         o.shellRunOptions(env),
 		LogShowAbsPaths:      o.LogShowAbsPaths,
 		WorkingDir:           o.CacheDir,
 		RootWorkingDir:       o.RootWorkingDir,

--- a/internal/runner/run/options_internal_test.go
+++ b/internal/runner/run/options_internal_test.go
@@ -22,7 +22,7 @@ func TestRemoteStateOptsPropagatesExperiments(t *testing.T) {
 		DisableBucketUpdate:          true,
 	}
 
-	got := o.remoteStateOpts()
+	got := o.remoteStateOpts(map[string]string{})
 
 	assert.True(t, got.Experiments.Evaluate(experiment.AzureBackend), "enabled experiments must reach backend options")
 	assert.True(t, got.NonInteractive)

--- a/internal/runner/run/run.go
+++ b/internal/runner/run/run.go
@@ -192,7 +192,7 @@ func Run(
 	// We do the debug file generation here, after all the terragrunt generated terraform files are created so that we
 	// can ensure the tfvars json file only includes the vars that are defined in the module.
 	if updatedOpts.Debug {
-		if err := WriteTerragruntDebugFile(l, v.FS, v.Env, updatedOpts, cfg); err != nil {
+		if err := WriteTerragruntDebugFile(l, v, updatedOpts, cfg); err != nil {
 			return err
 		}
 	}
@@ -324,14 +324,14 @@ func runTerragruntWithConfig(
 	}
 
 	// Write null-valued inputs to a tfvars.json file that OpenTofu/Terraform will auto-load.
-	nullVarsFile, err := setTerragruntNullValuesRunCfg(opts, cfg)
+	nullVarsFile, err := setTerragruntNullValuesRunCfg(v, opts, cfg)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
 		if nullVarsFile != "" {
-			if removeErr := os.Remove(
+			if removeErr := v.FS.Remove(
 				nullVarsFile,
 			); removeErr != nil &&
 				!errors.Is(removeErr, os.ErrNotExist) {
@@ -362,7 +362,7 @@ func runTerragruntWithConfig(
 			// Execute the underlying command once; retries and ignores are handled by outer RunWithErrorHandling
 			out, runTerraformError := tf.RunCommandWithOutput(
 				childCtx, l, v,
-				opts.tfRunOptions(), opts.TerraformCliArgs.Slice()...,
+				opts.tfRunOptions(v.Env), opts.TerraformCliArgs.Slice()...,
 			)
 
 			var lockFileError error
@@ -667,7 +667,7 @@ func remoteStateNeedsInit(
 		return false, nil
 	}
 
-	if ok, err := remoteState.NeedsBootstrap(ctx, l, v, opts.remoteStateOpts()); err != nil || !ok {
+	if ok, err := remoteState.NeedsBootstrap(ctx, l, v, opts.remoteStateOpts(v.Env)); err != nil || !ok {
 		return false, err
 	}
 
@@ -827,7 +827,7 @@ func prepareInitCommandRunCfg(
 		return nil
 	}
 
-	if err := cfg.RemoteState.Bootstrap(ctx, l, v, opts.remoteStateOpts()); err != nil {
+	if err := cfg.RemoteState.Bootstrap(ctx, l, v, opts.remoteStateOpts(v.Env)); err != nil {
 		return err
 	}
 
@@ -970,7 +970,7 @@ func checkProtectedModuleRunCfg(opts *Options, cfg *runcfg.RunConfig) error {
 // that OpenTofu/Terraform will auto-load. This is necessary because OpenTofu/Terraform
 // cannot accept null values via environment variables (TF_VAR_*), but it can read them
 // from .auto.tfvars.json files.
-func setTerragruntNullValuesRunCfg(opts *Options, cfg *runcfg.RunConfig) (string, error) {
+func setTerragruntNullValuesRunCfg(v *venv.Venv, opts *Options, cfg *runcfg.RunConfig) (string, error) {
 	jsonEmptyVars := make(map[string]any)
 
 	for varName, varValue := range cfg.Inputs {
@@ -992,7 +992,8 @@ func setTerragruntNullValuesRunCfg(opts *Options, cfg *runcfg.RunConfig) (string
 
 	const ownerReadWritePermissions = 0600
 
-	if err := os.WriteFile(
+	if err := vfs.WriteFile(
+		v.FS,
 		varFile,
 		jsonContents,
 		os.FileMode(ownerReadWritePermissions),

--- a/internal/runner/run/version_check_mem_test.go
+++ b/internal/runner/run/version_check_mem_test.go
@@ -156,6 +156,6 @@ func TestGetTFVersionStripsTFCLIArgs(t *testing.T) {
 func newVersionTFOptions(tfPath string) *tf.TFOptions {
 	return &tf.TFOptions{
 		TerraformCliArgs: iacargs.New(),
-		ShellOptions:     shell.NewShellOptions().WithTFPath(tfPath),
+		ShellOptions:     shell.NewShellOptions(map[string]string{}).WithTFPath(tfPath),
 	}
 }

--- a/internal/runner/run/version_check_test.go
+++ b/internal/runner/run/version_check_test.go
@@ -223,7 +223,7 @@ func TestPopulateTFVersionRespectsTFPath(t *testing.T) {
 	tfOpts := func(binary string) *tf.TFOptions {
 		return &tf.TFOptions{
 			TerraformCliArgs: iacargs.New(),
-			ShellOptions: shell.NewShellOptions().
+			ShellOptions: shell.NewShellOptions(map[string]string{}).
 				WithTFPath(binary).
 				WithWorkingDir(t.TempDir()),
 		}

--- a/internal/runner/runall/runall.go
+++ b/internal/runner/runall/runall.go
@@ -137,7 +137,7 @@ func Run(
 		}
 
 		defer func() {
-			cleanupErr := wts.Cleanup(ctx, l)
+			cleanupErr := wts.Cleanup(ctx, l, v.FS)
 			if cleanupErr != nil {
 				l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 			}
@@ -160,7 +160,7 @@ func Run(
 						opts.WorkingDir,
 					)
 
-					return clean.CleanStacks(l, opts)
+					return clean.CleanStacks(l, v.FS, opts)
 				})
 			if errClean != nil {
 				return fmt.Errorf(

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -114,7 +114,7 @@ func findMatchingUnitsInPath(
 	// Construct the full path to terragrunt.hcl in the directory
 	configPath := filepath.Join(dir, filepath.Base(opts.TerragruntConfigPath))
 
-	cfgOpts, err := options.NewTerragruntOptionsWithConfigPath(configPath)
+	cfgOpts, err := options.NewTerragruntOptionsWithConfigPath(v.Exec, configPath)
 	if err != nil {
 		l.Debugf("Failed to build terragrunt options from %s %v", configPath, err)
 		return matchedUnitsMap

--- a/internal/runner/runnerpool/builder_helpers.go
+++ b/internal/runner/runnerpool/builder_helpers.go
@@ -265,7 +265,7 @@ func checkUnitVersionConstraints(
 	}
 
 	_, ver, impl, err := run.PopulateTFVersion(ctx, l, v, run.PopulateTFVersionInput{
-		TFOpts:       configbridge.TFRunOptsFromOpts(unitOpts),
+		TFOpts:       configbridge.TFRunOptsFromOpts(v.Env, unitOpts),
 		WorkingDir:   unitOpts.WorkingDir,
 		VersionFiles: unitOpts.VersionManagerFileName,
 	})

--- a/internal/runner/runnerpool/graph_fallback_test.go
+++ b/internal/runner/runnerpool/graph_fallback_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runnerpool"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	thlogger "github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -62,7 +63,7 @@ dependency "db" {
 	expected := []string{vpcDir, dbDir, appDir}
 
 	// Path 1: experiment ON, use discovery filter
-	optsOn := options.NewTerragruntOptions()
+	optsOn := options.NewTerragruntOptions(vexec.NewOSExec())
 	optsOn.WorkingDir = vpcDir
 	optsOn.RootWorkingDir = tmpDir
 	// Enable the filter-flag experiment
@@ -82,7 +83,7 @@ dependency "db" {
 	}
 
 	// Path 2: experiment OFF, use fallback option
-	optsOff := options.NewTerragruntOptions()
+	optsOff := options.NewTerragruntOptions(vexec.NewOSExec())
 	optsOff.WorkingDir = vpcDir
 	optsOff.RootWorkingDir = tmpDir
 	// No filter queries; rely on fallback graph target option

--- a/internal/runner/runnerpool/runner.go
+++ b/internal/runner/runnerpool/runner.go
@@ -531,7 +531,7 @@ func (rnr *Runner) Run(
 					unitLogger,
 					unitV,
 					unitOpts.AuthProviderCmd,
-					configbridge.ShellRunOptsFromOpts(unitOpts),
+					configbridge.ShellRunOptsFromOpts(v.Env, unitOpts),
 				)
 				if err != nil {
 					logTaskOutcome(childCtx, l, unitPath, unitOpts.TerraformCommand, err)

--- a/internal/services/catalog/component/kind.go
+++ b/internal/services/catalog/component/kind.go
@@ -93,7 +93,7 @@ type Markers struct {
 
 // Inspect reads dir and reports the component markers it carries.
 func Inspect(fsys vfs.FS, dir string) (Markers, error) {
-	entries, err := vfs.ReadDirEntries(fsys, dir)
+	entries, err := vfs.ReadDir(fsys, dir)
 	if err != nil {
 		return Markers{}, err
 	}

--- a/internal/services/catalog/module/doc.go
+++ b/internal/services/catalog/module/doc.go
@@ -1,10 +1,11 @@
 package module
 
 import (
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 )
 
 const (
@@ -139,10 +140,10 @@ func NewDoc(rawContent, fileExt string) *Doc {
 	return doc
 }
 
-func FindDoc(dir string) (*Doc, error) {
+func FindDoc(fsys vfs.FS, dir string) (*Doc, error) {
 	var filePath, fileExt string
 
-	files, err := os.ReadDir(dir)
+	files, err := vfs.ReadDir(fsys, dir)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +172,7 @@ func FindDoc(dir string) (*Doc, error) {
 		return &Doc{}, nil
 	}
 
-	contentByte, err := os.ReadFile(filePath)
+	contentByte, err := vfs.ReadFile(fsys, filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/catalog/module/module.go
+++ b/internal/services/catalog/module/module.go
@@ -2,12 +2,12 @@
 package module
 
 import (
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
@@ -31,7 +31,7 @@ type Module struct {
 }
 
 // NewModule returns a module instance if the given `moduleDir` path contains an OpenTofu/Terraform module, otherwise returns nil.
-func NewModule(l log.Logger, repo *Repo, moduleDir string) (*Module, error) {
+func NewModule(l log.Logger, fsys vfs.FS, repo *Repo, moduleDir string) (*Module, error) {
 	module := &Module{
 		Repo:      repo,
 		cloneURL:  repo.cloneURL,
@@ -39,7 +39,7 @@ func NewModule(l log.Logger, repo *Repo, moduleDir string) (*Module, error) {
 		moduleDir: moduleDir,
 	}
 
-	if ok, err := module.isValid(); !ok || err != nil {
+	if ok, err := module.isValid(fsys); !ok || err != nil {
 		return nil, err
 	}
 
@@ -51,7 +51,7 @@ func NewModule(l log.Logger, repo *Repo, moduleDir string) (*Module, error) {
 
 	modulePath := filepath.Join(module.repoPath, module.moduleDir)
 
-	doc, err := FindDoc(modulePath)
+	doc, err := FindDoc(fsys, modulePath)
 	if err != nil {
 		return nil, err
 	}
@@ -106,8 +106,8 @@ func (module *Module) TerraformSourcePath() string {
 	return result
 }
 
-func (module *Module) isValid() (bool, error) {
-	files, err := os.ReadDir(filepath.Join(module.repoPath, module.moduleDir))
+func (module *Module) isValid(fsys vfs.FS) (bool, error) {
+	files, err := vfs.ReadDir(fsys, filepath.Join(module.repoPath, module.moduleDir))
 	if err != nil {
 		return false, err
 	}

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -21,7 +21,6 @@ import (
 	gitpkg "github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -125,7 +124,7 @@ func (repo *Repo) FindModules(ctx context.Context, l log.Logger, fsys vfs.FS) (M
 	var modules Modules
 
 	// check if root repo path is a module dir
-	if module, err := NewModule(l, repo, ""); err != nil {
+	if module, err := NewModule(l, fsys, repo, ""); err != nil {
 		return nil, err
 	} else if module != nil {
 		modules = append(modules, module)
@@ -170,7 +169,7 @@ func (repo *Repo) FindModules(ctx context.Context, l log.Logger, fsys vfs.FS) (M
 
 				moduleDir = filepath.ToSlash(moduleDir)
 
-				if module, err := NewModule(l, repo, moduleDir); err != nil {
+				if module, err := NewModule(l, fsys, repo, moduleDir); err != nil {
 					return err
 				} else if module != nil {
 					modules = append(modules, module)
@@ -284,7 +283,7 @@ func (repo *Repo) CloneURL() string {
 // semver tags, LatestTag is left empty. Local catalog sources skip the
 // lookup entirely so a stale or unreachable origin URL in a local working
 // copy can't stall discovery.
-func (repo *Repo) ResolveLatestTag(ctx context.Context, l log.Logger, exec vexec.Exec) {
+func (repo *Repo) ResolveLatestTag(ctx context.Context, l log.Logger, v *venv.Venv) {
 	if repo.isLocal {
 		return
 	}
@@ -294,7 +293,7 @@ func (repo *Repo) ResolveLatestTag(ctx context.Context, l log.Logger, exec vexec
 		return
 	}
 
-	runner, err := gitpkg.NewGitRunner(exec)
+	runner, err := gitpkg.NewGitRunner(v)
 	if err != nil {
 		l.Debugf("catalog: skip tag lookup: %v", err)
 
@@ -504,7 +503,7 @@ func (repo *Repo) performClone(
 			return err
 		}
 
-		if _, err := gitpkg.NewGitRunner(v.Exec); err != nil {
+		if _, err := gitpkg.NewGitRunner(v); err != nil {
 			return err
 		}
 

--- a/internal/services/catalog/module/repo_tag_test.go
+++ b/internal/services/catalog/module/repo_tag_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,7 +21,7 @@ func TestResolveLatestTag_FindsHighestSemver(t *testing.T) {
 
 	repo := &module.Repo{RemoteURL: "https://example.com/org/repo.git"}
 
-	repo.ResolveLatestTag(t.Context(), l, exec)
+	repo.ResolveLatestTag(t.Context(), l, venvtest.New().WithExec(exec))
 
 	assert.Equal(t, "v1.10.2", repo.LatestTag)
 }
@@ -36,7 +37,7 @@ func TestResolveLatestTag_NoTags(t *testing.T) {
 
 	repo := &module.Repo{RemoteURL: "https://example.com/org/repo.git"}
 
-	repo.ResolveLatestTag(t.Context(), l, exec)
+	repo.ResolveLatestTag(t.Context(), l, venvtest.New().WithExec(exec))
 
 	assert.Empty(t, repo.LatestTag)
 }
@@ -54,7 +55,7 @@ func TestResolveLatestTag_EmptyRemoteURL(t *testing.T) {
 
 	repo := &module.Repo{}
 
-	repo.ResolveLatestTag(t.Context(), l, exec)
+	repo.ResolveLatestTag(t.Context(), l, venvtest.New().WithExec(exec))
 
 	assert.Empty(t, repo.LatestTag)
 }
@@ -71,7 +72,7 @@ func TestResolveLatestTag_SkipsPrereleases(t *testing.T) {
 
 	repo := &module.Repo{RemoteURL: "https://example.com/org/repo.git"}
 
-	repo.ResolveLatestTag(t.Context(), l, exec)
+	repo.ResolveLatestTag(t.Context(), l, venvtest.New().WithExec(exec))
 
 	assert.Equal(t, "v1.5.0", repo.LatestTag, "v2.0.0-rc1 is a prerelease and must be skipped")
 }
@@ -92,7 +93,7 @@ func TestResolveLatestTag_GitFailureLeavesTagEmpty(t *testing.T) {
 	repo := &module.Repo{RemoteURL: "https://unreachable.example/repo.git"}
 
 	require.NotPanics(t, func() {
-		repo.ResolveLatestTag(t.Context(), l, exec)
+		repo.ResolveLatestTag(t.Context(), l, venvtest.New().WithExec(exec))
 	})
 
 	assert.Empty(

--- a/internal/shell/git.go
+++ b/internal/shell/git.go
@@ -79,7 +79,7 @@ func GitTopLevelDir(ctx context.Context, l log.Logger, v *venv.Venv, path string
 
 	gitV := v.WithWriter(&stdout).WithErrWriter(&stderr)
 
-	gitRunOpts := NewShellOptions().WithWorkingDir(path)
+	gitRunOpts := NewShellOptions(v.Env).WithWorkingDir(path)
 
 	cmd, err := RunCommandWithOutput(
 		ctx,
@@ -205,7 +205,7 @@ func GitRepoTags(
 
 	gitV := v.WithWriter(&stdout).WithErrWriter(&stderr)
 
-	gitRunOpts := NewShellOptions().WithWorkingDir(workingDir)
+	gitRunOpts := NewShellOptions(v.Env).WithWorkingDir(workingDir)
 
 	output, err := RunCommandWithOutput(
 		ctx,

--- a/internal/shell/prompt.go
+++ b/internal/shell/prompt.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 
@@ -16,6 +17,9 @@ import (
 // unreachable afterwards: not to the next prompt, and not to a subprocess that
 // inherits the same stream. A prompt is a handful of bytes typed by a person,
 // so the syscall per byte costs nothing worth having.
+//
+// A final line that ends at EOF instead of a newline is returned as the answer,
+// so a piped `printf yes` reads the same as a typed one.
 func readLine(r io.Reader) (string, error) {
 	var line []byte
 
@@ -32,6 +36,10 @@ func readLine(r io.Reader) (string, error) {
 		}
 
 		if err != nil {
+			if errors.Is(err, io.EOF) && len(line) > 0 {
+				return string(line), nil
+			}
+
 			return "", err
 		}
 	}

--- a/internal/shell/prompt_test.go
+++ b/internal/shell/prompt_test.go
@@ -1,6 +1,7 @@
 package shell_test
 
 import (
+	"io"
 	"strings"
 	"testing"
 
@@ -31,6 +32,39 @@ func TestPromptUserForInputSequential(t *testing.T) {
 	assert.Equal(t, "second", second)
 }
 
+// TestPromptUserForInputUnterminatedFinalLine pins that an answer ending at EOF
+// without a trailing newline is still read, so `printf yes | terragrunt ...`
+// answers a prompt.
+func TestPromptUserForInputUnterminatedFinalLine(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	v := venvtest.New().WithStdin(strings.NewReader("first\nsecond"))
+
+	first, err := shell.PromptUserForInput(t.Context(), l, v, "one: ", false)
+	require.NoError(t, err)
+	assert.Equal(t, "first", first)
+
+	second, err := shell.PromptUserForInput(t.Context(), l, v, "two: ", false)
+	require.NoError(t, err)
+	assert.Equal(t, "second", second)
+
+	_, err = shell.PromptUserForInput(t.Context(), l, v, "three: ", false)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+// TestPromptUserForInputEmptyStdin pins that stdin closed without any answer is
+// an error rather than an empty answer, which yes/no prompts would read as "no".
+func TestPromptUserForInputEmptyStdin(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	v := venvtest.New().WithStdin(strings.NewReader(""))
+
+	_, err := shell.PromptUserForInput(t.Context(), l, v, "one: ", false)
+	require.ErrorIs(t, err, io.EOF)
+}
+
 func TestPromptUserForYesNo(t *testing.T) {
 	t.Parallel()
 
@@ -44,6 +78,7 @@ func TestPromptUserForYesNo(t *testing.T) {
 		{name: "uppercase yes", input: "YES\n", expected: true},
 		{name: "n", input: "n\n", expected: false},
 		{name: "anything else", input: "maybe\n", expected: false},
+		{name: "yes without trailing newline", input: "yes", expected: true},
 	}
 
 	for _, tt := range tc {

--- a/internal/shell/run_cmd.go
+++ b/internal/shell/run_cmd.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -58,12 +57,14 @@ type ShellOptions struct {
 // NewShellOptions creates ShellOptions with sensible defaults. Telemetry is
 // always non-nil; TRACEPARENT is read from the environment when set. Use the
 // With* methods to override any field.
-func NewShellOptions() *ShellOptions {
+func NewShellOptions(env map[string]string) *ShellOptions {
+	venv.RequireEnvMap(env)
+
 	opts := &ShellOptions{
 		Telemetry: &telemetry.Options{},
 	}
 
-	if tp := os.Getenv(telemetry.TraceParentEnv); tp != "" {
+	if tp := env[telemetry.TraceParentEnv]; tp != "" {
 		opts.Telemetry.TraceParent = tp
 	}
 

--- a/internal/shell/run_cmd_mem_test.go
+++ b/internal/shell/run_cmd_mem_test.go
@@ -39,7 +39,7 @@ func TestRunCommandMemBackendWithRacing(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	opts := shell.NewShellOptions()
+	opts := shell.NewShellOptions(map[string]string{})
 
 	v := venvtest.New().WithExec(e).WithWriter(stdout).WithErrWriter(stderr)
 
@@ -77,7 +77,7 @@ func TestRunCommandRoutesStdoutAndStderrSeparately(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	opts := shell.NewShellOptions()
+	opts := shell.NewShellOptions(map[string]string{})
 
 	v := venvtest.New().WithExec(e).WithWriter(stdout).WithErrWriter(stderr)
 

--- a/internal/shell/run_cmd_output_test.go
+++ b/internal/shell/run_cmd_output_test.go
@@ -94,7 +94,7 @@ func testCommandOutput(
 		t.Context(),
 		l,
 		v,
-		configbridge.ShellRunOptsFromOpts(terragruntOptions),
+		configbridge.ShellRunOptsFromOpts(map[string]string{}, terragruntOptions),
 		"",
 		!allocateStdout,
 		false,

--- a/internal/shell/run_cmd_unix_test.go
+++ b/internal/shell/run_cmd_unix_test.go
@@ -39,7 +39,7 @@ func TestRunCommandWithOutputInterrupt(t *testing.T) {
 	cmdPath := "testdata/test_sigint_wait.sh"
 	readyPath := filepath.Join(t.TempDir(), "sigint-ready")
 
-	shellOpts := configbridge.ShellRunOptsFromOpts(terragruntOptions)
+	shellOpts := configbridge.ShellRunOptsFromOpts(map[string]string{}, terragruntOptions)
 	// Forward the interrupt near-immediately instead of waiting the production
 	// grace period so the test does not pay that delay.
 	shellOpts.SignalForwardingDelay = 100 * time.Millisecond

--- a/internal/shell/run_cmd_windows_test.go
+++ b/internal/shell/run_cmd_windows_test.go
@@ -28,6 +28,7 @@ func TestWindowsRunCommandWithOutputInterrupt(t *testing.T) {
 	assert.Nil(t, err, "Unexpected error creating NewTerragruntOptionsForTest: %v", err)
 
 	l := logger.CreateLogger()
+	v := venv.OSVenv()
 
 	errCh := make(chan error)
 	expectedWait := 5
@@ -40,8 +41,8 @@ func TestWindowsRunCommandWithOutputInterrupt(t *testing.T) {
 		_, err := shell.RunCommandWithOutput(
 			ctx,
 			l,
-			venv.OSVenv(),
-			configbridge.ShellRunOptsFromOpts(terragruntOptions),
+			v,
+			configbridge.ShellRunOptsFromOpts(v.Env, terragruntOptions),
 			"",
 			false,
 			false,

--- a/internal/stacks/clean/clean.go
+++ b/internal/stacks/clean/clean.go
@@ -3,17 +3,18 @@ package clean
 
 import (
 	"errors"
-	"os"
+	"io/fs"
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
 // CleanStacks removes stack directories within the specified working directory, unless the command is "destroy".
 // It returns an error if any issues occur during the deletion process, or nil if successful.
-func CleanStacks(l log.Logger, opts *options.TerragruntOptions) error {
+func CleanStacks(l log.Logger, fsys vfs.FS, opts *options.TerragruntOptions) error {
 	if opts.TerraformCommand == tf.CommandNameDestroy {
 		l.Debugf("Skipping stack clean for %s, as part of delete command", opts.WorkingDir)
 		return nil
@@ -21,7 +22,7 @@ func CleanStacks(l log.Logger, opts *options.TerragruntOptions) error {
 
 	var errs []error
 
-	walkFn := func(path string, d os.DirEntry, walkErr error) error {
+	walkFn := func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			l.Warnf("Error accessing path %s: %v", path, walkErr)
 
@@ -38,18 +39,18 @@ func CleanStacks(l log.Logger, opts *options.TerragruntOptions) error {
 
 			l.Infof("Deleting stack directory: %s", relPath)
 
-			if rmErr := os.RemoveAll(path); rmErr != nil {
+			if rmErr := fsys.RemoveAll(path); rmErr != nil {
 				l.Errorf("Failed to delete stack directory %s: %v", relPath, rmErr)
 
 				errs = append(errs, rmErr)
 			}
 
-			return filepath.SkipDir
+			return fs.SkipDir
 		}
 
 		return nil
 	}
-	if walkErr := filepath.WalkDir(opts.WorkingDir, walkFn); walkErr != nil {
+	if walkErr := vfs.WalkDir(fsys, opts.WorkingDir, walkFn); walkErr != nil {
 		errs = append(errs, walkErr)
 	}
 

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -674,7 +674,7 @@ func worktreeStacksToGenerate(
 	}
 
 	for _, pair := range w.WorktreePairs {
-		fromFilters, toFilters, err := pair.Expand()
+		fromFilters, toFilters, err := pair.Expand(v.FS)
 		if err != nil {
 			return nil, fmt.Errorf("failed to expand worktree pair: %w", err)
 		}

--- a/internal/stacks/generate/generate_test.go
+++ b/internal/stacks/generate/generate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -48,7 +49,7 @@ func TestGenerateStacksCyclicSource_FailsAtMaxLevel(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = liveDir
 	opts.RootWorkingDir = liveDir
 	opts.Parallelism = 1

--- a/internal/stacks/output/output.go
+++ b/internal/stacks/output/output.go
@@ -89,7 +89,7 @@ func StackOutput(
 
 	if wts != nil {
 		defer func() {
-			if cleanupErr := wts.Cleanup(ctx, l); cleanupErr != nil {
+			if cleanupErr := wts.Cleanup(ctx, l, v.FS); cleanupErr != nil {
 				l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 			}
 		}()

--- a/internal/telemetry/logger_test.go
+++ b/internal/telemetry/logger_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -64,7 +65,7 @@ func TestNewLogsExporter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			opts.Telemetry.LogsExporter = tt.exporterType
 			opts.Telemetry.LogsExporterInsecureEndpoint = tt.insecure
 
@@ -86,7 +87,7 @@ func TestNewLogger(t *testing.T) {
 
 	ctx := t.Context()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.Telemetry.LogsExporter = "console"
 
 	logger, err := telemetry.NewLogger(ctx, "terragrunt", "test", io.Discard, opts.Telemetry)

--- a/internal/telemetry/meter_test.go
+++ b/internal/telemetry/meter_test.go
@@ -7,6 +7,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,7 +60,7 @@ func TestNewMetricsExporter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			opts.Telemetry.MetricExporter = tt.exporterType
 			opts.Telemetry.MetricExporterInsecureEndpoint = tt.insecure
 

--- a/internal/telemetry/otel_update_test.go
+++ b/internal/telemetry/otel_update_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -24,7 +25,7 @@ func TestCollectEmitsSpanAndMetric(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.Telemetry.TraceExporter = consoleExporter
 	opts.Telemetry.MetricExporter = consoleExporter
 
@@ -52,7 +53,7 @@ func TestCollectEmitsSpanAndMetric(t *testing.T) {
 func TestCollectPropagatesError(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.Telemetry.TraceExporter = consoleExporter
 	opts.Telemetry.MetricExporter = consoleExporter
 
@@ -74,7 +75,7 @@ func TestCollectPropagatesError(t *testing.T) {
 func TestCollectWithLoggerBindsContext(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.Telemetry.TraceExporter = consoleExporter
 
 	l := logger.CreateLogger()
@@ -107,7 +108,7 @@ func TestCollectWithLoggerBindsContext(t *testing.T) {
 func TestShutdownIdempotent(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.Telemetry.TraceExporter = consoleExporter
 	opts.Telemetry.MetricExporter = consoleExporter
 
@@ -150,7 +151,7 @@ func TestTelemeterFromContextNoOp(t *testing.T) {
 func TestContextWithTelemeterRoundtrip(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.Telemetry.TraceExporter = consoleExporter
 
 	tlm, err := telemetry.NewTelemeter(
@@ -169,7 +170,7 @@ func TestTelemeterConsoleOutputValidJSON(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.Telemetry.TraceExporter = consoleExporter
 	opts.Telemetry.MetricExporter = consoleExporter
 
@@ -201,7 +202,7 @@ func TestTelemeterConsoleOutputValidJSON(t *testing.T) {
 func TestNewTelemeterNoExporters(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 	tlm, err := telemetry.NewTelemeter(
 		t.Context(), nil, "terragrunt", "v0.0.0-test", io.Discard, opts.Telemetry, false,

--- a/internal/telemetry/telemeter_test.go
+++ b/internal/telemetry/telemeter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,7 +49,7 @@ func TestNewTelemeterEnvOverrides(t *testing.T) {
 
 			var buf bytes.Buffer
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			opts.Telemetry.TraceExporter = "console"
 			opts.Telemetry.MetricExporter = "console"
 

--- a/internal/telemetry/tracer_test.go
+++ b/internal/telemetry/tracer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -71,7 +72,7 @@ func TestNewTraceExporter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts := options.NewTerragruntOptions()
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
 			opts.Telemetry.TraceExporter = tt.traceExporter
 			opts.Telemetry.TraceExporterHTTPEndpoint = tt.traceExporterHTTPEndpoint
 

--- a/internal/tf/cache/handlers/filesystem_mirror_provider.go
+++ b/internal/tf/cache/handlers/filesystem_mirror_provider.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/models"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -19,16 +20,19 @@ var _ ProviderHandler = new(FilesystemMirrorProviderHandler)
 type FilesystemMirrorProviderHandler struct {
 	*CommonProviderHandler
 
+	fsys                 vfs.FS
 	filesystemMirrorPath string
 }
 
 func NewFilesystemMirrorProviderHandler(
 	l log.Logger,
 	c vhttp.Client,
+	fsys vfs.FS,
 	method *cliconfig.ProviderInstallationFilesystemMirror,
 ) *FilesystemMirrorProviderHandler {
 	return &FilesystemMirrorProviderHandler{
 		CommonProviderHandler: NewCommonProviderHandler(l, c, method.Include, method.Exclude),
+		fsys:                  fsys,
 		filesystemMirrorPath:  method.Path,
 	}
 }
@@ -116,7 +120,7 @@ func (handler *FilesystemMirrorProviderHandler) GetPlatform(
 func (handler *FilesystemMirrorProviderHandler) readMirrorData(filename string, value any) error {
 	filename = filepath.Join(handler.filesystemMirrorPath, filename)
 
-	data, err := os.ReadFile(filename)
+	data, err := vfs.ReadFile(handler.fsys, filename)
 	if err != nil {
 		// A mirror that carries no data for this provider is not an error; the
 		// caller reports an empty result and moves on to the next handler.

--- a/internal/tf/cache/handlers/provider.go
+++ b/internal/tf/cache/handlers/provider.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/models"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -39,6 +40,8 @@ func NewProviderHandlers(
 	cliCfg *cliconfig.Config,
 	l log.Logger,
 	c vhttp.Client,
+	fsys vfs.FS,
+	env map[string]string,
 	registryNames []string,
 ) (ProviderHandlers, error) {
 	var (
@@ -56,14 +59,14 @@ func NewProviderHandlers(
 		case *cliconfig.ProviderInstallationFilesystemMirror:
 			providerHandlers = append(
 				providerHandlers,
-				NewFilesystemMirrorProviderHandler(l, c, method),
+				NewFilesystemMirrorProviderHandler(l, c, fsys, method),
 			)
 		case *cliconfig.ProviderInstallationNetworkMirror:
 			networkMirrorHandler, err := NewNetworkMirrorProviderHandler(
 				l,
 				c,
 				method,
-				cliCfg.CredentialsSource(),
+				cliCfg.CredentialsSource(env),
 			)
 			if err != nil {
 				return nil, err
@@ -73,7 +76,7 @@ func NewProviderHandlers(
 		case *cliconfig.ProviderInstallationDirect:
 			providerHandlers = append(
 				providerHandlers,
-				NewDirectProviderHandler(l, c, method, cliCfg.CredentialsSource()),
+				NewDirectProviderHandler(l, c, method, cliCfg.CredentialsSource(env)),
 			)
 			directIsDefined = true
 		}
@@ -89,7 +92,7 @@ func NewProviderHandlers(
 				l,
 				c,
 				new(cliconfig.ProviderInstallationDirect),
-				cliCfg.CredentialsSource(),
+				cliCfg.CredentialsSource(env),
 			),
 		)
 	}

--- a/internal/tf/cache/handlers/provider_test.go
+++ b/internal/tf/cache/handlers/provider_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
@@ -132,6 +133,8 @@ func TestProviderHandlers_DiscoveryURL_WithNetworkMirrorForBlockedRegistry(t *te
 		cfg,
 		log.New(),
 		vhttp.NewNoNetworkClient(),
+		vfs.NewMemMapFS(),
+		map[string]string{},
 		nil,
 	)
 	require.NoError(t, err)

--- a/internal/tf/cache/helpers/http.go
+++ b/internal/tf/cache/helpers/http.go
@@ -9,10 +9,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strconv"
 
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 )
 
@@ -50,8 +50,8 @@ func Fetch(ctx context.Context, c vhttp.Client, req *http.Request, dst io.Writer
 }
 
 // FetchToFile downloads req's response through c into the file at dst.
-func FetchToFile(ctx context.Context, c vhttp.Client, req *http.Request, dst string) error {
-	file, err := os.Create(dst)
+func FetchToFile(ctx context.Context, c vhttp.Client, fsys vfs.FS, req *http.Request, dst string) error {
+	file, err := fsys.Create(dst)
 	if err != nil {
 		return err
 	}

--- a/internal/tf/cache/services/provider_cache.go
+++ b/internal/tf/cache/services/provider_cache.go
@@ -210,7 +210,7 @@ func (cache *ProviderCache) AuthenticatePackage(
 		)
 	}
 
-	return getproviders.PackageAuthenticationAll(checks...).Authenticate(cache.archivePath)
+	return getproviders.PackageAuthenticationAll(checks...).Authenticate(cache.ProviderService.FS(), cache.archivePath)
 }
 
 func (cache *ProviderCache) ArchivePath() string {
@@ -405,7 +405,7 @@ func (cache *ProviderCache) warmUp(ctx context.Context) error {
 					return err
 				}
 
-				return helpers.FetchToFile(ctx, cache.HTTPClient(), req, cache.archivePath)
+				return helpers.FetchToFile(ctx, cache.HTTPClient(), cache.ProviderService.FS(), req, cache.archivePath)
 			},
 		); err != nil {
 			return err
@@ -858,7 +858,12 @@ func (service *ProviderService) startProviderCaching(
 		service.logger.Errorf("Failed to acquire lock file for %s: %v", cache.Provider, err)
 		return err
 	}
-	defer lockfile.Unlock() //nolint:errcheck
+
+	defer func() {
+		if unlockErr := lockfile.Unlock(service.FS()); unlockErr != nil {
+			service.logger.Errorf("Failed to release lock file for %s: %v", cache.Provider, unlockErr)
+		}
+	}()
 
 	service.logger.Debugf("Acquired lock file for %s, starting warm up", cache.Provider)
 

--- a/internal/tf/cliconfig/config.go
+++ b/internal/tf/cliconfig/config.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"slices"
 
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -33,7 +34,6 @@ type ConfigCredentialsHelper struct {
 type ConfigOption func(*Config) *Config
 
 // WithFS sets the filesystem for file operations.
-// If not set, defaults to the real OS filesystem.
 func WithFS(fsys vfs.FS) ConfigOption {
 	return func(cfg *Config) *Config {
 		cfg.fsys = fsys
@@ -50,12 +50,13 @@ func NewConfig(fsys vfs.FS) *Config {
 
 // Config provides methods to create a terraform [CLI config file](https://developer.hashicorp.com/terraform/cli/config/config-file).
 // The main purpose of which is to create a local config that will inherit the default user CLI config and adding new sections to force Terraform to send requests through the Terragrunt Cache server and use the provider cache directory.
+//
+// Every exported field is HCL-encoded into that file, so the filesystem the
+// config is written through stays unexported.
 type Config struct {
 	CredentialsHelpers   *ConfigCredentialsHelper `hcl:"credentials_helper,block"`
 	ProviderInstallation *ProviderInstallation    `hcl:"provider_installation,block"`
 
-	// fsys is the filesystem for saving config. Unexported to skip HCL encoding.
-	// Defaults to vfs.NewOsFs() if nil.
 	fsys vfs.FS
 
 	PluginCacheDir             string              `hcl:"plugin_cache_dir"`
@@ -215,7 +216,9 @@ func (cfg *Config) Save(configPath string) error {
 }
 
 // CredentialsSource creates and returns a service credentials source whose behavior depends on which "credentials" if are present in the receiving config.
-func (cfg *Config) CredentialsSource() *CredentialsSource {
+func (cfg *Config) CredentialsSource(env map[string]string) *CredentialsSource {
+	venv.RequireEnvMap(env)
+
 	configured := make(map[svchost.Hostname]string)
 
 	for _, creds := range cfg.Credentials {
@@ -230,5 +233,6 @@ func (cfg *Config) CredentialsSource() *CredentialsSource {
 
 	return &CredentialsSource{
 		configured: configured,
+		env:        env,
 	}
 }

--- a/internal/tf/cliconfig/credentials.go
+++ b/internal/tf/cliconfig/credentials.go
@@ -1,7 +1,8 @@
 package cliconfig
 
 import (
-	"os"
+	"maps"
+	"slices"
 	"strings"
 
 	svchost "github.com/hashicorp/terraform-svchost"
@@ -11,11 +12,14 @@ import (
 type CredentialsSource struct {
 	// configured describes the credentials explicitly configured in the CLI config via "credentials" blocks.
 	configured map[svchost.Hostname]string
+	// env is the run's environment, held by reference so credentials an auth
+	// provider contributes part-way through a run are still found here.
+	env map[string]string
 }
 
 func (s *CredentialsSource) ForHost(host svchost.Hostname) svcauth.HostCredentials {
 	// The first order of precedence for credentials is a host-specific environment variable
-	if envCreds := hostCredentialsFromEnv(host); envCreds != nil {
+	if envCreds := hostCredentialsFromEnv(s.env, host); envCreds != nil {
 		return envCreds
 	}
 
@@ -30,8 +34,8 @@ func (s *CredentialsSource) ForHost(host svchost.Hostname) svcauth.HostCredentia
 // hostCredentialsFromEnv returns a token credential by searching for a hostname-specific environment variable. The host parameter is expected to be in the "comparison" form, for example, hostnames containing non-ASCII characters like "café.fr" should be expressed as "xn--caf-dma.fr". If the variable based on the hostname is not defined, nil is returned.
 //
 // Hyphen and period characters are allowed in environment variable names, but are not valid POSIX variable names. However, it's still possible to set variable names with these characters using utilities like env or docker. Variable names may have periods translated to underscores and hyphens translated to double underscores in the variable name. For the example "café.fr", you may use the variable names "TF_TOKEN_xn____caf__dma_fr", "TF_TOKEN_xn--caf-dma_fr", or "TF_TOKEN_xn--caf-dma.fr"
-func hostCredentialsFromEnv(host svchost.Hostname) svcauth.HostCredentials {
-	token, ok := collectCredentialsFromEnv()[host]
+func hostCredentialsFromEnv(env map[string]string, host svchost.Hostname) svcauth.HostCredentials {
+	token, ok := collectCredentialsFromEnv(env)[host]
 	if !ok {
 		return nil
 	}
@@ -39,20 +43,20 @@ func hostCredentialsFromEnv(host svchost.Hostname) svcauth.HostCredentials {
 	return svcauth.HostCredentialsToken(token)
 }
 
-func collectCredentialsFromEnv() map[svchost.Hostname]string {
+func collectCredentialsFromEnv(env map[string]string) map[svchost.Hostname]string {
 	const prefix = "TF_TOKEN_"
 
 	ret := make(map[svchost.Hostname]string)
 
-	for _, ev := range os.Environ() {
-		name, value, ok := strings.Cut(ev, "=")
-		if !ok {
-			continue
-		}
-
+	// A host spells as either UTF-8 or Punycode, and casing folds away as well,
+	// so two variable names can normalize to one hostname. Sorting keeps the
+	// winner from depending on map iteration order.
+	for _, name := range slices.Sorted(maps.Keys(env)) {
 		if !strings.HasPrefix(name, prefix) {
 			continue
 		}
+
+		value := env[name]
 
 		rawHost := name[len(prefix):]
 

--- a/internal/tf/getproviders/constraints.go
+++ b/internal/tf/getproviders/constraints.go
@@ -2,14 +2,17 @@ package getproviders
 
 import (
 	"fmt"
+	"io/fs"
 	"maps"
-	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"errors"
 
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -20,39 +23,59 @@ import (
 type ProviderConstraints map[string]string
 
 // ParseProviderConstraints parses all .tf and .tofu files in the given directory and extracts required_providers constraints
-func ParseProviderConstraints(impl tfimpl.Type, workingDir string) (ProviderConstraints, error) {
+func ParseProviderConstraints(
+	fsys vfs.FS,
+	env map[string]string,
+	impl tfimpl.Type,
+	workingDir string,
+) (ProviderConstraints, error) {
+	// Whether env is consulted at all depends on what the directory holds, so
+	// asserting at the first read would let a nil pass unnoticed until some
+	// unrelated unit happened to declare a provider.
+	venv.RequireEnvMap(env)
+
 	constraints := make(ProviderConstraints)
 
-	var allFiles []string
-
-	tfFiles, err := filepath.Glob(filepath.Join(workingDir, "*.tf"))
+	entries, err := vfs.ReadDir(fsys, workingDir)
 	if err != nil {
+		// A unit whose directory has not been materialized yet constrains
+		// nothing, which is the same answer an empty directory gives.
+		if errors.Is(err, fs.ErrNotExist) {
+			return constraints, nil
+		}
+
 		return nil, err
 	}
 
-	allFiles = append(allFiles, tfFiles...)
+	// A module directory holds mostly `.tf` files and rarely a `.tofu` file, so
+	// `tfFiles` is the only slice worth sizing up front.
+	tfFiles := make([]string, 0, len(entries))
 
-	tofuFiles, err := filepath.Glob(filepath.Join(workingDir, "*.tofu"))
-	if err != nil {
-		return nil, err
-	}
+	var tofuFiles []string
 
-	allFiles = append(allFiles, tofuFiles...)
-
-	// If no terraform files found, return empty constraints (not an error)
-	if len(allFiles) == 0 {
-		return constraints, nil
-	}
-
-	for _, file := range allFiles {
-		fileConstraints, err := parseProviderConstraintsFromFile(impl, file)
-		if err != nil {
-			// Log parsing errors but continue processing other files
-			// This allows partial success when some files have syntax errors
+	for _, entry := range entries {
+		if entry.IsDir() {
 			continue
 		}
 
-		// Merge constraints from this file
+		switch filepath.Ext(entry.Name()) {
+		case ".tf":
+			tfFiles = append(tfFiles, filepath.Join(workingDir, entry.Name()))
+		case ".tofu":
+			tofuFiles = append(tofuFiles, filepath.Join(workingDir, entry.Name()))
+		}
+	}
+
+	// A provider declared in both a .tf and a .tofu file takes the .tofu
+	// constraint, so the .tofu files are merged last.
+	for _, file := range slices.Concat(tfFiles, tofuFiles) {
+		fileConstraints, err := parseProviderConstraintsFromFile(fsys, env, impl, file)
+		if err != nil {
+			// One file that does not parse must not cost the constraints the
+			// rest of the directory declares.
+			continue
+		}
+
 		maps.Copy(constraints, fileConstraints)
 	}
 
@@ -61,12 +84,14 @@ func ParseProviderConstraints(impl tfimpl.Type, workingDir string) (ProviderCons
 
 // parseProviderConstraintsFromFile parses a single .tf file and extracts required_providers constraints
 func parseProviderConstraintsFromFile(
+	fsys vfs.FS,
+	env map[string]string,
 	impl tfimpl.Type,
 	filename string,
 ) (ProviderConstraints, error) {
 	constraints := make(ProviderConstraints)
 
-	content, err := os.ReadFile(filename)
+	content, err := vfs.ReadFile(fsys, filename)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +120,7 @@ func parseProviderConstraintsFromFile(
 			}
 
 			// Parse each provider in the required_providers block
-			providerConstraints := parseProvidersFromRequiredProvidersBlock(impl, nestedBlock)
+			providerConstraints := parseProvidersFromRequiredProvidersBlock(env, impl, nestedBlock)
 
 			// Merge constraints from this required_providers block
 			maps.Copy(constraints, providerConstraints)
@@ -107,6 +132,7 @@ func parseProviderConstraintsFromFile(
 
 // parseProvidersFromRequiredProvidersBlock extracts provider constraints from a required_providers block
 func parseProvidersFromRequiredProvidersBlock(
+	env map[string]string,
 	impl tfimpl.Type,
 	block *hclsyntax.Block,
 ) ProviderConstraints {
@@ -181,11 +207,11 @@ func parseProvidersFromRequiredProvidersBlock(
 		// If we have both source and version, create the constraint mapping
 		if source != "" && version != "" {
 			// Normalize the source address to full registry format
-			providerAddr := normalizeProviderAddress(impl, source)
+			providerAddr := normalizeProviderAddress(env, impl, source)
 			constraints[providerAddr] = normalizeVersionConstraint(version)
 		} else if source == "" && version != "" {
 			// If only version is specified, assume it's a hashicorp provider
-			registryDomain := tfimpl.DefaultRegistryDomain(impl)
+			registryDomain := tfimpl.DefaultRegistryDomain(env, impl)
 			providerAddr := fmt.Sprintf("%s/hashicorp/%s", registryDomain, name)
 			constraints[providerAddr] = normalizeVersionConstraint(version)
 		}
@@ -195,9 +221,9 @@ func parseProvidersFromRequiredProvidersBlock(
 }
 
 // normalizeProviderAddress converts provider source to full registry format
-func normalizeProviderAddress(impl tfimpl.Type, source string) string {
+func normalizeProviderAddress(env map[string]string, impl tfimpl.Type, source string) string {
 	parts := strings.Split(source, "/")
-	registryDomain := tfimpl.DefaultRegistryDomain(impl)
+	registryDomain := tfimpl.DefaultRegistryDomain(env, impl)
 
 	const (
 		singlePart    = 1

--- a/internal/tf/getproviders/constraints_test.go
+++ b/internal/tf/getproviders/constraints_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/getproviders"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,14 +39,14 @@ terraform {
 	require.NoError(t, err)
 
 	// Test parsing with Terraform implementation
-	constraints, err := getproviders.ParseProviderConstraints(tfimpl.Terraform, testDir)
+	constraints, err := getproviders.ParseProviderConstraints(vfs.NewOSFS(), map[string]string{}, tfimpl.Terraform, testDir)
 	require.NoError(t, err)
 
 	assert.Equal(t, "~> 5.0.0", constraints["registry.terraform.io/hashicorp/aws"])
 	assert.Equal(t, "~> 4.0.0", constraints["registry.terraform.io/cloudflare/cloudflare"])
 
 	// Test parsing with OpenTofu implementation
-	constraints, err = getproviders.ParseProviderConstraints(tfimpl.OpenTofu, testDir)
+	constraints, err = getproviders.ParseProviderConstraints(vfs.NewOSFS(), map[string]string{}, tfimpl.OpenTofu, testDir)
 	require.NoError(t, err)
 
 	assert.Equal(t, "~> 5.0.0", constraints["registry.opentofu.org/hashicorp/aws"])
@@ -73,14 +74,14 @@ terraform {
 	require.NoError(t, err)
 
 	// Test parsing with Terraform implementation
-	constraints, err := getproviders.ParseProviderConstraints(tfimpl.Terraform, testDir)
+	constraints, err := getproviders.ParseProviderConstraints(vfs.NewOSFS(), map[string]string{}, tfimpl.Terraform, testDir)
 	require.NoError(t, err)
 
 	// Verify the parsed constraints default to terraform registry and are normalized
 	assert.Equal(t, "~> 5.0.0", constraints["registry.terraform.io/hashicorp/aws"])
 
 	// Test parsing with OpenTofu implementation
-	constraints, err = getproviders.ParseProviderConstraints(tfimpl.OpenTofu, testDir)
+	constraints, err = getproviders.ParseProviderConstraints(vfs.NewOSFS(), map[string]string{}, tfimpl.OpenTofu, testDir)
 	require.NoError(t, err)
 
 	// Verify the parsed constraints default to OpenTofu registry and are normalized
@@ -88,6 +89,8 @@ terraform {
 }
 
 func TestParseProviderConstraintsWithEnvironmentOverride(t *testing.T) {
+	t.Parallel()
+
 	// Create a temporary directory for testing
 	testDir := helpers.TmpDirWOSymlinks(t)
 
@@ -109,12 +112,11 @@ terraform {
 	err := os.WriteFile(filepath.Join(testDir, "main.tf"), []byte(terraformContent), 0644)
 	require.NoError(t, err)
 
-	// Set the environment variable to override the default registry
 	customRegistry := "custom.registry.example.com"
-	t.Setenv("TG_TF_DEFAULT_REGISTRY_HOST", customRegistry)
+	env := map[string]string{"TG_TF_DEFAULT_REGISTRY_HOST": customRegistry}
 
 	// Test parsing with Terraform implementation - should use custom registry
-	constraints, err := getproviders.ParseProviderConstraints(tfimpl.Terraform, testDir)
+	constraints, err := getproviders.ParseProviderConstraints(vfs.NewOSFS(), env, tfimpl.Terraform, testDir)
 	require.NoError(t, err)
 
 	// Verify the parsed constraints use custom registry for implicit providers and are normalized
@@ -123,7 +125,7 @@ terraform {
 	assert.Equal(t, "~> 1.0.0", constraints[customRegistry+"/example/custom"])
 
 	// Test parsing with OpenTofu implementation - should also use custom registry (environment override takes precedence)
-	constraints, err = getproviders.ParseProviderConstraints(tfimpl.OpenTofu, testDir)
+	constraints, err = getproviders.ParseProviderConstraints(vfs.NewOSFS(), env, tfimpl.OpenTofu, testDir)
 	require.NoError(t, err)
 
 	// Verify the parsed constraints use custom registry even with OpenTofu and are normalized
@@ -166,7 +168,7 @@ terraform {
 	require.NoError(t, err)
 
 	// Test parsing with OpenTofu implementation
-	constraints, err := getproviders.ParseProviderConstraints(tfimpl.OpenTofu, testDir)
+	constraints, err := getproviders.ParseProviderConstraints(vfs.NewOSFS(), map[string]string{}, tfimpl.OpenTofu, testDir)
 	require.NoError(t, err)
 
 	// Verify constraints from both .tf and .tofu files are parsed and normalized
@@ -174,12 +176,46 @@ terraform {
 	assert.Equal(t, "~> 3.0.0", constraints["registry.opentofu.org/hashicorp/azurerm"])
 
 	// Test parsing with Terraform implementation
-	constraints, err = getproviders.ParseProviderConstraints(tfimpl.Terraform, testDir)
+	constraints, err = getproviders.ParseProviderConstraints(vfs.NewOSFS(), map[string]string{}, tfimpl.Terraform, testDir)
 	require.NoError(t, err)
 
 	// Verify constraints from both .tf and .tofu files are parsed with Terraform registry and normalized
 	assert.Equal(t, "~> 5.0.0", constraints["registry.terraform.io/hashicorp/aws"])
 	assert.Equal(t, "~> 3.0.0", constraints["registry.terraform.io/hashicorp/azurerm"])
+}
+
+// TestParseProviderConstraintsTofuWins pins which constraint survives when the
+// same provider is declared in both a .tf and a .tofu file.
+func TestParseProviderConstraintsTofuWins(t *testing.T) {
+	t.Parallel()
+
+	testDir := helpers.TmpDirWOSymlinks(t)
+
+	declare := func(filename, version string) {
+		content := `
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "` + version + `"
+    }
+  }
+}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(testDir, filename), []byte(content), 0644))
+	}
+
+	declare("main.tf", "~> 5.0")
+	declare("main.tofu", "~> 6.0")
+
+	constraints, err := getproviders.ParseProviderConstraints(
+		vfs.NewOSFS(),
+		map[string]string{},
+		tfimpl.OpenTofu,
+		testDir,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "~> 6.0.0", constraints["registry.opentofu.org/hashicorp/aws"])
 }
 
 func TestParseProviderConstraintsWithEqualsPrefix(t *testing.T) {
@@ -212,7 +248,7 @@ terraform {
 	require.NoError(t, err)
 
 	// Test parsing with Terraform implementation
-	constraints, err := getproviders.ParseProviderConstraints(tfimpl.Terraform, testDir)
+	constraints, err := getproviders.ParseProviderConstraints(vfs.NewOSFS(), map[string]string{}, tfimpl.Terraform, testDir)
 	require.NoError(t, err)
 
 	// Verify the parsed constraints are normalized (no "=" prefix)
@@ -221,7 +257,7 @@ terraform {
 	assert.Equal(t, ">= 0.10.0", constraints["registry.terraform.io/hashicorp/time"])
 
 	// Test parsing with OpenTofu implementation
-	constraints, err = getproviders.ParseProviderConstraints(tfimpl.OpenTofu, testDir)
+	constraints, err = getproviders.ParseProviderConstraints(vfs.NewOSFS(), map[string]string{}, tfimpl.OpenTofu, testDir)
 	require.NoError(t, err)
 
 	// Verify the parsed constraints are normalized with OpenTofu registry
@@ -324,7 +360,7 @@ func TestNormalizeVersionConstraint(t *testing.T) {
 			err := os.WriteFile(filepath.Join(testDir, "main.tf"), []byte(terraformContent), 0644)
 			require.NoError(t, err)
 
-			constraints, err := getproviders.ParseProviderConstraints(tfimpl.Terraform, testDir)
+			constraints, err := getproviders.ParseProviderConstraints(vfs.NewOSFS(), map[string]string{}, tfimpl.Terraform, testDir)
 			require.NoError(t, err)
 
 			result := constraints["registry.terraform.io/example/test"]

--- a/internal/tf/getproviders/hash.go
+++ b/internal/tf/getproviders/hash.go
@@ -7,9 +7,10 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"os"
+	"io/fs"
 	"path/filepath"
 
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"golang.org/x/mod/sumdb/dirhash"
 )
 
@@ -34,24 +35,16 @@ func (scheme HashScheme) New(value string) Hash {
 }
 
 // PackageHashLegacyZipSHA implements the old provider package hashing scheme of taking a SHA256 hash of the containing .zip archive itself, rather than of the contents of the archive.
-func PackageHashLegacyZipSHA(path string) (Hash, error) {
-	archivePath, err := filepath.EvalSymlinks(path)
+func PackageHashLegacyZipSHA(fsys vfs.FS, path string) (Hash, error) {
+	archivePath, err := vfs.EvalSymlinks(fsys, path)
 	if err != nil {
 		return "", err
 	}
 
-	file, err := os.Open(archivePath)
+	gotHash, err := vfs.FileSHA256(fsys, archivePath)
 	if err != nil {
 		return "", err
 	}
-	defer file.Close()
-
-	hash := sha256.New()
-	if _, err = io.Copy(hash, file); err != nil {
-		return "", err
-	}
-
-	gotHash := hash.Sum(nil)
 
 	return HashSchemeZip.New(hex.EncodeToString(gotHash)), nil
 }
@@ -62,22 +55,61 @@ func HashLegacyZipSHAFromSHA(sum [sha256.Size]byte) Hash {
 }
 
 // PackageHashV1 computes a hash of the contents of the package at the given location using hash algorithm 1. The resulting Hash is guaranteed to have the scheme HashScheme1.
-func PackageHashV1(path string) (Hash, error) {
+func PackageHashV1(fsys vfs.FS, path string) (Hash, error) {
 	// We'll first dereference a possible symlink at our PackageDir location, as would be created if this package were linked in from another cache.
-	packageDir, err := filepath.EvalSymlinks(path)
+	packageDir, err := vfs.EvalSymlinks(fsys, path)
 	if err != nil {
 		return "", err
 	}
 
-	if fileInfo, err := os.Stat(packageDir); err != nil {
+	if fileInfo, err := fsys.Stat(packageDir); err != nil {
 		return "", err
 	} else if !fileInfo.IsDir() {
 		return "", fmt.Errorf("packageDir is not a directory %q", packageDir)
 	}
 
-	s, err := dirhash.HashDir(packageDir, "", dirhash.Hash1)
+	s, err := hashDir(fsys, packageDir)
 
 	return Hash(s), err
+}
+
+// hashDir reproduces [dirhash.HashDir] over fsys. The hash itself still comes
+// from [dirhash.Hash1], which is pure once it is handed the file list and a way
+// to open each entry, so only the directory walk and the opens change.
+func hashDir(fsys vfs.FS, dir string) (string, error) {
+	dir = filepath.Clean(dir)
+
+	var files []string
+
+	err := vfs.WalkDir(fsys, dir, func(entry string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if entry == dir {
+			return fmt.Errorf("%s is not a directory", dir)
+		}
+
+		rel := entry
+		if dir != "." {
+			rel = entry[len(dir)+1:]
+		}
+
+		files = append(files, filepath.ToSlash(rel))
+
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return dirhash.Hash1(files, func(name string) (io.ReadCloser, error) {
+		return fsys.Open(filepath.Join(dir, name))
+	})
 }
 
 func DocumentHashes(doc []byte) []Hash {

--- a/internal/tf/getproviders/hash_test.go
+++ b/internal/tf/getproviders/hash_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/getproviders"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,7 +47,7 @@ func TestPackageHashLegacyZipSHA(t *testing.T) {
 		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
 			t.Parallel()
 
-			hash, err := getproviders.PackageHashLegacyZipSHA(tc.path)
+			hash, err := getproviders.PackageHashLegacyZipSHA(vfs.NewOSFS(), tc.path)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedHash, hash)

--- a/internal/tf/getproviders/hash_v1_test.go
+++ b/internal/tf/getproviders/hash_v1_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/getproviders"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,17 +37,17 @@ func TestPackageHashV1(t *testing.T) {
 
 	dir := writePackageDir(t, "package contents")
 
-	hash, err := getproviders.PackageHashV1(dir)
+	hash, err := getproviders.PackageHashV1(vfs.NewOSFS(), dir)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(hash.String(), "h1:"), "expected h1: scheme, got %q", hash)
 
 	// The content hash must be deterministic for identical directory contents.
-	again, err := getproviders.PackageHashV1(dir)
+	again, err := getproviders.PackageHashV1(vfs.NewOSFS(), dir)
 	require.NoError(t, err)
 	assert.Equal(t, hash, again)
 
 	// Different contents must yield a different hash.
-	other, err := getproviders.PackageHashV1(writePackageDir(t, "different contents"))
+	other, err := getproviders.PackageHashV1(vfs.NewOSFS(), writePackageDir(t, "different contents"))
 	require.NoError(t, err)
 	assert.NotEqual(t, hash, other)
 }
@@ -60,7 +61,7 @@ func TestPackageHashV1NotADirectory(t *testing.T) {
 	const ownerWriteGlobalReadPerms = 0644
 	require.NoError(t, os.WriteFile(filePath, []byte("x"), ownerWriteGlobalReadPerms))
 
-	hash, err := getproviders.PackageHashV1(filePath)
+	hash, err := getproviders.PackageHashV1(vfs.NewOSFS(), filePath)
 	require.Error(t, err)
 	assert.Empty(t, hash.String())
 }
@@ -70,7 +71,7 @@ func TestPackageHashV1MissingPath(t *testing.T) {
 
 	missing := filepath.Join(helpers.TmpDirWOSymlinks(t), "does-not-exist")
 
-	hash, err := getproviders.PackageHashV1(missing)
+	hash, err := getproviders.PackageHashV1(vfs.NewOSFS(), missing)
 	require.ErrorIs(t, err, fs.ErrNotExist)
 	assert.Empty(t, hash.String())
 }

--- a/internal/tf/getproviders/lock.go
+++ b/internal/tf/getproviders/lock.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -17,6 +16,7 @@ import (
 	"unicode"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -25,7 +25,7 @@ import (
 )
 
 // UpdateLockfile updates the dependency lock file. If `.terraform.lock.hcl` does not exist, it will be created, otherwise it will be updated.
-func UpdateLockfile(ctx context.Context, workingDir string, providers []Provider) error {
+func UpdateLockfile(ctx context.Context, fsys vfs.FS, workingDir string, providers []Provider) error {
 	var (
 		filename = filepath.Join(workingDir, tf.TerraformLockFile)
 		file     = hclwrite.NewFile()
@@ -33,7 +33,7 @@ func UpdateLockfile(ctx context.Context, workingDir string, providers []Provider
 
 	// A missing lock file is the first-run case: the empty file built above is
 	// written out as-is.
-	content, err := os.ReadFile(filename)
+	content, err := vfs.ReadFile(fsys, filename)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
@@ -47,24 +47,24 @@ func UpdateLockfile(ctx context.Context, workingDir string, providers []Provider
 		}
 	}
 
-	if err := updateLockfile(ctx, file, providers); err != nil {
+	if err := updateLockfile(ctx, fsys, file, providers); err != nil {
 		return err
 	}
 
 	// CAS may materialize the lock file as a read-only hard link, so remove it before writing
-	if err := os.Remove(filename); err != nil && !errors.Is(err, fs.ErrNotExist) {
+	if err := fsys.Remove(filename); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("failed to remove lock file %s before writing: %w", filename, err)
 	}
 
 	const ownerWriteGlobalReadPerms = 0644
-	if err := os.WriteFile(filename, file.Bytes(), ownerWriteGlobalReadPerms); err != nil {
+	if err := vfs.WriteFile(fsys, filename, file.Bytes(), ownerWriteGlobalReadPerms); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func updateLockfile(ctx context.Context, file *hclwrite.File, providers []Provider) error {
+func updateLockfile(ctx context.Context, fsys vfs.FS, file *hclwrite.File, providers []Provider) error {
 	sort.Slice(providers, func(i, j int) bool {
 		return providers[i].Address() < providers[j].Address()
 	})
@@ -73,7 +73,7 @@ func updateLockfile(ctx context.Context, file *hclwrite.File, providers []Provid
 		providerBlock := file.Body().FirstMatchingBlock("provider", []string{provider.Address()})
 		if providerBlock != nil {
 			// update the existing provider block
-			if err := updateProviderBlock(ctx, providerBlock, provider); err != nil {
+			if err := updateProviderBlock(ctx, fsys, providerBlock, provider); err != nil {
 				return err
 			}
 		} else {
@@ -81,7 +81,7 @@ func updateLockfile(ctx context.Context, file *hclwrite.File, providers []Provid
 			file.Body().AppendNewline()
 			providerBlock = file.Body().AppendNewBlock("provider", []string{provider.Address()})
 
-			if err := updateProviderBlock(ctx, providerBlock, provider); err != nil {
+			if err := updateProviderBlock(ctx, fsys, providerBlock, provider); err != nil {
 				return err
 			}
 		}
@@ -93,6 +93,7 @@ func updateLockfile(ctx context.Context, file *hclwrite.File, providers []Provid
 // updateProviderBlock updates the provider block in the dependency lock file.
 func updateProviderBlock(
 	ctx context.Context,
+	fsys vfs.FS,
 	providerBlock *hclwrite.Block,
 	provider Provider,
 ) error {
@@ -117,7 +118,7 @@ func updateProviderBlock(
 		providerBlock.Body().SetAttributeValue("constraints", cty.StringVal(constraintsValue))
 	}
 
-	newHashes, err := collectNewHashes(ctx, provider)
+	newHashes, err := collectNewHashes(ctx, fsys, provider)
 	if err != nil {
 		return err
 	}
@@ -142,8 +143,8 @@ func updateProviderBlock(
 // entry for the running platform. When the registry supplies per-platform
 // hashes (the OpenTofu 1.12 `packages` field), those are merged in; otherwise
 // the shasums document supplies the additional `zh:` hashes.
-func collectNewHashes(ctx context.Context, provider Provider) ([]Hash, error) {
-	h1Hash, err := PackageHashV1(provider.PackageDir())
+func collectNewHashes(ctx context.Context, fsys vfs.FS, provider Provider) ([]Hash, error) {
+	h1Hash, err := PackageHashV1(fsys, provider.PackageDir())
 	if err != nil {
 		return nil, err
 	}
@@ -320,12 +321,13 @@ func tokensForListPerLine(hashes []Hash) hclwrite.Tokens {
 // but no providers were newly downloaded
 func UpdateLockfileConstraints(
 	ctx context.Context,
+	fsys vfs.FS,
 	workingDir string,
 	constraints ProviderConstraints,
 ) error {
 	filename := filepath.Join(workingDir, tf.TerraformLockFile)
 
-	content, err := os.ReadFile(filename)
+	content, err := vfs.ReadFile(fsys, filename)
 	if err != nil {
 		// Nothing to update when no lock file has been written yet.
 		if errors.Is(err, fs.ErrNotExist) {
@@ -384,7 +386,7 @@ func UpdateLockfileConstraints(
 
 	if updated {
 		const ownerWriteGlobalReadPerms = 0644
-		if err := os.WriteFile(filename, file.Bytes(), ownerWriteGlobalReadPerms); err != nil {
+		if err := vfs.WriteFile(fsys, filename, file.Bytes(), ownerWriteGlobalReadPerms); err != nil {
 			return err
 		}
 	}

--- a/internal/tf/getproviders/lock_test.go
+++ b/internal/tf/getproviders/lock_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/getproviders"
 	"github.com/gruntwork-io/terragrunt/internal/tf/getproviders/mocks"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
@@ -293,7 +294,7 @@ provider "registry.terraform.io/hashicorp/template" {
 				require.NoError(t, err)
 			}
 
-			err := getproviders.UpdateLockfile(t.Context(), workingDir, tc.providers)
+			err := getproviders.UpdateLockfile(t.Context(), vfs.NewOSFS(), workingDir, tc.providers)
 			require.NoError(t, err)
 
 			actualLockfile, err := os.ReadFile(lockfilePath)
@@ -354,13 +355,13 @@ func TestMockUpdateLockfileWithRegistryHashes(t *testing.T) {
 		},
 	)
 
-	localH1, err := getproviders.PackageHashV1(packageDir)
+	localH1, err := getproviders.PackageHashV1(vfs.NewOSFS(), packageDir)
 	require.NoError(t, err)
 
 	workingDir := helpers.TmpDirWOSymlinks(t)
 	lockfilePath := filepath.Join(workingDir, ".terraform.lock.hcl")
 
-	err = getproviders.UpdateLockfile(t.Context(), workingDir, []getproviders.Provider{provider})
+	err = getproviders.UpdateLockfile(t.Context(), vfs.NewOSFS(), workingDir, []getproviders.Provider{provider})
 	require.NoError(t, err)
 
 	actual, err := os.ReadFile(lockfilePath)
@@ -427,7 +428,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 	err := os.WriteFile(lockfilePath, []byte(initialLockfile), 0644)
 	require.NoError(t, err)
 
-	err = getproviders.UpdateLockfile(t.Context(), workingDir, []getproviders.Provider{provider})
+	err = getproviders.UpdateLockfile(t.Context(), vfs.NewOSFS(), workingDir, []getproviders.Provider{provider})
 	require.NoError(t, err)
 
 	actualLockfile, err := os.ReadFile(lockfilePath)

--- a/internal/tf/getproviders/lock_update_test.go
+++ b/internal/tf/getproviders/lock_update_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/tf/getproviders"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,7 +38,7 @@ func TestUpdateLockfileReplacesReadOnlyLockfile(t *testing.T) {
 	require.NoError(t, os.WriteFile(lockfilePath, []byte(readOnlyLockfileContents), 0644))
 	require.NoError(t, os.Chmod(lockfilePath, 0444))
 
-	require.NoError(t, getproviders.UpdateLockfile(t.Context(), workingDir, nil))
+	require.NoError(t, getproviders.UpdateLockfile(t.Context(), vfs.NewOSFS(), workingDir, nil))
 
 	content, err := os.ReadFile(lockfilePath)
 	require.NoError(t, err)
@@ -72,7 +73,7 @@ func TestUpdateLockfileDoesNotMutateHardlinkedStore(t *testing.T) {
 	storeInfoBefore, err := os.Stat(storePath)
 	require.NoError(t, err)
 
-	require.NoError(t, getproviders.UpdateLockfile(t.Context(), workingDir, nil))
+	require.NoError(t, getproviders.UpdateLockfile(t.Context(), vfs.NewOSFS(), workingDir, nil))
 
 	storeContent, err := os.ReadFile(storePath)
 	require.NoError(t, err)

--- a/internal/tf/getproviders/package_authentication.go
+++ b/internal/tf/getproviders/package_authentication.go
@@ -6,10 +6,10 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
 	"errors"
@@ -61,7 +61,7 @@ func (result PackageAuthenticationResult) ThirdPartySigned() bool {
 // PackageAuthentication implementation is responsible for authenticating that a package is what its distributor intended to distribute and that it has not been tampered with.
 type PackageAuthentication interface {
 	// Authenticate takes the path  of a package and returns a PackageAuthenticationResult, or an error if the authentication checks fail.
-	Authenticate(path string) (*PackageAuthenticationResult, error)
+	Authenticate(fsys vfs.FS, path string) (*PackageAuthenticationResult, error)
 }
 
 // PackageAuthenticationHashes is an optional interface implemented by PackageAuthentication implementations that are able to return a set of hashes they would consider valid
@@ -81,6 +81,7 @@ func PackageAuthenticationAll(checks ...PackageAuthentication) PackageAuthentica
 }
 
 func (checks packageAuthenticationAll) Authenticate(
+	fsys vfs.FS,
 	path string,
 ) (*PackageAuthenticationResult, error) {
 	var authResult *PackageAuthenticationResult
@@ -88,7 +89,7 @@ func (checks packageAuthenticationAll) Authenticate(
 	for _, check := range checks {
 		var err error
 
-		authResult, err = check.Authenticate(path)
+		authResult, err = check.Authenticate(fsys, path)
 		if err != nil {
 			return authResult, err
 		}
@@ -123,15 +124,16 @@ func NewArchiveChecksumAuthentication(wantSHA256Sum [sha256.Size]byte) PackageAu
 }
 
 func (auth archiveHashAuthentication) Authenticate(
+	fsys vfs.FS,
 	path string,
 ) (*PackageAuthenticationResult, error) {
-	if fileInfo, err := os.Stat(path); err != nil {
+	if fileInfo, err := fsys.Stat(path); err != nil {
 		return nil, err
 	} else if fileInfo.IsDir() {
 		return nil, fmt.Errorf("cannot check archive hash for non-archive location %s", path)
 	}
 
-	gotHash, err := PackageHashLegacyZipSHA(path)
+	gotHash, err := PackageHashLegacyZipSHA(fsys, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute checksum for %s: %w", path, err)
 	}
@@ -169,6 +171,7 @@ func NewMatchingChecksumAuthentication(
 }
 
 func (auth matchingChecksumAuthentication) Authenticate(
+	_ vfs.FS,
 	location string,
 ) (*PackageAuthenticationResult, error) {
 	// Find the checksum in the list with matching filename. The document is in the form "0123456789abcdef filename.zip".
@@ -220,6 +223,7 @@ func NewSignatureAuthentication(
 }
 
 func (auth signatureAuthentication) Authenticate(
+	_ vfs.FS,
 	location string,
 ) (*PackageAuthenticationResult, error) {
 	// Find the key that signed the checksum file. This can fail if there is no valid signature for any of the provided keys.

--- a/internal/tf/getproviders/package_authentication_pure_test.go
+++ b/internal/tf/getproviders/package_authentication_pure_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/getproviders"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -86,7 +87,7 @@ func TestPackageAuthenticationAllAuthenticate(t *testing.T) {
 			passingChecksumAuth("second.zip", want),
 		)
 
-		result, err := auth.Authenticate("unused-path")
+		result, err := auth.Authenticate(vfs.NewOSFS(), "unused-path")
 		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
@@ -105,7 +106,7 @@ func TestPackageAuthenticationAllAuthenticate(t *testing.T) {
 			passingChecksumAuth("second.zip", want),
 		)
 
-		_, err := auth.Authenticate("unused-path")
+		_, err := auth.Authenticate(vfs.NewOSFS(), "unused-path")
 		require.Error(t, err)
 	})
 }

--- a/internal/tf/getproviders/package_authentication_test.go
+++ b/internal/tf/getproviders/package_authentication_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/getproviders"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -139,7 +140,7 @@ func TestArchiveChecksumAuthentication(t *testing.T) {
 			t.Parallel()
 
 			auth := getproviders.NewArchiveChecksumAuthentication(tc.wantSHA256Sum)
-			actualResult, actualErr := auth.Authenticate(tc.path)
+			actualResult, actualErr := auth.Authenticate(vfs.NewOSFS(), tc.path)
 
 			if tc.expectedErr != nil {
 				if actualErr == nil {
@@ -234,7 +235,7 @@ func TestNewMatchingChecksumAuthentication(t *testing.T) {
 				tc.filename,
 				tc.wantSHA256Sum,
 			)
-			_, actualErr := auth.Authenticate(tc.path)
+			_, actualErr := auth.Authenticate(vfs.NewOSFS(), tc.path)
 
 			if tc.expectedErr != nil {
 				require.EqualError(t, actualErr, tc.expectedErr.Error())
@@ -365,7 +366,7 @@ func TestSignatureAuthenticate(t *testing.T) {
 			require.NoError(t, err)
 
 			auth := getproviders.NewSignatureAuthentication(tc.document, signature, tc.keys)
-			actualResult, actualErr := auth.Authenticate(tc.path)
+			actualResult, actualErr := auth.Authenticate(vfs.NewOSFS(), tc.path)
 
 			if tc.expectedErr != nil {
 				require.EqualError(t, actualErr, tc.expectedErr.Error())

--- a/internal/tf/run_cmd_test.go
+++ b/internal/tf/run_cmd_test.go
@@ -95,7 +95,7 @@ func testCommandOutput(
 		t.Context(),
 		l,
 		v,
-		configbridge.TFRunOptsFromOpts(terragruntOptions),
+		configbridge.TFRunOptsFromOpts(map[string]string{}, terragruntOptions),
 		"same",
 	)
 

--- a/internal/tf/source.go
+++ b/internal/tf/source.go
@@ -8,7 +8,6 @@ import (
 	"hash"
 	"io/fs"
 	"net/url"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -257,6 +256,7 @@ func (src Source) WriteVersionFile(
 //     version number in /T/W/H/.terragrunt-source-version doesn't match the current version.
 func NewSource(
 	l log.Logger,
+	fsys vfs.FS,
 	source string,
 	downloadDir string,
 	workingDir string,
@@ -269,7 +269,7 @@ func NewSource(
 		return nil, err
 	}
 
-	rootSourceURL, modulePath, err := SplitSourceURL(l, canonicalSourceURL)
+	rootSourceURL, modulePath, err := SplitSourceURL(l, fsys, canonicalSourceURL)
 	if err != nil {
 		return nil, err
 	}
@@ -394,7 +394,7 @@ func IsLocalSource(sourceURL *url.URL) bool {
 // A cas:: reference parses as an opaque URL (scheme "cas::sha1", opaque
 // "<hash>//modules/foo"), so the "//" is split out of the opaque component
 // rather than the path.
-func SplitSourceURL(l log.Logger, sourceURL *url.URL) (*url.URL, string, error) {
+func SplitSourceURL(l log.Logger, fsys vfs.FS, sourceURL *url.URL) (*url.URL, string, error) {
 	if sourceURL.Opaque != "" {
 		opaqueSplitOnDoubleSlash := strings.SplitN(sourceURL.Opaque, "//", 2) //nolint:mnd
 		if len(opaqueSplitOnDoubleSlash) > 1 {
@@ -424,7 +424,7 @@ func SplitSourceURL(l log.Logger, sourceURL *url.URL) (*url.URL, string, error) 
 		return sourceURL, "", nil
 	}
 	// check if sourceUrl.Path is a local file path
-	_, err := os.Stat(sourceURL.Path)
+	_, err := fsys.Stat(sourceURL.Path)
 	if err != nil {
 		// log warning message to notify user that sourceUrl.Path may not work
 		l.Warnf(

--- a/internal/tf/source_test.go
+++ b/internal/tf/source_test.go
@@ -134,7 +134,7 @@ func TestSplitSourceUrl(t *testing.T) {
 
 			l := logger.CreateLogger()
 
-			actualRootRepo, actualModulePath, err := tf.SplitSourceURL(l, sourceURL)
+			actualRootRepo, actualModulePath, err := tf.SplitSourceURL(l, vfs.NewOSFS(), sourceURL)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedSo, actualRootRepo.String())
@@ -303,7 +303,7 @@ func TestRegressionSupportForGitRemoteCodecommit(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	actualRootRepo, actualModulePath, err := tf.SplitSourceURL(l, sourceURL)
+	actualRootRepo, actualModulePath, err := tf.SplitSourceURL(l, vfs.NewOSFS(), sourceURL)
 	require.NoError(t, err)
 
 	require.Equal(t, "git::codecommit::ap-northeast-1://my_app_modules", actualRootRepo.String())
@@ -324,7 +324,7 @@ func TestRegressionCASRefPreservesSubdir(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	actualRootRepo, actualModulePath, err := tf.SplitSourceURL(l, sourceURL)
+	actualRootRepo, actualModulePath, err := tf.SplitSourceURL(l, vfs.NewOSFS(), sourceURL)
 	require.NoError(t, err)
 
 	require.Equal(t, "cas::sha1:"+hash, actualRootRepo.String())
@@ -342,7 +342,7 @@ func TestRegressionCASRefSubdirWorkingDir(t *testing.T) {
 	l := logger.CreateLogger()
 	downloadDir := t.TempDir()
 
-	src, err := tf.NewSource(l, "cas::sha1:"+hash+"//modules/vpc", downloadDir, t.TempDir(), false)
+	src, err := tf.NewSource(l, vfs.NewOSFS(), "cas::sha1:"+hash+"//modules/vpc", downloadDir, t.TempDir(), false)
 	require.NoError(t, err)
 
 	assert.Equal(t, "cas::sha1:"+hash, src.CanonicalSourceURL.String())
@@ -364,7 +364,7 @@ func TestRegressionCASRefNoSubdir(t *testing.T) {
 
 	l := logger.CreateLogger()
 
-	actualRootRepo, actualModulePath, err := tf.SplitSourceURL(l, sourceURL)
+	actualRootRepo, actualModulePath, err := tf.SplitSourceURL(l, vfs.NewOSFS(), sourceURL)
 	require.NoError(t, err)
 
 	require.Equal(t, "cas::sha1:"+hash, actualRootRepo.String())
@@ -372,7 +372,7 @@ func TestRegressionCASRefNoSubdir(t *testing.T) {
 
 	downloadDir := t.TempDir()
 
-	src, err := tf.NewSource(l, "cas::sha1:"+hash, downloadDir, t.TempDir(), false)
+	src, err := tf.NewSource(l, vfs.NewOSFS(), "cas::sha1:"+hash, downloadDir, t.TempDir(), false)
 	require.NoError(t, err)
 
 	assert.Equal(t, "cas::sha1:"+hash, src.CanonicalSourceURL.String())
@@ -476,7 +476,7 @@ func TestEncodeSourceVersionTracksOnlyCopiedFiles(t *testing.T) {
 					copyOpts = slices.Concat(copyOpts, []util.CopyOption{util.WithFastCopy()})
 				}
 
-				src, err := tf.NewSource(l, sourceDir, t.TempDir(), sourceDir, false)
+				src, err := tf.NewSource(l, vfs.NewOSFS(), sourceDir, t.TempDir(), sourceDir, false)
 				require.NoError(t, err)
 
 				before, err := src.EncodeSourceVersion(l, vfs.NewOSFS(), copyOpts...)
@@ -559,7 +559,7 @@ func memSource(t *testing.T, l log.Logger) (*tf.Source, vfs.FS, string) {
 	)
 	require.NoDirExists(t, sourceDir)
 
-	src, err := tf.NewSource(l, sourceDir, t.TempDir(), sourceDir, false)
+	src, err := tf.NewSource(l, vfs.NewOSFS(), sourceDir, t.TempDir(), sourceDir, false)
 	require.NoError(t, err)
 
 	return src, fsys, sourceDir

--- a/internal/tfimpl/tfimpl.go
+++ b/internal/tfimpl/tfimpl.go
@@ -1,7 +1,7 @@
 // Package tfimpl defines the Terraform implementation type constants.
 package tfimpl
 
-import "os"
+import "github.com/gruntwork-io/terragrunt/internal/venv"
 
 // Type represents which Terraform implementation is being used.
 type Type string
@@ -29,8 +29,10 @@ const (
 // The TG_TF_DEFAULT_REGISTRY_HOST env var wins if set; otherwise the choice
 // follows impl: OpenTofu → registry.opentofu.org, anything else →
 // registry.terraform.io.
-func DefaultRegistryDomain(impl Type) string {
-	if v := os.Getenv(defaultRegistryEnvName); v != "" {
+func DefaultRegistryDomain(env map[string]string, impl Type) string {
+	venv.RequireEnvMap(env)
+
+	if v := env[defaultRegistryEnvName]; v != "" {
 		return v
 	}
 

--- a/internal/tflint/tflint_test.go
+++ b/internal/tflint/tflint_test.go
@@ -613,7 +613,7 @@ func runWithOpts(
 	t.Helper()
 
 	opts := &tflint.TFLintOptions{
-		ShellOptions:      shell.NewShellOptions(),
+		ShellOptions:      shell.NewShellOptions(map[string]string{}),
 		WorkingDir:        "/work/unit",
 		RootWorkingDir:    "/work",
 		MaxFoldersToCheck: 5,

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -215,22 +215,20 @@ func DirContainsTFFiles(fsys vfs.FS, dirPath string) (bool, error) {
 	return found, err
 }
 
-// IsTFFile checks if a given file is a Terraform/OpenTofu file (.tf, .tofu, .tf.json, .tofu.json)
+// tfFileSuffixes are the suffixes of the files OpenTofu/Terraform reads
+// configuration from.
+var tfFileSuffixes = []string{
+	".tf",
+	".tofu",
+	".tf.json",
+	".tofu.json",
+}
+
+// IsTFFile checks if a given file is an OpenTofu/Terraform file (.tf, .tofu, .tf.json, .tofu.json)
 func IsTFFile(path string) bool {
-	suffixes := []string{
-		".tf",
-		".tofu",
-		".tf.json",
-		".tofu.json",
-	}
-
-	for _, suffix := range suffixes {
-		if strings.HasSuffix(path, suffix) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(tfFileSuffixes, func(suffix string) bool {
+		return strings.HasSuffix(path, suffix)
+	})
 }
 
 func listContainsElementWithPrefix(list []string, elementPrefix string) bool {
@@ -257,7 +255,7 @@ func pathContainsPrefix(path string, prefixes []string) bool {
 func expandGlobPath(fsys vfs.FS, source, absoluteGlobPath string) ([]string, error) {
 	includeExpandedGlobs := []string{}
 
-	absoluteExpandGlob, err := glob.LegacyExpand(absoluteGlobPath)
+	absoluteExpandGlob, err := glob.LegacyExpand(fsys, absoluteGlobPath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		// we ignore not exist error as we only care about the globs that exist in the src dir
 		return nil, err
@@ -911,7 +909,7 @@ func CopyFolderContentsWithFilter(
 	// Read the directory a level at a time rather than walking it. filepath.Walk
 	// ignores symlinks, and a full walk would lstat entries this copy is going to
 	// skip anyway.
-	entries, err := vfs.ReadDirEntries(fsys, source)
+	entries, err := vfs.ReadDir(fsys, source)
 	if err != nil {
 		return err
 	}
@@ -1650,25 +1648,7 @@ func (err PathIsNotFile) Error() string {
 
 // ListTfFiles returns the OpenTofu/Terraform files in the given directory.
 func ListTfFiles(fsys vfs.FS, directoryPath string) ([]string, error) {
-	entries, err := vfs.ReadDirEntries(fsys, directoryPath)
-	if err != nil {
-		return nil, err
-	}
-
-	tfFiles := make([]string, 0, len(entries))
-
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-
-		path := filepath.Join(directoryPath, entry.Name())
-		if IsTFFile(path) {
-			tfFiles = append(tfFiles, path)
-		}
-	}
-
-	return tfFiles, nil
+	return vfs.ListFilesWithSuffixes(fsys, directoryPath, tfFileSuffixes...)
 }
 
 // EnsureCacheDir returns the global terragrunt cache directory for the current user.

--- a/internal/util/lockfile.go
+++ b/internal/util/lockfile.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/gofrs/flock"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 )
 
 type Lockfile struct {
@@ -14,31 +15,27 @@ type Lockfile struct {
 
 func NewLockfile(filename string) *Lockfile {
 	return &Lockfile{
-		flock.New(filename),
+		Flock: flock.New(filename),
 	}
 }
 
-func (lockfile *Lockfile) Unlock() error {
-	if lockfile.Flock == nil {
-		return nil
-	}
-
-	if err := lockfile.Flock.Unlock(); err != nil {
+func (lf *Lockfile) Unlock(fsys vfs.FS) error {
+	if err := lf.Flock.Unlock(); err != nil {
 		return err
 	}
 
-	if err := os.Remove(lockfile.Path()); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := fsys.Remove(lf.Path()); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
 	return nil
 }
 
-func (lockfile *Lockfile) TryLock() error {
-	if locked, err := lockfile.Flock.TryLock(); err != nil {
+func (lf *Lockfile) TryLock() error {
+	if locked, err := lf.Flock.TryLock(); err != nil {
 		return err
 	} else if !locked {
-		return fmt.Errorf("unable to lock file %s", lockfile.Path())
+		return fmt.Errorf("unable to lock file %s", lf.Path())
 	}
 
 	return nil

--- a/internal/venv/venv.go
+++ b/internal/venv/venv.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
@@ -87,6 +88,9 @@ var ErrVenvPlatformUnset = errors.New("venv.Venv.Platform is required but unset"
 // ErrVenvGOOSUnset is the panic value [Venv.RequireGOOS] raises when GOOS is empty.
 var ErrVenvGOOSUnset = errors.New("venv.Venv.Platform.GOOS is required but unset")
 
+// ErrVenvGOARCHUnset is the panic value [Venv.RequireGOARCH] raises when GOARCH is empty.
+var ErrVenvGOARCHUnset = errors.New("venv.Venv.Platform.GOARCH is required but unset")
+
 // ErrVenvUserHomeDirUnset is the panic value [Venv.RequireUserHomeDir] raises
 // when UserHomeDir is nil.
 var ErrVenvUserHomeDirUnset = errors.New("venv.Venv.Platform.UserHomeDir is required but unset")
@@ -107,6 +111,7 @@ type Platform struct {
 	Getwd        func() (string, error)
 	GetPID       func() int
 	GOOS         string
+	GOARCH       string
 }
 
 // Terminal reports the console a run's output is adapting to: whether each
@@ -237,6 +242,19 @@ func (v *Venv) WithGOOS(goos string) *Venv {
 	return &c
 }
 
+// WithGOARCH returns a copy of v whose architecture identifier is goarch.
+func (v *Venv) WithGOARCH(goarch string) *Venv {
+	v.RequirePlatform()
+
+	platform := *v.Platform
+	platform.GOARCH = goarch
+
+	c := *v
+	c.Platform = &platform
+
+	return &c
+}
+
 // WithUserHomeDir returns a copy of v whose home-directory lookup is userHomeDir.
 func (v *Venv) WithUserHomeDir(userHomeDir func() (string, error)) *Venv {
 	v.RequirePlatform()
@@ -292,6 +310,16 @@ func (v *Venv) WithEnvCloned() *Venv {
 // functions that write into the shared environment.
 func (v *Venv) RequireEnv() {
 	if v.Env == nil {
+		panic(ErrVenvEnvUnset)
+	}
+}
+
+// RequireEnvMap panics with [ErrVenvEnvUnset] when env is nil. A nil map reads
+// as empty rather than failing, so a function handed one would resolve every
+// lookup to "" and report a run that simply found no environment. Callers that
+// take an environment as a parameter assert it here.
+func RequireEnvMap(env map[string]string) {
+	if env == nil {
 		panic(ErrVenvEnvUnset)
 	}
 }
@@ -382,6 +410,16 @@ func (v *Venv) RequireGOOS() {
 	}
 }
 
+// RequireGOARCH panics with [ErrVenvGOARCHUnset] when GOARCH is empty. The two
+// halves of a platform identifier have to come from the same place: a run that
+// took its GOOS from the venv and its architecture from the binary would name
+// a target that exists on no machine.
+func (v *Venv) RequireGOARCH() {
+	if v.Platform == nil || v.Platform.GOARCH == "" {
+		panic(ErrVenvGOARCHUnset)
+	}
+}
+
 // RequireUserHomeDir panics with [ErrVenvUserHomeDirUnset] when UserHomeDir is nil.
 func (v *Venv) RequireUserHomeDir() {
 	if v.Platform == nil || v.Platform.UserHomeDir == nil {
@@ -430,6 +468,7 @@ func OSVenv() *Venv {
 			Getwd:        os.Getwd,
 			GetPID:       os.Getpid,
 			GOOS:         runtime.GOOS,
+			GOARCH:       runtime.GOARCH,
 		},
 		Terminal: &Terminal{
 			StdinIsTTY:  func() bool { return term.IsTerminal(int(os.Stdin.Fd())) },
@@ -451,6 +490,20 @@ func osTerminalWidth() int {
 	}
 
 	return width
+}
+
+// Environ turns an environment map back into os.Environ-style KEY=VALUE
+// entries, sorted so the result does not vary with map iteration order. It is
+// the inverse of [ParseEnviron].
+func Environ(env map[string]string) []string {
+	out := make([]string, 0, len(env))
+	for k, v := range env {
+		out = append(out, k+"="+v)
+	}
+
+	slices.Sort(out)
+
+	return out
 }
 
 // ParseEnviron turns os.Environ-style KEY=VALUE entries into a map, splitting

--- a/internal/venv/venv_test.go
+++ b/internal/venv/venv_test.go
@@ -135,6 +135,7 @@ func TestOSVenvProvidesPlatformHandles(t *testing.T) {
 
 	require.NotNil(t, v.Platform)
 	assert.Equal(t, runtime.GOOS, v.Platform.GOOS)
+	assert.Equal(t, runtime.GOARCH, v.Platform.GOARCH)
 	assert.NotNil(t, v.Platform.UserHomeDir)
 }
 
@@ -145,13 +146,15 @@ func TestVenvPlatformBuilders(t *testing.T) {
 	homeDir := func() (string, error) { return "", wantHomeErr }
 	original := venv.OSVenv()
 
-	got := original.WithGOOS("plan9").WithUserHomeDir(homeDir)
+	got := original.WithGOOS("plan9").WithGOARCH("mips").WithUserHomeDir(homeDir)
 
 	require.NotNil(t, got.Platform)
 	assert.Equal(t, "plan9", got.Platform.GOOS)
+	assert.Equal(t, "mips", got.Platform.GOARCH)
 	_, err := got.Platform.UserHomeDir()
 	require.ErrorIs(t, err, wantHomeErr)
 	assert.Equal(t, runtime.GOOS, original.Platform.GOOS)
+	assert.Equal(t, runtime.GOARCH, original.Platform.GOARCH)
 }
 
 func TestVenvWriterBuildersIsolateCopies(t *testing.T) {
@@ -176,8 +179,17 @@ func TestVenvPlatformRequirements(t *testing.T) {
 	assert.PanicsWithValue(t, venv.ErrVenvFSUnset, func() {
 		(&venv.Venv{}).RequireFS()
 	})
+	assert.PanicsWithValue(t, venv.ErrVenvEnvUnset, func() {
+		venv.RequireEnvMap(nil)
+	})
+	assert.NotPanics(t, func() {
+		venv.RequireEnvMap(map[string]string{})
+	})
 	assert.PanicsWithValue(t, venv.ErrVenvGOOSUnset, func() {
 		(&venv.Venv{}).RequireGOOS()
+	})
+	assert.PanicsWithValue(t, venv.ErrVenvGOARCHUnset, func() {
+		(&venv.Venv{}).RequireGOARCH()
 	})
 	assert.PanicsWithValue(t, venv.ErrVenvUserHomeDirUnset, func() {
 		(&venv.Venv{}).RequireUserHomeDir()
@@ -210,6 +222,9 @@ func TestVenvPlatformBuildersRequireAPlatform(t *testing.T) {
 
 	assert.PanicsWithValue(t, venv.ErrVenvPlatformUnset, func() {
 		(&venv.Venv{}).WithGOOS("plan9")
+	})
+	assert.PanicsWithValue(t, venv.ErrVenvPlatformUnset, func() {
+		(&venv.Venv{}).WithGOARCH("mips")
 	})
 	assert.PanicsWithValue(t, venv.ErrVenvPlatformUnset, func() {
 		(&venv.Venv{}).WithUserHomeDir(func() (string, error) { return "", nil })
@@ -261,14 +276,14 @@ func TestVenvHandleBuildersReturnCopies(t *testing.T) {
 		{
 			name: "WithSops",
 			build: func(v *venv.Venv) *venv.Venv {
-				return v.WithSops(vsops.NewMemDecrypter(func(string, string) ([]byte, error) {
+				return v.WithSops(vsops.NewMemDecrypter(func(map[string]string, string, string) ([]byte, error) {
 					return nil, wantSopsErr
 				}))
 			},
 			verify: func(t *testing.T, got *venv.Venv) {
 				t.Helper()
 
-				_, err := got.Sops.DecryptFile("/secrets.yaml", "yaml")
+				_, err := got.Sops.DecryptFile(map[string]string{}, "/secrets.yaml", "yaml")
 				require.ErrorIs(t, err, wantSopsErr)
 			},
 		},

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	iofs "io/fs"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -102,7 +102,7 @@ func FileExists(fsys FS, path string) (bool, error) {
 		return true, nil
 	}
 
-	if errors.Is(err, iofs.ErrNotExist) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return false, nil
 	}
 
@@ -218,7 +218,7 @@ func WriteFileWithSamePermissions(fsys FS, source, destination string, contents 
 	}
 
 	// CAS may place read-only files at the destination, which would block a plain open.
-	if err := fsys.Remove(destination); err != nil && !errors.Is(err, iofs.ErrNotExist) {
+	if err := fsys.Remove(destination); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 
@@ -354,7 +354,7 @@ func ParentPathHasSymlink(fsys FS, rootDir, rel string) (bool, error) {
 		current = filepath.Join(current, part)
 
 		info, err := Lstat(fsys, current)
-		if errors.Is(err, iofs.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return false, nil
 		}
 
@@ -470,7 +470,7 @@ type walkDirParallelConfig struct {
 // guarded by fastwalk's ancestor-cycle detection.
 //
 // Without this option, symlinked directories are visited as single
-// entries with `d.IsDir() == false`, matching stdlib [iofs.WalkDir].
+// entries with `d.IsDir() == false`, matching stdlib [fs.WalkDir].
 func WithFollowSymlinks() WalkDirParallelOption {
 	return func(c *walkDirParallelConfig) {
 		c.followSymlinks = true
@@ -486,7 +486,7 @@ func WithFollowSymlinks() WalkDirParallelOption {
 // gives no ordering guarantee across directories. Callers that depend
 // on deterministic order, or that write to shared state from fn, must
 // use [WalkDir] or serialize access themselves.
-func WalkDirParallel(fsys FS, root string, fn iofs.WalkDirFunc, opts ...WalkDirParallelOption) error {
+func WalkDirParallel(fsys FS, root string, fn fs.WalkDirFunc, opts ...WalkDirParallelOption) error {
 	if _, ok := fsys.(*osFS); !ok {
 		return WalkDir(fsys, root, fn)
 	}
@@ -511,19 +511,19 @@ func WalkDirParallel(fsys FS, root string, fn iofs.WalkDirFunc, opts ...WalkDirP
 }
 
 // WalkDir walks the file tree rooted at root, calling fn for each file or
-// directory in the tree, including root. The fn callback receives an iofs.DirEntry
-// instead of os.FileInfo, which can be more efficient since it does not require
+// directory in the tree, including root. The fn callback receives an [fs.DirEntry]
+// instead of [os.FileInfo], which can be more efficient since it does not require
 // a stat call for every visited file.
 //
 // All errors that arise visiting files and directories are filtered by fn:
-// see the iofs.WalkDirFunc documentation for details.
+// see the [fs.WalkDirFunc] documentation for details.
 //
 // The files are walked in lexical order, which makes the output deterministic
 // but means that for very large directories WalkDir can be inefficient.
 // WalkDir does not follow symbolic links.
 //
 // Adapted from spf13/afero#571; replace with afero.WalkDir once merged.
-func WalkDir(fsys FS, root string, fn iofs.WalkDirFunc) error {
+func WalkDir(fsys FS, root string, fn fs.WalkDirFunc) error {
 	info, err := lstatIfPossible(fsys, root)
 	if err != nil {
 		err = fn(root, nil, err)
@@ -547,7 +547,7 @@ func WalkDir(fsys FS, root string, fn iofs.WalkDirFunc) error {
 // Each logical path is reported once, so a directory reachable through several
 // links is visited once, and a link pointing back at an ancestor terminates
 // instead of looping.
-func WalkDirWithSymlinks(fsys FS, root string, fn iofs.WalkDirFunc) error {
+func WalkDirWithSymlinks(fsys FS, root string, fn fs.WalkDirFunc) error {
 	w := &symlinkWalker{
 		fsys:           fsys,
 		fn:             fn,
@@ -567,14 +567,14 @@ func WalkDirWithSymlinks(fsys FS, root string, fn iofs.WalkDirFunc) error {
 // nested walks it starts for each followed link.
 type symlinkWalker struct {
 	fsys           FS
-	fn             iofs.WalkDirFunc
+	fn             fs.WalkDirFunc
 	visited        map[string]bool
 	visitedLogical map[string]bool
 }
 
 // walk traverses the tree at physical, reporting entries under logical.
 func (w *symlinkWalker) walk(physical, logical string) error {
-	return WalkDir(w.fsys, physical, func(current string, d iofs.DirEntry, err error) error {
+	return WalkDir(w.fsys, physical, func(current string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return w.fn(current, d, err)
 		}
@@ -599,7 +599,7 @@ func (w *symlinkWalker) walk(physical, logical string) error {
 			}
 		}
 
-		if d.Type()&iofs.ModeSymlink == 0 {
+		if d.Type()&fs.ModeSymlink == 0 {
 			return nil
 		}
 
@@ -1075,16 +1075,16 @@ func (z *ZipDecompressor) extractRegularFile(
 	return nil
 }
 
-// FileInfoDirEntry wraps os.FileInfo to implement iofs.DirEntry.
+// FileInfoDirEntry wraps [os.FileInfo] to implement [fs.DirEntry].
 // Adapted from spf13/afero#571; replace with afero equivalent once merged.
 type FileInfoDirEntry struct {
 	FileInfo os.FileInfo
 }
 
-func (d FileInfoDirEntry) Name() string                 { return d.FileInfo.Name() }
-func (d FileInfoDirEntry) IsDir() bool                  { return d.FileInfo.IsDir() }
-func (d FileInfoDirEntry) Type() iofs.FileMode          { return d.FileInfo.Mode().Type() }
-func (d FileInfoDirEntry) Info() (iofs.FileInfo, error) { return d.FileInfo, nil }
+func (d FileInfoDirEntry) Name() string               { return d.FileInfo.Name() }
+func (d FileInfoDirEntry) IsDir() bool                { return d.FileInfo.IsDir() }
+func (d FileInfoDirEntry) Type() fs.FileMode          { return d.FileInfo.Mode().Type() }
+func (d FileInfoDirEntry) Info() (fs.FileInfo, error) { return d.FileInfo, nil }
 
 // limitedReader wraps a reader and enforces a size limit.
 type limitedReader struct {
@@ -1221,7 +1221,7 @@ func (state *symlinkWalkState) processComponent(fsys FS, part string, end int) (
 		return false, err
 	}
 
-	if info.Mode()&iofs.ModeSymlink == 0 {
+	if info.Mode()&fs.ModeSymlink == 0 {
 		return state.processRegularComponent(info, end)
 	}
 
@@ -1335,7 +1335,7 @@ func walkSymlinksLinkParent(dest string, vol string, volLen int) string {
 
 // walkDir recursively descends path, calling walkDirFn.
 // Adapted from https://go.dev/src/path/filepath/path.go
-func walkDir(fsys FS, path string, d iofs.DirEntry, walkDirFn iofs.WalkDirFunc) error {
+func walkDir(fsys FS, path string, d fs.DirEntry, walkDirFn fs.WalkDirFunc) error {
 	if err := walkDirFn(path, d, nil); err != nil || !d.IsDir() {
 		if errors.Is(err, filepath.SkipDir) && d.IsDir() {
 			err = nil
@@ -1344,7 +1344,7 @@ func walkDir(fsys FS, path string, d iofs.DirEntry, walkDirFn iofs.WalkDirFunc) 
 		return err
 	}
 
-	entries, err := ReadDirEntries(fsys, path)
+	entries, err := ReadDir(fsys, path)
 	if err != nil {
 		err = walkDirFn(path, d, err)
 		if err != nil {
@@ -1370,22 +1370,24 @@ func walkDir(fsys FS, path string, d iofs.DirEntry, walkDirFn iofs.WalkDirFunc) 
 	return nil
 }
 
-// ReadDirEntries reads the directory named by dirname and returns a sorted
-// list of directory entries. It prefers the iofs.ReadDirFile fast path when the
-// backing file supports it, and otherwise falls back to Readdir wrapped in
-// FileInfoDirEntry so backings that only expose the legacy os.File API still
-// work.
-func ReadDirEntries(fsys FS, dirname string) ([]iofs.DirEntry, error) {
+// ReadDir reads the directory named by dirname and returns a sorted list of
+// directory entries, as [fs.ReadDir] does. It prefers the [fs.ReadDirFile] fast
+// path when the backing file supports it, and otherwise falls back to Readdir
+// wrapped in [FileInfoDirEntry] so backings that only expose the legacy [os.File]
+// API still work.
+func ReadDir(fsys FS, dirname string) (_ []fs.DirEntry, retErr error) {
 	f, err := fsys.Open(dirname)
 	if err != nil {
 		return nil, err
 	}
 
 	defer func() {
-		_ = f.Close()
+		if err := f.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
 	}()
 
-	if rdf, ok := f.(iofs.ReadDirFile); ok {
+	if rdf, ok := f.(fs.ReadDirFile); ok {
 		entries, err := rdf.ReadDir(-1)
 		if err != nil {
 			return nil, err
@@ -1393,7 +1395,7 @@ func ReadDirEntries(fsys FS, dirname string) ([]iofs.DirEntry, error) {
 
 		slices.SortFunc(
 			entries,
-			func(a, b iofs.DirEntry) int { return strings.Compare(a.Name(), b.Name()) },
+			func(a, b fs.DirEntry) int { return strings.Compare(a.Name(), b.Name()) },
 		)
 
 		return entries, nil
@@ -1404,7 +1406,7 @@ func ReadDirEntries(fsys FS, dirname string) ([]iofs.DirEntry, error) {
 		return nil, err
 	}
 
-	entries := make([]iofs.DirEntry, len(infos))
+	entries := make([]fs.DirEntry, len(infos))
 
 	for i, info := range infos {
 		entries[i] = FileInfoDirEntry{FileInfo: info}
@@ -1412,10 +1414,40 @@ func ReadDirEntries(fsys FS, dirname string) ([]iofs.DirEntry, error) {
 
 	slices.SortFunc(
 		entries,
-		func(a, b iofs.DirEntry) int { return strings.Compare(a.Name(), b.Name()) },
+		func(a, b fs.DirEntry) int { return strings.Compare(a.Name(), b.Name()) },
 	)
 
 	return entries, nil
+}
+
+// ListFilesWithSuffixes returns the paths of the files directly under dir whose
+// names end in any of the given suffixes, in the order [ReadDir] yields
+// them. Subdirectories are skipped, and each match is joined to dir.
+func ListFilesWithSuffixes(fsys FS, dir string, suffixes ...string) ([]string, error) {
+	entries, err := ReadDir(fsys, dir)
+	if err != nil {
+		return nil, err
+	}
+
+	files := make([]string, 0, len(entries))
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+
+		if !slices.ContainsFunc(suffixes, func(suffix string) bool {
+			return strings.HasSuffix(name, suffix)
+		}) {
+			continue
+		}
+
+		files = append(files, filepath.Join(dir, name))
+	}
+
+	return files, nil
 }
 
 // containsDotDot checks if a path contains ".." as a path component.

--- a/internal/vfs/vfs_test.go
+++ b/internal/vfs/vfs_test.go
@@ -1373,7 +1373,7 @@ func walkSymlinkedPaths(t *testing.T, root string) []string {
 	return paths
 }
 
-func TestReadDirEntries(t *testing.T) {
+func TestReadDir(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns sorted entries from MemMapFS", func(t *testing.T) {
@@ -1385,7 +1385,7 @@ func TestReadDirEntries(t *testing.T) {
 		require.NoError(t, vfs.WriteFile(fsys, "/dir/bravo.txt", []byte("b"), 0644))
 		require.NoError(t, vfs.WriteFile(fsys, "/dir/sub/nested.txt", []byte("n"), 0644))
 
-		entries, err := vfs.ReadDirEntries(fsys, "/dir")
+		entries, err := vfs.ReadDir(fsys, "/dir")
 		require.NoError(t, err)
 
 		names := make([]string, len(entries))
@@ -1416,7 +1416,7 @@ func TestReadDirEntries(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), 0644))
 		require.NoError(t, os.Mkdir(filepath.Join(dir, "m"), 0755))
 
-		entries, err := vfs.ReadDirEntries(vfs.NewOSFS(), dir)
+		entries, err := vfs.ReadDir(vfs.NewOSFS(), dir)
 		require.NoError(t, err)
 
 		names := make([]string, len(entries))
@@ -1433,7 +1433,7 @@ func TestReadDirEntries(t *testing.T) {
 		fsys := vfs.NewMemMapFS()
 		require.NoError(t, fsys.Mkdir("/empty", 0755))
 
-		entries, err := vfs.ReadDirEntries(fsys, "/empty")
+		entries, err := vfs.ReadDir(fsys, "/empty")
 		require.NoError(t, err)
 		assert.Empty(t, entries)
 	})
@@ -1443,8 +1443,101 @@ func TestReadDirEntries(t *testing.T) {
 
 		fsys := vfs.NewMemMapFS()
 
-		_, err := vfs.ReadDirEntries(fsys, "/does-not-exist")
+		_, err := vfs.ReadDir(fsys, "/does-not-exist")
 		require.Error(t, err)
+	})
+
+	t.Run("reports a failed close", func(t *testing.T) {
+		t.Parallel()
+
+		mem := vfs.NewMemMapFS()
+		require.NoError(t, vfs.WriteFile(mem, "/dir/alpha.txt", []byte("a"), 0644))
+
+		_, err := vfs.ReadDir(&closeFailFS{FS: mem}, "/dir")
+		require.ErrorIs(t, err, errCloseFailed)
+	})
+}
+
+var errCloseFailed = errors.New("close failed")
+
+// closeFailFS hands out files whose Close fails, so a caller that drops the
+// error reads a directory it never finished with as a success.
+type closeFailFS struct {
+	vfs.FS
+}
+
+func (fsys *closeFailFS) Open(name string) (vfs.File, error) {
+	f, err := fsys.FS.Open(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return closeFailFile{File: f}, nil
+}
+
+type closeFailFile struct {
+	vfs.File
+}
+
+func (f closeFailFile) Close() error {
+	return errors.Join(f.File.Close(), errCloseFailed)
+}
+
+func TestListFilesWithSuffixes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns matching files joined to the directory", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := vfs.NewMemMapFS()
+		require.NoError(t, vfs.WriteFile(fsys, "/dir/main.tf", []byte("t"), 0644))
+		require.NoError(t, vfs.WriteFile(fsys, "/dir/vars.tofu", []byte("t"), 0644))
+		require.NoError(t, vfs.WriteFile(fsys, "/dir/README.md", []byte("r"), 0644))
+		require.NoError(t, vfs.WriteFile(fsys, "/dir/sub.tf/nested.tf", []byte("n"), 0644))
+
+		files, err := vfs.ListFilesWithSuffixes(fsys, "/dir", ".tf", ".tofu")
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{
+			filepath.Join("/dir", "main.tf"),
+			filepath.Join("/dir", "vars.tofu"),
+		}, files)
+	})
+
+	// A ".auto.tfvars.json" file does not end in ".auto.tfvars", so overlapping
+	// suffixes of this shape cannot collect the same file twice.
+	t.Run("returns each match once for overlapping suffixes", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := vfs.NewMemMapFS()
+		require.NoError(t, vfs.WriteFile(fsys, "/dir/a.auto.tfvars", []byte("a"), 0644))
+		require.NoError(t, vfs.WriteFile(fsys, "/dir/b.auto.tfvars.json", []byte("b"), 0644))
+
+		files, err := vfs.ListFilesWithSuffixes(fsys, "/dir", ".auto.tfvars", ".auto.tfvars.json")
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{
+			filepath.Join("/dir", "a.auto.tfvars"),
+			filepath.Join("/dir", "b.auto.tfvars.json"),
+		}, files)
+	})
+
+	t.Run("returns no files when no suffixes are given", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := vfs.NewMemMapFS()
+		require.NoError(t, vfs.WriteFile(fsys, "/dir/main.tf", []byte("t"), 0644))
+
+		files, err := vfs.ListFilesWithSuffixes(fsys, "/dir")
+		require.NoError(t, err)
+		assert.Empty(t, files)
+	})
+
+	t.Run("returns error for missing directory", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := vfs.ListFilesWithSuffixes(vfs.NewMemMapFS(), "/does-not-exist", ".tf")
+		require.ErrorIs(t, err, fs.ErrNotExist)
 	})
 }
 

--- a/internal/vsops/env_fuzz_test.go
+++ b/internal/vsops/env_fuzz_test.go
@@ -1,0 +1,61 @@
+package vsops_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/vsops"
+	"github.com/stretchr/testify/require"
+)
+
+// setenv wraps os.Setenv so the fuzz target can seed a variable without
+// t.Setenv, which a fuzz target may not call.
+func setenv(name, value string) error {
+	return os.Setenv(name, value)
+}
+
+// FuzzOSDecrypterRestoresEnv validates the assumption the OS decrypter's
+// restore path asserts on: whatever name and value a caller's environment
+// carries, a decrypt either leaves the process environment untouched or puts
+// back exactly what it displaced.
+//
+// The interesting inputs are the names os.Setenv rejects (empty, holding a
+// NUL, holding an "=" on Unix), since those are the ones that could be
+// published without being restorable. A rejected name must never reach the
+// restore set, and the panic it would raise there is what this proves absent.
+func FuzzOSDecrypterRestoresEnv(f *testing.F) {
+	f.Add("SOPS_FUZZ_KEY", "prior", "published", true)
+	f.Add("SOPS_FUZZ_KEY", "", "published", false)
+	f.Add("SOPS_FUZZ_KEY", "prior", "", true)
+	f.Add("", "prior", "published", false)
+	f.Add("SOPS=FUZZ", "prior", "published", false)
+	f.Add("SOPS\x00FUZZ", "prior", "published", false)
+	f.Add("SOPS_FUZZ_KEY", "same", "same", true)
+
+	path := filepath.Join(f.TempDir(), "secret.json")
+	require.NoError(f, os.WriteFile(path, []byte(`{"value":1}`), 0o600))
+
+	d := vsops.NewOSDecrypter()
+
+	f.Fuzz(func(t *testing.T, name, prior, published string, hasPrior bool) {
+		// A name the process cannot hold in the first place says nothing about
+		// restore, and setting it here would fail for reasons of its own.
+		if hasPrior && setenv(name, prior) != nil {
+			t.Skip("the OS rejects this name, so there is no prior value to displace")
+		}
+
+		wantValue, wantSet := os.LookupEnv(name)
+
+		_, err := d.DecryptFile(map[string]string{name: published}, path, "json")
+		require.Error(t, err)
+
+		gotValue, gotSet := os.LookupEnv(name)
+		require.Equal(t, wantSet, gotSet, "presence of %q changed across the decrypt", name)
+		require.Equal(t, wantValue, gotValue, "value of %q changed across the decrypt", name)
+
+		if hasPrior {
+			require.NoError(t, os.Unsetenv(name))
+		}
+	})
+}

--- a/internal/vsops/env_test.go
+++ b/internal/vsops/env_test.go
@@ -1,0 +1,140 @@
+package vsops_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/vsops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOSDecrypterEnvIsolationWithRacing is a regression test for
+// https://github.com/gruntwork-io/terragrunt/issues/5515. The CI "Race" job
+// runs tests matching .*WithRacing with -race, which is what catches two
+// decrypts holding the process environment at once.
+//
+// The files are not sops documents, so every decrypt fails. The failure is the
+// point: the environment has to be restored on the error path too.
+func TestOSDecrypterEnvIsolationWithRacing(t *testing.T) {
+	t.Parallel()
+
+	const (
+		authKey       = "SOPS_RACE_TEST_TOKEN"
+		numGoroutines = 10
+	)
+
+	dir := t.TempDir()
+	d := vsops.NewOSDecrypter()
+
+	files := make([]string, 0, numGoroutines)
+
+	for i := range numGoroutines {
+		path := filepath.Join(dir, fmt.Sprintf("secret-%02d.json", i))
+		require.NoError(t, os.WriteFile(path, fmt.Appendf(nil, `{"value":%d}`, i), 0o600))
+
+		files = append(files, path)
+	}
+
+	var (
+		wg      sync.WaitGroup
+		barrier = make(chan struct{})
+	)
+
+	for i, path := range files {
+		wg.Go(func() {
+			<-barrier
+
+			env := map[string]string{authKey: fmt.Sprintf("token-%d", i)}
+
+			_, err := d.DecryptFile(env, path, "json")
+			assert.Error(t, err)
+		})
+	}
+
+	close(barrier)
+	wg.Wait()
+
+	_, exists := os.LookupEnv(authKey)
+	assert.False(t, exists, "the decrypt window must not outlive the decrypt")
+}
+
+// TestOSDecrypterRestoresDisplacedEnv pins the restore half of the window: a
+// variable the process already carried has to come back with its own value,
+// not the one a decrypt borrowed the slot for.
+func TestOSDecrypterRestoresDisplacedEnv(t *testing.T) {
+	const (
+		key   = "SOPS_RESTORE_TEST_TOKEN"
+		prior = "value-the-process-started-with"
+	)
+
+	t.Setenv(key, prior)
+
+	path := filepath.Join(t.TempDir(), "secret.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"value":1}`), 0o600))
+
+	_, err := vsops.NewOSDecrypter().DecryptFile(map[string]string{key: "value-from-the-venv"}, path, "json")
+	require.Error(t, err)
+
+	assert.Equal(t, prior, os.Getenv(key))
+}
+
+// TestPublishEnvHoldsTheVenvValue pins what the process environment holds
+// while the window is open, including the blank case [vsops.PublishEnv]
+// documents.
+//
+// Each case reads the variable while the window is open, closes it, and
+// asserts afterwards, so a failed expectation cannot leave [vsops.PublishEnv]
+// holding the lock.
+func TestPublishEnvHoldsTheVenvValue(t *testing.T) {
+	const key = "SOPS_PUBLISH_TEST_TOKEN"
+
+	testCases := []struct {
+		name      string
+		prior     string
+		published string
+		wantPrior bool
+	}{
+		{
+			name:      "venv value displaces the process value",
+			prior:     "process-credential",
+			published: "venv-credential",
+			wantPrior: true,
+		},
+		{
+			name:      "blank displaces the process value",
+			prior:     "session-token-the-process-started-with",
+			published: "",
+			wantPrior: true,
+		},
+		{
+			name:      "venv value fills a name the process lacks",
+			published: "venv-credential",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.wantPrior {
+				t.Setenv(key, tc.prior)
+			} else {
+				require.NoError(t, os.Unsetenv(key))
+			}
+
+			restore := vsops.PublishEnv(map[string]string{key: tc.published})
+			published, publishedSet := os.LookupEnv(key)
+
+			restore()
+
+			restored, restoredSet := os.LookupEnv(key)
+
+			assert.True(t, publishedSet, "%q has to be set inside the window", key)
+			assert.Equal(t, tc.published, published, "the venv value has to win inside the window")
+			assert.Equal(t, tc.wantPrior, restoredSet, "presence of %q changed across the window", key)
+			assert.Equal(t, tc.prior, restored)
+		})
+	}
+}

--- a/internal/vsops/vsops.go
+++ b/internal/vsops/vsops.go
@@ -5,24 +5,41 @@ package vsops
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"reflect"
 
 	"github.com/getsops/sops/v3/cmd/sops/formats"
 	"github.com/getsops/sops/v3/decrypt"
+	"github.com/gruntwork-io/terragrunt/internal/locks"
 )
+
+// ErrEnvRestore is the panic value the OS decrypter raises when it cannot put
+// a variable back after a decrypt. Restore only touches names the publishing
+// half already set successfully, so a failure here means the environment is
+// left holding another unit's credentials, which is not a state to continue a
+// run in.
+var ErrEnvRestore = errors.New("vsops: cannot restore the process environment after decrypting")
+
+// ErrEnvNil is the panic value [Decrypter.DecryptFile] raises when its env
+// argument is nil. Production callers take the map from a [venv.Venv], which
+// guarantees a non-nil Env, so a nil points at a caller bug rather than a
+// runtime condition.
+var ErrEnvNil = errors.New("vsops: DecryptFile env must not be nil")
 
 // Decrypter is the SOPS decryption interface used throughout the codebase.
 // It provides an abstraction over the real sops library and in-memory
 // decryption.
 type Decrypter interface {
 	// DecryptFile decrypts the SOPS-encrypted file at path, parsing its
-	// content according to format, and returns the cleartext data.
-	DecryptFile(path, format string) ([]byte, error)
+	// content according to format, and returns the cleartext data. It panics
+	// with [ErrEnvNil] on a nil env.
+	DecryptFile(env map[string]string, path, format string) ([]byte, error)
 }
 
 // Handler processes a single decryption request for the in-memory backend and
 // returns the cleartext. It is invoked synchronously by [Decrypter.DecryptFile].
-type Handler func(path, format string) ([]byte, error)
+type Handler func(env map[string]string, path, format string) ([]byte, error)
 
 // FormatForPath returns the sops format name implied by the file extension of
 // path: "yaml", "json", "dotenv", or "ini", falling back to "binary" for
@@ -31,10 +48,16 @@ func FormatForPath(path string) string {
 	return formatNames[formats.FormatForPath(path)]
 }
 
-// NewOSDecrypter returns a [Decrypter] backed by the real sops library. It reads
-// the encrypted file from the OS filesystem and resolves data keys through the
-// key services named in the file's sops metadata, which draw credentials from
-// the process environment.
+// NewOSDecrypter returns a [Decrypter] backed by the real sops library. It
+// reads the encrypted file from the OS filesystem and resolves data keys
+// through the key services named in the file's sops metadata.
+//
+// Those key services read credentials from the process environment, and sops'
+// only stable API, decrypt.File, takes no configuration through which they
+// could be supplied instead. Reaching past the venv is unavoidable here, so it
+// happens here rather than at a call site: DecryptFile publishes env into the
+// process environment for the length of one decrypt and restores what it
+// displaced.
 func NewOSDecrypter() Decrypter {
 	return osDecrypter{}
 }
@@ -62,7 +85,11 @@ var formatNames = map[formats.Format]string{
 
 type osDecrypter struct{}
 
-func (osDecrypter) DecryptFile(path, format string) ([]byte, error) {
+func (osDecrypter) DecryptFile(env map[string]string, path, format string) ([]byte, error) {
+	requireEnv(env)
+
+	defer PublishEnv(env)()
+
 	data, err := decrypt.File(path, format)
 	if err != nil {
 		if groupErrs := dataKeyGroupErrors(err); len(groupErrs) > 0 {
@@ -79,8 +106,70 @@ type memDecrypter struct {
 	handler Handler
 }
 
-func (d memDecrypter) DecryptFile(path, format string) ([]byte, error) {
-	return d.handler(path, format)
+func (d memDecrypter) DecryptFile(env map[string]string, path, format string) ([]byte, error) {
+	requireEnv(env)
+
+	return d.handler(env, path, format)
+}
+
+func requireEnv(env map[string]string) {
+	if env == nil {
+		panic(ErrEnvNil)
+	}
+}
+
+// PublishEnv mirrors env into the process environment and returns the function
+// that puts the environment back. It holds [locks.EnvLock] until that function
+// runs, so no two callers hold the environment at once. [NewOSDecrypter] is
+// the caller that needs it.
+//
+// It publishes blanks too. Credentials apply as a set, and an auth provider
+// returning static keys reports an empty AWS_SESSION_TOKEN. Skipping that
+// blank would pair the unit's key with the session token the process started
+// with, an identity that belongs to neither.
+func PublishEnv(env map[string]string) func() {
+	locks.EnvLock.Lock()
+
+	type displaced struct {
+		value string
+		set   bool
+	}
+
+	prior := make(map[string]displaced, len(env))
+
+	for k, v := range env {
+		old, ok := os.LookupEnv(k)
+		if ok && old == v {
+			continue
+		}
+
+		if err := os.Setenv(k, v); err != nil {
+			continue
+		}
+
+		prior[k] = displaced{value: old, set: ok}
+	}
+
+	return func() {
+		defer locks.EnvLock.Unlock()
+
+		for k, d := range prior {
+			if err := restore(k, d.value, d.set); err != nil {
+				panic(fmt.Errorf("%w: %q: %w", ErrEnvRestore, k, err))
+			}
+		}
+	}
+}
+
+// restore puts one variable back to the value it held before the decrypt, or
+// removes it when the process did not carry it. FuzzOSDecrypterRestoresEnv
+// exercises the names that make its error return fire.
+func restore(name, value string, set bool) error {
+	if !set {
+		return os.Unsetenv(name)
+	}
+
+	return os.Setenv(name, value)
 }
 
 // dataKeyGroupErrors returns the per-key-group failures hidden in sops'

--- a/internal/vsops/vsops_test.go
+++ b/internal/vsops/vsops_test.go
@@ -40,14 +40,14 @@ func TestFormatForPath(t *testing.T) {
 func TestMemDecrypterDispatchesToHandler(t *testing.T) {
 	t.Parallel()
 
-	d := vsops.NewMemDecrypter(func(path, format string) ([]byte, error) {
+	d := vsops.NewMemDecrypter(func(_ map[string]string, path, format string) ([]byte, error) {
 		assert.Equal(t, "secrets.env", path)
 		assert.Equal(t, "dotenv", format)
 
 		return []byte("value=cleartext"), nil
 	})
 
-	data, err := d.DecryptFile("secrets.env", "dotenv")
+	data, err := d.DecryptFile(map[string]string{}, "secrets.env", "dotenv")
 	require.NoError(t, err)
 	assert.Equal(t, "value=cleartext", string(data))
 }
@@ -57,11 +57,11 @@ func TestMemDecrypterReturnsHandlerError(t *testing.T) {
 
 	handlerErr := errors.New("no data key")
 
-	d := vsops.NewMemDecrypter(func(string, string) ([]byte, error) {
+	d := vsops.NewMemDecrypter(func(map[string]string, string, string) ([]byte, error) {
 		return nil, handlerErr
 	})
 
-	data, err := d.DecryptFile("secrets.json", "json")
+	data, err := d.DecryptFile(map[string]string{}, "secrets.json", "json")
 	require.ErrorIs(t, err, handlerErr)
 	assert.Nil(t, data)
 }
@@ -79,7 +79,7 @@ func TestOSDecrypterMissingFile(t *testing.T) {
 
 	d := vsops.NewOSDecrypter()
 
-	_, err := d.DecryptFile(filepath.Join(t.TempDir(), "missing.json"), "json")
+	_, err := d.DecryptFile(map[string]string{}, filepath.Join(t.TempDir(), "missing.json"), "json")
 	require.ErrorIs(t, err, fs.ErrNotExist)
 }
 
@@ -91,6 +91,6 @@ func TestOSDecrypterFileWithoutSopsMetadata(t *testing.T) {
 
 	d := vsops.NewOSDecrypter()
 
-	_, err := d.DecryptFile(path, "json")
+	_, err := d.DecryptFile(map[string]string{}, path, "json")
 	require.Error(t, err)
 }

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"golang.org/x/sync/errgroup"
@@ -112,7 +113,7 @@ func (w *Worktrees) DisplayPath(worktreePath string) string {
 }
 
 // Cleanup removes all created Git worktrees and their temporary directories.
-func (w *Worktrees) Cleanup(ctx context.Context, l log.Logger) error {
+func (w *Worktrees) Cleanup(ctx context.Context, l log.Logger, fsys vfs.FS) error {
 	// Get repo remote for telemetry
 	var repoRemote string
 	if w.gitRunner != nil {
@@ -135,7 +136,7 @@ func (w *Worktrees) Cleanup(ctx context.Context, l log.Logger) error {
 					seen[worktree.Path] = struct{}{}
 
 					// Skip removal if the worktree path doesn't exist (may have been cleaned up already)
-					if _, err := os.Stat(worktree.Path); errors.Is(err, fs.ErrNotExist) {
+					if _, err := fsys.Stat(worktree.Path); errors.Is(err, fs.ErrNotExist) {
 						l.Debugf(
 							"Worktree path %s already removed, skipping cleanup",
 							worktree.Path,
@@ -290,7 +291,7 @@ func (w *Worktrees) Stacks() StackDiff {
 
 // Expand expands a worktree pair with an associated Git expression into the equivalent to and from filter
 // expressions based on the provided diffs for the worktree pair.
-func (wp *WorktreePair) Expand() (filter.Filters, filter.Filters, error) {
+func (wp *WorktreePair) Expand(fsys vfs.FS) (filter.Filters, filter.Filters, error) {
 	diffs := wp.Diffs
 
 	toPath := wp.ToWorktree.Path
@@ -299,11 +300,11 @@ func (wp *WorktreePair) Expand() (filter.Filters, filter.Filters, error) {
 	toExpressions := make(filter.Expressions, 0, len(diffs.Added)+len(diffs.Changed))
 
 	// Build simple expressions that can be determined simply from the diffs.
-	if err := expandDiffPaths(diffs.Removed, toPath, &fromExpressions, &toExpressions); err != nil {
+	if err := expandDiffPaths(fsys, diffs.Removed, toPath, &fromExpressions, &toExpressions); err != nil {
 		return nil, nil, err
 	}
 
-	if err := expandDiffPaths(diffs.Added, toPath, &toExpressions, &toExpressions); err != nil {
+	if err := expandDiffPaths(fsys, diffs.Added, toPath, &toExpressions, &toExpressions); err != nil {
 		return nil, nil, err
 	}
 
@@ -321,7 +322,7 @@ func (wp *WorktreePair) Expand() (filter.Filters, filter.Filters, error) {
 		default:
 			// Check to see if the changed file is in the same directory as a unit in the to worktree.
 			// If so, we'll consider the unit modified.
-			if _, err := os.Stat(
+			if _, err := fsys.Stat(
 				filepath.Join(toPath, dir, config.DefaultTerragruntConfigPath),
 			); err == nil {
 				expr, err := filter.NewPathFilter(dir)
@@ -393,7 +394,7 @@ func NewWorktrees(
 
 	v.RequireExec()
 
-	gitRunner, err := git.NewGitRunner(v.Exec)
+	gitRunner, err := git.NewGitRunner(v)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Git runner for worktree creation: %w", err)
 	}
@@ -545,7 +546,7 @@ func NewWorktrees(
 
 	// cleanup worktrees
 	if outerErr != nil && worktrees != nil {
-		if cleanupErr := worktrees.Cleanup(ctx, l); cleanupErr != nil {
+		if cleanupErr := worktrees.Cleanup(ctx, l, v.FS); cleanupErr != nil {
 			l.Warnf("failed to cleanup worktrees: %v", cleanupErr)
 		}
 	}
@@ -559,6 +560,7 @@ func NewWorktrees(
 // matched against the same worktree the file exists in. fallbackExprs receives path filters for non-config
 // files adjacent to a unit in the "to" worktree.
 func expandDiffPaths(
+	fsys vfs.FS,
 	paths []string,
 	toPath string,
 	primaryExprs, fallbackExprs *filter.Expressions,
@@ -587,7 +589,7 @@ func expandDiffPaths(
 
 			*primaryExprs = append(*primaryExprs, dirExpr, globExpr)
 		default:
-			if _, err := os.Stat(
+			if _, err := fsys.Stat(
 				filepath.Join(toPath, dir, config.DefaultTerragruntConfigPath),
 			); err == nil {
 				expr, err := filter.NewPathFilter(dir)
@@ -649,7 +651,7 @@ func createGitWorktrees(
 	refsToPaths := make(map[string]string, len(gitRefs))
 
 	for _, ref := range gitRefs {
-		tmpDir, err := os.MkdirTemp("", "terragrunt-worktree-"+sanitizeRef(ref)+"-*")
+		tmpDir, err := vfs.MkdirTemp(v.FS, v.Platform.TempDir(), "terragrunt-worktree-"+sanitizeRef(ref)+"-")
 		if err != nil {
 			errs = append(
 				errs,
@@ -662,9 +664,9 @@ func createGitWorktrees(
 		// macOS will create the temporary directory with symlinks, so we need to evaluate them.
 		origTmpDir := tmpDir
 
-		tmpDir, err = filepath.EvalSymlinks(tmpDir)
+		tmpDir, err = vfs.EvalSymlinks(v.FS, tmpDir)
 		if err != nil {
-			if cleanErr := os.RemoveAll(origTmpDir); cleanErr != nil {
+			if cleanErr := v.FS.RemoveAll(origTmpDir); cleanErr != nil {
 				l.Warnf("failed to clean worktree directory %s: %v", origTmpDir, cleanErr)
 			}
 
@@ -699,7 +701,7 @@ func createGitWorktrees(
 				return gitRunner.CreateDetachedWorktree(ctx, tmpDir, ref)
 			})
 		if err != nil {
-			if cleanErr := os.RemoveAll(tmpDir); cleanErr != nil {
+			if cleanErr := v.FS.RemoveAll(tmpDir); cleanErr != nil {
 				l.Warnf("failed to clean worktree directory %s: %v", tmpDir, cleanErr)
 			}
 

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -40,7 +42,7 @@ func TestNewWorktrees(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.Background(), logger.CreateLogger())
+		cleanupErr := w.Cleanup(context.Background(), logger.CreateLogger(), vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -56,7 +58,7 @@ func TestNewWorktreesWithInvalidReference(t *testing.T) {
 	runner := helpers.InitTestGitRunner(t, tmpDir)
 	require.NoError(t, runner.Commit(t.Context(), "Initial commit", "--allow-empty"))
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 
@@ -192,7 +194,7 @@ func TestExpressionExpansion(t *testing.T) {
 				Diffs: tt.diffs,
 			}
 
-			fromFilters, toFilters, err := wp.Expand()
+			fromFilters, toFilters, err := wp.Expand(vfs.NewOSFS())
 			require.NoError(t, err)
 
 			// Verify from filters count
@@ -325,7 +327,7 @@ func TestExpansionAttributeReadingFilters(t *testing.T) {
 				Diffs: tt.diffs,
 			}
 
-			_, toFilters, err := wp.Expand()
+			_, toFilters, err := wp.Expand(vfs.NewOSFS())
 			require.NoError(t, err)
 
 			// Extract reading filters
@@ -586,7 +588,7 @@ func TestExpandWithUnitDirectoryDetection(t *testing.T) {
 				},
 			}
 
-			fromFilters, toFilters, err := wp.Expand()
+			fromFilters, toFilters, err := wp.Expand(vfs.NewOSFS())
 			require.NoError(t, err)
 
 			// Verify from filters count
@@ -658,7 +660,7 @@ func TestWorktreeCleanup(t *testing.T) {
 		require.NoError(t, runner.Commit(t.Context(), fmt.Sprintf("Commit %d", i), "--allow-empty"))
 	}
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = tmpDir
 	opts.RootWorkingDir = tmpDir
 

--- a/main.go
+++ b/main.go
@@ -27,8 +27,8 @@ func run() (code int) {
 	originalConsole := exec.SaveConsoleState()
 	defer originalConsole.Restore()
 
-	opts := options.NewTerragruntOptions()
 	v := venv.OSVenv()
+	opts := options.NewTerragruntOptions(v.Exec)
 
 	l := log.New(
 		log.WithOutput(v.Writers.ErrWriter),

--- a/pkg/config/catalog.go
+++ b/pkg/config/catalog.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 
@@ -55,21 +54,21 @@ func (cfg *CatalogConfig) String() string {
 	)
 }
 
-func (cfg *CatalogConfig) normalize(configPath string) {
+func (cfg *CatalogConfig) normalize(fsys vfs.FS, configPath string) {
 	configDir := filepath.Dir(configPath)
 
 	// transform relative paths to absolute ones
 	for i, url := range cfg.URLs {
 		url := filepath.Join(configDir, url)
 
-		if _, err := os.Stat(url); err == nil {
+		if _, err := fsys.Stat(url); err == nil {
 			cfg.URLs[i] = url
 		}
 	}
 
 	if cfg.DefaultTemplate != "" {
 		path := filepath.Join(configDir, cfg.DefaultTemplate)
-		if _, err := os.Stat(path); err == nil {
+		if _, err := fsys.Stat(path); err == nil {
 			cfg.DefaultTemplate = path
 		}
 	}
@@ -196,7 +195,7 @@ func convertToTerragruntCatalogConfig(
 
 	if terragruntConfigFromFile.Catalog != nil {
 		terragruntConfig.Catalog = terragruntConfigFromFile.Catalog
-		terragruntConfig.Catalog.normalize(configPath)
+		terragruntConfig.Catalog.normalize(pctx.Venv.FS, configPath)
 		terragruntConfig.SetFieldMetadata(MetadataCatalog, defaultMetadata)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,7 +9,6 @@ import (
 	"io/fs"
 	"maps"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -206,6 +205,7 @@ func (cfg *TerragruntConfig) GetRemoteState(
 
 		tfSource, err := tf.NewSource(
 			l,
+			pctx.Venv.FS,
 			canonicalSourceURL,
 			pctx.DownloadDir,
 			pctx.WorkingDir,
@@ -1222,9 +1222,9 @@ func adjustSourceWithMap(
 
 // GetDefaultConfigPath returns the default path to use for the Terragrunt configuration
 // that exists within the path giving preference to `terragrunt.hcl`
-func GetDefaultConfigPath(workingDir string) string {
+func GetDefaultConfigPath(fsys vfs.FS, workingDir string) string {
 	// check if a configuration file was passed as `workingDir`.
-	if info, err := os.Stat(workingDir); err == nil && !info.IsDir() {
+	if info, err := fsys.Stat(workingDir); err == nil && !info.IsDir() {
 		return workingDir
 	}
 
@@ -1235,7 +1235,7 @@ func GetDefaultConfigPath(workingDir string) string {
 			configPath = filepath.Join(workingDir, configPath)
 		}
 
-		if _, err := os.Stat(configPath); err == nil {
+		if _, err := fsys.Stat(configPath); err == nil {
 			break
 		}
 	}
@@ -2337,8 +2337,8 @@ func validateGenerateBlocks(blocks *[]terragruntGenerateBlock) error {
 // configFileHasDependencyBlock statically checks the terrragrunt config file at the given path and checks if it has any
 // dependency or dependencies blocks defined. Note that this does not do any decoding of the blocks, as it is only meant
 // to check for block presence.
-func configFileHasDependencyBlock(configPath string) (bool, error) {
-	configBytes, err := os.ReadFile(configPath)
+func configFileHasDependencyBlock(fsys vfs.FS, configPath string) (bool, error) {
+	configBytes, err := vfs.ReadFile(fsys, configPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return false, DependencyFileNotFoundError{Path: configPath}

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -6,11 +6,9 @@ import (
 	"fmt"
 	"io"
 	"maps"
-	"os"
 	"path"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -35,7 +33,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/glob"
-	"github.com/gruntwork-io/terragrunt/internal/locks"
 	"github.com/gruntwork-io/terragrunt/internal/retry"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
@@ -434,7 +431,9 @@ func createTerragruntEvalContext(
 
 // Return the OS platform
 func getPlatform(ctx context.Context, pctx *ParsingContext, l log.Logger) (string, error) {
-	return runtime.GOOS, nil
+	pctx.Venv.RequireGOOS()
+
+	return pctx.Venv.Platform.GOOS, nil
 }
 
 // Return the repository root as an absolute path
@@ -793,7 +792,7 @@ func findInParentFoldersImpl(
 			}
 		}
 
-		fileToFind := parentFileCandidate(currentDir, fileToFindParam)
+		fileToFind := parentFileCandidate(pctx.Venv.FS, currentDir, fileToFindParam)
 
 		if parentFileExists(ctx, pctx.Venv.FS, probes, fileToFind) {
 			return fileToFind, nil
@@ -813,9 +812,9 @@ func findInParentFoldersImpl(
 // the caller passed no argument and wants whichever default config name is
 // present, which costs a probe per known name, so [GetDefaultConfigPath] is
 // only consulted in that case.
-func parentFileCandidate(dir, fileName string) string {
+func parentFileCandidate(fsys vfs.FS, dir, fileName string) string {
 	if fileName == "" {
-		return GetDefaultConfigPath(dir)
+		return GetDefaultConfigPath(fsys, dir)
 	}
 
 	return filepath.Join(dir, fileName)
@@ -965,7 +964,7 @@ func getWorkingDir(ctx context.Context, pctx *ParsingContext, l log.Logger) (str
 	// source resolves to a different cache directory.
 	sourceURL = tf.RewriteLegacyGCSPublicSource(ctx, l, sourceURL, pctx.StrictControls)
 
-	source, err := tf.NewSource(l, sourceURL, pctx.DownloadDir, pctx.WorkingDir, walkWithSymlinks)
+	source, err := tf.NewSource(l, pctx.Venv.FS, sourceURL, pctx.DownloadDir, pctx.WorkingDir, walkWithSymlinks)
 	if err != nil {
 		return "", err
 	}
@@ -1212,7 +1211,7 @@ func getCleanedTargetConfigPath(fsys vfs.FS, configPath string, workingPath stri
 	}
 
 	if vfs.IsDir(fsys, targetConfig) {
-		targetConfig = GetDefaultConfigPath(targetConfig)
+		targetConfig = GetDefaultConfigPath(fsys, targetConfig)
 	}
 
 	return filepath.Clean(targetConfig)
@@ -1333,58 +1332,30 @@ func sopsDecryptFileImpl(
 	format string,
 	d vsops.Decrypter,
 ) (string, error) {
+	pctx.Venv.RequireEnv()
+
 	sopsCache := cache.ContextCache[string](ctx, SopsCacheContextKey)
 
-	// Fast path: check cache before acquiring lock.
-	// Cache has its own sync.RWMutex, safe for concurrent reads.
 	if val, ok := sopsCache.Get(ctx, path); ok {
 		l.Debugf("sops decrypt: cache hit for %s (len=%d)", path, len(val))
 
 		return val, nil
 	}
 
-	// Cache miss: acquire lock for env mutation + decrypt.
-	// The lock serializes os.Setenv/os.Unsetenv to prevent race conditions
-	// when multiple units decrypt concurrently with different auth credentials.
-	// See https://github.com/gruntwork-io/terragrunt/issues/5515
-	l.Debugf("sops decrypt: cache miss, acquiring lock for %s (format=%s)", path, format)
+	sopsLocks := sopsLocksFromContext(ctx)
 
-	locks.EnvLock.Lock()
-	defer locks.EnvLock.Unlock()
+	sopsLocks.Lock(path)
+	defer sopsLocks.Unlock(path)
 
-	// Double-check: another goroutine may have populated cache while we waited for the lock.
+	// Whoever held the lock may have been decrypting this very path, so the
+	// cache is consulted again before paying for a decrypt of our own.
 	if val, ok := sopsCache.Get(ctx, path); ok {
 		l.Debugf("sops decrypt: cache hit after lock for %s (len=%d)", path, len(val))
 
 		return val, nil
 	}
 
-	// Set env vars from the venv environment that are missing from process env.
-	// Auth-provider credentials (e.g., AWS_SESSION_TOKEN) may not exist
-	// in process env yet — SOPS needs them for KMS auth.
-	// Existing process env vars are preserved to avoid overriding real
-	// credentials with empty auth-provider values.
-	env := pctx.Venv.Env
-
-	setKeys := make([]string, 0, len(env))
-
-	for k, v := range env {
-		if _, exists := os.LookupEnv(k); exists {
-			continue
-		}
-
-		os.Setenv(k, v) //nolint:errcheck
-
-		setKeys = append(setKeys, k)
-	}
-
-	defer func() {
-		for _, k := range setKeys {
-			os.Unsetenv(k) //nolint:errcheck
-		}
-	}()
-
-	l.Debugf("sops decrypt: decrypting %s", path)
+	l.Debugf("sops decrypt: decrypting %s (format=%s)", path, format)
 
 	var rawData []byte
 
@@ -1395,7 +1366,7 @@ func sopsDecryptFileImpl(
 		}, func(ctx context.Context, l log.Logger) error {
 			var decryptErr error
 
-			rawData, decryptErr = d.DecryptFile(path, format)
+			rawData, decryptErr = d.DecryptFile(pctx.Venv.Env, path, format)
 
 			return decryptErr
 		})
@@ -1411,6 +1382,18 @@ func sopsDecryptFileImpl(
 	}
 
 	return "", InvalidSopsFormatError{SourceFilePath: path}
+}
+
+// sopsLocksFromContext returns the per-path decrypt locks, so units sharing an
+// encrypted file wait for the first decrypt rather than each paying for one. A
+// decrypt can be a KMS round-trip, which is why the duplicate work is worth
+// waiting out.
+func sopsLocksFromContext(ctx context.Context) *util.KeyLocks {
+	if val, ok := ctx.Value(SopsLocksContextKey).(*util.KeyLocks); ok && val != nil {
+		return val
+	}
+
+	return util.NewKeyLocks()
 }
 
 // Return the location of the Terraform files provided via --source
@@ -1575,7 +1558,7 @@ func readTFVarsFileImpl(pctx *ParsingContext, l log.Logger, args []string) (stri
 	// Track that this file was read during parsing
 	pctx.FilesRead.Add(varFile)
 
-	fileContents, err := os.ReadFile(varFile)
+	fileContents, err := vfs.ReadFile(pctx.Venv.FS, varFile)
 	if err != nil {
 		return "", fmt.Errorf("could not read file %q: %w", varFile, err)
 	}

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
@@ -1148,7 +1147,7 @@ func autoIncludeCacheKeySuffix(
 
 	// Fingerprint the sibling cheaply so a cache hit reuses the content based suffix without re-reading the file.
 	fingerprint := autoIncludePath
-	if info, statErr := os.Stat(autoIncludePath); statErr == nil {
+	if info, statErr := pctx.Venv.FS.Stat(autoIncludePath); statErr == nil {
 		fingerprint = fmt.Sprintf(
 			"%s-%d-%d",
 			autoIncludePath,

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -18,6 +18,7 @@ const (
 	JSONOutputCacheContextKey        configKey = iota
 	OutputLocksContextKey            configKey = iota
 	SopsCacheContextKey              configKey = iota
+	SopsLocksContextKey              configKey = iota
 	AutoIncludeSuffixCacheContextKey configKey = iota
 	ParentFileProbeCacheContextKey   configKey = iota
 
@@ -56,6 +57,7 @@ func WithConfigValues(ctx context.Context) context.Context {
 	)
 	ctx = context.WithValue(ctx, OutputLocksContextKey, util.NewKeyLocks())
 	ctx = context.WithValue(ctx, SopsCacheContextKey, cache.NewCache[string](sopsCacheName))
+	ctx = context.WithValue(ctx, SopsLocksContextKey, util.NewKeyLocks())
 	ctx = context.WithValue(
 		ctx,
 		AutoIncludeSuffixCacheContextKey,

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"maps"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -1615,6 +1614,7 @@ func terragruntAlreadyInit(
 
 	terraformSource, err := tf.NewSource(
 		l,
+		pctx.Venv.FS,
 		sourceURL,
 		pctx.DownloadDir,
 		pctx.WorkingDir,
@@ -2039,7 +2039,7 @@ func runTerragruntOutputJSON(
 
 // shellRunOptsFromPctx builds a *shell.ShellOptions from ParsingContext flat fields.
 func shellRunOptsFromPctx(pctx *ParsingContext) *shell.ShellOptions {
-	s := shell.NewShellOptions().
+	s := shell.NewShellOptions(pctx.Venv.Env).
 		WithWorkingDir(pctx.WorkingDir).
 		WithTelemetry(pctx.Telemetry).
 		WithEngine(pctx.EngineConfig, pctx.EngineOptions).
@@ -2218,7 +2218,7 @@ func parseAutoIncludeFileCached(
 	pctx *ParsingContext,
 	autoIncludePath string,
 ) (*hclparse.File, error) {
-	fileInfo, err := os.Stat(autoIncludePath)
+	fileInfo, err := pctx.Venv.FS.Stat(autoIncludePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/external_test.go
+++ b/pkg/config/external_test.go
@@ -393,7 +393,7 @@ func TestExternalGetDefaultConfigPath(t *testing.T) {
 
 	// When given a non-existent directory, GetDefaultConfigPath returns a path
 	// ending with the default config file name.
-	result := config.GetDefaultConfigPath("/some/nonexistent/path")
+	result := config.GetDefaultConfigPath(venvtest.New().FS, "/some/nonexistent/path")
 	assert.Contains(t, result, "terragrunt.hcl")
 }
 

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -84,7 +84,7 @@ func parseIncludedConfig(
 	// NOTE: To make the logic easier to implement, we implement the inverse here, where we check whether the included
 	// config has a dependency block, and if we are in the middle of a partial parse, we perform a partial parse of the
 	// included config.
-	hasDependency, err := configFileHasDependencyBlock(includePath)
+	hasDependency, err := configFileHasDependencyBlock(pctx.Venv.FS, includePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/sops_race_test.go
+++ b/pkg/config/sops_race_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/internal/vsops"
@@ -15,15 +17,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSOPSDecryptConcurrencyWithRacing is a regression test for
-// https://github.com/gruntwork-io/terragrunt/issues/5515
+// TestSOPSDecryptConcurrencyWithRacing covers the config half of
+// https://github.com/gruntwork-io/terragrunt/issues/5515: units decrypting at
+// the same time each reach the decrypter with their own credentials, and the
+// shared decrypt cache tolerates the concurrency. internal/vsops covers the
+// process-environment window those credentials travel through.
 //
-// Run with -race to detect data races in env var handling during concurrent
-// SOPS decryption. The CI "Race" job runs tests matching .*WithRacing with -race.
-//
-// Multiple goroutines call sopsDecryptFileImpl concurrently with different
-// opts.Env credentials. Without proper locking, the race detector catches
-// concurrent os.Setenv/os.Getenv/os.Unsetenv calls.
+// The CI "Race" job runs tests matching .*WithRacing with -race.
 func TestSOPSDecryptConcurrencyWithRacing(t *testing.T) {
 	t.Parallel()
 
@@ -34,25 +34,29 @@ func TestSOPSDecryptConcurrencyWithRacing(t *testing.T) {
 
 	dir := t.TempDir()
 
-	var files []string
+	files := make([]string, 0, numGoroutines)
 
 	for i := 1; i <= numGoroutines; i++ {
 		unitDir := filepath.Join(dir, fmt.Sprintf("unit-%02d", i))
-		require.NoError(t, os.MkdirAll(unitDir, 0755))
+		require.NoError(t, os.MkdirAll(unitDir, 0o755))
 
 		secretFile := filepath.Join(unitDir, "secret.enc.json")
 		require.NoError(t, os.WriteFile(secretFile,
-			fmt.Appendf(nil, `{"value":"secret-from-unit-%02d"}`, i), 0644))
+			fmt.Appendf(nil, `{"value":"secret-from-unit-%02d"}`, i), 0o644))
 
 		files = append(files, secretFile)
 	}
 
-	// Mock decrypter that reads the env var (creating a read that races with
-	// concurrent Setenv/Unsetenv if locking is broken).
-	mockDecrypter := vsops.NewMemDecrypter(func(path string, _ string) ([]byte, error) {
-		_ = os.Getenv(authKey) // read that would race without lock
+	// Echoing the token back into the cleartext is what ties each result to the
+	// venv it was decrypted with, so a leak between units shows up as a
+	// mismatch rather than as a passing test.
+	mockDecrypter := vsops.NewMemDecrypter(func(env map[string]string, path string, _ string) ([]byte, error) {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
 
-		return os.ReadFile(path)
+		return fmt.Appendf(data, "\n%s", env[authKey]), nil
 	})
 
 	var (
@@ -70,8 +74,10 @@ func TestSOPSDecryptConcurrencyWithRacing(t *testing.T) {
 
 			<-barrier
 
+			token := fmt.Sprintf("token-%d", idx)
+
 			l := logger.CreateLogger()
-			v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: fmt.Sprintf("token-%d", idx)})
+			v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: token})
 
 			_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
 			pctx.WorkingDir = filepath.Dir(filePath)
@@ -79,13 +85,126 @@ func TestSOPSDecryptConcurrencyWithRacing(t *testing.T) {
 			result, err := sopsDecryptFileImpl(ctx, pctx, l, filePath, "json", mockDecrypter)
 			assert.NoError(t, err)
 			assert.Contains(t, result, `"value":"secret-from-unit-`)
+			assert.Contains(t, result, token)
 		}(i, f)
 	}
 
 	close(barrier)
 	wg.Wait()
+}
 
-	// Verify env is clean after all goroutines complete.
-	_, exists := os.LookupEnv(authKey)
-	require.False(t, exists, "env var must be cleaned up after concurrent decrypts")
+// TestSOPSDecryptDistinctPathsOverlapWithRacing pins that a decrypt holds up
+// only the units reading the same file. Every decrypter here blocks until all
+// of them have been entered, so a lock covering the whole cache would never let
+// the last one arrive.
+func TestSOPSDecryptDistinctPathsOverlapWithRacing(t *testing.T) {
+	t.Parallel()
+
+	const numUnits = 4
+
+	dir := t.TempDir()
+
+	files := make([]string, 0, numUnits)
+
+	for i := range numUnits {
+		secretFile := filepath.Join(dir, fmt.Sprintf("unit-%02d.enc.json", i))
+		require.NoError(t, os.WriteFile(secretFile, []byte(`{"value":"secret"}`), 0o644))
+
+		files = append(files, secretFile)
+	}
+
+	var (
+		entered = make(chan struct{}, numUnits)
+		release = make(chan struct{})
+	)
+
+	blockingDecrypter := vsops.NewMemDecrypter(
+		func(_ map[string]string, path string, _ string) ([]byte, error) {
+			entered <- struct{}{}
+
+			<-release
+
+			return os.ReadFile(path)
+		})
+
+	ctx := WithConfigValues(t.Context())
+
+	var wg sync.WaitGroup
+
+	for _, f := range files {
+		wg.Go(func() {
+			l := logger.CreateLogger()
+			v := venvtest.NewWithOSFS().WithEnv(map[string]string{})
+
+			_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
+			pctx.WorkingDir = dir
+
+			result, err := sopsDecryptFileImpl(ctx, pctx, l, f, "json", blockingDecrypter)
+			require.NoError(t, err)
+			assert.Contains(t, result, `"value":"secret"`)
+		})
+	}
+
+	for range numUnits {
+		select {
+		case <-entered:
+		case <-time.After(10 * time.Second):
+			close(release)
+			wg.Wait()
+			t.Fatal("decrypts of distinct files did not overlap")
+		}
+	}
+
+	close(release)
+	wg.Wait()
+}
+
+// TestSOPSDecryptDeduplicatesSamePathWithRacing pins that units sharing an
+// encrypted file pay for one decrypt between them. A SOPS decrypt can be a KMS
+// round-trip, so a second one is not merely wasted CPU.
+func TestSOPSDecryptDeduplicatesSamePathWithRacing(t *testing.T) {
+	t.Parallel()
+
+	const numGoroutines = 8
+
+	dir := t.TempDir()
+	secretFile := filepath.Join(dir, "shared.enc.json")
+	require.NoError(t, os.WriteFile(secretFile, []byte(`{"value":"shared"}`), 0o644))
+
+	var decrypts atomic.Int64
+
+	countingDecrypter := vsops.NewMemDecrypter(
+		func(_ map[string]string, path string, _ string) ([]byte, error) {
+			decrypts.Add(1)
+
+			return os.ReadFile(path)
+		})
+
+	var (
+		wg      sync.WaitGroup
+		barrier = make(chan struct{})
+	)
+
+	ctx := WithConfigValues(t.Context())
+
+	for range numGoroutines {
+		wg.Go(func() {
+			<-barrier
+
+			l := logger.CreateLogger()
+			v := venvtest.NewWithOSFS().WithEnv(map[string]string{})
+
+			_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
+			pctx.WorkingDir = dir
+
+			result, err := sopsDecryptFileImpl(ctx, pctx, l, secretFile, "json", countingDecrypter)
+			require.NoError(t, err)
+			assert.Contains(t, result, `"value":"shared"`)
+		})
+	}
+
+	close(barrier)
+	wg.Wait()
+
+	assert.Equal(t, int64(1), decrypts.Load(), "the file should be decrypted once for all readers")
 }

--- a/pkg/config/sops_test.go
+++ b/pkg/config/sops_test.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
@@ -34,7 +32,7 @@ func generateTestSecretFiles(t *testing.T, count int) []string {
 
 		secretFile := filepath.Join(unitDir, "secret.enc.json")
 		require.NoError(t, os.WriteFile(secretFile,
-			[]byte(fmt.Sprintf(`{"value":"secret-from-unit-%02d"}`, i)), 0644))
+			fmt.Appendf(nil, `{"value":"secret-from-unit-%02d"}`, i), 0644))
 
 		files = append(files, secretFile)
 	}
@@ -43,211 +41,84 @@ func generateTestSecretFiles(t *testing.T, count int) []string {
 }
 
 // TestSOPSDecryptEnvPropagation is a deterministic regression test for
-// https://github.com/gruntwork-io/terragrunt/issues/5515
+// https://github.com/gruntwork-io/terragrunt/issues/5515, where
+// sops_decrypt_file() could not authenticate to KMS because the auth provider's
+// credentials had not reached the decrypt.
 //
-// The original customer-reported bug: sops_decrypt_file() during HCL evaluation
-// couldn't authenticate to KMS because auth-provider credentials were not yet
-// loaded into opts.Env. This caused SOPS to return empty/wrong secrets.
-//
-// This test verifies the env propagation contract of sopsDecryptFileImpl:
-//   - Existing process env vars are preserved (not overridden by opts.Env)
-//   - Missing env vars from opts.Env are set during decrypt and unset after
-//   - Without credentials, decrypt fails (reproduces the original bug)
-//   - Concurrent goroutines with different credentials are properly isolated
-func TestSOPSDecryptEnvPropagation(t *testing.T) { //nolint:paralleltest // mutates process env vars
+// A decrypt runs with the credentials the venv carries, and the config layer
+// hands that environment to the decrypter as it stands. Publishing them into
+// the process environment for the length of one decrypt belongs to the OS
+// decrypter, so internal/vsops covers that window, and
+// [TestSOPSDecryptConcurrencyWithRacing] covers units decrypting at once.
+func TestSOPSDecryptEnvPropagation(t *testing.T) {
+	t.Parallel()
+
 	const authKey = "SOPS_TEST_AUTH_CRED"
 
-	t.Cleanup(func() {
-		os.Unsetenv(authKey) //nolint:errcheck
+	secretFile := generateTestSecretFiles(t, 1)[0]
+
+	authRequiringDecrypter := vsops.NewMemDecrypter(
+		func(env map[string]string, path string, _ string) ([]byte, error) {
+			if env[authKey] == "" {
+				return nil, errors.New("KMS auth failed: no credential set")
+			}
+
+			return os.ReadFile(path)
+		})
+
+	t.Run("creds_from_venv_reach_the_decrypter", func(t *testing.T) {
+		t.Parallel()
+
+		l := logger.CreateLogger()
+		ctx := WithConfigValues(t.Context())
+		v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: "fresh-token"})
+
+		_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
+		pctx.WorkingDir = filepath.Dir(secretFile)
+
+		result, err := sopsDecryptFileImpl(ctx, pctx, l, secretFile, "json", authRequiringDecrypter)
+		require.NoError(t, err, "decrypt must succeed with credentials from the venv")
+		assert.Contains(t, result, `"value":"secret-from-unit-01"`)
 	})
 
-	secretFiles := generateTestSecretFiles(t, 1)
-	secretFile := secretFiles[0]
+	t.Run("missing_creds_fails_decrypt", func(t *testing.T) {
+		t.Parallel()
 
-	// Mock decrypter that requires authKey to be set, simulating KMS auth.
-	authRequiringDecrypter := vsops.NewMemDecrypter(func(path string, _ string) ([]byte, error) {
-		token := os.Getenv(authKey)
-		if token == "" {
-			return nil, errors.New("KMS auth failed: no credential set")
-		}
+		l := logger.CreateLogger()
+		ctx := WithConfigValues(t.Context())
+		v := venvtest.NewWithOSFS().WithEnv(map[string]string{})
 
+		_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
+		pctx.WorkingDir = filepath.Dir(secretFile)
+
+		_, err := sopsDecryptFileImpl(ctx, pctx, l, secretFile, "json", authRequiringDecrypter)
+		require.Error(t, err,
+			"decrypt must fail without auth credentials, reproducing original issue #5515")
+	})
+}
+
+// TestSOPSDecryptLeavesProcessEnvAlone pins that a credential the run was
+// started with outlives a decrypt that carried its own value for the same name.
+func TestSOPSDecryptLeavesProcessEnvAlone(t *testing.T) { //nolint:paralleltest // t.Setenv
+	const authKey = "SOPS_TEST_UNTOUCHED_CRED"
+
+	t.Setenv(authKey, "real-ci-token")
+
+	secretFile := generateTestSecretFiles(t, 1)[0]
+
+	d := vsops.NewMemDecrypter(func(_ map[string]string, path string, _ string) ([]byte, error) {
 		return os.ReadFile(path)
 	})
 
-	// Subtest 1: Existing process env vars are preserved (not overridden).
-	// Models: CI runner has real AWS_SESSION_TOKEN, auth-provider returns empty token.
-	// sopsDecryptFileImpl must NOT override the real token with empty, since SOPS uses process env.
-	t.Run(
-		"existing_process_env_preserved",
-		func(t *testing.T) { //nolint:paralleltest // mutates process env
-			t.Setenv(authKey, "real-ci-token")
+	l := logger.CreateLogger()
+	ctx := WithConfigValues(t.Context())
+	v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: "venv-token"})
 
-			l := logger.CreateLogger()
-			ctx := WithConfigValues(t.Context())
-			v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: ""})
+	_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
+	pctx.WorkingDir = filepath.Dir(secretFile)
 
-			_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
-			pctx.WorkingDir = filepath.Dir(secretFile)
+	_, err := sopsDecryptFileImpl(ctx, pctx, l, secretFile, "json", d)
+	require.NoError(t, err)
 
-			result, err := sopsDecryptFileImpl(
-				ctx,
-				pctx,
-				l,
-				secretFile,
-				"json",
-				authRequiringDecrypter,
-			)
-			require.NoError(t, err, "decrypt must succeed using existing process env credentials")
-			assert.Contains(t, result, `"value":"secret-from-unit-01"`)
-
-			// Process env must still have the real token, not overridden
-			assert.Equal(t, "real-ci-token", os.Getenv(authKey),
-				"existing process env var must not be overridden")
-		},
-	)
-
-	// Subtest 2: Credentials injected when absent from process env.
-	// Models: first run, auth-provider loaded creds into opts.Env, process env was empty.
-	t.Run( //nolint:paralleltest // mutates process env
-		"new_creds_set_when_absent_from_process_env",
-		func(t *testing.T) {
-			os.Unsetenv(authKey) //nolint:errcheck
-
-			l := logger.CreateLogger()
-			ctx := WithConfigValues(t.Context())
-			v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: "fresh-token"})
-
-			_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
-			pctx.WorkingDir = filepath.Dir(secretFile)
-
-			result, err := sopsDecryptFileImpl(
-				ctx,
-				pctx,
-				l,
-				secretFile,
-				"json",
-				authRequiringDecrypter,
-			)
-			require.NoError(t, err, "decrypt must succeed with fresh credentials from opts.Env")
-			assert.Contains(t, result, `"value":"secret-from-unit-01"`)
-
-			// Process env must be unset (not empty string) after decrypt
-			_, exists := os.LookupEnv(authKey)
-			assert.False(t, exists,
-				"env var must be unset after decrypt, not set to empty string")
-		},
-	)
-
-	// Subtest 3: Missing credentials cause decrypt failure.
-	// Reproduces the ORIGINAL bug: auth-provider hasn't run yet, opts.Env has no
-	// auth token, process env has no auth token → SOPS can't authenticate to KMS.
-	t.Run( //nolint:paralleltest // mutates process env
-		"missing_creds_fails_decrypt",
-		func(t *testing.T) {
-			os.Unsetenv(authKey) //nolint:errcheck
-
-			l := logger.CreateLogger()
-			ctx := WithConfigValues(t.Context())
-			v := venvtest.NewWithOSFS().WithEnv(map[string]string{})
-
-			_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
-			pctx.WorkingDir = filepath.Dir(secretFile)
-
-			_, err := sopsDecryptFileImpl(ctx, pctx, l, secretFile, "json", authRequiringDecrypter)
-			require.Error(t, err,
-				"decrypt must fail without auth credentials, reproducing original issue #5515")
-		},
-	)
-
-	// Subtest 4: Concurrent goroutines with DIFFERENT auth tokens are isolated.
-	// Models production: multiple units decrypt in parallel, each with different
-	// auth-provider credentials. The lock must ensure each sees its OWN token.
-	t.Run( //nolint:paralleltest // mutates process env
-		"concurrent_different_creds_isolated",
-		func(t *testing.T) {
-			const numGoroutines = 5
-
-			os.Unsetenv(authKey) //nolint:errcheck
-
-			files := generateTestSecretFiles(t, numGoroutines)
-
-			var wg sync.WaitGroup
-
-			barrier := make(chan struct{})
-
-			var failures atomic.Int32
-
-			ctx := WithConfigValues(t.Context())
-
-			for i, f := range files {
-				wg.Add(1)
-
-				go func(idx int, filePath string) {
-					defer wg.Done()
-
-					<-barrier
-
-					expectedToken := fmt.Sprintf("token-%d", idx)
-
-					// Each goroutine's decrypter verifies it sees ITS OWN token
-					tokenCheckDecrypter := vsops.NewMemDecrypter(
-						func(path string, _ string) ([]byte, error) {
-							actual := os.Getenv(authKey)
-							if actual != expectedToken {
-								return nil, fmt.Errorf(
-									"goroutine %d: expected %q, got %q",
-									idx,
-									expectedToken,
-									actual,
-								)
-							}
-
-							return os.ReadFile(path)
-						},
-					)
-
-					l := logger.CreateLogger()
-					v := venvtest.NewWithOSFS().
-						WithEnv(map[string]string{authKey: expectedToken})
-
-					_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
-					pctx.WorkingDir = filepath.Dir(filePath)
-
-					result, decryptErr := sopsDecryptFileImpl(
-						ctx,
-						pctx,
-						l,
-						filePath,
-						"json",
-						tokenCheckDecrypter,
-					)
-					if decryptErr != nil {
-						t.Logf("goroutine %d failed: %v", idx, decryptErr)
-						failures.Add(1)
-
-						return
-					}
-
-					expectedPrefix := `{"value":"secret-from-unit-`
-					if len(result) < len(expectedPrefix) ||
-						result[:len(expectedPrefix)] != expectedPrefix {
-						t.Logf("goroutine %d: wrong content: %s", idx, result)
-						failures.Add(1)
-					}
-				}(i, f)
-			}
-
-			close(barrier)
-			wg.Wait()
-
-			require.Zero(
-				t,
-				failures.Load(),
-				"all goroutines must see their own auth token during decrypt; env isolation failed",
-			)
-
-			assert.Empty(t, os.Getenv(authKey),
-				"process env must be clean after all concurrent decrypts")
-		},
-	)
+	assert.Equal(t, "real-ci-token", os.Getenv(authKey))
 }

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -258,7 +258,7 @@ func resolveStackAutoIncludes(
 	}
 
 	// stackSrcBytes is read separately for the autoinclude parser, which slices expression byte ranges from the original file when generating terragrunt.autoinclude.hcl.
-	stackSrcBytes, err := os.ReadFile(stackFilePath)
+	stackSrcBytes, err := vfs.ReadFile(pctx.Venv.FS, stackFilePath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read stack file bytes %s: %w", stackFilePath, err)
 	}
@@ -433,7 +433,7 @@ func setupCAS(l log.Logger, v *venv.Venv, enabled bool, cloneDepth int) (casSetu
 		return casSetup{}, nil
 	}
 
-	if _, err := git.NewGitRunner(v.Exec); err != nil {
+	if _, err := git.NewGitRunner(v); err != nil {
 		l.Warnf("Failed to initialize CAS environment: %v. CAS features disabled.", err)
 		return casSetup{}, nil
 	}
@@ -612,6 +612,7 @@ func resolveDestPath(cmp *componentToGenerate, opts *generateOpts) (string, erro
 // validateGeneratedComponent validates the generated component directory contains the expected config file.
 func validateGeneratedComponent(
 	l log.Logger,
+	fsys vfs.FS,
 	cmp *componentToGenerate,
 	opts *generateOpts,
 	dest string,
@@ -639,7 +640,7 @@ func validateGeneratedComponent(
 		expectedFile = DefaultStackFile
 	}
 
-	if err := validateTargetDir(kindStr, cmp.name, dest, expectedFile); err != nil {
+	if err := validateTargetDir(fsys, kindStr, cmp.name, dest, expectedFile); err != nil {
 		if opts.noStackValidate {
 			l.Warnf(
 				"Suppressing validation error for %s %s at path %s: expected %s to generate with %s file at root of generated directory.",
@@ -749,7 +750,7 @@ func generateComponent(
 		}
 	}
 
-	if err := validateGeneratedComponent(l, cmp, opts, dest); err != nil {
+	if err := validateGeneratedComponent(l, v.FS, cmp, opts, dest); err != nil {
 		return err
 	}
 
@@ -799,7 +800,7 @@ func fetchComponentSource(
 			)
 		}
 
-		if err := os.MkdirAll(dest, os.ModePerm); err != nil {
+		if err := v.FS.MkdirAll(dest, os.ModePerm); err != nil {
 			return fmt.Errorf("failed to create directory %s for %s %w", dest, cmp.name, err)
 		}
 
@@ -2016,10 +2017,10 @@ func processLocals(
 }
 
 // validateTargetDir target destination directory.
-func validateTargetDir(kind, name, destDir, expectedFile string) error {
+func validateTargetDir(fsys vfs.FS, kind, name, destDir, expectedFile string) error {
 	expectedPath := filepath.Join(destDir, expectedFile)
 
-	info, err := os.Stat(expectedPath)
+	info, err := fsys.Stat(expectedPath)
 	if err != nil {
 		return fmt.Errorf(
 			"%s '%s': expected file '%s' not found in target directory '%s': %w",

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -27,7 +26,9 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/tips"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
@@ -329,9 +330,9 @@ func WithIAMWebIdentityToken(token string) TerragruntOptionsFunc {
 
 // NewTerragruntOptions creates a new TerragruntOptions object with
 // reasonable defaults for real usage.
-func NewTerragruntOptions() *TerragruntOptions {
+func NewTerragruntOptions(e vexec.Exec) *TerragruntOptions {
 	return &TerragruntOptions{
-		TFPath:                   IdentifyDefaultWrappedExecutable(vexec.NewOSExec()),
+		TFPath:                   IdentifyDefaultWrappedExecutable(e),
 		ExcludesFile:             defaultExcludesFile,
 		FiltersFile:              defaultFiltersFile,
 		AutoInit:                 true,
@@ -359,8 +360,11 @@ func NewTerragruntOptions() *TerragruntOptions {
 	}
 }
 
-func NewTerragruntOptionsWithConfigPath(terragruntConfigPath string) (*TerragruntOptions, error) {
-	opts := NewTerragruntOptions()
+func NewTerragruntOptionsWithConfigPath(
+	e vexec.Exec,
+	terragruntConfigPath string,
+) (*TerragruntOptions, error) {
+	opts := NewTerragruntOptions(e)
 
 	// Ensure config path is absolute so downstream code can rely on it.
 	// Skip resolution for empty paths (sentinel meaning "not set").
@@ -400,7 +404,7 @@ func NewTerragruntOptionsForTest(
 	formatter := format.NewFormatter(format.NewKeyValueFormatPlaceholders())
 	formatter.SetDisabledColors(true)
 
-	opts, err := NewTerragruntOptionsWithConfigPath(terragruntConfigPath)
+	opts, err := NewTerragruntOptionsWithConfigPath(venv.OSVenv().Exec, terragruntConfigPath)
 	if err != nil {
 		log.WithOptions(log.WithLevel(log.DebugLevel), log.WithFormatter(formatter)).
 			Errorf("%v\n", err)
@@ -588,6 +592,7 @@ func IdentifyDefaultWrappedExecutable(e vexec.Exec) string {
 func (opts *TerragruntOptions) RunWithErrorHandling(
 	ctx context.Context,
 	l log.Logger,
+	fsys vfs.FS,
 	r *report.Report,
 	operation func() error,
 ) error {
@@ -633,7 +638,7 @@ func (opts *TerragruntOptions) RunWithErrorHandling(
 
 			// Handle ignore signals if any are configured
 			if len(action.IgnoreSignals) > 0 {
-				if err := opts.handleIgnoreSignals(l, action.IgnoreSignals); err != nil {
+				if err := opts.handleIgnoreSignals(l, fsys, action.IgnoreSignals); err != nil {
 					return err
 				}
 			}
@@ -703,7 +708,7 @@ func (opts *TerragruntOptions) RunWithErrorHandling(
 	}
 }
 
-func (opts *TerragruntOptions) handleIgnoreSignals(l log.Logger, signals map[string]any) error {
+func (opts *TerragruntOptions) handleIgnoreSignals(l log.Logger, fsys vfs.FS, signals map[string]any) error {
 	workingDir := opts.WorkingDir
 	signalsFile := filepath.Join(workingDir, DefaultSignalsFile)
 
@@ -716,7 +721,7 @@ func (opts *TerragruntOptions) handleIgnoreSignals(l log.Logger, signals map[str
 
 	l.Warnf("Writing error signals to %s", signalsFile)
 
-	if err := os.WriteFile(signalsFile, signalsJSON, ownerPerms); err != nil {
+	if err := vfs.WriteFile(fsys, signalsFile, signalsJSON, ownerPerms); err != nil {
 		return fmt.Errorf("failed to write signals file %s: %w", signalsFile, err)
 	}
 

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -82,7 +82,7 @@ func TestInsertTerraformCliArgsNilGuard(t *testing.T) {
 func TestNewTerragruntOptions_DefaultCASCloneDepth(t *testing.T) {
 	t.Parallel()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	assert.Equal(t, cas.DefaultCASCloneDepth, opts.CASCloneDepth)
 }
 

--- a/test/benchmarks/helpers/helpers.go
+++ b/test/benchmarks/helpers/helpers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -30,7 +31,7 @@ const (
 func RunTerragruntCommand(b *testing.B, args ...string) {
 	b.Helper()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 	l := logger.CreateLogger().WithOptions(log.WithOutput(io.Discard))
 

--- a/test/fixtures/auth-provider-cmd/sops/creds.config
+++ b/test/fixtures/auth-provider-cmd/sops/creds.config
@@ -1,4 +1,4 @@
 access_key_id=__FILL_AWS_ACCESS_KEY_ID__
 secret_access_key=__FILL_AWS_SECRET_ACCESS_KEY__
-session_token=
+session_token=__FILL_AWS_SESSION_TOKEN__
 tf_var_foo=

--- a/test/helpers/git_server.go
+++ b/test/helpers/git_server.go
@@ -17,7 +17,7 @@ import (
 
 	gliderssh "github.com/gliderlabs/ssh"
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -560,7 +560,7 @@ func commitDirs(
 func InitTestGitRunner(t *testing.T, tmpDir string) *git.GitRunner {
 	t.Helper()
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpDir)

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -1193,7 +1193,7 @@ func RunTerragruntCommandWithContext(
 	syncWriter := util.NewSyncWriter(writer)
 	syncErrWriter := util.NewSyncWriter(errwriter)
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 	v := venv.OSVenv()
 	v.Writers = &writerpkg.Writers{Writer: syncWriter, ErrWriter: syncErrWriter}

--- a/test/helpers/report.go
+++ b/test/helpers/report.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,7 +13,7 @@ import (
 func ReadReport(t *testing.T, rootPath string, reportFile string) report.JSONRuns {
 	t.Helper()
 
-	runs, err := report.ParseJSONRunsFromFile(filepath.Join(rootPath, reportFile))
+	runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), filepath.Join(rootPath, reportFile))
 	require.NoError(t, err)
 
 	return runs

--- a/test/helpers/test_helpers.go
+++ b/test/helpers/test_helpers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/os/signal"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run/creds/providers/externalcmd"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/require"
 )
@@ -192,7 +193,7 @@ func MakeDiscoveryContext(
 
 // MakeOpts creates terragrunt options for a given directory.
 func MakeOpts(dir string) *options.TerragruntOptions {
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	opts.WorkingDir = dir
 	opts.RootWorkingDir = dir
 

--- a/test/helpers/venvtest/venvtest.go
+++ b/test/helpers/venvtest/venvtest.go
@@ -1,6 +1,7 @@
 // Package venvtest builds in-memory [venv.Venv] values for tests. New seeds
 // the mem defaults; callers refine individual handles with venv.Venv's fluent
 // With methods (WithHandler, WithExec, WithFS, WithSops, WithEnv, WithGOOS,
+// WithGOARCH,
 // WithUserHomeDir). Production code builds venvs through [venv.OSVenv] instead.
 package venvtest
 
@@ -59,7 +60,7 @@ func New() *venv.Venv {
 		Exec: vexec.NewNoSpawnExec(),
 		FS:   vfs.NewMemMapFS(),
 		HTTP: vhttp.NewNoNetworkClient(),
-		Sops: vsops.NewMemDecrypter(func(string, string) ([]byte, error) { return nil, nil }),
+		Sops: vsops.NewMemDecrypter(func(map[string]string, string, string) ([]byte, error) { return nil, nil }),
 		Listen: func(context.Context, string, string) (net.Listener, error) {
 			return nil, ErrNoListen
 		},
@@ -81,7 +82,8 @@ func New() *venv.Venv {
 			GetPID: func() int {
 				return memPID
 			},
-			GOOS: runtime.GOOS,
+			GOOS:   runtime.GOOS,
+			GOARCH: runtime.GOARCH,
 		},
 		Terminal: &venv.Terminal{
 			StdinIsTTY:  func() bool { return false },

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -1974,7 +1973,7 @@ func TestAwsProviderPatch(t *testing.T) {
 	// fill in branch so we can test against updates to the test case file
 	mainContents, err := vfs.ReadFileAsString(vfs.NewOSFS(), mainTFFile)
 	require.NoError(t, err)
-	gitRunner, err := git.NewGitRunner(vexec.NewOSExec())
+	gitRunner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	branchName := gitRunner.WithWorkDir(modulePath).GetCurrentBranch(t.Context())
 	// https://www.terraform.io/docs/language/modules/sources.html#modules-in-package-sub-directories
@@ -3055,6 +3054,13 @@ func TestAwsReadTerragruntAuthProviderCmdWithSops(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAuthProviderCmd)
 	sopsPath := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "sops")
 	mockAuthCmd := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "mock-auth-cmd.sh")
+
+	credsConfig := filepath.Join(sopsPath, "creds.config")
+	helpers.CopyAndFillMapPlaceholders(t, credsConfig, credsConfig, map[string]string{
+		"__FILL_AWS_ACCESS_KEY_ID__":     os.Getenv("AWS_ACCESS_KEY_ID"),
+		"__FILL_AWS_SECRET_ACCESS_KEY__": os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		"__FILL_AWS_SESSION_TOKEN__":     os.Getenv("AWS_SESSION_TOKEN"),
+	})
 
 	helpers.ValidateAuthProviderScript(t, sopsPath, mockAuthCmd)
 

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -741,7 +741,7 @@ func ignoreFileAction(
 ) clihelper.FlagActionFunc[string] {
 	t.Helper()
 
-	flagList := catalog.NewFlags(catalog.NewOptions(opts), nil)
+	flagList := catalog.NewFlags(vfs.NewOSFS(), catalog.NewOptions(opts), nil)
 
 	flag := flagList.Get(catalog.IgnoreFileFlagName)
 	require.NotNil(t, flag, "--%s flag not registered", catalog.IgnoreFileFlagName)

--- a/test/integration_debug_tf_test.go
+++ b/test/integration_debug_tf_test.go
@@ -56,7 +56,7 @@ func TestTFDebugGeneratedInputs(t *testing.T) {
 			t.Context(),
 			l,
 			venv.OSVenv(),
-			configbridge.TFRunOptsFromOpts(mockOptions),
+			configbridge.TFRunOptsFromOpts(map[string]string{}, mockOptions),
 			"apply", "-auto-approve", "-var-file", debugFile,
 		),
 	)

--- a/test/integration_destroy_test.go
+++ b/test/integration_destroy_test.go
@@ -14,7 +14,8 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/report"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,7 +55,7 @@ func TestTFTerragruntDestroyOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	// Parse the report file to verify dependency order
-	runs, err := report.ParseJSONRunsFromFile(reportFile)
+	runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 	require.NoError(t, err)
 
 	// Verify all modules are in the report
@@ -110,7 +111,7 @@ func TestTFTerragruntApplyDestroyOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	// Parse the report file to verify dependency order
-	runs, err := report.ParseJSONRunsFromFile(reportFile)
+	runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 	require.NoError(t, err)
 
 	runA := runs.FindByName("module-a")
@@ -171,7 +172,7 @@ func TestTFTerragruntDestroyOrderWithQueueIgnoreErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	// Parse the report file to verify dependency order
-	runs, err := report.ParseJSONRunsFromFile(reportFile)
+	runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 	require.NoError(t, err)
 
 	// Verify all modules are in the report
@@ -267,7 +268,7 @@ func TestTFDestroyDependentModule(t *testing.T) {
 	)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureDestroyDependentModule)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(rootPath)
@@ -513,7 +514,7 @@ func TestTFTerragruntSkipConfirmExternalDependencies(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, tmpEnvPath)
 	testPath := filepath.Join(tmpEnvPath, testFixtureExternalDependency)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpEnvPath)

--- a/test/integration_discovery_boundary_tf_test.go
+++ b/test/integration_discovery_boundary_tf_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,7 +57,7 @@ func TestTFDiscoveryBoundaryBoundsWhatRunAllApplies(t *testing.T) {
 
 			require.FileExists(t, reportFile)
 
-			runs, parseErr := report.ParseJSONRunsFromFile(reportFile)
+			runs, parseErr := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 			require.NoError(t, parseErr)
 
 			assert.ElementsMatch(t, tc.expected, relativeRunNames(t, runs.Names(), fixtureDir))
@@ -92,7 +93,7 @@ func TestTFDiscoveryBoundaryRunAllConsumesWithheldDependency(t *testing.T) {
 
 	require.FileExists(t, reportFile)
 
-	runs, parseErr := report.ParseJSONRunsFromFile(reportFile)
+	runs, parseErr := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 	require.NoError(t, parseErr)
 
 	require.ElementsMatch(t, []string{"app", "db"}, relativeRunNames(t, runs.Names(), fixtureDir))

--- a/test/integration_docs_aws_tofu_test.go
+++ b/test/integration_docs_aws_tofu_test.go
@@ -135,6 +135,7 @@ func TestAwsDocsTerralithToTerragruntGuide(t *testing.T) {
 		//
 		// We need our infrastructure to persist between steps so that we can test stateful refactoring.
 		pass := false
+
 		defer func() {
 			if !pass {
 				helpers.ExecWithMiseAndTestLogger(t, liveDir, "tofu", "destroy", "-auto-approve")
@@ -249,6 +250,7 @@ force_destroy = true
 		)
 
 		t.Log("Step 1 - Starting the Terralith completed successfully")
+
 		pass = true
 	}()
 
@@ -259,6 +261,7 @@ force_destroy = true
 		//
 		// We need our infrastructure to persist between steps so that we can test stateful refactoring.
 		pass := false
+
 		defer func() {
 			if !pass {
 				helpers.ExecWithMiseAndTestLogger(t, liveDir, "tofu", "destroy", "-auto-approve")
@@ -351,6 +354,7 @@ force_destroy = true
 		assert.Contains(t, outputStdout, "dynamodb_table_name")
 
 		t.Log("Step 2 - Refactoring completed successfully")
+
 		pass = true
 	}()
 
@@ -361,6 +365,7 @@ force_destroy = true
 		//
 		// We need our infrastructure to persist between steps so that we can test stateful refactoring.
 		pass := false
+
 		defer func() {
 			if !pass {
 				helpers.ExecWithMiseAndTestLogger(t, liveDir, "tofu", "destroy", "-auto-approve")
@@ -457,6 +462,7 @@ force_destroy = true
 		assert.NotEqual(t, strings.TrimSpace(devFunctionURL), strings.TrimSpace(prodFunctionURL))
 
 		t.Log("Step 3 - Adding dev completed successfully")
+
 		pass = true
 	}()
 
@@ -467,6 +473,7 @@ force_destroy = true
 		//
 		// We need our infrastructure to persist between steps so that we can test stateful refactoring.
 		pass := false
+
 		defer func() {
 			if !pass {
 				// Cleanup both dev and prod environments if we get here.
@@ -684,6 +691,7 @@ force_destroy = true
 		assert.NotEqual(t, strings.TrimSpace(devBucketName), strings.TrimSpace(prodBucketName))
 
 		t.Log("Step 4 - Breaking the Terralith completed successfully")
+
 		pass = true
 	}()
 
@@ -694,6 +702,7 @@ force_destroy = true
 		//
 		// We need our infrastructure to persist between steps so that we can test stateful refactoring.
 		pass := false
+
 		defer func() {
 			if !pass {
 				// Cleanup both dev and prod environments if we get here.
@@ -922,6 +931,7 @@ inputs = {
 		assert.Contains(t, prodOutputStdout, "s3_bucket_name")
 
 		t.Log("Step 5 - Adding Terragrunt completed successfully")
+
 		pass = true
 	}()
 
@@ -932,6 +942,7 @@ inputs = {
 		//
 		// We need our infrastructure to persist between steps so that we can test stateful refactoring.
 		pass := false
+
 		defer func() {
 			if !pass {
 				// Cleanup all component units if we get here.
@@ -1222,6 +1233,7 @@ inputs = {
 		assert.Contains(t, prodLambdaPlan, "found no differences, so no changes are needed.")
 
 		t.Log("Step 6 - Breaking the Terralith Further completed successfully")
+
 		pass = true
 	}()
 
@@ -1232,6 +1244,7 @@ inputs = {
 		//
 		// We need our infrastructure to persist between steps so that we can test stateful refactoring.
 		pass := false
+
 		defer func() {
 			if !pass {
 				// Cleanup all component units if we get here.
@@ -1318,6 +1331,7 @@ EOF
 
 			// Copy .terraform.lock.hcl if it exists
 			lockFilePath := filepath.Join(devComponentDir, ".terraform.lock.hcl")
+
 			catalogLockFilePath := filepath.Join(catalogComponentDir, ".terraform.lock.hcl")
 			if _, err := os.Stat(lockFilePath); err == nil {
 				helpers.CopyFile(t, lockFilePath, catalogLockFilePath)
@@ -1480,6 +1494,7 @@ EOF
 		assert.Contains(t, prodLambdaPlan, "found no differences, so no changes are needed.")
 
 		t.Log("Step 7 - Taking advantage of Terragrunt Stacks completed successfully")
+
 		pass = true
 	}()
 
@@ -1490,6 +1505,7 @@ EOF
 		//
 		// We need our infrastructure to persist between steps so that we can test stateful refactoring.
 		pass := false
+
 		defer func() {
 			if !pass {
 				// Cleanup all component units if we get here.
@@ -1754,6 +1770,7 @@ EOF
 		// Verify the directory structure is clean - dev and prod should only contain terragrunt.stack.hcl
 		devEntries, err := os.ReadDir(devDir)
 		require.NoError(t, err)
+
 		devFileNames := make([]string, 0, len(devEntries))
 		for _, entry := range devEntries {
 			if !strings.HasPrefix(
@@ -1763,10 +1780,12 @@ EOF
 				devFileNames = append(devFileNames, entry.Name())
 			}
 		}
+
 		assert.Equal(t, []string{"terragrunt.stack.hcl"}, devFileNames)
 
 		prodEntries, err := os.ReadDir(prodDir)
 		require.NoError(t, err)
+
 		prodFileNames := make([]string, 0, len(prodEntries))
 		for _, entry := range prodEntries {
 			if !strings.HasPrefix(
@@ -1776,9 +1795,11 @@ EOF
 				prodFileNames = append(prodFileNames, entry.Name())
 			}
 		}
+
 		assert.Equal(t, []string{"terragrunt.stack.hcl"}, prodFileNames)
 
 		t.Log("Step 8 - Refactoring state with Terragrunt Stacks completed successfully")
+
 		pass = true
 	}()
 

--- a/test/integration_docs_tf_test.go
+++ b/test/integration_docs_tf_test.go
@@ -38,7 +38,6 @@ func TestTFDocsQuickStart(t *testing.T) {
 		)
 		require.NoError(t, err)
 		assert.Contains(t, stdout, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.")
-
 	})
 
 	t.Run("step-01.1", func(t *testing.T) {
@@ -224,6 +223,7 @@ func TestTFStacksWithLocalState(t *testing.T) {
 	fooPath := filepath.Join(stackPath, "foo")
 	barPath := filepath.Join(stackPath, "bar")
 	bazPath := filepath.Join(stackPath, "baz")
+
 	require.DirExists(t, fooPath)
 	require.DirExists(t, barPath)
 	require.DirExists(t, bazPath)

--- a/test/integration_download_tf_test.go
+++ b/test/integration_download_tf_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
@@ -384,7 +385,7 @@ func TestTFCustomLockFile(t *testing.T) {
 
 	source := "../custom-lock-file-module"
 	downloadDir := filepath.Join(rootPath, helpers.TerragruntCache)
-	result, err := tf.NewSource(createLogger(), source, downloadDir, rootPath, false)
+	result, err := tf.NewSource(createLogger(), vfs.NewOSFS(), source, downloadDir, rootPath, false)
 	require.NoError(t, err)
 
 	lockFilePath := filepath.Join(result.WorkingDir, util.TerraformLockFile)

--- a/test/integration_exclude_test.go
+++ b/test/integration_exclude_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -216,7 +217,7 @@ func TestTFExcludeBlockBehavior(t *testing.T) {
 				return
 			}
 
-			runs, err := report.ParseJSONRunsFromFile(reportFile)
+			runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 			require.NoError(t, err, "Failed to parse report file")
 
 			for unitName, expected := range tc.expectedUnits {

--- a/test/integration_filter_graph_tf_test.go
+++ b/test/integration_filter_graph_tf_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,7 +85,7 @@ func TestTFFilterFlagWithRunAllGraphExpressions(t *testing.T) {
 
 			require.FileExists(t, reportFile)
 
-			runs, parseErr := report.ParseJSONRunsFromFile(reportFile)
+			runs, parseErr := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 			require.NoError(t, parseErr)
 
 			reportUnits := runs.Names()
@@ -114,7 +115,7 @@ func TestTFFilterFlagWithRunAllGraphExpressionsVerifyExecutionOrder(t *testing.T
 
 	require.FileExists(t, reportFile)
 
-	runs, parseErr := report.ParseJSONRunsFromFile(reportFile)
+	runs, parseErr := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 	require.NoError(t, parseErr)
 
 	// Verify execution order: dependencies (vpc, db, cache) should start before service
@@ -277,7 +278,7 @@ dependency "vpc" {
 
 			require.FileExists(t, reportFile)
 
-			runs, parseErr := report.ParseJSONRunsFromFile(reportFile)
+			runs, parseErr := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 			require.NoError(t, parseErr)
 
 			assert.ElementsMatch(t, tc.expectedUnits, runs.Names())

--- a/test/integration_filter_tf_test.go
+++ b/test/integration_filter_tf_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -139,7 +140,7 @@ func TestTFFilterFlagWithRunAllGitFilter(t *testing.T) {
 				assert.FileExists(t, reportFilePath, "Report file should exist")
 
 				// Read and parse the report file
-				runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+				runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 				require.NoError(t, err, "Should be able to parse report JSON")
 
 				// Create a map of unit names to records for easier lookup
@@ -556,7 +557,7 @@ unit "unit-to-be-created-2" {
 				assert.FileExists(t, reportFilePath, "Report file should exist")
 
 				// Read and parse the report file
-				runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+				runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 				require.NoError(t, err, "Should be able to parse report JSON")
 
 				// Create a map of unit names to records for easier lookup
@@ -696,7 +697,7 @@ func TestTFFilterFlagMinimizesParsing(t *testing.T) {
 		// Verify the report file exists and parse it
 		reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
 		require.FileExists(t, reportFilePath, "Report file should exist")
-		runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+		runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 		require.NoError(t, err, "Should be able to parse report JSON")
 
 		names := runs.Names()
@@ -735,7 +736,7 @@ func TestTFFilterFlagMinimizesParsing(t *testing.T) {
 		reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
 		require.FileExists(t, reportFilePath)
 
-		runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+		runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 		require.NoError(t, err, "Should be able to parse report JSON")
 
 		names := runs.Names()
@@ -774,7 +775,7 @@ func TestTFFilterFlagMinimizesParsing(t *testing.T) {
 		reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
 		require.FileExists(t, reportFilePath)
 
-		runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+		runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 		require.NoError(t, err, "Should be able to parse report JSON")
 
 		names := runs.Names()
@@ -811,7 +812,7 @@ func TestTFFilterFlagMinimizesParsing(t *testing.T) {
 		reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
 		require.FileExists(t, reportFilePath)
 
-		runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+		runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 		require.NoError(t, err, "Should be able to parse report JSON")
 
 		names := runs.Names()
@@ -887,7 +888,7 @@ func TestTFFilterFlagMinimizesParsing(t *testing.T) {
 		reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
 		require.FileExists(t, reportFilePath)
 
-		runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+		runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 		require.NoError(t, err, "Should be able to parse report JSON")
 
 		names := runs.Names()
@@ -938,7 +939,7 @@ func TestTFFilterFlagMinimizesParsing(t *testing.T) {
 		reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
 		require.FileExists(t, reportFilePath)
 
-		runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+		runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 		require.NoError(t, err, "Should be able to parse report JSON")
 
 		names := runs.Names()
@@ -991,7 +992,7 @@ func TestTFFilterFlagAutoEnablesAll(t *testing.T) {
 			reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
 			assert.FileExists(t, reportFilePath)
 
-			r, err := report.ParseJSONRunsFromFile(reportFilePath)
+			r, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 			require.NoError(t, err)
 
 			runs := r.Names()
@@ -1416,7 +1417,7 @@ func TestTFRunAllGitFilterMarkGlobAsReadDeleted(t *testing.T) {
 
 			require.FileExists(t, reportFilePath, "Report file should exist at %s", reportFilePath)
 
-			runs, parseErr := report.ParseJSONRunsFromFile(reportFilePath)
+			runs, parseErr := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 			require.NoError(t, parseErr, "Should be able to parse report JSON")
 
 			var found bool

--- a/test/integration_functions_test.go
+++ b/test/integration_functions_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/util"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -206,7 +206,7 @@ func TestTFGetRepoRootCaching(t *testing.T) {
 	tmpEnvPath, _ := filepath.EvalSymlinks(helpers.CopyEnvironment(t, testFixtureGetRepoRoot))
 	rootPath := filepath.Join(tmpEnvPath, testFixtureGetRepoRoot)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(rootPath)
@@ -233,7 +233,7 @@ func TestTFGetRepoRoot(t *testing.T) {
 	tmpEnvPath, _ := filepath.EvalSymlinks(helpers.CopyEnvironment(t, testFixtureGetRepoRoot))
 	rootPath := filepath.Join(tmpEnvPath, testFixtureGetRepoRoot)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(rootPath)
@@ -274,7 +274,7 @@ func TestTFGetWorkingDirBuiltInFunc(t *testing.T) {
 	tmpEnvPath, _ := filepath.EvalSymlinks(helpers.CopyEnvironment(t, testFixtureGetWorkingDir))
 	rootPath := filepath.Join(tmpEnvPath, testFixtureGetWorkingDir)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(rootPath)
@@ -362,7 +362,7 @@ func TestTFPathRelativeFromInclude(t *testing.T) {
 	basePath := filepath.Join(rootPath, "base")
 	clusterPath := filepath.Join(rootPath, "cluster")
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpEnvPath)
@@ -413,7 +413,7 @@ func TestTFGetPathFromRepoRoot(t *testing.T) {
 	)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureGetPathFromRepoRoot)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpEnvPath)
@@ -454,7 +454,7 @@ func TestTFGetPathToRepoRoot(t *testing.T) {
 	rootPath := filepath.Join(tmpEnvPath, testFixtureGetPathToRepoRoot)
 	helpers.CleanupTerraformFolder(t, rootPath)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpEnvPath)

--- a/test/integration_gcp_test.go
+++ b/test/integration_gcp_test.go
@@ -18,6 +18,7 @@ import (
 	gcsbackend "github.com/gruntwork-io/terragrunt/internal/remotestate/backend/gcs"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
@@ -615,7 +616,7 @@ func validateGCSBucketExistsAndIsLabeled(
 		},
 	}
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 	gcsClient, err := gcsbackend.NewClient(
 		t.Context(),
@@ -663,7 +664,7 @@ func doesGCSBucketObjectExist(t *testing.T, bucketName, prefix string) bool {
 		},
 	}
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 	gcsClient, err := gcsbackend.NewClient(
 		ctx,
@@ -704,7 +705,7 @@ func gcsObjectAttrs(t *testing.T, bucketName string, objectName string) *storage
 		},
 	}
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 	gcsClient, err := gcsbackend.NewClient(
 		ctx,
@@ -759,7 +760,7 @@ func createGCSBucket(t *testing.T, projectID string, location string, bucketName
 
 	extGCSCfg := &gcsbackend.ExtendedRemoteStateConfigGCS{}
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 	gcsClient, err := gcsbackend.NewClient(
 		ctx,
@@ -799,7 +800,7 @@ func deleteGCSBucket(t *testing.T, bucketName string) {
 
 	extGCSCfg := &gcsbackend.ExtendedRemoteStateConfigGCS{}
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 	gcsClient, err := gcsbackend.NewClient(
 		ctx,

--- a/test/integration_include_test.go
+++ b/test/integration_include_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/report"
 	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -332,7 +333,7 @@ func TestTFTerragruntWorksWithRootTerragruntHCL(t *testing.T) {
 	require.NoError(t, err)
 
 	// Parse the report file to verify the correct units ran
-	runs, err := report.ParseJSONRunsFromFile(reportFile)
+	runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 	require.NoError(t, err, "Should be able to parse JSON report")
 
 	runNames := runs.Names()

--- a/test/integration_mark_many_as_read_tf_test.go
+++ b/test/integration_mark_many_as_read_tf_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +37,7 @@ func TestTFMarkManyAsReadRelpathSourceTriggersDiscovery(t *testing.T) {
 	assert.NotContains(t, stdout+stderr, "No units discovered",
 		"unit should be discovered via the local module source walk")
 
-	runs, err := report.ParseJSONRunsFromFile(filepath.Join(rootPath, helpers.ReportFile))
+	runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), filepath.Join(rootPath, helpers.ReportFile))
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"live/unit"}, runs.Names())
 }
@@ -64,7 +65,7 @@ func TestTFMarkManyAsReadDefaultDiscoversModuleChanges(t *testing.T) {
 	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(t, cmd)
 	require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
 
-	runs, err := report.ParseJSONRunsFromFile(filepath.Join(rootPath, helpers.ReportFile))
+	runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), filepath.Join(rootPath, helpers.ReportFile))
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"live/unit"}, runs.Names(),
 		"module source changes should cascade to the unit by default")

--- a/test/integration_registry_test.go
+++ b/test/integration_registry_test.go
@@ -96,6 +96,7 @@ func TestTFTerraformRegistryVersionConstraintPinsResolvedVersion(t *testing.T) {
 
 	pinned, err := tf.NewSource(
 		l,
+		vfs.NewOSFS(),
 		registryTestModuleSource+"?version=0.0.2",
 		filepath.Join(rootPath, ".terragrunt-cache"),
 		rootPath,
@@ -113,6 +114,7 @@ func TestTFTerraformRegistryVersionConstraintPinsResolvedVersion(t *testing.T) {
 	// below could not tell 0.0.2 apart from 0.0.1.
 	otherPin, err := tf.NewSource(
 		l,
+		vfs.NewOSFS(),
 		registryTestModuleSource+"?version=0.0.1",
 		filepath.Join(rootPath, ".terragrunt-cache"),
 		rootPath,
@@ -154,6 +156,7 @@ func TestTFTerraformRegistryVersionConstraintSharedAcrossUnitsWithRacing(t *test
 
 		pinned, err := tf.NewSource(
 			l,
+			vfs.NewOSFS(),
 			registryTestModuleSource+"?version=0.0.2",
 			filepath.Join(unitPath, ".terragrunt-cache"),
 			unitPath,

--- a/test/integration_regressions_tf_test.go
+++ b/test/integration_regressions_tf_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -309,7 +309,7 @@ func TestTFDependencyEmptyConfigPath_ReportsError(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureDependencyEmptyConfigPath)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureDependencyEmptyConfigPath)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)

--- a/test/integration_report_tf_test.go
+++ b/test/integration_report_tf_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -654,7 +655,7 @@ func TestTFTerragruntReportWithGitFilter(t *testing.T) {
 
 			switch tc.reportFormat {
 			case "json":
-				runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+				runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 				require.NoError(t, err, "Should be able to parse JSON report")
 
 				runNames := runs.Names()
@@ -702,7 +703,7 @@ func TestTFTerragruntReportWithGitFilter(t *testing.T) {
 				}
 
 			case "csv":
-				runs, err := report.ParseCSVRunsFromFile(reportFilePath)
+				runs, err := report.ParseCSVRunsFromFile(vfs.NewOSFS(), reportFilePath)
 				require.NoError(t, err, "Should be able to parse CSV report")
 
 				runNames := runs.Names()
@@ -812,7 +813,7 @@ func TestTFTerragruntReportSingleUnit(t *testing.T) {
 
 			switch tc.reportFormat {
 			case "json":
-				runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+				runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 				require.NoError(t, err, "Should be able to parse JSON report")
 
 				require.Len(t, runs, 1, "Single unit run should have exactly one entry in report")
@@ -825,7 +826,7 @@ func TestTFTerragruntReportSingleUnit(t *testing.T) {
 				assert.False(t, run.Ended.IsZero(), "Ended timestamp should not be zero")
 
 			case "csv":
-				runs, err := report.ParseCSVRunsFromFile(reportFilePath)
+				runs, err := report.ParseCSVRunsFromFile(vfs.NewOSFS(), reportFilePath)
 				require.NoError(t, err, "Should be able to parse CSV report")
 
 				require.Len(t, runs, 1, "Single unit run should have exactly one entry in report")

--- a/test/integration_runner_pool_test.go
+++ b/test/integration_runner_pool_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/require"
 )
@@ -193,7 +194,7 @@ func TestTFRunnerPoolFailFast(t *testing.T) {
 			reportFilePath := filepath.Join(testPath, helpers.ReportFile)
 			assert.FileExists(t, reportFilePath)
 
-			runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+			runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 			require.NoError(t, err)
 
 			// Verify expected units are in the report

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -150,7 +150,7 @@ func TestStackDepsAutoIncludeTemplateLiteralInterpolation(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsAutoIncTemplateLiteral)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsAutoIncTemplateLiteral)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -183,7 +183,7 @@ func TestStackDepsAutoIncludeResolvesValuesReference(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsAutoIncValuesResolved)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsAutoIncValuesResolved)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -361,7 +361,7 @@ func TestStackDepsDAGExpandsStackToUnits(t *testing.T) {
 	)
 
 	l := logger.CreateLogger()
-	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), options.NewTerragruntOptions())
+	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), options.NewTerragruntOptions(vexec.NewOSExec()))
 
 	unitPaths, err := inthclparse.UnitPathsFromStackDir(
 		vfs.NewOSFS(),
@@ -404,7 +404,7 @@ func TestStackDepsUnitPathsFromNestedOnlyStack(t *testing.T) {
 	)
 
 	l := logger.CreateLogger()
-	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), options.NewTerragruntOptions())
+	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), options.NewTerragruntOptions(vexec.NewOSExec()))
 
 	unitPaths, err := inthclparse.UnitPathsFromStackDir(
 		vfs.NewOSFS(),
@@ -430,7 +430,7 @@ func TestStackDepsUnitPathsFromMissingStackFile(t *testing.T) {
 	root := helpers.TmpDirWOSymlinks(t)
 
 	l := logger.CreateLogger()
-	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), options.NewTerragruntOptions())
+	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), options.NewTerragruntOptions(vexec.NewOSExec()))
 
 	unitPaths, err := inthclparse.UnitPathsFromStackDir(
 		vfs.NewOSFS(),
@@ -1492,7 +1492,7 @@ func TestStackDepsStackLevelAutoInclude(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackAutoInclude)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackAutoInclude)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -1560,7 +1560,7 @@ func TestStackDepsStackLevelAutoIncludeMergedIntoNestedStack(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackAutoInclude)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackAutoInclude)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -1612,7 +1612,7 @@ func TestStackDepsStackLevelAutoIncludeOverridesSameNameUnit(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackAutoIncOverride)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackAutoIncOverride)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -1704,7 +1704,7 @@ func TestStackDepsStackLevelAutoIncludeOverridePathUsesLocal(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackAutoIncLocalPath)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackAutoIncLocalPath)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -1732,7 +1732,7 @@ func TestStackDepsStackLevelAutoIncludeInjectsNestedStack(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackAutoIncludeNested)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackAutoIncludeNested)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -1768,7 +1768,7 @@ func TestStackDepsStackAutoIncludeDepValuesIsClearError(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsStackAutoIncDepValues)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackAutoIncDepValues)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -1813,7 +1813,7 @@ func TestStackDepsLocalsReadConfigWithDep(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsLocalsReadConfigDep)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsLocalsReadConfigDep)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -1916,7 +1916,7 @@ func newStackDepsParsingContext(
 ) (context.Context, *config.ParsingContext) {
 	t.Helper()
 
-	opts := options.NewTerragruntOptions()
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.StackDependencies))
 	opts.TerragruntConfigPath = configPath
 

--- a/test/integration_stack_dependencies_tf_test.go
+++ b/test/integration_stack_dependencies_tf_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	inthclparse "github.com/gruntwork-io/terragrunt/internal/hclparse"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +28,7 @@ func TestTFStackDepsMockLocalResolvesLocal(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsMockLocal)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsMockLocal)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -102,7 +102,7 @@ func TestTFStackDepsAutoIncludeResolvesObjectKey(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsAutoIncObjectKey)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsAutoIncObjectKey)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -162,7 +162,7 @@ func TestTFStackDepsAutoIncludeFunctionsAndDeps(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsAutoIncFuncs)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsAutoIncFuncs)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -317,7 +317,7 @@ func TestTFStackDepsNestedRemoteStateDependency(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsNestedRemoteStateDep)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsNestedRemoteStateDep)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -360,7 +360,7 @@ func TestTFStackDepsNestedUnitAutoIncludeDependency(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsNestedUnitDep)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsNestedUnitDep)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -611,7 +611,7 @@ func TestTFStackDepsE2ECrossStack(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsCrossStack)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsCrossStack)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	err = runner.WithWorkDir(gitPath).Init(t.Context())
@@ -711,7 +711,7 @@ func TestTFStackDepsStackValuesInLocals(t *testing.T) {
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsStackValuesLocals)
 
 	// The child stack uses get_repo_root() for unit sources, so the fixture copy must be a git repo.
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	err = runner.WithWorkDir(gitPath).Init(t.Context())
@@ -1082,7 +1082,7 @@ func TestTFStackDepsCrossLevelViaValues(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsCrossLevelValues)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsCrossLevelValues)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 
@@ -1139,7 +1139,7 @@ func TestTFStackDepsValuesRefWithSiblingAutoInclude(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackDepsValuesSiblingAutoInc)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackDepsValuesSiblingAutoInc)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 	require.NoError(t, runner.WithWorkDir(gitPath).Init(t.Context()))
 

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
 	"github.com/gruntwork-io/terragrunt/internal/tips"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -82,7 +82,7 @@ func TestNestedStacksGenerate(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNestedStacks)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureNestedStacks)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -123,7 +123,7 @@ func TestStacksGenerateErrorOnCoexistingHclAndStackFiles(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackCoexistHclAndStack)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackCoexistHclAndStack)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -152,7 +152,7 @@ func TestStacksGenerateLocals(t *testing.T) {
 
 	helpers.CleanupTerraformFolder(t, testFixtureStacksLocals)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksLocals)
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(tmpEnvPath)
@@ -246,7 +246,7 @@ func TestStackCleanRecursively(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, testFixtureNestedStacks)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNestedStacks)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureNestedStacks)
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -326,7 +326,7 @@ func TestStackValuesGeneration(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackValues)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackValues)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -365,7 +365,7 @@ func TestStacksGenerateAbsolutePathError(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackAbsolutePath)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureStackAbsolutePath, "live")
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(rootPath)
@@ -388,7 +388,7 @@ func TestStacksGenerateIncorrectSource(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackIncorrectSource)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureStackIncorrectSource, "live")
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(rootPath)
@@ -412,7 +412,7 @@ func TestStacksGenerateRelativePathError(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackRelativePathOutsideOfStack)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureStackRelativePathOutsideOfStack, "live")
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(rootPath)
@@ -438,7 +438,7 @@ func TestStacksGenerateNoStack(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNoStack)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureNoStack)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -516,7 +516,7 @@ func TestStackUnitValidation(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackValidationUnitPath)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackValidationUnitPath)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -555,7 +555,7 @@ func TestStackValidation(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackValidationStackPath)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackValidationStackPath)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -725,7 +725,7 @@ func TestStackGenerateWithFilter(t *testing.T) {
 	rootPath := filepath.Join(tmpEnvPath, testFixtureNestedStacks)
 	liveDir := filepath.Join(rootPath, "live")
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(rootPath)
@@ -789,7 +789,7 @@ func TestStackGenerateFilterNestedStacksTip(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNestedStackFilter)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureNestedStackFilter)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(rootPath)
@@ -815,7 +815,7 @@ func TestStackGenerateFilterRecursiveNoTip(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNestedStackFilter)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureNestedStackFilter)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(rootPath)

--- a/test/integration_stacks_tf_test.go
+++ b/test/integration_stacks_tf_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/util"
-	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -594,7 +594,7 @@ func TestTFNestedStackOutput(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNestedStacks)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureNestedStacks)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -647,7 +647,7 @@ func TestTFNestedStacksApply(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNestedStacks)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureNestedStacks)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -678,7 +678,7 @@ func TestTFStackValuesApply(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackValues)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackValues)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -718,7 +718,7 @@ func TestTFStackValuesOutput(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackValues)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackValues)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -1055,7 +1055,7 @@ func TestTFStacksApplyNoStack(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureNoStack)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureNoStack)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -1080,7 +1080,7 @@ func TestTFStacksReadFiles(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureReadStack)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureReadStack)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -1236,7 +1236,7 @@ func TestTFStackNestedOutputs(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackNestedOutputs)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackNestedOutputs)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)
@@ -1527,7 +1527,7 @@ func TestTFStackTerragruntDir(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackTerragruntDir)
 	gitPath := filepath.Join(tmpEnvPath, testFixtureStackTerragruntDir)
 
-	runner, err := git.NewGitRunner(vexec.NewOSExec())
+	runner, err := git.NewGitRunner(venv.OSVenv())
 	require.NoError(t, err)
 
 	runner = runner.WithWorkDir(gitPath)

--- a/test/integration_tf_test.go
+++ b/test/integration_tf_test.go
@@ -5367,7 +5367,7 @@ func TestTFRunAllDetectsHiddenDirectories(t *testing.T) {
 	require.NoError(t, err)
 
 	// Parse the report file to verify the correct units ran
-	runs, err := report.ParseJSONRunsFromFile(reportFile)
+	runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFile)
 	require.NoError(t, err, "Should be able to parse JSON report")
 
 	runNames := runs.Names()

--- a/test/integration_units_reading_test.go
+++ b/test/integration_units_reading_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -176,7 +177,7 @@ func TestSOPSUnitsReading(t *testing.T) {
 			reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
 			assert.FileExists(t, reportFilePath, "Report file should exist")
 
-			runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+			runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 			require.NoError(t, err, "Should be able to parse report file")
 
 			assert.ElementsMatch(t, tc.expectedUnits, runs.Names())
@@ -334,7 +335,7 @@ func TestSOPSUnitsReadingWithFilter(t *testing.T) {
 			reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
 			assert.FileExists(t, reportFilePath, "Report file should exist")
 
-			runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+			runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 			require.NoError(t, err, "Should be able to parse report file")
 
 			assert.ElementsMatch(t, tc.expectedUnits, runs.Names())
@@ -366,7 +367,7 @@ func TestSOPSQueueStrictIncludeWithUnitsReading(t *testing.T) {
 	reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
 	assert.FileExists(t, reportFilePath, "Report file should exist")
 
-	runs, err := report.ParseJSONRunsFromFile(reportFilePath)
+	runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
 	require.NoError(t, err, "Should be able to parse report file")
 
 	// Units that read shared.hcl should be included


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

🤞🏽 Should complete the venv abstraction 🤞🏽.

Closes some gaps related to GOOS and GOARCH usage. Also closes direct homedir access. 

Closes more gaps from direct filesystem and exec usage. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
