### PR TITLE
docs: proxy CORS-less GTM tags so they load under Partytown

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -185,6 +185,41 @@ export default defineConfig({
         logScriptExecution: false,
         logStackTraces: false,
         forward: ['dataLayer.push'],
+        // Partytown runs the GTM container in a web worker, and a worker can
+        // only pull a script in with `fetch()`. That makes every cross-origin
+        // tag GTM injects subject to CORS, and vendors that serve their
+        // loaders off a plain CDN don't send `Access-Control-Allow-Origin`.
+        // The fetch fails, the tag never runs, and the console fills with
+        // "has been blocked by CORS policy".
+        //
+        // Route those hosts through same-origin rewrites (see vercel.json) so
+        // the request never crosses an origin boundary and CORS never applies.
+        // Only `script`/`fetch`/`xhr` are affected; `image` requests are
+        // issued `no-cors`, and `iframe` isn't a fetch at all.
+        //
+        // NOTE: this function is serialized to a string and re-evaluated
+        // inside the worker, so it must not close over anything outside its
+        // own body.
+        resolveUrl(url, location, type) {
+          const proxiedHosts = {
+            // Vector (cdn.vector.co sends no ACAO header)
+            'cdn.vector.co': '/vtag',
+            // HubSpot analytics, injected by the js.hs-scripts.com loader
+            // (which does send ACAO; js.hs-analytics.net does not)
+            'js.hs-analytics.net': '/htag',
+          };
+
+          const prefix = proxiedHosts[url.hostname];
+          if (!prefix || (type !== 'script' && type !== 'fetch' && type !== 'xhr')) {
+            return url;
+          }
+
+          const proxied = new URL(String(location));
+          proxied.pathname = prefix + url.pathname;
+          proxied.search = url.search;
+          proxied.hash = '';
+          return proxied;
+        },
       },
     }),
     sitemap({

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -25,6 +25,14 @@
     {
       "source": "/mtag/:path*",
       "destination": "https://www.googletagmanager.com/:path*"
+    },
+    {
+      "source": "/vtag/:path*",
+      "destination": "https://cdn.vector.co/:path*"
+    },
+    {
+      "source": "/htag/:path*",
+      "destination": "https://js.hs-analytics.net/:path*"
     }
   ],
   "redirects": [


### PR DESCRIPTION
Partytown runs GTM in a web worker, which can only load a script via fetch(), so cross-origin tags need CORS. cdn.vector.co and js.hs-analytics.net send no Access-Control-Allow-Origin, so Vector and HubSpot analytics fail to load and spam the console. Serve them first-party via Vercel rewrites, same as the existing /mtag/ proxy, and point Partytown at them with resolveUrl.

<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved analytics script loading through same-origin routing.
  * Added routing support for Vector and HubSpot analytics resources.
  * Preserved existing behavior for unrelated hosts and request types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->