### PR TITLE
fix: Addressing nil `Range` and `Snippet` in `SourceSnippets`

### DIFF
--- a/docs/src/data/changelog/v1.1.4/hcl-validate-diagnostic-without-location.mdx
+++ b/docs/src/data/changelog/v1.1.4/hcl-validate-diagnostic-without-location.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.4"
+category: "bug-fixes"
+---
+
+#### `hcl validate` no longer crashes on errors that carry no source location
+
+`terragrunt hcl validate` crashed while formatting its output when one of the errors it found had no position in the configuration. Terragrunt now prints that error's summary and detail, without a location line.

--- a/internal/view/human_render.go
+++ b/internal/view/human_render.go
@@ -202,11 +202,15 @@ func (render *HumanRender) Diagnostic(diag *diagnostic.Diagnostic) (string, erro
 }
 
 func (render *HumanRender) SourceSnippets(diag *diagnostic.Diagnostic) (string, error) {
-	if diag.Range == nil || diag.Snippet == nil {
-		// This should generally not happen, as long as sources are always
-		// loaded through the main loader. We may load things in other
-		// ways in weird cases, so we'll tolerate it at the expense of
-		// a not-so-helpful error message.
+	// [diagnostic.NewDiagnostic] leaves Range nil for an HCL diagnostic that has no
+	// Subject, meaning it points at no position in the configuration.
+	if diag.Range == nil {
+		return "", nil
+	}
+
+	// [diagnostic.NewDiagnostic] fills Range and Snippet together, so only a
+	// diagnostic built elsewhere reaches here with a position and no snippet.
+	if diag.Snippet == nil {
 		return fmt.Sprintf(
 			"  on %s line %d:\n  (source code not available)\n",
 			diag.Range.Filename,

--- a/internal/view/human_render_test.go
+++ b/internal/view/human_render_test.go
@@ -1,0 +1,67 @@
+package view_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/view"
+	"github.com/gruntwork-io/terragrunt/internal/view/diagnostic"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHumanRenderDiagnosticsWithoutSourceCode(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		diag     *diagnostic.Diagnostic
+		name     string
+		expected string
+	}{
+		{
+			name: "range and snippet missing",
+			diag: &diagnostic.Diagnostic{
+				Severity: diagnostic.DiagnosticSeverity(hcl.DiagError),
+				Summary:  "Failed to read configuration",
+				Detail:   "The file could not be opened.",
+			},
+			expected: "╷\n" +
+				"│ Error: Failed to read configuration\n" +
+				"│\n" +
+				"│ The file could not be opened.\n" +
+				"╵\n",
+		},
+		{
+			name: "snippet missing",
+			diag: &diagnostic.Diagnostic{
+				Range: &diagnostic.Range{
+					Filename: "terragrunt.hcl",
+					Start:    diagnostic.Pos{Line: 7, Column: 1, Byte: 42},
+					End:      diagnostic.Pos{Line: 7, Column: 9, Byte: 50},
+				},
+				Severity: diagnostic.DiagnosticSeverity(hcl.DiagError),
+				Summary:  "Unsupported block type",
+				Detail:   "Blocks of type \"foo\" are not expected here.",
+			},
+			expected: "╷\n" +
+				"│ Error: Unsupported block type\n" +
+				"│\n" +
+				"│   on terragrunt.hcl line 7:\n" +
+				"│   (source code not available)\n" +
+				"│ Blocks of type \"foo\" are not expected here.\n" +
+				"╵\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			render := view.NewHumanRender(venvtest.New(), true)
+
+			actual, err := render.Diagnostics(diagnostic.Diagnostics{tc.diag})
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

`SourceSnippets` can panic without these guards. Range can't realistically be nil in prod, but I didn't bother adding a panic there.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `terragrunt hcl validate` output for diagnostics without source locations.
  - Validation messages now display their summary and details without an empty or misleading location line.
  - Diagnostics with a source location but unavailable source code continue to provide a clear fallback message.

- **Documentation**
  - Added changelog documentation for this fix in v1.1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->