### PR TITLE
fix: Fixing deprecated `TG_HCLVALIDATE_STRICT_VALIDATE` env var

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -142,14 +142,10 @@ export default defineConfig({
             "http://localhost:16686/",
             "http://localhost:9090/",
 
-            // Unfortunately, these have to be ignored, as they're referencing content
-            // that is generated outside the contents of the markdown file.
-            "/reference/cli/commands/run#*",
-            "/reference/cli/commands/run/#*",
-            "/reference/cli/commands/list#*",
-            "/reference/cli/commands/list/#*",
-            "/reference/cli/commands/find#*",
-            "/reference/cli/commands/find/#*",
+            // Command pages are assembled by `src/pages/reference/cli/commands/[...slug].astro`
+            // from the `commands` and `flags` collections, so the validator never sees the
+            // headings these anchors point at. Page paths themselves are still validated.
+            "/reference/cli/commands/**/*#*",
 
             // Custom .astro pages — can't be validated statically
             "/reference/experiments/active",

--- a/docs/src/data/changelog/v1.1.4/hcl-validate-show-config-path-env-var.mdx
+++ b/docs/src/data/changelog/v1.1.4/hcl-validate-show-config-path-env-var.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.4"
+category: "bug-fixes"
+---
+
+#### Fixed the deprecated environment variables for `hcl validate`
+
+`TG_HCLVALIDATE_STRICT_VALIDATE`, the deprecated name for [`--strict`](/reference/cli/commands/hcl/validate#strict), also turned on [`--show-config-path`](/reference/cli/commands/hcl/validate#show-config-path). `--strict` only takes effect alongside `--inputs`, and `--show-config-path` cannot be combined with `--inputs`. With that variable set, `terragrunt hcl validate --inputs` failed with `specifying both -show-config-path and -inputs is invalid`.
+
+`TG_HCLVALIDATE_SHOW_CONFIG_PATH`, the deprecated name for `--show-config-path`, was not recognized at all.
+
+`TG_HCLVALIDATE_STRICT_VALIDATE` now sets only `--strict`, and `TG_HCLVALIDATE_SHOW_CONFIG_PATH` sets `--show-config-path`. `TG_STRICT_VALIDATE`, `TERRAGRUNT_STRICT_VALIDATE`, and `TERRAGRUNT_HCLVALIDATE_SHOW_CONFIG_PATH` are unchanged.

--- a/internal/cli/commands/hcl/validate/cli.go
+++ b/internal/cli/commands/hcl/validate/cli.go
@@ -59,9 +59,9 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) clihe
 				Destination: &opts.HCLValidateShowConfigPath,
 			},
 			flags.WithDeprecatedEnvVars(
-				tgPrefix.EnvVars("hclvalidate-strict-validate"),
+				tgPrefix.EnvVars("hclvalidate-show-config-path"),
 				opts.StrictControls,
-			), // `TG_HCLVALIDATE_STRICT_VALIDATE`
+			), // `TG_HCLVALIDATE_SHOW_CONFIG_PATH`
 			flags.WithDeprecatedEnvVars(
 				terragruntPrefix.EnvVars("hclvalidate-show-config-path"),
 				opts.StrictControls,

--- a/internal/cli/commands/hcl/validate/cli_test.go
+++ b/internal/cli/commands/hcl/validate/cli_test.go
@@ -1,0 +1,90 @@
+package validate_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/hcl/validate"
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewFlagsMapsEachEnvVarToOneFlag pins every env var of the command's own
+// flags, current and deprecated, to the single flag it sets. Each case checks
+// all four destinations, so an env var wired to a second flag fails here.
+func TestNewFlagsMapsEachEnvVarToOneFlag(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		envVar             string
+		wantStrict         bool
+		wantInputs         bool
+		wantShowConfigPath bool
+		wantJSONOutput     bool
+	}{
+		{
+			envVar:     "TG_STRICT",
+			wantStrict: true,
+		},
+		{
+			envVar:     "TG_STRICT_VALIDATE",
+			wantStrict: true,
+		},
+		{
+			envVar:     "TG_HCLVALIDATE_STRICT_VALIDATE",
+			wantStrict: true,
+		},
+		{
+			envVar:     "TERRAGRUNT_STRICT_VALIDATE",
+			wantStrict: true,
+		},
+		{
+			envVar:     "TG_INPUTS",
+			wantInputs: true,
+		},
+		{
+			envVar:             "TG_SHOW_CONFIG_PATH",
+			wantShowConfigPath: true,
+		},
+		{
+			envVar:             "TG_HCLVALIDATE_SHOW_CONFIG_PATH",
+			wantShowConfigPath: true,
+		},
+		{
+			envVar:             "TERRAGRUNT_HCLVALIDATE_SHOW_CONFIG_PATH",
+			wantShowConfigPath: true,
+		},
+		{
+			envVar:         "TG_JSON",
+			wantJSONOutput: true,
+		},
+		{
+			envVar:         "TG_HCLVALIDATE_JSON",
+			wantJSONOutput: true,
+		},
+		{
+			envVar:         "TERRAGRUNT_HCLVALIDATE_JSON",
+			wantJSONOutput: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.envVar, func(t *testing.T) {
+			t.Parallel()
+
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
+			flagSet := validate.NewFlags(logger.CreateLogger(), opts, venvtest.New())
+
+			require.NoError(t, flagSet.Parse(clihelper.Args{}, map[string]string{tc.envVar: "true"}))
+
+			assert.Equal(t, tc.wantStrict, opts.HCLValidateStrict, validate.StrictFlagName)
+			assert.Equal(t, tc.wantInputs, opts.HCLValidateInputs, validate.InputsFlagName)
+			assert.Equal(t, tc.wantShowConfigPath, opts.HCLValidateShowConfigPath, validate.ShowConfigPathFlagName)
+			assert.Equal(t, tc.wantJSONOutput, opts.HCLValidateJSONOutput, validate.JSONFlagName)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

The `--show-config-path` flag for `hcl validate` accidentally registered `TG_HCLVALIDATE_STRICT_VALIDATE` as one of its deprecated env var names. This was a copy/paste bug from the `--strict` flag above it.

Corrects the deprecated env var on `--show-config-path`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected deprecated environment-variable handling for HCL validation.
  - `TG_HCLVALIDATE_STRICT_VALIDATE` now controls only strict mode.
  - `TG_HCLVALIDATE_SHOW_CONFIG_PATH` now correctly controls configuration-path display.

- **Documentation**
  - Added a changelog entry describing the corrected environment-variable behavior.
  - Improved documentation for command-page link validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->