### PR TITLE
chore: Updating `TestNewSignalsForwarderMultipleUnix` to actually check for the signal

### DIFF
--- a/internal/os/exec/cmd_unix_test.go
+++ b/internal/os/exec/cmd_unix_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,6 +37,23 @@ func requireTrapReady(t *testing.T, readyPath string) {
 
 		return err == nil
 	}, 10*time.Second, 10*time.Millisecond, "child never wrote the trap-ready marker")
+}
+
+// requireInterruptCount blocks until the subprocess records that its INT trap has run
+// want times.
+func requireInterruptCount(t *testing.T, readyPath string, want int) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		content, err := os.ReadFile(readyPath)
+		if err != nil {
+			return false
+		}
+
+		got, err := strconv.Atoi(strings.TrimSpace(string(content)))
+
+		return err == nil && got == want
+	}, 10*time.Second, 10*time.Millisecond, "child never acknowledged interrupt %d", want)
 }
 
 func TestExitCodeUnix(t *testing.T) {
@@ -138,32 +156,20 @@ func TestNewSignalsForwarderMultipleUnix(t *testing.T) {
 
 	requireTrapReady(t, readyPath)
 
-	interruptAndWaitForProcess := func() (int, error) {
-		var (
-			interrupts int
-			err        error
-		)
+	// Bash defers its trap until the running `sleep` returns, so two signals delivered within
+	// one sleep window collapse into a single handler run. Waiting for the child to
+	// acknowledge each interrupt before sending the next keeps the count exact.
+	for interrupts := 1; interrupts <= expectedInterrupts; interrupts++ {
+		cmd.SendSignal(l, os.Interrupt)
 
-		for {
-			time.Sleep(500 * time.Millisecond)
-
-			select {
-			case err = <-runChannel:
-				return interrupts, err
-			default:
-				cmd.SendSignal(l, os.Interrupt)
-
-				interrupts++
-			}
-		}
+		requireInterruptCount(t, readyPath, interrupts)
 	}
 
-	interrupts, err := interruptAndWaitForProcess()
+	err := <-runChannel
 	require.Error(t, err)
 
 	retCode, err := util.GetExitCode(err)
 	require.NoError(t, err)
-	assert.LessOrEqual(t, retCode, interrupts, "Subprocess received wrong number of signals")
 	assert.Equal(t, expectedInterrupts, retCode, "Subprocess didn't receive multiple signals")
 }
 

--- a/internal/os/exec/testdata/test_sigint_multiple.sh
+++ b/internal/os/exec/testdata/test_sigint_multiple.sh
@@ -11,10 +11,12 @@ trap int_handler INT
 # shellcheck disable=SC2329  # invoked indirectly via trap
 function int_handler() {
 	INT_COUNTER=$((INT_COUNTER + 1))
+	printf '%s\n' "$INT_COUNTER" >"$READY_FILE"
 }
 
-# The marker tells the test the INT trap is installed and a signal can be sent.
-: >"$READY_FILE"
+# A readable count tells the test the INT trap is installed and, from then on, how many
+# signals have actually been handled.
+printf '%s\n' "$INT_COUNTER" >"$READY_FILE"
 
 while [[ $INT_COUNTER -lt $INT_REQUIRED ]]; do
 	sleep 0.1


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Updates `TestNewSignalsForwarderMultipleUnix` to move on signal instead of waiting in a sleep.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved Unix interrupt handling tests by verifying each signal is acknowledged before sending the next.
  - Enhanced test readiness reporting for more reliable signal-processing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->