### PR TITLE
chore: Use an injectable cap in `TestPartialEval_DeeplyNestedExpressionReturnsTypedError`

### DIFF
--- a/internal/hclparse/partial_eval.go
+++ b/internal/hclparse/partial_eval.go
@@ -21,15 +21,25 @@ var deferredRoots = map[string]bool{
 	varDependency: true,
 }
 
-// maxPartialEvalDepth bounds recursion for pathological deeply-nested expressions; past this, fall back to source bytes.
-const maxPartialEvalDepth = 10000
+// defaultMaxPartialEvalDepth bounds recursion for pathological deeply-nested expressions; past this, fall back to source bytes.
+const defaultMaxPartialEvalDepth = 10000
 
 // EvalArgs bundles the shared arguments for partial evaluation functions.
 type EvalArgs struct {
 	EvalCtx  *hcl.EvalContext
 	Deferred map[string]bool
 	SrcBytes []byte
+	MaxDepth int
 	depth    int
+}
+
+// maxDepth returns the recursion bound to enforce, falling back to defaultMaxPartialEvalDepth when the caller leaves MaxDepth unset.
+func (args *EvalArgs) maxDepth() int {
+	if args.MaxDepth > 0 {
+		return args.MaxDepth
+	}
+
+	return defaultMaxPartialEvalDepth
 }
 
 // PartialEval walks an hclsyntax.Expression tree and returns HCL source text; pure parts evaluate to literals, deferred parts stay verbatim, error signals pathological inputs.
@@ -38,12 +48,13 @@ func PartialEval(expr hclsyntax.Expression, args *EvalArgs) ([]byte, error) {
 		return RangeBytes(args.SrcBytes, expr.Range()), nil
 	}
 
-	if args.depth > maxPartialEvalDepth {
+	maxDepth := args.maxDepth()
+	if args.depth > maxDepth {
 		return RangeBytes(
 				args.SrcBytes,
 				expr.Range(),
 			), PartialEvalDepthExceededError{
-				MaxDepth: maxPartialEvalDepth,
+				MaxDepth: maxDepth,
 			}
 	}
 
@@ -413,7 +424,7 @@ func valueToHCLBytes(val cty.Value) []byte {
 }
 
 // maxCtyRenderWalkDepth bounds the valueRendersAsHCLLiteral walk to prevent stack overflow on pathological values.
-const maxCtyRenderWalkDepth = maxPartialEvalDepth
+const maxCtyRenderWalkDepth = defaultMaxPartialEvalDepth
 
 // valueRendersAsHCLLiteral reports whether val and its nested elements contain no non-finite number (which hclwrite emits as an invalid bare "Inf").
 func valueRendersAsHCLLiteral(val cty.Value, depth int) bool {

--- a/internal/hclparse/partial_eval_test.go
+++ b/internal/hclparse/partial_eval_test.go
@@ -559,25 +559,34 @@ func TestPartialEval_PreservesConditionalReferencingDependency(t *testing.T) {
 func TestPartialEval_DeeplyNestedExpressionReturnsTypedError(t *testing.T) {
 	t.Parallel()
 
-	const depth = 20000
+	const (
+		maxDepth = 8
+		nesting  = maxDepth * 2
+	)
 
 	hcl := "val = " + strings.Repeat(
 		"(",
-		depth,
+		nesting,
 	) + "dependency.vpc.outputs.id" + strings.Repeat(
 		")",
-		depth,
+		nesting,
 	)
 	expr, srcBytes := parseFirstAttrExpr(t, hcl)
 
 	resultBytes, err := hclparse.PartialEval(
 		expr,
-		&hclparse.EvalArgs{SrcBytes: srcBytes, EvalCtx: buildEvalCtx(), Deferred: testDeferred},
+		&hclparse.EvalArgs{
+			SrcBytes: srcBytes,
+			EvalCtx:  buildEvalCtx(),
+			Deferred: testDeferred,
+			MaxDepth: maxDepth,
+		},
 	)
 
 	var depthErr hclparse.PartialEvalDepthExceededError
 
 	require.ErrorAs(t, err, &depthErr)
+	assert.Equal(t, maxDepth, depthErr.MaxDepth, "the configured cap is the one enforced")
 	assert.NotEmpty(
 		t,
 		resultBytes,


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds an injectable cap for `TestPartialEval_DeeplyNestedExpressionReturnsTypedError` so that we can test it faster.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable recursion depth limits for partial evaluation.
  * Depth-related errors now report the active limit.
* **Bug Fixes**
  * Aligned nested value rendering with the standard recursion depth limit.
* **Tests**
  * Added coverage for custom depth limits and the resulting error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->