### PR TITLE
chore: Moving the `TestDiscovery_GraphConcurrentConfigAccessWithRacing` in-memory

### DIFF
--- a/internal/discovery/concurrent_parse_race_test.go
+++ b/internal/discovery/concurrent_parse_race_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
-	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/require"
 )
@@ -20,20 +19,21 @@ import (
 // guard against: the graph phase reaches a shared unit from several goroutines
 // at once, so one goroutine's parse stores the config while others read it.
 //
-// The shared unit gets a large config and many dependents, repeated across
-// several Discover calls, so the read/write overlap is reliably observable;
-// the config size and iteration count carry a margin over the smallest values
-// that still detect the race on every run. All fixture files live on an
-// in-memory filesystem, so only parsing costs wall time.
+// The shared unit gets a large config and many dependents, so the read/write
+// overlap is reliably observable. The dependent count is the load-bearing knob:
+// at six dependents the overlap stops being observable at all, so the fixture
+// carries double the smallest count that detects the race on every run. The
+// whole repo lives on an in-memory filesystem, so only parsing costs wall time
+// and a single Discover call suffices.
 //
 // To confirm the locks are load-bearing, drop the lock/unlock calls from Unit's
 // Config, StoreConfig, Reading, and SetReading and run with -race.
 func TestDiscovery_GraphConcurrentConfigAccessWithRacing(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := helpers.TmpDirWOSymlinks(t)
+	repoRoot := string(filepath.Separator) + "repo"
 
-	v := memGitTopLevelVenv(t, tmpDir)
+	v := memGitTopLevelVenv(t, repoRoot)
 
 	// remote_state is partially decoded during discovery, so a large block is
 	// walked during parse rather than skipped, which lengthens the parse.
@@ -51,13 +51,13 @@ func TestDiscovery_GraphConcurrentConfigAccessWithRacing(t *testing.T) {
 	sharedConfig.WriteString("  }\n}\n")
 
 	units := map[string]string{
-		filepath.Join(tmpDir, "vpc"): sharedConfig.String(),
+		filepath.Join(repoRoot, "vpc"): sharedConfig.String(),
 	}
 
-	const leaves = 8
+	const leaves = 16
 
 	for i := range leaves {
-		units[filepath.Join(tmpDir, fmt.Sprintf("app%d", i))] = `
+		units[filepath.Join(repoRoot, fmt.Sprintf("app%d", i))] = `
 		dependency "vpc" {
 			config_path = "../vpc"
 		}
@@ -68,19 +68,17 @@ func TestDiscovery_GraphConcurrentConfigAccessWithRacing(t *testing.T) {
 
 	l := logger.CreateLogger()
 	opts := &options.TerragruntOptions{
-		WorkingDir:     tmpDir,
-		RootWorkingDir: tmpDir,
+		WorkingDir:     repoRoot,
+		RootWorkingDir: repoRoot,
 	}
 
 	filters, err := filter.ParseFilterQueries(l, []string{"{./**}..."})
 	require.NoError(t, err)
 
-	for range 4 {
-		d := discovery.NewDiscovery(tmpDir).
-			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
-			WithFilters(filters)
+	d := discovery.NewDiscovery(repoRoot).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: repoRoot}).
+		WithFilters(filters)
 
-		_, err := d.Discover(t.Context(), l, v, opts)
-		require.NoError(t, err)
-	}
+	_, err = d.Discover(t.Context(), l, v, opts)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Updated `TestDiscovery_GraphConcurrentConfigAccessWithRacing` to run in-memory so that it runs faster.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
