### PR TITLE
fix: Handling situation when diagnostics contain nil range

### DIFF
--- a/internal/view/diagnostic/diagnostic.go
+++ b/internal/view/diagnostic/diagnostic.go
@@ -8,9 +8,11 @@ import (
 
 type Diagnostics []*Diagnostic
 
+// Contains reports whether diags holds a diagnostic with the same source range as find.
+// A diagnostic without a range matches nothing, not even another one without a range.
 func (diags *Diagnostics) Contains(find *Diagnostic) bool {
 	for _, diag := range *diags {
-		if find.Range != nil && find.Range.String() == diag.Range.String() {
+		if find.Range != nil && diag.Range != nil && find.Range.String() == diag.Range.String() {
 			return true
 		}
 	}

--- a/internal/view/diagnostic/diagnostic_test.go
+++ b/internal/view/diagnostic/diagnostic_test.go
@@ -1,0 +1,83 @@
+package diagnostic_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/view/diagnostic"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rangeOnLine(line int) *diagnostic.Range {
+	return &diagnostic.Range{
+		Filename: "terragrunt.hcl",
+		Start:    diagnostic.Pos{Line: line, Column: 1, Byte: 0},
+		End:      diagnostic.Pos{Line: line, Column: 5, Byte: 4},
+	}
+}
+
+func TestDiagnosticsContains(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		find     *diagnostic.Diagnostic
+		name     string
+		stored   diagnostic.Diagnostics
+		expected bool
+	}{
+		{
+			name:     "same range",
+			stored:   diagnostic.Diagnostics{{Range: rangeOnLine(1)}},
+			find:     &diagnostic.Diagnostic{Range: rangeOnLine(1)},
+			expected: true,
+		},
+		{
+			name:     "different range",
+			stored:   diagnostic.Diagnostics{{Range: rangeOnLine(1)}},
+			find:     &diagnostic.Diagnostic{Range: rangeOnLine(2)},
+			expected: false,
+		},
+		{
+			name:     "stored diagnostic without a range is skipped",
+			stored:   diagnostic.Diagnostics{{Summary: "no subject"}, {Range: rangeOnLine(1)}},
+			find:     &diagnostic.Diagnostic{Range: rangeOnLine(1)},
+			expected: true,
+		},
+		{
+			name:     "searched diagnostic without a range",
+			stored:   diagnostic.Diagnostics{{Range: rangeOnLine(1)}},
+			find:     &diagnostic.Diagnostic{Summary: "no subject"},
+			expected: false,
+		},
+		{
+			name:     "neither has a range",
+			stored:   diagnostic.Diagnostics{{Summary: "no subject"}},
+			find:     &diagnostic.Diagnostic{Summary: "no subject"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, tt.stored.Contains(tt.find))
+		})
+	}
+}
+
+func TestDiagnosticsContainsDiagnosticWithoutSubject(t *testing.T) {
+	t.Parallel()
+
+	withoutSubject := diagnostic.NewDiagnostic(nil, &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Multiple terraform blocks",
+	})
+	require.Nil(t, withoutSubject.Range)
+
+	diags := diagnostic.Diagnostics{withoutSubject}
+
+	assert.False(t, diags.Contains(withoutSubject))
+	assert.False(t, diags.Contains(&diagnostic.Diagnostic{Range: rangeOnLine(1)}))
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Realistically this shouldn't ever happen, but I guess we could theoretically add diagnostics ourselves in the future that leave range out.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic matching so entries without source ranges are no longer incorrectly treated as matches.
  * Diagnostic comparisons now require valid ranges on both entries.
* **Tests**
  * Added coverage for matching and differing ranges, missing ranges, and diagnostics without associated subjects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->