### PR TITLE
docs: point --exclude-dir users at the --filter flag

### DIFF
--- a/internal/cli/commands/hcl/format/cli.go
+++ b/internal/cli/commands/hcl/format/cli.go
@@ -49,7 +49,7 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv, prefi
 				Name:        ExcludeDirFlagName,
 				EnvVars:     tgPrefix.EnvVars(ExcludeDirFlagName),
 				Destination: &opts.HclExclude,
-				Usage:       "Skip HCL formatting in given directories.",
+				Usage:       "Skip HCL formatting in given directories. Supported for legacy reasons; prefer the --filter flag, which accepts Terragrunt filter expressions (e.g. --filter='!./terraform/module').",
 			},
 			flags.WithDeprecatedEnvVars(
 				tgPrefix.EnvVars("hclfmt-exclude-dir"),


### PR DESCRIPTION
As suggested by @yhakbar in the review of #6733: `--exclude-dir` is supported for legacy reasons and its path matching is narrower than `--filter`'s Terragrunt filter expressions. The flag's help text now says so and points users at `--filter`.

## Scope

Only the `--exclude-dir` flag description in `internal/cli/commands/hcl/format/cli.go` — no behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `--exclude-dir` option description to identify it as legacy.
  * Added guidance to use `--filter` instead, including an example filter expression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->