### PR TITLE
fix(cas): use venvtest helper in depth query param tests

### DIFF
--- a/internal/cas/clone_e2e_test.go
+++ b/internal/cas/clone_e2e_test.go
@@ -221,7 +221,7 @@ func TestCASClone_E2E_DepthQueryParamWithTag(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 	l := logger.CreateLogger()
 
 	// Ambient depth left at the CAS default of 1, which is what makes this
@@ -272,7 +272,7 @@ func TestCASClone_E2E_AmbientDepthBeatsURLDepth(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 	l := logger.CreateLogger()
 
 	g := getter.NewCASGetter(l, c, v, &cas.CloneOptions{})

--- a/internal/cas/stacks_test.go
+++ b/internal/cas/stacks_test.go
@@ -625,7 +625,7 @@ func TestProcessStackComponent_AcceptsDepthQueryParam(t *testing.T) {
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithCloneDepth(-1))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venvtest.NewOSWithEmptyEnv()
 
 	source := "git::" + repoURL + "//stacks/my-stack?depth=1&ref=main"
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CAS end-to-end and integration tests to run in isolated, empty OS-backed virtual environments.
  * Improved test consistency by avoiding reliance on the default virtual environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->