### PR TITLE
feat: Adding bare `enabled` to unit and stack blocks

### DIFF
--- a/internal/stacks/output/output.go
+++ b/internal/stacks/output/output.go
@@ -154,6 +154,10 @@ func StackOutput(
 		targetDir := filepath.Join(dir, config.StackDir)
 
 		for _, stack := range stackFile.Stacks {
+			if !stack.IsEnabled() {
+				continue
+			}
+
 			declaredStacks[filepath.Join(targetDir, stack.Path)] = stack.Name
 			l.Debugf(
 				"Registered stack %s at path %s",
@@ -163,6 +167,10 @@ func StackOutput(
 		}
 
 		for _, unit := range stackFile.Units {
+			if !unit.IsEnabled() {
+				continue
+			}
+
 			unitDir := unit.GeneratedPath(dir)
 
 			// Excluded units are fully omitted from the final output, matching stack run behavior.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1504,7 +1504,7 @@ func ParseConfig(
 		return nil, err
 	}
 
-	if err := ValidateExpansionExperiment(pctx.Experiments, file); err != nil {
+	if err := ValidateBlockIterationExperiment(pctx.Experiments, file); err != nil {
 		return nil, err
 	}
 

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -618,7 +618,7 @@ func PartialParseConfig(
 		return nil, err
 	}
 
-	if err := ValidateExpansionExperiment(pctx.Experiments, file); err != nil {
+	if err := ValidateBlockIterationExperiment(pctx.Experiments, file); err != nil {
 		return nil, err
 	}
 

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1002,6 +1002,10 @@ func collectStackUnitOutputs(
 	unitOutputs := make(map[string]cty.Value)
 
 	for _, unit := range units {
+		if !unit.IsEnabled() {
+			continue
+		}
+
 		unitDir := unit.GeneratedPath(stackDir)
 		unitConfigPath := filepath.Join(unitDir, DefaultTerragruntConfigPath)
 

--- a/pkg/config/enabled_test.go
+++ b/pkg/config/enabled_test.go
@@ -1,0 +1,379 @@
+package config_test
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/worker"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const enabledStackDir = "/virtual/stack"
+
+const enabledUnitSource = "./units/app"
+
+const enabledStackSource = "./stacks/team"
+
+const unitWithEnabledHCL = `
+unit "app" {
+  enabled = false
+
+  source = "` + enabledUnitSource + `"
+  path   = "app"
+}
+`
+
+const stackWithEnabledHCL = `
+stack "team" {
+  enabled = true
+
+  source = "` + enabledStackSource + `"
+  path   = "team"
+}
+`
+
+// unitWithEnabledJSON is the JSON encoding of unitWithEnabledHCL. Stack files are only ever
+// HCL, but an include block may point at a JSON file, so the gate has to read one.
+const unitWithEnabledJSON = `{
+  "unit": {
+    "app": {
+      "enabled": false,
+      "source": "` + enabledUnitSource + `",
+      "path": "app"
+    }
+  }
+}`
+
+// generatedStack is one in-memory generation run, so a test can ask what landed under
+// .terragrunt-stack without touching disk.
+type generatedStack struct {
+	fs  vfs.FS
+	dir string
+}
+
+// generated reports whether the named path exists under the generated stack directory.
+func (gen generatedStack) generated(path ...string) bool {
+	return vfs.Exists(gen.fs, filepath.Join(slices.Concat([]string{gen.dir}, path)...))
+}
+
+// generateEnabledStack writes stackHCL alongside a local unit source and a local nested
+// stack source, then generates into an in-memory filesystem.
+func generateEnabledStack(t *testing.T, stackHCL string) generatedStack {
+	t.Helper()
+
+	v := venvtest.New()
+
+	for path, body := range map[string]string{
+		filepath.Join("units", "app", "main.tf"):                                               "",
+		filepath.Join("units", "app", config.DefaultTerragruntConfigPath):                      "",
+		filepath.Join("stacks", "team", "units", "member", "main.tf"):                          "",
+		filepath.Join("stacks", "team", "units", "member", config.DefaultTerragruntConfigPath): "",
+		filepath.Join("stacks", "team", config.DefaultStackFile): `
+unit "member" {
+  source = "./units/member"
+  path   = "member"
+}
+`,
+		config.DefaultStackFile: stackHCL,
+	} {
+		require.NoError(
+			t,
+			vfs.WriteFile(v.FS, filepath.Join(enabledStackDir, path), []byte(body), 0o644),
+		)
+	}
+
+	stackPath := filepath.Join(enabledStackDir, config.DefaultStackFile)
+
+	l := logger.CreateLogger()
+	ctx, pctx := newTestParsingContext(t, v, stackPath)
+	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.BlockIteration))
+
+	pctx.TerragruntStackConfigPath = stackPath
+	// CAS shells out to git, which the no-spawn venv refuses, and a local source has
+	// nothing to clone anyway.
+	pctx.NoCAS = true
+
+	pool := worker.NewWorkerPool(1)
+	pool.Start()
+
+	defer pool.Stop()
+
+	require.NoError(t, config.GenerateStackFile(ctx, l, pctx, pool, stackPath))
+	require.NoError(t, pool.Wait())
+
+	return generatedStack{fs: v.FS, dir: filepath.Join(enabledStackDir, config.StackDir)}
+}
+
+func TestGenerateStackSkipsDisabledComponents(t *testing.T) {
+	t.Parallel()
+
+	gen := generateEnabledStack(t, `
+unit "kept_unit" {
+  source = "`+enabledUnitSource+`"
+  path   = "kept-unit"
+}
+
+unit "dropped_unit" {
+  enabled = false
+
+  source = "`+enabledUnitSource+`"
+  path   = "dropped-unit"
+}
+
+stack "kept_stack" {
+  source = "`+enabledStackSource+`"
+  path   = "kept-stack"
+}
+
+stack "dropped_stack" {
+  enabled = false
+
+  source = "`+enabledStackSource+`"
+  path   = "dropped-stack"
+}
+`)
+
+	assert.True(t, gen.generated("kept-unit", config.DefaultTerragruntConfigPath))
+	assert.False(t, gen.generated("dropped-unit"))
+
+	assert.True(t, gen.generated("kept-stack", config.DefaultStackFile))
+	assert.False(t, gen.generated("dropped-stack"))
+}
+
+// TestGenerateStackDisabledEverywhereGeneratesNothing pins that a stack whose every
+// component is disabled generates nothing and succeeds, rather than failing the way a
+// stack file declaring no components at all does.
+func TestGenerateStackDisabledEverywhereGeneratesNothing(t *testing.T) {
+	t.Parallel()
+
+	gen := generateEnabledStack(t, `
+unit "app" {
+  enabled = false
+
+  source = "`+enabledUnitSource+`"
+  path   = "app"
+}
+
+stack "team" {
+  enabled = false
+
+  source = "`+enabledStackSource+`"
+  path   = "team"
+}
+`)
+
+	assert.False(t, gen.generated("app"))
+	assert.False(t, gen.generated("team"))
+}
+
+// TestGenerateStackEnabledKeepsBareAddress pins that a conditional unit generates at its
+// declared path. The count = cond ? 1 : 0 workaround it replaces would put the unit under
+// an index segment instead.
+func TestGenerateStackEnabledKeepsBareAddress(t *testing.T) {
+	t.Parallel()
+
+	gen := generateEnabledStack(t, `
+unit "vpc" {
+  enabled = true
+
+  source = "`+enabledUnitSource+`"
+  path   = "vpc"
+}
+`)
+
+	assert.True(t, gen.generated("vpc", config.DefaultTerragruntConfigPath))
+	assert.False(t, gen.generated("vpc", "0"))
+}
+
+func TestGenerateStackEnabledGatesWholeExpandedSet(t *testing.T) {
+	t.Parallel()
+
+	gen := generateEnabledStack(t, `
+unit "shard" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  enabled = false
+
+  source = "`+enabledUnitSource+`"
+  path   = "shard/${each.key}"
+}
+`)
+
+	assert.False(t, gen.generated("shard"))
+}
+
+func TestGenerateStackEnabledResolvesPerExpandedElement(t *testing.T) {
+	t.Parallel()
+
+	gen := generateEnabledStack(t, `
+unit "shard" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  enabled = each.key != "api"
+
+  source = "`+enabledUnitSource+`"
+  path   = "shard/${each.key}"
+}
+`)
+
+	assert.True(t, gen.generated("shard", "web", config.DefaultTerragruntConfigPath))
+	assert.False(t, gen.generated("shard", "api"))
+}
+
+// TestUnitAndStackDecodeEnabled pins that enabled reaches the decoded config rather than
+// falling into the `hcl:",remain"` field that used to absorb it.
+func TestUnitAndStackDecodeEnabled(t *testing.T) {
+	t.Parallel()
+
+	stackCfg, err := parseStackString(t, unitWithEnabledHCL+stackWithEnabledHCL)
+	require.NoError(t, err)
+	require.Len(t, stackCfg.Units, 1)
+	require.Len(t, stackCfg.Stacks, 1)
+
+	require.NotNil(t, stackCfg.Units[0].Enabled)
+	assert.False(t, *stackCfg.Units[0].Enabled)
+
+	require.NotNil(t, stackCfg.Stacks[0].Enabled)
+	assert.True(t, *stackCfg.Stacks[0].Enabled)
+}
+
+// TestValidateBlockIterationExperimentGatesEnabled pins which block types reject a bare
+// enabled attribute while the experiment is off. The dependency row expects no error,
+// since that block has always accepted enabled.
+func TestValidateBlockIterationExperimentGatesEnabled(t *testing.T) {
+	t.Parallel()
+
+	skipInExperimentMode(t)
+
+	testCases := []struct {
+		name          string
+		configPath    string
+		cfg           string
+		wantBlockType string
+		wantLabel     string
+		wantErr       bool
+	}{
+		{
+			name:          "unit",
+			configPath:    config.DefaultStackFile,
+			cfg:           unitWithEnabledHCL,
+			wantBlockType: "unit",
+			wantLabel:     "app",
+			wantErr:       true,
+		},
+		{
+			name:          "stack",
+			configPath:    config.DefaultStackFile,
+			cfg:           stackWithEnabledHCL,
+			wantBlockType: "stack",
+			wantLabel:     "team",
+			wantErr:       true,
+		},
+		{
+			name:          "unit in a json body",
+			configPath:    "extra.json",
+			cfg:           unitWithEnabledJSON,
+			wantBlockType: "unit",
+			wantLabel:     "app",
+			wantErr:       true,
+		},
+		{
+			name:       "dependency",
+			configPath: config.DefaultTerragruntConfigPath,
+			cfg: `
+dependency "vpc" {
+  enabled     = false
+  config_path = "../vpc"
+}
+`,
+		},
+		{
+			name:       "unit without enabled",
+			configPath: config.DefaultStackFile,
+			cfg: `
+unit "app" {
+  source = "./units/app"
+  path   = "app"
+}
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			file := parseHCLString(t, tc.cfg, tc.configPath)
+
+			err := config.ValidateBlockIterationExperiment(experiment.NewExperiments(), file)
+
+			if !tc.wantErr {
+				require.NoError(t, err)
+
+				return
+			}
+
+			var typed config.EnabledRequiresExperimentError
+			require.ErrorAs(t, err, &typed)
+			assert.Equal(t, tc.wantBlockType, typed.BlockType)
+			assert.Equal(t, tc.wantLabel, typed.BlockLabel)
+			assert.Equal(t, tc.configPath, typed.ConfigPath)
+		})
+	}
+}
+
+// TestReadStackConfigStringEnabledRequiresExperiment proves the gate is wired into the
+// stack parse, not just callable on its own.
+func TestReadStackConfigStringEnabledRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	skipInExperimentMode(t)
+
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultStackFile)
+
+	_, err := config.ReadStackConfigString(
+		ctx,
+		logger.CreateLogger(),
+		pctx,
+		config.DefaultStackFile,
+		unitWithEnabledHCL,
+		nil,
+	)
+
+	var typed config.EnabledRequiresExperimentError
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, "unit", typed.BlockType)
+	assert.Equal(t, "app", typed.BlockLabel)
+}
+
+// TestEnabledRequiresExperimentErrorNamesTheFlag pins that the error a user reads names
+// the experiment they need, with and without a block label.
+func TestEnabledRequiresExperimentErrorNamesTheFlag(t *testing.T) {
+	t.Parallel()
+
+	labeled := config.EnabledRequiresExperimentError{
+		ConfigPath: config.DefaultStackFile,
+		BlockType:  "unit",
+		BlockLabel: "app",
+	}
+	assert.Contains(t, labeled.Error(), experiment.BlockIteration)
+	assert.Contains(t, labeled.Error(), `unit "app"`)
+
+	unlabeled := config.EnabledRequiresExperimentError{
+		ConfigPath: config.DefaultStackFile,
+		BlockType:  "stack",
+	}
+	assert.Contains(t, unlabeled.Error(), experiment.BlockIteration)
+	assert.NotContains(t, unlabeled.Error(), `""`)
+}

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -549,3 +550,32 @@ func (err ExpansionRequiresExperimentError) Error() string {
 		experiment.BlockIteration,
 	)
 }
+
+// EnabledRequiresExperimentError is returned when a unit or stack block carries a bare
+// enabled attribute while the block-iteration experiment is off.
+type EnabledRequiresExperimentError struct {
+	ConfigPath string
+	BlockType  string
+	BlockLabel string
+}
+
+func (err EnabledRequiresExperimentError) Error() string {
+	block := err.BlockType
+	if err.BlockLabel != "" {
+		block = fmt.Sprintf("%s %q", err.BlockType, err.BlockLabel)
+	}
+
+	return fmt.Sprintf(
+		"the %s block in %s uses an enabled attribute, which requires the '%s' experiment; enable it with --experiment %s",
+		block,
+		err.ConfigPath,
+		experiment.BlockIteration,
+		experiment.BlockIteration,
+	)
+}
+
+// ErrStackHasNoComponents is returned when a stack file declares no unit or stack block at
+// all. A file whose blocks resolve to no components is a different thing entirely and stays
+// valid: every block may be disabled, or expanded over an empty collection, leaving nothing
+// to generate.
+var ErrStackHasNoComponents = errors.New("stack config must contain at least one unit or stack")

--- a/pkg/config/expansion.go
+++ b/pkg/config/expansion.go
@@ -3,54 +3,80 @@ package config
 import (
 	"slices"
 
-	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 )
 
-// expansionCapableBlocks are the block types an expansion block may appear in.
-var expansionCapableBlocks = []string{MetadataDependency, MetadataUnit, MetadataStack}
+const enabledAttrName = "enabled"
 
-// ValidateExpansionExperiment rejects expansion blocks while the block-iteration
-// experiment is disabled.
+// enabledGatedBlocks omits dependency, which accepted a bare enabled attribute long
+// before this experiment existed.
+var enabledGatedBlocks = []string{MetadataUnit, MetadataStack}
+
+// blockIterationCandidateSchema matches every block type block-iteration syntax may appear in.
+// All three carry a single name label.
+var blockIterationCandidateSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: MetadataDependency, LabelNames: []string{"name"}},
+		{Type: MetadataUnit, LabelNames: []string{"name"}},
+		{Type: MetadataStack, LabelNames: []string{"name"}},
+	},
+}
+
+// blockIterationSyntaxSchema matches the two pieces of block-iteration syntax a candidate
+// block may carry.
+var blockIterationSyntaxSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{{Name: enabledAttrName}},
+	Blocks:     []hcl.BlockHeaderSchema{{Type: hclparse.ExpansionBlockName}},
+}
+
+// ValidateBlockIterationExperiment rejects block-iteration syntax while the experiment is
+// off: an expansion block on a dependency, unit, or stack, and a bare enabled attribute on
+// a unit or stack.
 //
 // This reads the raw body rather than the decoded config because unit and stack blocks
 // decode through an `hcl:",remain"` field, which absorbs an unrecognized expansion block
-// instead of rejecting it. Without this pass a user who writes expansion without the
-// experiment watches the block silently do nothing.
-//
-// JSON configs parse into a body this cannot walk, so this pass does not cover them.
-func ValidateExpansionExperiment(experiments experiment.Experiments, file *hclparse.File) error {
+// or attribute instead of rejecting it. Without this pass a user who writes expansion or
+// enabled without the experiment watches the block silently do nothing.
+func ValidateBlockIterationExperiment(experiments experiment.Experiments, file *hclparse.File) error {
 	if experiments.Evaluate(experiment.BlockIteration) {
 		return nil
 	}
 
-	body, ok := file.Body.(*hclsyntax.Body)
-	if !ok {
-		return nil
-	}
+	// Diagnostics are dropped throughout this pass: a body malformed enough to produce them
+	// fails the decode that follows with a message pointing at the real problem, and this
+	// gate has nothing to add to it.
+	content, _, _ := file.Body.PartialContent(blockIterationCandidateSchema)
 
-	for _, block := range body.Blocks {
-		if !slices.Contains(expansionCapableBlocks, block.Type) {
-			continue
-		}
-
-		if !slices.ContainsFunc(block.Body.Blocks, func(inner *hclsyntax.Block) bool {
-			return inner.Type == hclparse.ExpansionBlockName
-		}) {
-			continue
-		}
-
-		err := ExpansionRequiresExperimentError{
-			ConfigPath: file.ConfigPath,
-			BlockType:  block.Type,
-		}
+	for _, block := range content.Blocks {
+		label := ""
 		if len(block.Labels) > 0 {
-			err.BlockLabel = block.Labels[0]
+			label = block.Labels[0]
 		}
 
-		return err
+		inner, _, _ := block.Body.PartialContent(blockIterationSyntaxSchema)
+
+		if len(inner.Blocks) > 0 {
+			return ExpansionRequiresExperimentError{
+				ConfigPath: file.ConfigPath,
+				BlockType:  block.Type,
+				BlockLabel: label,
+			}
+		}
+
+		if !slices.Contains(enabledGatedBlocks, block.Type) {
+			continue
+		}
+
+		if _, declared := inner.Attributes[enabledAttrName]; declared {
+			return EnabledRequiresExperimentError{
+				ConfigPath: file.ConfigPath,
+				BlockType:  block.Type,
+				BlockLabel: label,
+			}
+		}
 	}
 
 	return nil

--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -3,7 +3,6 @@ package config_test
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -496,12 +495,16 @@ func TestIncludeMergeKeepsEveryExpandedInstance(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			dir := t.TempDir()
+			dir := filepath.Join("/virtual", "include-merge")
+			configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
 
-			require.NoError(t, os.MkdirAll(filepath.Join(dir, "network"), 0o755))
-			require.NoError(t, os.MkdirAll(filepath.Join(dir, "logging"), 0o755))
+			ctx, pctx := newExpansionParsingContext(t, configPath)
+			fsys := pctx.Venv.FS
 
-			require.NoError(t, os.WriteFile(filepath.Join(dir, "root.hcl"), []byte(`
+			require.NoError(t, vfs.EnsureDirectory(fsys, filepath.Join(dir, "network")))
+			require.NoError(t, vfs.EnsureDirectory(fsys, filepath.Join(dir, "logging")))
+
+			require.NoError(t, vfs.WriteFile(fsys, filepath.Join(dir, "root.hcl"), []byte(`
 dependencies {
   paths = ["./network"]
 }
@@ -512,8 +515,7 @@ dependency "vpc" {
 }
 `), 0o644))
 
-			configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
-			require.NoError(t, os.WriteFile(configPath, []byte(`
+			require.NoError(t, vfs.WriteFile(fsys, configPath, []byte(`
 include "root" {
   path = "root.hcl"
   `+tc.mergeStrategy+`
@@ -532,8 +534,6 @@ dependency "shard" {
   config_path = "../shard-${count.index}"
 }
 `), 0o644))
-
-			ctx, pctx := newExpansionParsingContext(t, configPath)
 
 			cfg, err := config.ParseConfigFile(ctx, pctx, logger.CreateLogger(), configPath, nil)
 			require.NoError(t, err)
@@ -1340,7 +1340,7 @@ func newExpansionParsingContext(
 ) (context.Context, *config.ParsingContext) {
 	tb.Helper()
 
-	ctx, pctx := newTestParsingContext(tb, venvtest.NewWithOSFS(), configPath)
+	ctx, pctx := newTestParsingContext(tb, venvtest.New(), configPath)
 	require.NoError(tb, pctx.Experiments.EnableExperiment(experiment.BlockIteration))
 
 	return ctx, pctx

--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -59,9 +59,21 @@ stack "team" {
 }
 `
 
-// TestValidateExpansionExperiment pins which blocks the gate rejects while the
-// block-iteration experiment is off, and that it names the offending block.
-func TestValidateExpansionExperiment(t *testing.T) {
+// unitWithExpansionJSON is the JSON encoding of unitWithExpansionHCL. Stack files are only
+// ever HCL, but an include block may point at a JSON file, so the gate has to read one.
+const unitWithExpansionJSON = `{
+  "unit": {
+    "app": {
+      "expansion": {"for_each": ["web"]},
+      "source": "./modules/app",
+      "path": "app/${each.value}"
+    }
+  }
+}`
+
+// TestValidateBlockIterationExperimentGatesExpansion pins which block types reject an
+// expansion block while the experiment is off, and that the error names the offending block.
+func TestValidateBlockIterationExperimentGatesExpansion(t *testing.T) {
 	t.Parallel()
 
 	skipInExperimentMode(t)
@@ -96,6 +108,14 @@ func TestValidateExpansionExperiment(t *testing.T) {
 			cfg:           stackWithExpansionHCL,
 			wantBlockType: "stack",
 			wantLabel:     "team",
+			wantErr:       true,
+		},
+		{
+			name:          "unit with expansion in a json body",
+			configPath:    "extra.json",
+			cfg:           unitWithExpansionJSON,
+			wantBlockType: "unit",
+			wantLabel:     "app",
 			wantErr:       true,
 		},
 		{
@@ -140,7 +160,7 @@ generate "backend" {
 
 			file := parseHCLString(t, tc.cfg, tc.configPath)
 
-			err := config.ValidateExpansionExperiment(experiment.NewExperiments(), file)
+			err := config.ValidateBlockIterationExperiment(experiment.NewExperiments(), file)
 
 			if !tc.wantErr {
 				require.NoError(t, err)
@@ -156,9 +176,9 @@ generate "backend" {
 	}
 }
 
-// TestValidateExpansionExperimentEnabled pins that enabling the experiment clears the
-// gate for every block type it covers.
-func TestValidateExpansionExperimentEnabled(t *testing.T) {
+// TestValidateBlockIterationExperimentGateClearsWhenOn pins that turning the experiment on
+// clears the gate for both expansion blocks and bare enabled attributes.
+func TestValidateBlockIterationExperimentGateClearsWhenOn(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -181,6 +201,16 @@ func TestValidateExpansionExperimentEnabled(t *testing.T) {
 			configPath: config.DefaultStackFile,
 			cfg:        stackWithExpansionHCL,
 		},
+		{
+			name:       "unit with enabled",
+			configPath: config.DefaultStackFile,
+			cfg:        unitWithEnabledHCL,
+		},
+		{
+			name:       "stack with enabled",
+			configPath: config.DefaultStackFile,
+			cfg:        stackWithEnabledHCL,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -192,7 +222,7 @@ func TestValidateExpansionExperimentEnabled(t *testing.T) {
 
 			require.NoError(
 				t,
-				config.ValidateExpansionExperiment(
+				config.ValidateBlockIterationExperiment(
 					experiments,
 					parseHCLString(t, tc.cfg, tc.configPath),
 				),

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -84,6 +85,7 @@ type Unit struct {
 
 	Expansion *hclparse.ExpansionBlock `hcl:"expansion,block"`
 
+	Enabled             *bool      `hcl:"enabled,attr"`
 	UpdateSourceWithCAS *bool      `hcl:"update_source_with_cas,attr"`
 	Mutable             *bool      `hcl:"mutable,attr"`
 	NoStack             *bool      `hcl:"no_dot_terragrunt_stack,attr"`
@@ -92,6 +94,13 @@ type Unit struct {
 	Name                string     `hcl:",label"`
 	Source              string     `hcl:"source,attr"`
 	Path                string     `hcl:"path,attr"`
+}
+
+// IsEnabled reports whether this unit is present at all. Omitting enabled keeps the unit,
+// so only an explicit false drops it. Unlike expansion, this never changes the unit's
+// address, so toggling it leaves references and generated paths intact.
+func (u *Unit) IsEnabled() bool {
+	return u.Enabled == nil || *u.Enabled
 }
 
 // GeneratedPath returns the on-disk path this unit generates to under stackDir.
@@ -105,6 +114,7 @@ type Stack struct {
 
 	Expansion *hclparse.ExpansionBlock `hcl:"expansion,block"`
 
+	Enabled             *bool      `hcl:"enabled,attr"`
 	UpdateSourceWithCAS *bool      `hcl:"update_source_with_cas,attr"`
 	Mutable             *bool      `hcl:"mutable,attr"`
 	NoStack             *bool      `hcl:"no_dot_terragrunt_stack,attr"`
@@ -113,6 +123,12 @@ type Stack struct {
 	Name                string     `hcl:",label"`
 	Source              string     `hcl:"source,attr"`
 	Path                string     `hcl:"path,attr"`
+}
+
+// IsEnabled reports whether this stack is present at all. Omitting enabled keeps the
+// stack, so only an explicit false drops it.
+func (s *Stack) IsEnabled() bool {
+	return s.Enabled == nil || *s.Enabled
 }
 
 // GeneratedPath returns the on-disk path this stack generates to under stackDir.
@@ -169,6 +185,17 @@ func GenerateStackFile(
 		return err
 	}
 
+	// Without this the run is silent: every per-component log line belongs to a component
+	// that is generating, so a file where none of them do says nothing at all.
+	if !hasEnabledComponents(stackFile) {
+		l.Infof(
+			"Nothing to generate from %s: every unit and stack it declares is disabled or expanded to no elements",
+			util.RelPathForLog(pctx.RootWorkingDir, stackFilePath, pctx.LogShowAbsPaths),
+		)
+
+		return nil
+	}
+
 	cs, err := setupCAS(l, pctx.Venv, casEnabled, pctx.CASCloneDepth)
 	if err != nil {
 		return err
@@ -205,6 +232,12 @@ func GenerateStackFile(
 	}
 
 	return nil
+}
+
+// hasEnabledComponents reports whether any unit or stack in the file generates anything.
+func hasEnabledComponents(stackFile *StackConfig) bool {
+	return slices.ContainsFunc(stackFile.Units, (*Unit).IsEnabled) ||
+		slices.ContainsFunc(stackFile.Stacks, (*Stack).IsEnabled)
 }
 
 // ValidateStackAutoIncludes runs the strict autoinclude parse over the stack file at
@@ -472,6 +505,12 @@ func generateUnits(
 	units []*Unit,
 ) error {
 	for _, unit := range units {
+		if !unit.IsEnabled() {
+			l.Debugf("Skipping disabled unit %s", componentAddress(unit.Name, unit.Expansion))
+
+			continue
+		}
+
 		pool.Submit(func() error {
 			item := componentToGenerate{
 				sourceDir:    opts.sourceDir,
@@ -519,6 +558,12 @@ func generateStacks(
 	stacks []*Stack,
 ) error {
 	for _, stack := range stacks {
+		if !stack.IsEnabled() {
+			l.Debugf("Skipping disabled stack %s", componentAddress(stack.Name, stack.Expansion))
+
+			continue
+		}
+
 		pool.Submit(func() error {
 			item := componentToGenerate{
 				sourceDir:    opts.sourceDir,
@@ -1146,7 +1191,7 @@ func ParseStackConfig(
 		parser = parser.WithValues(values)
 	}
 
-	if err := ValidateExpansionExperiment(parser.Experiments, file); err != nil {
+	if err := ValidateBlockIterationExperiment(parser.Experiments, file); err != nil {
 		return nil, err
 	}
 
@@ -1224,6 +1269,13 @@ func ParseStackConfig(
 		Locals: localsParsed,
 		Stacks: config.Stacks,
 		Units:  config.Units,
+	}
+
+	// Counted from the declared blocks rather than the resolved components, so a file whose
+	// every component is disabled or expanded over an empty collection generates nothing
+	// instead of failing.
+	if len(config.UnitBlocks) == 0 && len(config.StackBlocks) == 0 {
+		return nil, ErrStackHasNoComponents
 	}
 
 	if err := ValidateStackConfig(config, filepath.Dir(file.ConfigPath)); err != nil {
@@ -1636,7 +1688,7 @@ func processStackConfigIncludes(
 			return fmt.Errorf("failed to read include %q: %w", inc.Name, err)
 		}
 
-		if err := ValidateExpansionExperiment(experiments, incFile); err != nil {
+		if err := ValidateBlockIterationExperiment(experiments, incFile); err != nil {
 			return err
 		}
 
@@ -1660,6 +1712,8 @@ func processStackConfigIncludes(
 
 		config.Units = append(config.Units, included.Units...)
 		config.Stacks = append(config.Stacks, included.Stacks...)
+		config.UnitBlocks = append(config.UnitBlocks, included.UnitBlocks...)
+		config.StackBlocks = append(config.StackBlocks, included.StackBlocks...)
 	}
 
 	// Validate no duplicate unit names after merge.
@@ -1737,7 +1791,7 @@ func mergeStackAutoIncludeFile(
 		return *typed
 	}
 
-	if err := ValidateExpansionExperiment(experiments, incFile); err != nil {
+	if err := ValidateBlockIterationExperiment(experiments, incFile); err != nil {
 		return err
 	}
 
@@ -1770,6 +1824,8 @@ func mergeStackAutoIncludeFile(
 	// A same-name injected unit/stack overrides the base block wholesale, matching unit autoinclude override semantics.
 	config.Units = util.MergeNamed(config.Units, included.Units, unitName)
 	config.Stacks = util.MergeNamed(config.Stacks, included.Stacks, stackName)
+	config.UnitBlocks = append(config.UnitBlocks, included.UnitBlocks...)
+	config.StackBlocks = append(config.StackBlocks, included.StackBlocks...)
 
 	return nil
 }

--- a/pkg/config/stack_validation.go
+++ b/pkg/config/stack_validation.go
@@ -7,7 +7,8 @@ import (
 	"errors"
 )
 
-// ValidateStackConfig validates a StackConfigFile instance according to the rules:
+// ValidateStackConfig validates the components a StackConfigFile resolved to, according to
+// the rules:
 // - Unit name, source, and path shouldn't be empty
 // - Unit names should be unique
 // - Units shouldn't have duplicate paths
@@ -18,14 +19,13 @@ import (
 //
 // stackDir is the directory containing the stack file; it is used to compute the
 // generated on-disk path of each unit and stack for the cross-kind collision check.
+//
+// Resolving to no components at all is valid here: a file that declares blocks which all
+// expand to zero elements or set enabled to false has nothing to generate, and
+// [ParseStackConfig] is what rejects a file that declares no blocks in the first place.
 func ValidateStackConfig(config *StackConfigFile, stackDir string) error {
 	if config == nil {
 		return errors.New("stack config cannot be nil")
-	}
-
-	// Check if we have any units or stacks
-	if len(config.Units) == 0 && len(config.Stacks) == 0 {
-		return errors.New("stack config must contain at least one unit or stack")
 	}
 
 	var validationErrors []error

--- a/pkg/config/stack_validation_test.go
+++ b/pkg/config/stack_validation_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	inthclparse "github.com/gruntwork-io/terragrunt/internal/hclparse"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -43,11 +44,11 @@ func TestValidateStackConfig(t *testing.T) {
 			wantErr: "",
 		},
 		{
-			name: "empty config",
+			name: "config that resolved to no components",
 			config: &config.StackConfigFile{
 				Units: []*config.Unit{},
 			},
-			wantErr: "stack config must contain at least one unit",
+			wantErr: "",
 		},
 		{
 			name: "empty unit name",
@@ -308,6 +309,70 @@ func TestValidateStackConfig(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+// TestParseStackConfigRejectsFileDeclaringNoComponents pins that the emptiness rule reads
+// the blocks a user wrote, so a file with nothing to generate is still an error.
+func TestParseStackConfigRejectsFileDeclaringNoComponents(t *testing.T) {
+	t.Parallel()
+
+	err := parseStackErr(t, `
+locals {
+  env = "dev"
+}
+`)
+
+	require.ErrorIs(t, err, config.ErrStackHasNoComponents)
+}
+
+// TestParseStackConfigAcceptsComponentsThatResolveToNothing pins the other side of that
+// rule: a file that declares blocks parses even when none of them survives, so a
+// conditional stack does not break in the case where its condition excludes everything.
+func TestParseStackConfigAcceptsComponentsThatResolveToNothing(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		cfg       string
+		wantUnits int
+	}{
+		{
+			name: "every unit disabled",
+			cfg: `
+unit "app" {
+  enabled = false
+
+  source = "./units/app"
+  path   = "app"
+}
+`,
+			wantUnits: 1,
+		},
+		{
+			name: "expansion over an empty collection",
+			cfg: `
+unit "app" {
+  expansion {
+    for_each = toset([])
+  }
+
+  source = "./units/app"
+  path   = "app/${each.value}"
+}
+`,
+			wantUnits: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stackCfg, err := parseStackString(t, tc.cfg)
+			require.NoError(t, err)
+			assert.Len(t, stackCfg.Units, tc.wantUnits)
 		})
 	}
 }
@@ -779,6 +844,37 @@ unit "vpc" {
 	var typed inthclparse.DuplicateUnitNameError
 	require.ErrorAs(t, err, &typed)
 	assert.Equal(t, "vpc", typed.Name)
+}
+
+// TestStackIncludeSatisfiesComponentDeclaration pins that the blocks an include contributes
+// count toward the emptiness rule, so a stack file that delegates every component to an
+// include still parses.
+func TestStackIncludeSatisfiesComponentDeclaration(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	stackDir := filepath.Join("/virtual", "stack")
+	stackFilePath := filepath.Join(stackDir, config.DefaultStackFile)
+
+	require.NoError(t, vfs.WriteFile(v.FS, stackFilePath, []byte(`
+include "shared" {
+  path = "./shared.hcl"
+}
+`), 0o644))
+
+	require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(stackDir, "shared.hcl"), []byte(`
+unit "vpc" {
+  source = "."
+  path   = "vpc"
+}
+`), 0o644))
+
+	ctx, pctx := newTestParsingContext(t, v, stackFilePath)
+
+	stackCfg, err := config.ReadStackConfigFile(ctx, logger.CreateLogger(), pctx, stackFilePath, nil)
+	require.NoError(t, err)
+	assert.Len(t, stackCfg.Units, 1)
 }
 
 // TestStackAutoIncludeOverrideUpdatesComponentPathRef pins that when the autoinclude override changes a

--- a/test/fixtures/stacks/enabled/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/enabled/live/terragrunt.stack.hcl
@@ -1,0 +1,36 @@
+unit "vpc" {
+  enabled = true
+
+  source = "../units/app"
+  path   = "vpc"
+
+  values = {
+    role = "vpc"
+  }
+}
+
+unit "legacy" {
+  enabled = false
+
+  source = "../units/app"
+  path   = "legacy"
+
+  values = {
+    role = "legacy"
+  }
+}
+
+unit "shard" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  enabled = false
+
+  source = "../units/app"
+  path   = "shard/${each.key}"
+
+  values = {
+    role = "shard-${each.key}"
+  }
+}

--- a/test/fixtures/stacks/enabled/none-enabled/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/enabled/none-enabled/terragrunt.stack.hcl
@@ -1,0 +1,21 @@
+unit "vpc" {
+  enabled = false
+
+  source = "../units/app"
+  path   = "vpc"
+
+  values = {
+    role = "vpc"
+  }
+}
+
+unit "app" {
+  enabled = false
+
+  source = "../units/app"
+  path   = "app"
+
+  values = {
+    role = "app"
+  }
+}

--- a/test/fixtures/stacks/enabled/units/app/main.tf
+++ b/test/fixtures/stacks/enabled/units/app/main.tf
@@ -1,0 +1,7 @@
+variable "role" {
+  type = string
+}
+
+output "role" {
+  value = var.role
+}

--- a/test/fixtures/stacks/enabled/units/app/terragrunt.hcl
+++ b/test/fixtures/stacks/enabled/units/app/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "."
+}
+
+inputs = {
+  role = values.role
+}

--- a/test/integration_stack_enabled_test.go
+++ b/test/integration_stack_enabled_test.go
@@ -1,0 +1,86 @@
+package test_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+)
+
+const testFixtureStacksEnabled = "fixtures/stacks/enabled"
+
+// generateEnabledStack copies the fixture and generates, returning the generated
+// .terragrunt-stack directory.
+func generateEnabledStack(t *testing.T) string {
+	t.Helper()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksEnabled)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksEnabled)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStacksEnabled, "live")
+
+	helpers.RunTerragrunt(
+		t,
+		"terragrunt stack generate --experiment block-iteration --working-dir "+rootPath,
+	)
+
+	return filepath.Join(rootPath, ".terragrunt-stack")
+}
+
+func TestStackEnabledSkipsDisabledUnits(t *testing.T) {
+	t.Parallel()
+
+	stackPath := generateEnabledStack(t)
+
+	assert.FileExists(t, filepath.Join(stackPath, "vpc", "terragrunt.hcl"))
+
+	assert.NoDirExists(t, filepath.Join(stackPath, "legacy"))
+
+	// The shard unit is expanded and disabled, so none of its elements generate.
+	assert.NoDirExists(t, filepath.Join(stackPath, "shard"))
+}
+
+// TestStackEnabledAllDisabledGeneratesNothing pins that disabling every unit in a stack
+// file generates nothing and succeeds. The emptiness rule that rejects a stack file
+// declaring no units reads the blocks a user wrote, not what they resolved to.
+func TestStackEnabledAllDisabledGeneratesNothing(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksEnabled)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksEnabled)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStacksEnabled, "none-enabled")
+
+	helpers.RunTerragrunt(
+		t,
+		"terragrunt stack generate --experiment block-iteration --working-dir "+rootPath,
+	)
+
+	assert.NoDirExists(t, filepath.Join(rootPath, ".terragrunt-stack"))
+}
+
+func TestStackEnabledRequiresExperiment(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsExperimentMode(t) {
+		t.Skip(
+			"Skipping: TG_EXPERIMENT_MODE forces all experiments on, opening the gate this test pins shut",
+		)
+	}
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksEnabled)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksEnabled)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStacksEnabled, "live")
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt stack generate --working-dir "+rootPath,
+	)
+
+	var enabledErr config.EnabledRequiresExperimentError
+	require.ErrorAs(t, err, &enabledErr)
+	assert.Equal(t, "unit", enabledErr.BlockType)
+	assert.Equal(t, "vpc", enabledErr.BlockLabel)
+}

--- a/test/integration_stack_enabled_tf_test.go
+++ b/test/integration_stack_enabled_tf_test.go
@@ -1,0 +1,41 @@
+//go:build tf
+
+package test_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+)
+
+// TestTFStackEnabledLeavesOutputsAddressable pins that a disabled unit drops out of stack
+// output without taking the rest of the stack with it. Without the skip, reading a
+// never-generated unit's outputs fails the whole command.
+func TestTFStackEnabledLeavesOutputsAddressable(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksEnabled)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksEnabled)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStacksEnabled, "live")
+
+	helpers.RunTerragrunt(
+		t,
+		"terragrunt stack run apply --experiment block-iteration --non-interactive --working-dir "+
+			rootPath+" -- -auto-approve",
+	)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt stack output --experiment block-iteration --non-interactive --working-dir "+
+			rootPath,
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "vpc")
+	assert.NotContains(t, stdout, "legacy")
+	assert.NotContains(t, stdout, "shard")
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds the `enabled` attribute to `unit` and `stack` blocks in `terragrunt.stack.hcl` files.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `enabled` controls for stacks and units.
  * Disabled stacks and units are omitted from generation and outputs.
  * Enabled units retain addressable outputs, including expanded units.
  * Added experiment-gated validation for `enabled` and block iteration settings.
  * Improved configuration errors with affected block details and required experiment guidance.

* **Tests**
  * Added coverage for enabled, disabled, expanded, empty, and included components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->