### PR TITLE
fix: make hcl fmt --exclude-dir match paths, not only directory basenames

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -169,7 +169,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/bmatcuk/doublestar v1.3.4 // indirect
+	github.com/bmatcuk/doublestar v1.3.4
 	github.com/buger/jsonparser v1.2.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/internal/cli/commands/hcl/format/format.go
+++ b/internal/cli/commands/hcl/format/format.go
@@ -3,6 +3,8 @@
 package format
 
 import (
+	"github.com/bmatcuk/doublestar"
+
 	"bufio"
 	"bytes"
 	"context"
@@ -85,7 +87,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *options.Terragru
 			return fs.SkipDir
 		}
 
-		if slices.Contains(opts.HclExclude, basename) {
+		if hclExcludeMatches(opts.HclExclude, workingDir, path) {
 			l.Debugf("%s directory ignored due to the %s flag", path, ExcludeDirFlagName)
 			return fs.SkipDir
 		}
@@ -302,4 +304,37 @@ func checkErrors(l log.Logger, v *venv.Venv, contents []byte, tgHclFile string) 
 // bytesDiff returns a unified diff between the original and formatted HCL contents.
 func bytesDiff(b1, b2 []byte, path string) []byte {
 	return diff.Diff(filepath.Join("old", path), b1, filepath.Join("new", path), b2)
+}
+
+// hclExcludeMatches reports whether the walked directory path matches any
+// --exclude-dir entry. Entries may be a directory name ("module"), a
+// slash-separated path relative to the working directory ("terraform/module",
+// "./terraform/module/"), or a doublestar pattern ("**/terraform/module").
+// Matching only the directory basename, as before, made every path-shaped
+// entry a silent no-op.
+func hclExcludeMatches(entries []string, workingDir, path string) bool {
+	rel, err := filepath.Rel(workingDir, path)
+	if err != nil {
+		rel = path
+	}
+	rel = filepath.ToSlash(rel)
+	basename := filepath.Base(path)
+
+	for _, entry := range entries {
+		entry = filepath.ToSlash(entry)
+		entry = strings.TrimPrefix(entry, "./")
+		entry = strings.TrimSuffix(entry, "/")
+
+		if entry == basename || entry == rel {
+			return true
+		}
+
+		if strings.ContainsAny(entry, "*?[") {
+			if matched, err := doublestar.Match(entry, rel); err == nil && matched {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/internal/cli/commands/hcl/format/format_test.go
+++ b/internal/cli/commands/hcl/format/format_test.go
@@ -557,3 +557,68 @@ func TestHCLFmtFilterNegation(t *testing.T) {
 		}
 	})
 }
+
+func TestHCLFmtExcludeDirPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		excludes []string
+		untouched []string
+		formatted []string
+	}{
+		{
+			name:      "relative path",
+			excludes:  []string{"a/b/c"},
+			untouched: []string{"a/b/c/terragrunt.hcl", "a/b/c/d/services.hcl", "a/b/c/d/e/terragrunt.hcl"},
+			formatted: []string{"terragrunt.hcl", "a/terragrunt.hcl"},
+		},
+		{
+			name:      "normalized path",
+			excludes:  []string{"./a/b/c/"},
+			untouched: []string{"a/b/c/terragrunt.hcl"},
+			formatted: []string{"a/terragrunt.hcl"},
+		},
+		{
+			name:      "doublestar pattern",
+			excludes:  []string{"**/c"},
+			untouched: []string{"a/b/c/terragrunt.hcl", "a/b/c/d/services.hcl"},
+			formatted: []string{"a/terragrunt.hcl"},
+		},
+		{
+			name:      "basename still works",
+			excludes:  []string{"c"},
+			untouched: []string{"a/b/c/terragrunt.hcl"},
+			formatted: []string{"a/terragrunt.hcl"},
+		},
+	}
+
+	unformatted := onDisk(t, "./testdata/fixtures/terragrunt.hcl")
+	expected := onDisk(t, "./testdata/fixtures/expected.hcl")
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			fsys, tmpPath := loadFixture(t, "./testdata/fixtures")
+
+			tgOptions, err := options.NewTerragruntOptionsForTest("")
+			require.NoError(t, err)
+
+			tgOptions.WorkingDir = tmpPath
+			tgOptions.HclExclude = c.excludes
+
+			err = format.Run(t.Context(), logger.CreateLogger(), venvtest.New().WithFS(fsys), tgOptions)
+			require.NoError(t, err)
+
+			for _, path := range c.untouched {
+				assert.Equal(t, unformatted, readFixture(t, fsys, tmpPath, filepath.FromSlash(path)),
+					"%s must stay untouched", path)
+			}
+			for _, path := range c.formatted {
+				assert.Equal(t, expected, readFixture(t, fsys, tmpPath, filepath.FromSlash(path)),
+					"%s must be formatted", path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #6721.

## Summary

`terragrunt hcl fmt --exclude-dir` compared every walked directory's **basename** against the raw flag value, so any path-shaped entry matched nothing and the excluded directories were still formatted:

```
terragrunt hcl fmt --exclude-dir './terraform/module'   # no-op
terragrunt hcl fmt --exclude-dir 'terraform/module'     # no-op
terragrunt hcl fmt --exclude-dir '**/terraform/module'  # no-op
```

Only single-segment names (`--exclude-dir module`) ever worked.

The flag now accepts:

- a directory name, as before (`module` — matches any directory with that basename);
- a slash-separated path relative to the working directory (`terraform/module`, `./terraform/module/` — normalized before matching);
- a doublestar pattern when the entry contains glob metacharacters (`**/terraform/module` — matched with the doublestar library already used by Terragrunt's filters).

## Testing

Added `TestHCLFmtExcludeDirPath` to the format command tests, parametrized over the four shapes above against the existing fixture tree: files under the excluded subtree stay byte-identical to the unformatted fixture while the rest are formatted.

```
go test ./internal/cli/commands/hcl/format/ -count=1 -run TestHCLFmtExcludeDirPath  # ok
```

Note: `TestBytesDiff`, `TestRunForFiles` and `TestHCLFmtFilterMultiple` fail on this Windows machine identically **with and without** this change (backslash-path assumptions in the tests themselves, unrelated to this fix).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HCL formatting exclusions now support directory names, relative paths, normalized paths, and doublestar patterns.
* **Bug Fixes**
  * Improved exclusion matching so files in targeted directories are correctly skipped, while other files continue to be formatted.
* **Tests**
  * Added coverage for basename, relative path, normalized path, and pattern-based exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->