### PR TITLE
fix: Fixing `info strict list` without `--all`

### DIFF
--- a/docs/src/data/changelog/v1.1.4/strict-list-detail-show-all.mdx
+++ b/docs/src/data/changelog/v1.1.4/strict-list-detail-show-all.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.4"
+category: "bug-fixes"
+---
+
+#### `info strict list <name>` now honors `--all`
+
+Passing a control name to [`info strict list`](/reference/cli/commands/info/strict) shows that control's subcontrols. Unlike the top-level listing, it ignored the `--all` flag and always included completed subcontrols.
+
+Terragrunt now applies the same rule when you name a control.

--- a/internal/cli/commands/info/strict/command.go
+++ b/internal/cli/commands/info/strict/command.go
@@ -76,7 +76,7 @@ func ListAction(
 				return strict.NewInvalidControlNameError(controls.Names())
 			}
 
-			return writer.DetailControl(control)
+			return writer.DetailSubcontrols(control.GetSubcontrols().FilterByStatus(allowedStatuses...))
 		}
 
 		return writer.List(controls)

--- a/internal/cli/commands/info/strict/command_test.go
+++ b/internal/cli/commands/info/strict/command_test.go
@@ -1,0 +1,95 @@
+package strict_test
+
+import (
+	"bytes"
+	"testing"
+
+	infostrict "github.com/gruntwork-io/terragrunt/internal/cli/commands/info/strict"
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/internal/strict"
+	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListActionFiltersCompletedControlsAndSubcontrols(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		args        clihelper.Args
+		contains    []string
+		notContains []string
+	}{
+		{
+			name:        "list without --all",
+			args:        clihelper.Args{"list"},
+			contains:    []string{"active-parent"},
+			notContains: []string{"done-parent"},
+		},
+		{
+			name:     "list with --all",
+			args:     clihelper.Args{"list", "--all"},
+			contains: []string{"active-parent", "done-parent"},
+		},
+		{
+			name:        "detail without --all",
+			args:        clihelper.Args{"list", "active-parent"},
+			contains:    []string{"active-sub"},
+			notContains: []string{"done-sub"},
+		},
+		{
+			name:     "detail with --all",
+			args:     clihelper.Args{"list", "--all", "active-parent"},
+			contains: []string{"active-sub", "done-sub"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
+			opts.StrictControls = strict.Controls{
+				&controls.Control{
+					Name:        "active-parent",
+					Description: "active parent description",
+					Subcontrols: strict.Controls{
+						&controls.Control{Name: "active-sub", Description: "active sub description"},
+						&controls.Control{
+							Name:        "done-sub",
+							Description: "done sub description",
+							Status:      strict.CompletedStatus,
+						},
+					},
+				},
+				&controls.Control{
+					Name:        "done-parent",
+					Description: "done parent description",
+					Status:      strict.CompletedStatus,
+				},
+			}
+
+			out := new(bytes.Buffer)
+
+			app := clihelper.NewApp(map[string]string{})
+			app.Writer = out
+
+			cmd := infostrict.NewCommand(logger.CreateLogger(), opts)
+			cliCtx := clihelper.NewAppContext(app, tc.args)
+
+			require.NoError(t, cmd.Run(t.Context(), cliCtx, tc.args))
+
+			for _, fragment := range tc.contains {
+				assert.Contains(t, out.String(), fragment)
+			}
+
+			for _, fragment := range tc.notContains {
+				assert.NotContains(t, out.String(), fragment)
+			}
+		})
+	}
+}

--- a/internal/strict/view/plaintext/render.go
+++ b/internal/strict/view/plaintext/render.go
@@ -51,7 +51,7 @@ func NewRender() *Render {
 	return &Render{}
 }
 
-// List implements view.Render interface.
+// List implements [view.Render].
 func (render *Render) List(controls strict.Controls) (string, error) {
 	result, err := render.executeTemplate(listTemplate, map[string]any{
 		"controls": controls,
@@ -63,9 +63,9 @@ func (render *Render) List(controls strict.Controls) (string, error) {
 	return result, nil
 }
 
-// DetailControl implements view.Render interface.
-func (render *Render) DetailControl(control strict.Control) (string, error) {
-	return render.executeTemplate(detailControlTemplate, map[string]any{"control": control}, nil)
+// DetailSubcontrols implements [view.Render].
+func (render *Render) DetailSubcontrols(subcontrols strict.Controls) (string, error) {
+	return render.executeTemplate(detailSubcontrolsTemplate, map[string]any{"subcontrols": subcontrols}, nil)
 }
 
 func (render *Render) buildTemplate(templ string, customFuncs map[string]any) *template.Template {

--- a/internal/strict/view/plaintext/render_internal_test.go
+++ b/internal/strict/view/plaintext/render_internal_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// panickyControl satisfies the strict.Control interface but panics when its
-// subcontrols are asked for. The text/template engine recovers the panic and
-// surfaces it as an Execute error, which lets us drive the error-wrapping
-// branches in List and DetailControl.
+// panickyControl satisfies [strict.Control] but panics from GetName and
+// GetSubcontrols. text/template recovers the panic and returns it as an
+// Execute error, which is how these tests reach the error paths in
+// [Render.List] and [Render.DetailSubcontrols].
 type panickyControl struct{}
 
 func (panickyControl) GetName() string                  { panic("boom") }
@@ -34,11 +34,11 @@ func TestRenderListExecuteError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestRenderDetailControlExecuteError(t *testing.T) {
+func TestRenderDetailSubcontrolsExecuteError(t *testing.T) {
 	t.Parallel()
 
 	r := NewRender()
-	_, err := r.DetailControl(panickyControl{})
+	_, err := r.DetailSubcontrols(strict.Controls{panickyControl{}})
 	require.Error(t, err)
 }
 

--- a/internal/strict/view/plaintext/render_test.go
+++ b/internal/strict/view/plaintext/render_test.go
@@ -68,46 +68,37 @@ func TestRenderList(t *testing.T) {
 	}
 }
 
-func TestRenderDetailControl(t *testing.T) {
+func TestRenderDetailSubcontrols(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		control  strict.Control
-		contains []string
+		name        string
+		subcontrols strict.Controls
+		contains    []string
 	}{
 		{
-			name:    "no subcontrols",
-			control: &controls.Control{Name: "parent"},
+			name:        "no subcontrols",
+			subcontrols: strict.Controls{},
 		},
 		{
 			name: "with subcontrol",
-			control: &controls.Control{
-				Name: "parent",
-				Subcontrols: strict.Controls{
-					&controls.Control{Name: "sub-a", Description: "desc a"},
-				},
+			subcontrols: strict.Controls{
+				&controls.Control{Name: "sub-a", Description: "desc a"},
 			},
 			contains: []string{"sub-a", "desc a"},
 		},
 		{
 			name: "duplicate subcontrols deduplicated",
-			control: &controls.Control{
-				Name: "parent",
-				Subcontrols: strict.Controls{
-					&controls.Control{Name: "dup", Description: "first"},
-					&controls.Control{Name: "dup", Description: "second"},
-				},
+			subcontrols: strict.Controls{
+				&controls.Control{Name: "dup", Description: "first"},
+				&controls.Control{Name: "dup", Description: "second"},
 			},
 			contains: []string{"dup", "first"},
 		},
 		{
 			name: "subcontrol falls back to warning",
-			control: &controls.Control{
-				Name: "parent",
-				Subcontrols: strict.Controls{
-					&controls.Control{Name: "sub-x", Warning: "warn x"},
-				},
+			subcontrols: strict.Controls{
+				&controls.Control{Name: "sub-x", Warning: "warn x"},
 			},
 			contains: []string{"sub-x", "warn x"},
 		},
@@ -119,7 +110,7 @@ func TestRenderDetailControl(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := render.DetailControl(tc.control)
+			got, err := render.DetailSubcontrols(tc.subcontrols)
 			require.NoError(t, err)
 
 			for _, fragment := range tc.contains {

--- a/internal/strict/view/plaintext/template.go
+++ b/internal/strict/view/plaintext/template.go
@@ -14,6 +14,6 @@ const listTemplate = `
    {{ template "rangeControlsTemplate" .controls }}
 `
 
-const detailControlTemplate = `
-   {{ template "rangeSubcontrolsTemplate" .control.GetSubcontrols.RemoveDuplicates }}
+const detailSubcontrolsTemplate = `
+   {{ template "rangeSubcontrolsTemplate" .subcontrols.RemoveDuplicates }}
 `

--- a/internal/strict/view/render.go
+++ b/internal/strict/view/render.go
@@ -6,6 +6,6 @@ type Render interface {
 	// List renders the list of controls.
 	List(controls strict.Controls) (string, error)
 
-	// DetailControl renders the detailed information about the control, including its subcontrols.
-	DetailControl(control strict.Control) (string, error)
+	// DetailSubcontrols renders the subcontrols of a single control.
+	DetailSubcontrols(subcontrols strict.Controls) (string, error)
 }

--- a/internal/strict/view/writer.go
+++ b/internal/strict/view/writer.go
@@ -32,9 +32,9 @@ func (writer *Writer) List(controls strict.Controls) error {
 	return writer.output(output)
 }
 
-// DetailControl renders the detailed information about the control, including its subcontrols.
-func (writer *Writer) DetailControl(control strict.Control) error {
-	output, err := writer.render.DetailControl(control)
+// DetailSubcontrols renders the given subcontrols of a single control.
+func (writer *Writer) DetailSubcontrols(subcontrols strict.Controls) error {
+	output, err := writer.render.DetailSubcontrols(subcontrols)
 	if err != nil {
 		return err
 	}

--- a/internal/strict/view/writer_test.go
+++ b/internal/strict/view/writer_test.go
@@ -15,11 +15,11 @@ import (
 
 type fakeRender struct {
 	listFn   func(strict.Controls) (string, error)
-	detailFn func(strict.Control) (string, error)
+	detailFn func(strict.Controls) (string, error)
 }
 
-func (f *fakeRender) List(c strict.Controls) (string, error)         { return f.listFn(c) }
-func (f *fakeRender) DetailControl(c strict.Control) (string, error) { return f.detailFn(c) }
+func (f *fakeRender) List(c strict.Controls) (string, error)              { return f.listFn(c) }
+func (f *fakeRender) DetailSubcontrols(c strict.Controls) (string, error) { return f.detailFn(c) }
 
 type failingWriter struct{ err error }
 
@@ -65,7 +65,7 @@ func TestWriterList(t *testing.T) {
 	})
 }
 
-func TestWriterDetailControl(t *testing.T) {
+func TestWriterDetailSubcontrols(t *testing.T) {
 	t.Parallel()
 
 	t.Run("happy path writes rendered output", func(t *testing.T) {
@@ -73,11 +73,11 @@ func TestWriterDetailControl(t *testing.T) {
 
 		buf := new(bytes.Buffer)
 		r := &fakeRender{
-			detailFn: func(strict.Control) (string, error) { return "detailed", nil },
+			detailFn: func(strict.Controls) (string, error) { return "detailed", nil },
 		}
 
 		w := view.NewWriter(buf, r)
-		require.NoError(t, w.DetailControl(&controls.Control{Name: "any"}))
+		require.NoError(t, w.DetailSubcontrols(strict.Controls{&controls.Control{Name: "any"}}))
 		assert.Equal(t, "detailed", buf.String())
 	})
 
@@ -86,11 +86,11 @@ func TestWriterDetailControl(t *testing.T) {
 
 		boomErr := errors.New("render boom")
 		r := &fakeRender{
-			detailFn: func(strict.Control) (string, error) { return "", boomErr },
+			detailFn: func(strict.Controls) (string, error) { return "", boomErr },
 		}
 
 		w := view.NewWriter(new(bytes.Buffer), r)
-		err := w.DetailControl(&controls.Control{Name: "any"})
+		err := w.DetailSubcontrols(strict.Controls{&controls.Control{Name: "any"}})
 		require.ErrorIs(t, err, boomErr)
 	})
 }
@@ -112,15 +112,15 @@ func TestWriterOutputError(t *testing.T) {
 		require.ErrorIs(t, err, sentinel)
 	})
 
-	t.Run("DetailControl output error wrapped", func(t *testing.T) {
+	t.Run("DetailSubcontrols output error wrapped", func(t *testing.T) {
 		t.Parallel()
 
 		r := &fakeRender{
-			detailFn: func(strict.Control) (string, error) { return "data", nil },
+			detailFn: func(strict.Controls) (string, error) { return "data", nil },
 		}
 		w := view.NewWriter(&failingWriter{err: sentinel}, r)
 
-		err := w.DetailControl(&controls.Control{Name: "any"})
+		err := w.DetailSubcontrols(strict.Controls{&controls.Control{Name: "any"}})
 		require.ErrorIs(t, err, sentinel)
 	})
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

`terragrunt info strict list <name>` lists a control's subcontrols, but it rendered the whole control and let the template pull `GetSubcontrols` directly, bypassing the status filter the command had already applied. Completed subcontrols showed up even without `--all`.

The renderer now takes the already-filtered subcontrols instead of the parent control, so naming a control follows the same `--all` rule as the top-level listing. `Render.DetailControl` / `Writer.DetailControl` become `DetailSubcontrols(strict.Controls)` accordingly.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `info strict list <name>` so `--all` consistently includes completed subcontrols.
  - Ensured completed controls and subcontrols are excluded by default.
  - Improved filtering when viewing named strict controls.

- **Tests**
  - Added coverage for default and `--all` listing behavior.
  - Expanded rendering tests for empty, populated, duplicate, and warning scenarios.

- **Documentation**
  - Added a v1.1.4 changelog entry documenting the listing fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->