### PR TITLE
fix: Use the appropriate absolute path to unit config file, not basename when checking version constraints

### DIFF
--- a/internal/runner/runnerpool/builder_helpers.go
+++ b/internal/runner/runnerpool/builder_helpers.go
@@ -208,7 +208,7 @@ func checkVersionConstraints(
 				return err
 			}
 
-			return checkUnitVersionConstraints(
+			return CheckUnitVersionConstraints(
 				checkCtx,
 				l,
 				v,
@@ -222,9 +222,10 @@ func checkVersionConstraints(
 	return g.Wait()
 }
 
-// checkUnitVersionConstraints checks version constraints for a single unit.
-// It handles config parsing if needed and performs version constraint validation.
-func checkUnitVersionConstraints(
+// CheckUnitVersionConstraints checks a single unit against the tofu and Terragrunt version
+// constraints its config declares. When discovery left the unit unparsed, it parses the
+// unit's config file first.
+func CheckUnitVersionConstraints(
 	ctx context.Context,
 	l log.Logger,
 	v *venv.Venv,
@@ -234,7 +235,6 @@ func checkUnitVersionConstraints(
 ) error {
 	unitConfig := unit.Config()
 
-	// This is almost definitely already parsed, but we'll check just in case.
 	if unitConfig == nil {
 		configCtx, pctx := configbridge.NewParsingContext(ctx, l, v, unitOpts)
 		pctx = pctx.WithDecodeList(
@@ -248,7 +248,7 @@ func checkUnitVersionConstraints(
 			configCtx,
 			pctx,
 			l,
-			unit.ConfigFile(),
+			unitOpts.TerragruntConfigPath,
 			nil,
 		)
 		if err != nil {

--- a/internal/runner/runnerpool/builder_test.go
+++ b/internal/runner/runnerpool/builder_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/runner/common"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
@@ -262,6 +263,33 @@ func TestBuild_VersionConstraints(t *testing.T) {
 			assert.Len(t, rnr.GetStack().Units, 1, "a unit meeting its constraints is kept")
 		})
 	}
+}
+
+// TestCheckUnitVersionConstraints_UnitLeftUnparsed pins that a unit discovery left unparsed
+// still gets the constraints its config declares. The check parses that config by its full
+// path, not by the bare filename discovery recorded.
+func TestCheckUnitVersionConstraints_UnitLeftUnparsed(t *testing.T) {
+	t.Parallel()
+
+	v := memVenv(tfVersionOutput)
+	unitDir := writeUnit(t, v, memRoot, "vpc", `terragrunt_version_constraint = ">= v99.0.0"`)
+
+	unit := component.NewUnit(unitDir)
+	require.Nil(t, unit.Config(), "the unit has no parsed config for the check to reuse")
+
+	opts := newStackOpts(t, memRoot, tf.CommandNamePlan)
+	opts.TerragruntVersion = goversion.Must(goversion.NewVersion("0.1.0"))
+
+	l := thlogger.CreateLogger()
+
+	unitOpts, unitLogger, err := runnerpool.BuildUnitOpts(l, opts, unit)
+	require.NoError(t, err)
+
+	err = runnerpool.CheckUnitVersionConstraints(t.Context(), l, v, unitOpts, unitLogger, unit)
+
+	var target run.InvalidTerragruntVersion
+
+	require.ErrorAs(t, err, &target)
 }
 
 // TestBuild_TerraformBinaryOverridesVersionProbe pins that the version probe runs a unit's terraform_binary.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

We use the base name right now, which will under-match. We should be using the full absolute path 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved version constraint validation for units discovered before their configuration is parsed.
  - Correctly identifies incompatible Terragrunt versions using the configured file path.
  - Added regression coverage to ensure invalid version constraints return the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->