### PR TITLE
feat: Keying `stack output` addresses by iteration key

### DIFF
--- a/internal/cli/commands/stack/filter_outputs_test.go
+++ b/internal/cli/commands/stack/filter_outputs_test.go
@@ -1,0 +1,169 @@
+package stack_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/stack"
+)
+
+// stackOutputs is the shape StackOutput builds: one object per unit, with an expanded
+// unit nesting one object per iteration key under its name.
+func stackOutputs() cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"vpc": cty.ObjectVal(map[string]cty.Value{
+			"id": cty.StringVal("vpc-id"),
+		}),
+		"shard": cty.ObjectVal(map[string]cty.Value{
+			"web":   cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("web-id")}),
+			"api":   cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("api-id")}),
+			"0":     cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("zero-id")}),
+			"a.b":   cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("dotted-id")}),
+			"12345": cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("numeric-id")}),
+		}),
+	})
+}
+
+func TestFilterOutputsResolvesAddresses(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		address string
+		want    string
+	}{
+		{
+			name:    "bare unit keeps working",
+			address: "vpc.id",
+			want:    "vpc-id",
+		},
+		{
+			name:    "quoted iteration key",
+			address: `shard["web"].id`,
+			want:    "web-id",
+		},
+		{
+			name:    "count index",
+			address: "shard[0].id",
+			want:    "zero-id",
+		},
+		{
+			name:    "count index quoted as a string",
+			address: `shard["0"].id`,
+			want:    "zero-id",
+		},
+		{
+			name:    "key containing a dot stays one segment",
+			address: `shard["a.b"].id`,
+			want:    "dotted-id",
+		},
+		{
+			name:    "numeric-looking key",
+			address: `shard["12345"].id`,
+			want:    "numeric-id",
+		},
+		{
+			name:    "dotted form addresses the same element",
+			address: "shard.api.id",
+			want:    "api-id",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			filtered, err := stack.FilterOutputs(stackOutputs(), tc.address)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.want, leafString(t, filtered))
+		})
+	}
+}
+
+// leafString walks to the single leaf of the nested object FilterOutputs rebuilds.
+func leafString(tb testing.TB, value cty.Value) string {
+	tb.Helper()
+
+	for value.Type().IsObjectType() {
+		values := value.AsValueMap()
+		require.Len(tb, values, 1)
+
+		for _, nested := range values {
+			value = nested
+		}
+	}
+
+	return value.AsString()
+}
+
+func TestFilterOutputsKeepsTheAddressItWasGiven(t *testing.T) {
+	t.Parallel()
+
+	filtered, err := stack.FilterOutputs(stackOutputs(), `shard["web"].id`)
+	require.NoError(t, err)
+
+	shard, ok := filtered.AsValueMap()["shard"]
+	require.True(t, ok, "the filtered result must stay wrapped in the unit name")
+
+	web, ok := shard.AsValueMap()["web"]
+	require.True(t, ok, "the filtered result must stay wrapped in the iteration key")
+
+	assert.Equal(t, cty.StringVal("web-id"), web.AsValueMap()["id"])
+}
+
+func TestFilterOutputsAddressingNothing(t *testing.T) {
+	t.Parallel()
+
+	for _, address := range []string{
+		"nope",
+		"vpc.nope",
+		`shard["nope"].id`,
+		"shard[99].id",
+		// A leaf has no attributes to walk into.
+		"vpc.id.deeper",
+	} {
+		t.Run(address, func(t *testing.T) {
+			t.Parallel()
+
+			filtered, err := stack.FilterOutputs(stackOutputs(), address)
+			require.NoError(t, err, "an address that names nothing is not an error")
+			assert.Equal(t, cty.NilVal, filtered)
+		})
+	}
+}
+
+func TestFilterOutputsRejectsUnreadableAddresses(t *testing.T) {
+	t.Parallel()
+
+	for _, address := range []string{
+		`shard["web"`,
+		"shard[",
+		"[0]",
+		"shard.",
+		"shard[web]",
+	} {
+		t.Run(address, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := stack.FilterOutputs(stackOutputs(), address)
+
+			var addressErr stack.InvalidOutputAddressError
+			require.ErrorAs(t, err, &addressErr)
+			assert.Equal(t, address, addressErr.Address)
+		})
+	}
+}
+
+func TestFilterOutputsWithoutAnAddress(t *testing.T) {
+	t.Parallel()
+
+	outputs := stackOutputs()
+
+	filtered, err := stack.FilterOutputs(outputs, "")
+	require.NoError(t, err)
+	assert.Equal(t, outputs, filtered)
+}

--- a/internal/cli/commands/stack/stack.go
+++ b/internal/cli/commands/stack/stack.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 
 	"github.com/gruntwork-io/terragrunt/internal/runner/runall"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
@@ -156,8 +158,10 @@ func RunOutput(
 		return err
 	}
 
-	// Filter outputs based on index key
-	filteredOutputs := FilterOutputs(outputs, index)
+	filteredOutputs, err := FilterOutputs(outputs, index)
+	if err != nil {
+		return err
+	}
 
 	// render outputs
 
@@ -181,41 +185,90 @@ func RunOutput(
 	return nil
 }
 
-// FilterOutputs filters the outputs based on the provided index key.
-func FilterOutputs(outputs cty.Value, index string) cty.Value {
+// FilterOutputs narrows outputs to the value at index, an address such as `vpc.id`,
+// `shard["web"].id`, or `shard[0].id`, still wrapped in the objects it was nested in.
+// An address that names nothing yields [cty.NilVal], which prints as no output.
+func FilterOutputs(outputs cty.Value, index string) (cty.Value, error) {
 	if !outputs.IsKnown() || outputs.IsNull() || len(index) == 0 {
-		return outputs
+		return outputs, nil
 	}
 
-	// Split the index into parts
-	indexParts := strings.Split(index, ".")
-	// Traverse the map using the index parts
-	currentValue := outputs
-	for _, part := range indexParts {
-		// Check if the current value is a map or object
-		if currentValue.Type().IsObjectType() || currentValue.Type().IsMapType() {
-			valueMap := currentValue.AsValueMap()
-			if nextValue, exists := valueMap[part]; exists {
-				currentValue = nextValue
-			} else {
-				// If any part of the index path is not found, return NilVal
-				return cty.NilVal
+	segments, err := parseOutputAddress(index)
+	if err != nil {
+		return cty.NilVal, err
+	}
+
+	current := outputs
+
+	for _, segment := range segments {
+		if !current.Type().IsObjectType() && !current.Type().IsMapType() {
+			return cty.NilVal, nil
+		}
+
+		next, exists := current.AsValueMap()[segment]
+		if !exists {
+			return cty.NilVal, nil
+		}
+
+		current = next
+	}
+
+	for i := len(segments) - 1; i >= 0; i-- {
+		current = cty.ObjectVal(map[string]cty.Value{segments[i]: current})
+	}
+
+	return current, nil
+}
+
+// parseOutputAddress splits an output address into the segments it names. It reads the
+// address as an HCL traversal rather than splitting on dots, so that one element of an
+// expanded unit can be addressed as `shard["web"]` and an iteration key containing a dot
+// stays in one piece.
+func parseOutputAddress(index string) ([]string, error) {
+	traversal, diags := hclsyntax.ParseTraversalAbs([]byte(index), "", hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, InvalidOutputAddressError{Address: index, Err: diags}
+	}
+
+	segments := make([]string, 0, len(traversal))
+
+	for _, step := range traversal {
+		switch step := step.(type) {
+		case hcl.TraverseRoot:
+			segments = append(segments, step.Name)
+		case hcl.TraverseAttr:
+			segments = append(segments, step.Name)
+		case hcl.TraverseIndex:
+			key, err := convert.Convert(step.Key, cty.String)
+			if err != nil {
+				return nil, InvalidOutputAddressError{Address: index, Err: err}
 			}
-		} else {
-			// If the current value is not a map or object, return NilVal
-			return cty.NilVal
+
+			segments = append(segments, key.AsString())
+		default:
+			return nil, InvalidOutputAddressError{
+				Address: index,
+				Err:     fmt.Errorf("unsupported address step %T", step),
+			}
 		}
 	}
 
-	// Reconstruct the nested map structure
-	nested := currentValue
-	for i := len(indexParts) - 1; i >= 0; i-- {
-		nested = cty.ObjectVal(map[string]cty.Value{
-			indexParts[i]: nested,
-		})
-	}
+	return segments, nil
+}
 
-	return nested
+// InvalidOutputAddressError reports an output address that cannot be parsed. An address
+// that parses but names no unit is not an error; it yields no output.
+type InvalidOutputAddressError struct {
+	Err     error
+	Address string
+}
+
+func (err InvalidOutputAddressError) Error() string {
+	return fmt.Sprintf("invalid output address %q: %v", err.Address, err.Err)
+}
+
+func (err InvalidOutputAddressError) Unwrap() error {
+	return err.Err
 }
 
 // RunClean recursively removes all stack directories under the specified WorkingDir.

--- a/internal/stacks/output/nest_outputs_test.go
+++ b/internal/stacks/output/nest_outputs_test.go
@@ -1,0 +1,237 @@
+package output_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/gruntwork-io/terragrunt/internal/stacks/output"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+const nestTestStackDir = "/stack/.terragrunt-stack"
+
+// expandedUnit builds a unit as the for_each decoder would leave it, carrying the
+// iteration key that keeps its instances apart.
+func expandedUnit(name, key, path string) output.UnitOutput {
+	return output.UnitOutput{
+		Unit: &config.Unit{
+			Name: name,
+			Path: path,
+			Expansion: &hclparse.ExpansionBlock{
+				InstanceKey: hclparse.InstanceKey{EachKey: &key},
+			},
+		},
+		Outputs: map[string]cty.Value{"id": cty.StringVal(name + "-" + key)},
+		Path:    filepath.Join(nestTestStackDir, path),
+	}
+}
+
+// countUnit builds a unit as the count decoder would leave it.
+func countUnit(name string, index int, path string) output.UnitOutput {
+	return output.UnitOutput{
+		Unit: &config.Unit{
+			Name: name,
+			Path: path,
+			Expansion: &hclparse.ExpansionBlock{
+				InstanceKey: hclparse.InstanceKey{CountIndex: &index},
+			},
+		},
+		Outputs: map[string]cty.Value{"id": cty.StringVal(path)},
+		Path:    filepath.Join(nestTestStackDir, path),
+	}
+}
+
+// plainUnit builds a unit that declares no expansion.
+func plainUnit(name, path string) output.UnitOutput {
+	return output.UnitOutput{
+		Unit:    &config.Unit{Name: name, Path: path},
+		Outputs: map[string]cty.Value{"id": cty.StringVal(name)},
+		Path:    filepath.Join(nestTestStackDir, path),
+	}
+}
+
+func nest(t *testing.T, stacks map[string][]string, units ...output.UnitOutput) map[string]any {
+	t.Helper()
+
+	nested, err := output.NestOutputs(logger.CreateLogger(), stacks, units)
+	require.NoError(t, err)
+
+	return nested
+}
+
+// noEnclosingStacks is what StackOutput hands over for a stack file whose units all sit
+// at the top level: a map with nothing in it, never a nil one.
+func noEnclosingStacks() map[string][]string {
+	return map[string][]string{}
+}
+
+// leaf walks the nested result to the outputs stored at address.
+func leaf(t *testing.T, nested map[string]any, address ...string) cty.Value {
+	t.Helper()
+
+	current := nested
+
+	for _, segment := range address[:len(address)-1] {
+		next, ok := current[segment].(map[string]any)
+		require.Truef(t, ok, "no branch at %q", segment)
+
+		current = next
+	}
+
+	value, ok := current[address[len(address)-1]].(cty.Value)
+	require.Truef(t, ok, "no outputs at %q", address[len(address)-1])
+
+	return value
+}
+
+func TestNestOutputsKeysExpandedUnitsByIterationKey(t *testing.T) {
+	t.Parallel()
+
+	nested := nest(t, noEnclosingStacks(),
+		expandedUnit("shard", "web", "shard/web"),
+		expandedUnit("shard", "api", "shard/api"),
+		plainUnit("vpc", "vpc"),
+	)
+
+	assert.Equal(t, cty.StringVal("shard-web"), leaf(t, nested, "shard", "web").AsValueMap()["id"])
+	assert.Equal(t, cty.StringVal("shard-api"), leaf(t, nested, "shard", "api").AsValueMap()["id"])
+
+	// An unexpanded unit keeps its bare address rather than gaining a key segment.
+	assert.Equal(t, cty.StringVal("vpc"), leaf(t, nested, "vpc").AsValueMap()["id"])
+}
+
+func TestNestOutputsKeysCountUnitsByIndex(t *testing.T) {
+	t.Parallel()
+
+	nested := nest(t, noEnclosingStacks(),
+		countUnit("shard", 0, "shard/0"),
+		countUnit("shard", 1, "shard/1"),
+	)
+
+	assert.Equal(t, cty.StringVal("shard/0"), leaf(t, nested, "shard", "0").AsValueMap()["id"])
+	assert.Equal(t, cty.StringVal("shard/1"), leaf(t, nested, "shard", "1").AsValueMap()["id"])
+}
+
+// TestNestOutputsKeepsDottedKeysWhole pins that an iteration key containing a dot stays
+// one level. Joining addresses into a dotted string and splitting it again would bury the
+// unit two levels down, out of reach of the address the user would write.
+func TestNestOutputsKeepsDottedKeysWhole(t *testing.T) {
+	t.Parallel()
+
+	nested := nest(t, noEnclosingStacks(), expandedUnit("shard", "a.b", "shard/a-b"))
+
+	assert.Equal(t, cty.StringVal("shard-a.b"), leaf(t, nested, "shard", "a.b").AsValueMap()["id"])
+}
+
+func TestNestOutputsNestsUnitsUnderTheirStacks(t *testing.T) {
+	t.Parallel()
+
+	stacks := map[string][]string{
+		filepath.Join(nestTestStackDir, "team"): {"team"},
+	}
+
+	nested := nest(t, stacks, plainUnit("member", "team/member"))
+
+	assert.Equal(t, cty.StringVal("member"), leaf(t, nested, "team", "member").AsValueMap()["id"])
+}
+
+// TestNestOutputsOrdersNestedStacksOutermostFirst pins the segment order when more than
+// one stack encloses a unit. Reversing it would address the unit as team.org.member,
+// which reads the nesting backwards.
+func TestNestOutputsOrdersNestedStacksOutermostFirst(t *testing.T) {
+	t.Parallel()
+
+	stacks := map[string][]string{
+		filepath.Join(nestTestStackDir, "org"):      {"org"},
+		filepath.Join(nestTestStackDir, "org/team"): {"team"},
+	}
+
+	nested := nest(t, stacks, plainUnit("member", "org/team/member"))
+
+	assert.Equal(
+		t,
+		cty.StringVal("member"),
+		leaf(t, nested, "org", "team", "member").AsValueMap()["id"],
+	)
+}
+
+// TestNestOutputsKeysExpandedStacks pins that units inside an expanded stack address
+// through the stack's iteration key. Without it every instance of the stack would claim
+// the same address and all but one unit would vanish from the output.
+func TestNestOutputsKeysExpandedStacks(t *testing.T) {
+	t.Parallel()
+
+	stacks := map[string][]string{
+		filepath.Join(nestTestStackDir, "team/0"): {"team", "0"},
+		filepath.Join(nestTestStackDir, "team/1"): {"team", "1"},
+	}
+
+	nested := nest(t, stacks,
+		plainUnit("member", "team/0/member"),
+		plainUnit("member", "team/1/member"),
+	)
+
+	assert.NotNil(t, leaf(t, nested, "team", "0", "member"))
+	assert.NotNil(t, leaf(t, nested, "team", "1", "member"))
+}
+
+// TestNestOutputsDoesNotConfuseSiblingIndexes pins that a stack generated to team/1 does
+// not claim the units under team/10, which a plain substring test on the path would.
+func TestNestOutputsDoesNotConfuseSiblingIndexes(t *testing.T) {
+	t.Parallel()
+
+	stacks := map[string][]string{
+		filepath.Join(nestTestStackDir, "team/1"):  {"team", "1"},
+		filepath.Join(nestTestStackDir, "team/10"): {"team", "10"},
+	}
+
+	nested := nest(t, stacks, plainUnit("member", "team/10/member"))
+
+	assert.NotNil(t, leaf(t, nested, "team", "10", "member"))
+
+	team, ok := nested["team"].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, team, "1", "team/10 must not also nest under team/1")
+}
+
+// TestNestOutputsRejectsANilStackMap pins the narrower contract: an empty map is how a
+// stack file with no stacks presents, so nil can only mean the caller skipped building
+// one. Reading it as "no enclosing stacks" would leave two spellings of the same input.
+func TestNestOutputsRejectsANilStackMap(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		_, _ = output.NestOutputs(logger.CreateLogger(), nil, []output.UnitOutput{
+			plainUnit("vpc", "vpc"),
+		})
+	})
+}
+
+// TestNestOutputsRejectsCollidingAddresses pins that two units resolving to one address
+// fail loudly rather than one silently overwriting the other.
+func TestNestOutputsRejectsCollidingAddresses(t *testing.T) {
+	t.Parallel()
+
+	stacks := map[string][]string{
+		filepath.Join(nestTestStackDir, "team"): {"team"},
+	}
+
+	// The unit expanded to team["member"] and the member unit inside the team stack both
+	// resolve to team.member.
+	_, err := output.NestOutputs(logger.CreateLogger(), stacks,
+		[]output.UnitOutput{
+			expandedUnit("team", "member", "team-member"),
+			plainUnit("member", "team/member"),
+		},
+	)
+
+	var collision output.UnitAddressCollisionError
+	require.ErrorAs(t, err, &collision)
+	assert.Equal(t, "team.member", collision.Address)
+}

--- a/internal/stacks/output/output.go
+++ b/internal/stacks/output/output.go
@@ -40,6 +40,17 @@ func (e UnitOutputError) Unwrap() error {
 	return e.Err
 }
 
+// UnitAddressCollisionError is returned when two units resolve to the same output
+// address. Expansion makes this reachable: a nested stack and an expanded unit can claim
+// the same name.key pair.
+type UnitAddressCollisionError struct {
+	Address string
+}
+
+func (e UnitAddressCollisionError) Error() string {
+	return fmt.Sprintf("more than one unit resolves to the output address %q", e.Address)
+}
+
 // StackOutput collects and returns the OpenTofu/Terraform output values for all declared units in a stack hierarchy.
 //
 // This function is a central component of Terragrunt's stack output system, providing a mechanism to
@@ -107,7 +118,7 @@ func StackOutput(
 	}
 
 	outputs := xsync.NewMap[string, map[string]cty.Value]()
-	declaredStacks := make(map[string]string)
+	declaredStacks := make(map[string][]string)
 	declaredUnits := make(map[string]*config.Unit)
 	parsedStackFiles := make(map[string]*config.StackConfig, len(foundFiles))
 
@@ -158,12 +169,11 @@ func StackOutput(
 				continue
 			}
 
-			declaredStacks[filepath.Join(targetDir, stack.Path)] = stack.Name
-			l.Debugf(
-				"Registered stack %s at path %s",
-				stack.Name,
-				filepath.Join(targetDir, stack.Path),
-			)
+			stackPath := filepath.Join(targetDir, stack.Path)
+			key, expanded := stack.InstanceKey()
+			declaredStacks[stackPath] = componentAddress(stack.Name, key, expanded)
+
+			l.Debugf("Registered stack %s at path %s", stack.Name, stackPath)
 		}
 
 		for _, unit := range stackFile.Units {
@@ -199,10 +209,8 @@ func StackOutput(
 		return cty.NilVal, err
 	}
 
-	unitOutputs := make(map[string]map[string]cty.Value)
+	collected := make([]UnitOutput, 0, len(declaredUnits))
 
-	// Build stack list separated by stacks, find all nested stacks, and build
-	// a dotted path. If no stack is found, use the unit name.
 	for path, unit := range declaredUnits {
 		output, found := outputs.Load(path)
 		if !found {
@@ -210,111 +218,154 @@ func StackOutput(
 			continue
 		}
 
-		// Implement more logic to find all stacks in which the path is located
-		stackNames := []string{}
-		nameToPath := make(map[string]string) // Map to track which path each stack name came from
-
-		for stackPath, stackName := range declaredStacks {
-			if strings.Contains(path, stackPath) {
-				stackNames = append(stackNames, stackName)
-				nameToPath[stackName] = stackPath
-			}
-		}
-
-		// Sort by stack path length so the outermost stack (shortest path) comes
-		// first; this preserves the parent.child nesting order in the joined key.
-		slices.SortFunc(stackNames, func(a, b string) int {
-			return len(nameToPath[a]) - len(nameToPath[b])
-		})
-
-		stackKey := unit.Name
-		if len(stackNames) > 0 {
-			stackKey = strings.Join(stackNames, ".") + "." + unit.Name
-		}
-
-		unitOutputs[stackKey] = output
-
-		l.Debugf("Added output for stack key %s", stackKey)
+		collected = append(collected, UnitOutput{Unit: unit, Outputs: output, Path: path})
 	}
 
-	// Convert finalMap into a cty.ObjectVal
-	result := make(map[string]cty.Value)
-
-	nestedOutputs, err := nestUnitOutputs(unitOutputs)
+	nestedOutputs, err := NestOutputs(l, declaredStacks, collected)
 	if err != nil {
 		return cty.NilVal, fmt.Errorf("failed to nest unit outputs: %w", err)
 	}
 
 	ctyResult, err := config.GoTypeToCty(nestedOutputs)
 	if err != nil {
-		return cty.NilVal, fmt.Errorf(
-			"failed to convert unit output to cty value: %s %w",
-			result,
-			err,
-		)
+		return cty.NilVal, fmt.Errorf("failed to convert unit outputs to a cty value: %w", err)
 	}
 
 	return ctyResult, nil
 }
 
-// nestUnitOutputs transforms a flat map of unit outputs into a nested hierarchical structure.
-//
-// This function is a critical part of Terragrunt/Opentofu's stack output system, converting flat key-value pairs
-// with dot notation into a proper nested object hierarchy. It processes each flattened key (e.g., "parent.child.unit")
-// by splitting it into path segments and recursively building the corresponding nested structure.
-//
-// The algorithm works as follows:
-//  1. For each entry in the flat map, split its key by dots to get the path segments
-//  2. Iteratively traverse the nested structure, creating intermediate maps as needed
-//  3. When reaching the final path segment, convert the map of cty.Values to a Go interface{}
-//     representation and store it at that location
-//  4. Continue until all flat entries have been properly nested
-//
-// This approach preserves the hierarchical relationship between stacks and units while making
-// the data structure easier to navigate and query programmatically.
-//
-// Parameters:
-//   - flat: A map where keys are dot-separated paths (e.g., "parent.child.unit") and values are
-//     maps of cty.Value representing the OpenTofu/Terraform outputs for each unit
-//
-// Returns:
-//   - map[string]any: A nested map structure reflecting the hierarchy implied by the dot notation
-//   - error: An error if conversion fails, particularly when building the nested structure
-//
-// Errors can occur during cty.Value conversion or when attempting to traverse the nested structure
-// if the path contains contradictory type information (e.g., a path segment is both a leaf and a branch).
-func nestUnitOutputs(flat map[string]map[string]cty.Value) (map[string]any, error) {
+// UnitOutput is one unit's outputs together with the on-disk path it generated to.
+type UnitOutput struct {
+	Unit    *config.Unit
+	Outputs map[string]cty.Value
+	Path    string
+}
+
+// NestOutputs arranges each unit's outputs under the address it is reachable at: a unit
+// inside a stack at stack.unit, and one element of an expanded unit at unit.key.
+func NestOutputs(
+	l log.Logger,
+	declaredStacks map[string][]string,
+	units []UnitOutput,
+) (map[string]any, error) {
+	// A stack file that declares no stacks still yields an empty map, so nil means the
+	// caller never built one rather than that there is nothing to place units under.
+	if declaredStacks == nil {
+		panic("NestOutputs requires the non-nil declaredStacks map that StackOutput builds")
+	}
+
+	addressed := make([]unitOutput, 0, len(units))
+
+	for _, unit := range units {
+		key, expanded := unit.Unit.InstanceKey()
+		address := slices.Concat(
+			enclosingStackAddress(declaredStacks, unit.Path),
+			componentAddress(unit.Unit.Name, key, expanded),
+		)
+
+		addressed = append(addressed, unitOutput{address: address, outputs: unit.Outputs})
+
+		l.Debugf("Added output for %s", strings.Join(address, "."))
+	}
+
+	return nestUnitOutputs(addressed)
+}
+
+// unitOutput pairs one unit's outputs with the address it is reachable at. The address
+// stays split into segments rather than joined with dots, so a stack name, unit name, or
+// iteration key that itself contains a dot cannot split into two levels of the result.
+type unitOutput struct {
+	outputs map[string]cty.Value
+	address []string
+}
+
+// componentAddress returns the address segments a unit or stack is reachable at. An
+// expanded component gets its iteration key as a segment of its own, so that
+// `foo["web"]` addresses one element the way `dependency.foo["web"]` already does.
+func componentAddress(name, key string, expanded bool) []string {
+	if !expanded {
+		return []string{name}
+	}
+
+	return []string{name, key}
+}
+
+// enclosingStackAddress returns the address segments of every stack the unit at path sits
+// inside, outermost first, so a unit in a nested stack addresses as parent.child.unit.
+func enclosingStackAddress(declaredStacks map[string][]string, path string) []string {
+	enclosing := make([]string, 0, len(declaredStacks))
+
+	for stackPath := range declaredStacks {
+		if containsPath(stackPath, path) {
+			enclosing = append(enclosing, stackPath)
+		}
+	}
+
+	// Every match is an ancestor of the same unit, so they form a chain in which each is
+	// a prefix of the next. Ordering them lexicographically therefore runs the nesting
+	// from the outermost stack inward.
+	slices.Sort(enclosing)
+
+	address := make([]string, 0, len(enclosing))
+	for _, stackPath := range enclosing {
+		address = append(address, declaredStacks[stackPath]...)
+	}
+
+	return address
+}
+
+// containsPath reports whether path sits inside dir. Comparing the cleaned relative path
+// rather than testing for a string prefix is what stops a stack generated to team/1 from
+// claiming the units under team/10.
+func containsPath(dir, path string) bool {
+	rel, err := filepath.Rel(dir, path)
+	if err != nil || rel == "." {
+		return false
+	}
+
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func nestUnitOutputs(unitOutputs []unitOutput) (map[string]any, error) {
 	nested := make(map[string]any)
 
-	for flatKey, value := range flat {
-		parts := strings.Split(flatKey, ".")
+	for _, unit := range unitOutputs {
 		current := nested
 
-		for i, part := range parts {
-			if i == len(parts)-1 {
-				ctyValue, err := config.ConvertValuesMapToCtyVal(value)
+		for i, segment := range unit.address {
+			// Both branches reject an address already spoken for. Overwriting it would
+			// drop a unit from the output with nothing to signal the loss.
+			if i == len(unit.address)-1 {
+				if _, taken := current[segment]; taken {
+					return nil, UnitAddressCollisionError{Address: strings.Join(unit.address, ".")}
+				}
+
+				ctyValue, err := config.ConvertValuesMapToCtyVal(unit.outputs)
 				if err != nil {
 					return nil, fmt.Errorf(
 						"failed to convert unit output to cty value: %s %w",
-						flatKey,
+						strings.Join(unit.address, "."),
 						err,
 					)
 				}
 
-				current[part] = ctyValue
-			} else {
-				if _, exists := current[part]; !exists { // Traverse or create next level
-					current[part] = make(map[string]any)
-				}
+				current[segment] = ctyValue
 
-				var ok bool
+				break
+			}
 
-				current, ok = current[part].(map[string]any)
+			if _, exists := current[segment]; !exists {
+				current[segment] = make(map[string]any)
+			}
 
-				if !ok {
-					return nil, fmt.Errorf("failed to traverse unit output: %v %s", flat, part)
+			next, ok := current[segment].(map[string]any)
+			if !ok {
+				return nil, UnitAddressCollisionError{
+					Address: strings.Join(unit.address[:i+1], "."),
 				}
 			}
+
+			current = next
 		}
 	}
 

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -103,6 +103,17 @@ func (u *Unit) IsEnabled() bool {
 	return u.Enabled == nil || *u.Enabled
 }
 
+// InstanceKey returns the key of the expansion element this unit came from, and whether
+// the unit was expanded at all. A declared expansion is not proof of one: a block decoded
+// outside the expanding decoder carries the declaration with no key.
+func (u *Unit) InstanceKey() (string, bool) {
+	if u.Expansion == nil {
+		return "", false
+	}
+
+	return u.Expansion.Key(), u.Expansion.Expanded()
+}
+
 // GeneratedPath returns the on-disk path this unit generates to under stackDir.
 func (u *Unit) GeneratedPath(stackDir string) string {
 	return inthclparse.GeneratedComponentPath(stackDir, u.Path, u.NoStack != nil && *u.NoStack)
@@ -129,6 +140,16 @@ type Stack struct {
 // stack, so only an explicit false drops it.
 func (s *Stack) IsEnabled() bool {
 	return s.Enabled == nil || *s.Enabled
+}
+
+// InstanceKey returns the key of the expansion element this stack came from, and whether
+// the stack was expanded at all.
+func (s *Stack) InstanceKey() (string, bool) {
+	if s.Expansion == nil {
+		return "", false
+	}
+
+	return s.Expansion.Key(), s.Expansion.Expanded()
 }
 
 // GeneratedPath returns the on-disk path this stack generates to under stackDir.

--- a/test/fixtures/stacks/expansion-outputs/live/terragrunt.stack.hcl
+++ b/test/fixtures/stacks/expansion-outputs/live/terragrunt.stack.hcl
@@ -1,0 +1,34 @@
+unit "aurora" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  source = "../units/app"
+  path   = "aurora/${each.key}"
+
+  values = {
+    role = each.key
+  }
+}
+
+unit "shard" {
+  expansion {
+    count = 2
+  }
+
+  source = "../units/app"
+  path   = "shard/${count.index}"
+
+  values = {
+    role = "shard-${count.index}"
+  }
+}
+
+unit "vpc" {
+  source = "../units/app"
+  path   = "vpc"
+
+  values = {
+    role = "vpc"
+  }
+}

--- a/test/fixtures/stacks/expansion-outputs/units/app/main.tf
+++ b/test/fixtures/stacks/expansion-outputs/units/app/main.tf
@@ -1,0 +1,7 @@
+variable "role" {
+  type = string
+}
+
+output "role" {
+  value = var.role
+}

--- a/test/fixtures/stacks/expansion-outputs/units/app/terragrunt.hcl
+++ b/test/fixtures/stacks/expansion-outputs/units/app/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "."
+}
+
+inputs = {
+  role = values.role
+}

--- a/test/integration_stack_expansion_output_tf_test.go
+++ b/test/integration_stack_expansion_output_tf_test.go
@@ -1,0 +1,102 @@
+//go:build tf
+
+package test_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+)
+
+const testFixtureStacksExpansionOutputs = "fixtures/stacks/expansion-outputs"
+
+// applyExpansionOutputStack generates and applies the fixture, returning its root.
+func applyExpansionOutputStack(t *testing.T) string {
+	t.Helper()
+
+	helpers.CleanupTerraformFolder(t, testFixtureStacksExpansionOutputs)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStacksExpansionOutputs)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureStacksExpansionOutputs, "live")
+
+	helpers.RunTerragrunt(
+		t,
+		"terragrunt stack run apply --experiment block-iteration --non-interactive --working-dir "+
+			rootPath+" -- -auto-approve",
+	)
+
+	return rootPath
+}
+
+func stackOutputAt(t *testing.T, rootPath, address string) string {
+	t.Helper()
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt stack output "+address+
+			" --experiment block-iteration --non-interactive --working-dir "+rootPath,
+	)
+	require.NoError(t, err)
+
+	return stdout
+}
+
+// TestTFStackOutputAddressesExpandedUnitsByKey pins the addressing scheme end to end.
+// Every element of an expanded unit is reachable by its key, and a unit that declares no
+// expansion still answers to its bare name.
+func TestTFStackOutputAddressesExpandedUnitsByKey(t *testing.T) {
+	t.Parallel()
+
+	rootPath := applyExpansionOutputStack(t)
+
+	testCases := []struct {
+		address string
+		want    string
+	}{
+		{address: `'aurora["web"].role'`, want: `"web"`},
+		{address: `'aurora["api"].role'`, want: `"api"`},
+		{address: `'shard[0].role'`, want: `"shard-0"`},
+		{address: `'shard[1].role'`, want: `"shard-1"`},
+		{address: "vpc.role", want: `"vpc"`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.address, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Contains(t, stackOutputAt(t, rootPath, tc.address), tc.want)
+		})
+	}
+}
+
+// TestTFStackOutputRawResolvesKeyedAddress pins that --format raw, the path automation
+// reads, narrows a keyed address to the bare value.
+func TestTFStackOutputRawResolvesKeyedAddress(t *testing.T) {
+	t.Parallel()
+
+	rootPath := applyExpansionOutputStack(t)
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		`terragrunt stack output 'aurora["web"].role' --format raw`+
+			" --experiment block-iteration --non-interactive --working-dir "+rootPath,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "web", strings.TrimSpace(stdout))
+}
+
+// TestTFStackOutputListsEveryExpandedElement pins that an unfiltered run carries every
+// element, rather than one instance of a block overwriting its siblings.
+func TestTFStackOutputListsEveryExpandedElement(t *testing.T) {
+	t.Parallel()
+
+	stdout := stackOutputAt(t, applyExpansionOutputStack(t), "")
+
+	for _, role := range []string{`"web"`, `"api"`, `"shard-0"`, `"shard-1"`, `"vpc"`} {
+		assert.Contains(t, stdout, role)
+	}
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds support for addressing components by address despite being expanded.

e.g.

```bash
# One element of a unit expanded over for_each
terragrunt stack output 'aurora["web"].role' --experiment block-iteration

# One element of a unit expanded over count, narrowed to the bare value
terragrunt stack output 'shard[0].role' --format raw --experiment block-iteration
```

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
