### PR TITLE
fix: Fixing `render --write` when no `--format` is supplied

### DIFF
--- a/docs/src/data/changelog/v1.1.4/render-write-default-filename.mdx
+++ b/docs/src/data/changelog/v1.1.4/render-write-default-filename.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.4"
+category: "bug-fixes"
+---
+
+#### `render --write` picks a default filename without a format flag
+
+`terragrunt render --write` failed with `is a directory` unless it was paired with `--format` or `--json`. Only those flags set the default filename, so a bare `--write` had no output path and Terragrunt tried to write to the unit directory itself.
+
+The default now follows the format in use. `terragrunt render --write` writes `terragrunt.rendered.hcl` next to the unit configuration, and `--json` or `--format=json` writes `terragrunt.rendered.json`. An explicit `--out` still takes precedence.

--- a/internal/cli/commands/render/cli.go
+++ b/internal/cli/commands/render/cli.go
@@ -4,8 +4,6 @@ package render
 import (
 	"context"
 
-	"errors"
-
 	runcmd "github.com/gruntwork-io/terragrunt/internal/cli/commands/run"
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags/shared"
@@ -37,25 +35,9 @@ func NewFlags(opts *Options, prefix flags.Prefix) clihelper.Flags {
 			Name:        FormatFlagName,
 			EnvVars:     tgPrefix.EnvVars(FormatFlagName),
 			Destination: &opts.Format,
-			Usage:       "The output format to render the config in. Currently supports: json",
+			Usage:       "The output format to render the config in. Supported values: hcl, json.",
 			Action: func(_ context.Context, _ *clihelper.Context, value string) error {
-				// Set the default output path based on the format.
-				switch value {
-				case FormatJSON:
-					if opts.OutputPath == "" {
-						opts.OutputPath = "terragrunt.rendered.json"
-					}
-
-					return nil
-				case FormatHCL:
-					if opts.OutputPath == "" {
-						opts.OutputPath = "terragrunt.rendered.hcl"
-					}
-
-					return nil
-				default:
-					return errors.New("invalid format: " + value)
-				}
+				return validateFormat(value)
 			},
 		}),
 
@@ -63,12 +45,8 @@ func NewFlags(opts *Options, prefix flags.Prefix) clihelper.Flags {
 			Name:    JSONFlagName,
 			EnvVars: tgPrefix.EnvVars(JSONFlagName),
 			Usage:   "Render the config in JSON format. Equivalent to --format=json.",
-			Action: func(_ context.Context, _ *clihelper.Context, value bool) error {
+			Action: func(_ context.Context, _ *clihelper.Context, _ bool) error {
 				opts.Format = FormatJSON
-
-				if opts.OutputPath == "" {
-					opts.OutputPath = "terragrunt.rendered.json"
-				}
 
 				return nil
 			},

--- a/internal/cli/commands/render/options.go
+++ b/internal/cli/commands/render/options.go
@@ -12,6 +12,9 @@ const (
 
 	// FormatJSON outputs the config in JSON format.
 	FormatJSON = "json"
+
+	hclOutputName  = "terragrunt.rendered.hcl"
+	jsonOutputName = "terragrunt.rendered.json"
 )
 
 type Options struct {
@@ -50,21 +53,33 @@ func (o *Options) Clone() *Options {
 	}
 }
 
+// Validate rejects an unrecognized format. It also fills in [Options.OutputPath] with a
+// name derived from the format when a write is requested without one.
 func (o *Options) Validate() error {
-	if err := o.validateFormat(); err != nil {
+	if err := validateFormat(o.Format); err != nil {
 		return err
+	}
+
+	if o.Write && o.OutputPath == "" {
+		o.OutputPath = defaultOutputName(o.Format)
 	}
 
 	return nil
 }
 
-func (o *Options) validateFormat() error {
-	switch o.Format {
-	case FormatHCL:
-		return nil
-	case FormatJSON:
+func validateFormat(format string) error {
+	switch format {
+	case FormatHCL, FormatJSON:
 		return nil
 	default:
-		return errors.New("invalid format: " + o.Format)
+		return errors.New("invalid format: " + format)
 	}
+}
+
+func defaultOutputName(format string) string {
+	if format == FormatJSON {
+		return jsonOutputName
+	}
+
+	return hclOutputName
 }

--- a/internal/cli/commands/render/render_test.go
+++ b/internal/cli/commands/render/render_test.go
@@ -104,6 +104,64 @@ func TestRenderJSON_WriteToFile(t *testing.T) {
 	validateRenderedJSON(t, result, false)
 }
 
+func TestRenderWriteWithoutOutputPath(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		check    func(t *testing.T, content []byte)
+		name     string
+		format   string
+		filename string
+	}{
+		{
+			name:     "hcl",
+			format:   render.FormatHCL,
+			filename: "terragrunt.rendered.hcl",
+			check: func(t *testing.T, content []byte) {
+				t.Helper()
+
+				assert.Equal(t, testTerragruntConfigFixture, string(content))
+			},
+		},
+		{
+			name:     "json",
+			format:   render.FormatJSON,
+			filename: "terragrunt.rendered.json",
+			check: func(t *testing.T, content []byte) {
+				t.Helper()
+
+				var result map[string]any
+
+				require.NoError(t, json.Unmarshal(content, &result))
+				validateRenderedJSON(t, result, false)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts, configPath := setupTest(t)
+			opts.Format = tc.format
+			opts.Write = true
+
+			err := render.Run(
+				t.Context(),
+				logger.CreateLogger(),
+				venvtest.NewOSWithEmptyEnv().WithWriter(io.Discard),
+				opts,
+			)
+			require.NoError(t, err)
+
+			content, err := os.ReadFile(filepath.Join(filepath.Dir(configPath), tc.filename))
+			require.NoError(t, err)
+
+			tc.check(t, content)
+		})
+	}
+}
+
 func TestRenderJSON_InvalidFormat(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Makes it so that `render --write` works even when users don't supply an `--out` flag. We already do this when `--json` is used, so it doesn't hurt to add a default case here. Makes it more consistent.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `terragrunt render --write` now uses `terragrunt.rendered.hcl` by default.
  - JSON output now uses `terragrunt.rendered.json` by default.
  - Explicit `--out` paths continue to take priority.
- **Documentation**
  - Added changelog documentation describing the updated default output filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->