### PR TITLE
fix: Preventing extremely small or large float exponents from crashing Terragrunt

### DIFF
--- a/docs/src/data/changelog/v1.1.4/extreme-number-literals.mdx
+++ b/docs/src/data/changelog/v1.1.4/extreme-number-literals.mdx
@@ -1,0 +1,16 @@
+---
+version: "v1.1.4"
+category: "bug-fixes"
+---
+
+#### Numbers with extreme exponents fail fast instead of stalling
+
+A number literal such as `9E9999999` in `inputs`, `locals`, or a `dependency` block's `mock_outputs` used to cost minutes of CPU on a single unit. Written out in decimal that number is ten million digits long, and `terragrunt render --format=json` spent over a minute producing it before failing with a ten megabyte error message.
+
+Terragrunt now rejects numbers larger than `1e4096`, and non-zero numbers smaller than `1e-4096`, before it tries to write them out, and names the attribute holding the value:
+
+```
+count: number is outside the supported range of 1e-4096 to 1e4096
+```
+
+Numbers inside that range are unaffected.

--- a/internal/cli/commands/render/render.go
+++ b/internal/cli/commands/render/render.go
@@ -198,6 +198,10 @@ func writeRendered(l log.Logger, fsys vfs.FS, opts *Options, data []byte) error 
 // just the "value".
 // NOTE: We have to do two marshalling passes so that we can extract just the value.
 func marshalCtyValueJSONWithoutType(ctyVal cty.Value) ([]byte, error) {
+	if err := ctyhelper.ValidateNumberRanges(ctyVal); err != nil {
+		return nil, err
+	}
+
 	jsonBytesIntermediate, err := ctyjson.Marshal(ctyVal, cty.DynamicPseudoType)
 	if err != nil {
 		return nil, err

--- a/internal/cli/commands/render/render_test.go
+++ b/internal/cli/commands/render/render_test.go
@@ -9,18 +9,20 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/render"
+	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestRenderJSON_Basic(t *testing.T) {
 	t.Parallel()
 
-	opts, _ := setupTest(t)
+	opts, _ := setupTest(t, testTerragruntConfigFixture)
 
 	var outputBuffer bytes.Buffer
 
@@ -48,7 +50,7 @@ func TestRenderJSON_Basic(t *testing.T) {
 func TestRenderJSON_WithMetadata(t *testing.T) {
 	t.Parallel()
 
-	opts, _ := setupTest(t)
+	opts, _ := setupTest(t, testTerragruntConfigFixture)
 
 	var outputBuffer bytes.Buffer
 
@@ -76,7 +78,7 @@ func TestRenderJSON_WithMetadata(t *testing.T) {
 func TestRenderJSON_WriteToFile(t *testing.T) {
 	t.Parallel()
 
-	opts, _ := setupTest(t)
+	opts, _ := setupTest(t, testTerragruntConfigFixture)
 	outputPath := filepath.Join(helpers.TmpDirWOSymlinks(t), "output.json")
 	opts.Format = render.FormatJSON
 	opts.RenderMetadata = false
@@ -107,7 +109,7 @@ func TestRenderJSON_WriteToFile(t *testing.T) {
 func TestRenderJSON_InvalidFormat(t *testing.T) {
 	t.Parallel()
 
-	opts, _ := setupTest(t)
+	opts, _ := setupTest(t, testTerragruntConfigFixture)
 	opts.Format = "invalid"
 
 	err := render.Run(
@@ -123,7 +125,7 @@ func TestRenderJSON_InvalidFormat(t *testing.T) {
 func TestRenderJSON_HCLFormat(t *testing.T) {
 	t.Parallel()
 
-	opts, _ := setupTest(t)
+	opts, _ := setupTest(t, testTerragruntConfigFixture)
 	opts.Format = render.FormatHCL
 
 	var renderedBuffer bytes.Buffer
@@ -139,13 +141,37 @@ func TestRenderJSON_HCLFormat(t *testing.T) {
 	assert.Equal(t, testTerragruntConfigFixture, renderedBuffer.String())
 }
 
-// setupTest creates a temporary directory with a terragrunt config file and returns the necessary test setup
-func setupTest(t *testing.T) (*render.Options, string) {
+func TestRenderJSON_NumberOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	opts, configPath := setupTest(t, testExtremeExponentConfigFixture)
+	depDir := filepath.Join(filepath.Dir(configPath), "dep")
+	require.NoError(t, os.MkdirAll(depDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(depDir, "terragrunt.hcl"), []byte("inputs = {}\n"), 0644))
+
+	opts.Format = render.FormatJSON
+	opts.Write = false
+
+	err := render.Run(
+		t.Context(),
+		logger.CreateLogger(),
+		venvtest.NewOSWithEmptyEnv().WithWriter(io.Discard),
+		opts,
+	)
+
+	var rangeErr ctyhelper.NumberOutOfRangeError
+
+	require.ErrorAs(t, err, &rangeErr)
+	assert.Equal(t, cty.GetAttrPath("dependency").GetAttr("dep").GetAttr("mock_outputs").GetAttr("count"), rangeErr.Path)
+}
+
+// setupTest writes config to a terragrunt.hcl in a fresh temporary directory
+func setupTest(t *testing.T, config string) (*render.Options, string) {
 	t.Helper()
 
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 	configPath := filepath.Join(tmpDir, "terragrunt.hcl")
-	err := os.WriteFile(configPath, []byte(testTerragruntConfigFixture), 0644)
+	err := os.WriteFile(configPath, []byte(config), 0644)
 	require.NoError(t, err)
 
 	tgOptions, err := options.NewTerragruntOptionsForTest(configPath)
@@ -231,5 +257,15 @@ inputs = {
   }
   number_input = 42
   string_input = "test"
+}
+`
+
+const testExtremeExponentConfigFixture = `dependency "dep" {
+  config_path  = "./dep"
+  skip_outputs = true
+
+  mock_outputs = {
+    count = 9E9999999
+  }
 }
 `

--- a/internal/ctyhelper/helper.go
+++ b/internal/ctyhelper/helper.go
@@ -6,6 +6,11 @@ package ctyhelper
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"math"
+	"math/big"
+	"strconv"
+	"strings"
 
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
@@ -37,6 +42,10 @@ func ParseCtyValueToMap(value cty.Value) (map[string]any, error) {
 
 	// Unmark the value (including nested values) before JSON serialization as JSON doesn't support marks.
 	unmarkedValue, _ := value.UnmarkDeep()
+
+	if err := ValidateNumberRanges(unmarkedValue); err != nil {
+		return nil, err
+	}
 
 	jsonBytes, err := ctyjson.Marshal(unmarkedValue, cty.DynamicPseudoType)
 	if err != nil {
@@ -116,4 +125,85 @@ func UpdateUnknownCtyValValues(value cty.Value) (cty.Value, error) {
 	}
 
 	return value, nil
+}
+
+// MaxNumberDecimalExponent is the largest power of ten a number's magnitude may reach, in
+// either direction, before Terragrunt refuses to serialize it.
+const MaxNumberDecimalExponent = 4096
+
+// NumberOutOfRangeError reports a number that is too far from zero, or too close to it, for
+// Terragrunt to serialize.
+type NumberOutOfRangeError struct {
+	Path cty.Path
+}
+
+func (err NumberOutOfRangeError) Error() string {
+	msg := fmt.Sprintf(
+		"number is outside the supported range of 1e-%d to 1e%d",
+		MaxNumberDecimalExponent, MaxNumberDecimalExponent,
+	)
+
+	if attrPath := strings.TrimPrefix(ctyPathString(err.Path), "."); attrPath != "" {
+		return attrPath + ": " + msg
+	}
+
+	return msg
+}
+
+// ValidateNumberRanges returns a [NumberOutOfRangeError] for the first number nested anywhere in
+// value whose magnitude runs past [MaxNumberDecimalExponent] powers of ten in either direction.
+//
+// Numbers reach Terragrunt as arbitrary-precision floats, and writing one out in decimal costs far
+// more time and memory than its digit count suggests. The literal 9E9999999 parses in microseconds
+// and then takes minutes to render as a ten megabyte string, so callers check the range before
+// serializing a value that came from a user.
+func ValidateNumberRanges(value cty.Value) error {
+	return cty.Walk(value, func(path cty.Path, val cty.Value) (bool, error) {
+		if !val.Type().Equals(cty.Number) || val.IsNull() || !val.IsKnown() {
+			return true, nil
+		}
+
+		unmarked, _ := val.Unmark()
+
+		exp := unmarked.AsBigFloat().MantExp(nil)
+		if (math.Abs(float64(exp))-1)*(math.Ln2/math.Ln10) > MaxNumberDecimalExponent {
+			return false, NumberOutOfRangeError{Path: path.Copy()}
+		}
+
+		return true, nil
+	})
+}
+
+func ctyPathString(path cty.Path) string {
+	var b strings.Builder
+
+	for _, step := range path {
+		switch s := step.(type) {
+		case cty.GetAttrStep:
+			b.WriteString("." + s.Name)
+		case cty.IndexStep:
+			b.WriteString("[" + ctyIndexKeyString(s.Key) + "]")
+		}
+	}
+
+	return b.String()
+}
+
+func ctyIndexKeyString(key cty.Value) string {
+	const unrenderableKey = "*"
+
+	if key.IsNull() || !key.IsKnown() {
+		return unrenderableKey
+	}
+
+	switch {
+	case key.Type().Equals(cty.String):
+		return strconv.Quote(key.AsString())
+	case key.Type().Equals(cty.Number):
+		if idx, acc := key.AsBigFloat().Int64(); acc == big.Exact {
+			return strconv.FormatInt(idx, 10)
+		}
+	}
+
+	return unrenderableKey
 }

--- a/internal/ctyhelper/helper_test.go
+++ b/internal/ctyhelper/helper_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
@@ -80,4 +81,138 @@ func TestUpdateUnknownCtyValValues(t *testing.T) {
 			assert.Equal(t, tc.expectedValue, actualValue)
 		})
 	}
+}
+
+func TestValidateNumberRanges(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		expectedErr *ctyhelper.NumberOutOfRangeError
+		value       cty.Value
+		name        string
+	}{
+		{
+			name:  "largest float64",
+			value: cty.MustParseNumberVal("1.7976931348623157E308"),
+		},
+		{
+			name:  "smallest normal float64",
+			value: cty.MustParseNumberVal("2.2250738585072014E-308"),
+		},
+		{
+			name:  "eighteen digit integer",
+			value: cty.MustParseNumberVal("111111111111111111"),
+		},
+		{
+			name:  "largest supported magnitude",
+			value: cty.MustParseNumberVal("1E4096"),
+		},
+		{
+			name:  "smallest supported magnitude",
+			value: cty.MustParseNumberVal("1E-4096"),
+		},
+		{
+			name:        "just past the largest supported magnitude",
+			value:       cty.MustParseNumberVal("1E4097"),
+			expectedErr: &ctyhelper.NumberOutOfRangeError{Path: cty.Path{}},
+		},
+		{
+			name:        "just past the smallest supported magnitude",
+			value:       cty.MustParseNumberVal("1E-4097"),
+			expectedErr: &ctyhelper.NumberOutOfRangeError{Path: cty.Path{}},
+		},
+		{
+			name:  "zero",
+			value: cty.Zero,
+		},
+		{
+			name: "null and unknown numbers",
+			value: cty.ObjectVal(map[string]cty.Value{
+				"unknown": cty.UnknownVal(cty.Number),
+				"null":    cty.NullVal(cty.Number),
+			}),
+		},
+		{
+			name:        "top level number",
+			value:       cty.MustParseNumberVal("9E9999999"),
+			expectedErr: &ctyhelper.NumberOutOfRangeError{Path: cty.Path{}},
+		},
+		{
+			name: "exponent far above the cap",
+			value: cty.ObjectVal(map[string]cty.Value{
+				"count": cty.MustParseNumberVal("9E9999999"),
+			}),
+			expectedErr: &ctyhelper.NumberOutOfRangeError{Path: cty.GetAttrPath("count")},
+		},
+		{
+			name: "exponent far below the cap",
+			value: cty.ObjectVal(map[string]cty.Value{
+				"count": cty.MustParseNumberVal("9E-9999999"),
+			}),
+			expectedErr: &ctyhelper.NumberOutOfRangeError{Path: cty.GetAttrPath("count")},
+		},
+		{
+			name: "nested in a list",
+			value: cty.ObjectVal(map[string]cty.Value{
+				"sizes": cty.ListVal([]cty.Value{
+					cty.NumberIntVal(1),
+					cty.MustParseNumberVal("9E9999999"),
+				}),
+			}),
+			expectedErr: &ctyhelper.NumberOutOfRangeError{Path: cty.GetAttrPath("sizes").IndexInt(1)},
+		},
+		{
+			name: "marked",
+			value: cty.ObjectVal(map[string]cty.Value{
+				"secret": cty.MustParseNumberVal("9E9999999").Mark("sensitive"),
+			}),
+			expectedErr: &ctyhelper.NumberOutOfRangeError{Path: cty.GetAttrPath("secret")},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ctyhelper.ValidateNumberRanges(tc.value)
+
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+
+				return
+			}
+
+			var rangeErr ctyhelper.NumberOutOfRangeError
+
+			require.ErrorAs(t, err, &rangeErr)
+			assert.Equal(t, tc.expectedErr.Path, rangeErr.Path)
+		})
+	}
+}
+
+func TestParseCtyValueToMapKeepsLargeNumbersWhole(t *testing.T) {
+	t.Parallel()
+
+	value := cty.ObjectVal(map[string]cty.Value{
+		"count": cty.MustParseNumberVal("9E4000"),
+	})
+
+	result, err := ctyhelper.ParseCtyValueToMap(value)
+	require.NoError(t, err)
+	assert.Equal(t, json.Number("9"+strings.Repeat("0", 4000)), result["count"])
+}
+
+func TestParseCtyValueToMapRejectsExtremeExponents(t *testing.T) {
+	t.Parallel()
+
+	value := cty.ObjectVal(map[string]cty.Value{
+		"count": cty.MustParseNumberVal("9E9999999"),
+	})
+
+	_, err := ctyhelper.ParseCtyValueToMap(value)
+
+	var rangeErr ctyhelper.NumberOutOfRangeError
+
+	require.ErrorAs(t, err, &rangeErr)
+	assert.Equal(t, cty.GetAttrPath("count"), rangeErr.Path)
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds validation to ensure that floating point exponents are a sensible value and throwing an error otherwise instead of tanking the CLI. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extreme numeric values in inputs, locals, and dependency mock outputs are now rejected promptly with a clear, attribute-specific error.
  * Values within the supported range continue to work as expected.
  * Large but valid numbers are preserved accurately during JSON rendering.
* **Documentation**
  * Added changelog documentation for the numeric range validation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->