### PR TITLE
fix: Fixing `hcl fmt` with `--stdin` combined with `--check` and/or `--diff`

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -142,14 +142,10 @@ export default defineConfig({
             "http://localhost:16686/",
             "http://localhost:9090/",
 
-            // Unfortunately, these have to be ignored, as they're referencing content
-            // that is generated outside the contents of the markdown file.
-            "/reference/cli/commands/run#*",
-            "/reference/cli/commands/run/#*",
-            "/reference/cli/commands/list#*",
-            "/reference/cli/commands/list/#*",
-            "/reference/cli/commands/find#*",
-            "/reference/cli/commands/find/#*",
+            // Command pages are assembled by `src/pages/reference/cli/commands/[...slug].astro`
+            // from the `commands` and `flags` collections, so the validator never sees the
+            // headings these anchors point at. Page paths themselves are still validated.
+            "/reference/cli/commands/**/*#*",
 
             // Custom .astro pages — can't be validated statically
             "/reference/experiments/active",

--- a/docs/src/data/changelog/v1.1.4/hcl-fmt-stdin-check-and-diff.mdx
+++ b/docs/src/data/changelog/v1.1.4/hcl-fmt-stdin-check-and-diff.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.4"
+category: "bug-fixes"
+---
+
+#### `hcl fmt --stdin` honors `--check` and `--diff`
+
+`terragrunt hcl fmt --stdin` ignored `--check` and `--diff`. It printed the reformatted HCL and exited 0 whether or not the input needed formatting.
+
+`--check` now exits with status code 1 when the input needs formatting, and `--diff` prints a unified diff labeled `old/stdin` and `new/stdin`. Neither flag prints the formatted content, so getting that content back means running `--stdin` without them.

--- a/docs/src/data/flags/hcl-fmt-stdin.mdx
+++ b/docs/src/data/flags/hcl-fmt-stdin.mdx
@@ -13,3 +13,5 @@ Example:
 ```bash
 echo 'locals { foo="bar" }' | terragrunt hcl fmt --stdin
 ```
+
+With [`--check`](/reference/cli/commands/hcl/fmt#check) or [`--diff`](/reference/cli/commands/hcl/fmt#diff), Terragrunt does not print the formatted content. `--check` exits with status code 1 when the input needs formatting, and `--diff` prints a unified diff labeled `old/stdin` and `new/stdin`.

--- a/internal/cli/commands/hcl/format/errors.go
+++ b/internal/cli/commands/hcl/format/errors.go
@@ -2,7 +2,7 @@ package format
 
 import "fmt"
 
-// FileNeedsFormattingError is an error that is returned when a file needs formatting.
+// FileNeedsFormattingError is returned when HCL input needs formatting.
 type FileNeedsFormattingError struct {
 	Path string
 }

--- a/internal/cli/commands/hcl/format/format.go
+++ b/internal/cli/commands/hcl/format/format.go
@@ -50,7 +50,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *options.Terragru
 			return errors.New("both stdin and path flags are specified")
 		}
 
-		return formatFromStdin(l, v)
+		return formatFromStdin(l, v, opts)
 	}
 
 	if targetFile != "" {
@@ -195,7 +195,9 @@ func RunForFiles(
 	return errors.Join(errs...)
 }
 
-func formatFromStdin(l log.Logger, v *venv.Venv) error {
+func formatFromStdin(l log.Logger, v *venv.Venv, opts *options.TerragruntOptions) error {
+	const stdinPath = "stdin"
+
 	contents, err := io.ReadAll(v.Stdin)
 	if err != nil {
 		l.Errorf("Error reading from stdin: %s", err)
@@ -203,13 +205,31 @@ func formatFromStdin(l log.Logger, v *venv.Venv) error {
 		return fmt.Errorf("error reading from stdin: %w", err)
 	}
 
-	if err = checkErrors(l, v, contents, "stdin"); err != nil {
+	if err = checkErrors(l, v, contents, stdinPath); err != nil {
 		l.Errorf("Error parsing hcl from stdin")
 
 		return fmt.Errorf("error parsing hcl from stdin: %w", err)
 	}
 
 	newContents := hclwrite.Format(contents)
+
+	needsFormatting := !bytes.Equal(newContents, contents)
+
+	if opts.Diff && needsFormatting {
+		if _, err := v.Writers.Writer.Write(bytesDiff(contents, newContents, stdinPath)); err != nil {
+			l.Errorf("Failed to print diff for stdin")
+
+			return err
+		}
+	}
+
+	if opts.Check && needsFormatting {
+		return &FileNeedsFormattingError{Path: stdinPath}
+	}
+
+	if opts.Diff || opts.Check {
+		return nil
+	}
 
 	buf := bufio.NewWriter(v.Writers.Writer)
 

--- a/internal/cli/commands/hcl/format/format_test.go
+++ b/internal/cli/commands/hcl/format/format_test.go
@@ -286,22 +286,90 @@ func TestHCLFmtStdin(t *testing.T) {
 	unformatted := onDisk(t, "../../../../../test/fixtures/hclfmt-stdin/terragrunt.hcl")
 	expected := onDisk(t, "../../../../../test/fixtures/hclfmt-stdin/expected.hcl")
 
-	tgOptions, err := options.NewTerragruntOptionsForTest("")
-	require.NoError(t, err)
+	tests := map[string]struct {
+		input               string
+		wantStdout          string
+		wantDiffLines       []string
+		check               bool
+		diff                bool
+		wantNeedsFormatting bool
+	}{
+		"formatted content goes to stdout": {
+			input:      unformatted,
+			wantStdout: expected,
+		},
+		"check reports unformatted input": {
+			input:               unformatted,
+			check:               true,
+			wantNeedsFormatting: true,
+		},
+		"check accepts formatted input": {
+			input: expected,
+			check: true,
+		},
+		"diff shows what would change": {
+			input:         unformatted,
+			diff:          true,
+			wantDiffLines: []string{"--- old/stdin", "+++ new/stdin", "+  foo = \"bar\""},
+		},
+		"diff is empty for formatted input": {
+			input: expected,
+			diff:  true,
+		},
+		"check and diff both apply": {
+			input:               unformatted,
+			check:               true,
+			diff:                true,
+			wantDiffLines:       []string{"--- old/stdin", "+++ new/stdin"},
+			wantNeedsFormatting: true,
+		},
+	}
 
-	var formatted bytes.Buffer
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	// format hcl from stdin
-	tgOptions.HclFromStdin = true
+			tgOptions, err := options.NewTerragruntOptionsForTest("")
+			require.NoError(t, err)
 
-	v := venvtest.New().
-		WithStdin(strings.NewReader(unformatted)).
-		WithWriter(&formatted)
+			tgOptions.HclFromStdin = true
+			tgOptions.Check = tc.check
+			tgOptions.Diff = tc.diff
 
-	err = format.Run(t.Context(), logger.CreateLogger(), v, tgOptions)
-	require.NoError(t, err)
+			var out bytes.Buffer
 
-	assert.Equal(t, expected, formatted.String())
+			v := venvtest.New().
+				WithStdin(strings.NewReader(tc.input)).
+				WithWriter(&out)
+
+			err = format.Run(t.Context(), logger.CreateLogger(), v, tgOptions)
+
+			stdout := out.String()
+
+			for _, want := range tc.wantDiffLines {
+				assert.Contains(t, stdout, want)
+			}
+
+			if len(tc.wantDiffLines) > 0 {
+				assert.NotContains(t, stdout, expected, "--diff prints the diff instead of the formatted content")
+			}
+
+			if len(tc.wantDiffLines) == 0 {
+				assert.Equal(t, tc.wantStdout, stdout)
+			}
+
+			if !tc.wantNeedsFormatting {
+				require.NoError(t, err)
+
+				return
+			}
+
+			var needsFormatting *format.FileNeedsFormattingError
+
+			require.ErrorAs(t, err, &needsFormatting)
+			assert.Equal(t, "stdin", needsFormatting.Path)
+		})
+	}
 }
 
 func TestHCLFmtHeredoc(t *testing.T) {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

The `--stdin` flag broke the interaction with `--check` and `--diff`. That interaction was fixed.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `hcl fmt --stdin` now supports `--check` and `--diff`.
  - `--check` reports when formatting is required with a failing status.
  - `--diff` displays a unified diff without replacing the input with formatted output.

- **Documentation**
  - Added guidance and changelog notes describing stdin formatting behavior and diff output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->