### PR TITLE
fix: Fixing `--queue-construct-as` resulting in empty tokenization

### DIFF
--- a/docs/src/data/changelog/v1.1.4/queue-construct-as-empty-value.mdx
+++ b/docs/src/data/changelog/v1.1.4/queue-construct-as-empty-value.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.4"
+category: "bug-fixes"
+---
+
+#### `find` and `list` reject a `--queue-construct-as` value that holds no command
+
+A value made only of shell punctuation, such as `terragrunt find --queue-construct-as=';'`, ended the run with a crash report. A value that quotes an empty command, such as `--queue-construct-as='""'`, was accepted even though it names no command.
+
+`find` and `list` now exit with an error that repeats the value you passed and shows what [`--queue-construct-as`](/reference/cli/commands/list#queue-construct-as) expects instead.

--- a/internal/discovery/constructor.go
+++ b/internal/discovery/constructor.go
@@ -84,6 +84,12 @@ func NewForDiscoveryCommand(l log.Logger, fsys vfs.FS, opts *DiscoveryCommandOpt
 			return nil, err
 		}
 
+		// The parser stops at a shell operator like ';' or '|' without reporting an error, so
+		// a value that leads with one yields no words. A quoted empty string yields one empty word.
+		if len(args) == 0 || args[0] == "" {
+			return nil, NewEmptyQueueConstructAsError(opts.QueueConstructAs)
+		}
+
 		cmd := args[0]
 		if len(args) > 1 {
 			args = args[1:]

--- a/internal/discovery/constructor_test.go
+++ b/internal/discovery/constructor_test.go
@@ -1,0 +1,66 @@
+package discovery_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewForDiscoveryCommand_QueueConstructAs(t *testing.T) {
+	t.Parallel()
+
+	newForDiscoveryCommand := func(t *testing.T, queueConstructAs string) (*discovery.Discovery, error) {
+		t.Helper()
+
+		v := venvtest.New()
+
+		return discovery.NewForDiscoveryCommand(logger.CreateLogger(), v.FS, &discovery.DiscoveryCommandOptions{
+			WorkingDir:       "/repo",
+			QueueConstructAs: queueConstructAs,
+		})
+	}
+
+	testCases := []struct {
+		name             string
+		queueConstructAs string
+	}{
+		{name: "semicolon", queueConstructAs: ";"},
+		{name: "pipe", queueConstructAs: "|"},
+		{name: "logical and", queueConstructAs: "&&"},
+		{name: "redirect", queueConstructAs: ">"},
+		{name: "stderr redirect", queueConstructAs: "2>&1"},
+		{name: "whitespace", queueConstructAs: "   "},
+		{name: "tab", queueConstructAs: "\t"},
+		{name: "command after separator", queueConstructAs: "; plan"},
+		{name: "double quoted empty string", queueConstructAs: `""`},
+		{name: "single quoted empty string", queueConstructAs: "''"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := newForDiscoveryCommand(t, tc.queueConstructAs)
+			require.ErrorAs(t, err, &discovery.EmptyQueueConstructAsError{})
+		})
+	}
+
+	t.Run("command with arguments", func(t *testing.T) {
+		t.Parallel()
+
+		d, err := newForDiscoveryCommand(t, "apply -destroy")
+		require.NoError(t, err)
+		require.NotNil(t, d)
+	})
+
+	t.Run("unbalanced quote", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newForDiscoveryCommand(t, "plan '")
+		require.Error(t, err)
+		require.NotErrorAs(t, err, &discovery.EmptyQueueConstructAsError{})
+	})
+}

--- a/internal/discovery/errors.go
+++ b/internal/discovery/errors.go
@@ -201,3 +201,22 @@ func (e DiscoveryBoundaryScopeError) Error() string {
 func NewDiscoveryBoundaryScopeError(boundary, workingDir string) error {
 	return DiscoveryBoundaryScopeError{Boundary: boundary, WorkingDir: workingDir}
 }
+
+// EmptyQueueConstructAsError represents an error that occurs when the value
+// given for the --queue-construct-as flag contains no command.
+type EmptyQueueConstructAsError struct {
+	Value string
+}
+
+func (e EmptyQueueConstructAsError) Error() string {
+	return fmt.Sprintf(
+		"The --queue-construct-as value %q contains no command. "+
+			"Pass the command to construct the queue as, like 'plan' or 'apply -destroy'.",
+		e.Value,
+	)
+}
+
+// NewEmptyQueueConstructAsError creates a new [EmptyQueueConstructAsError] for the given flag value.
+func NewEmptyQueueConstructAsError(value string) error {
+	return EmptyQueueConstructAsError{Value: value}
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Precents `--as` values that result in empty parsed cmd args from causing a panic.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `find` and `list` now reject queue construction values that do not include a command, including empty or shell-only values.
  - Error messages identify the invalid value and show the expected option format.
  - Valid commands with arguments continue to work as expected.

- **Documentation**
  - Added a changelog entry documenting this validation improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->