### PR TITLE
fix(cli): don't match an undefined flag against another flag's value

### DIFF
--- a/docs/src/data/changelog/v1.1.4/global-flag-value-shadowing-command-flag.mdx
+++ b/docs/src/data/changelog/v1.1.4/global-flag-value-shadowing-command-flag.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.4"
+category: "bug-fixes"
+---
+
+#### Fixed a global flag value that reads like a command flag being parsed as the command
+
+When the value passed to a global flag was spelled the same way as a command-specific flag, the CLI parser stopped reading the arguments one token too early. The value was left behind as a positional argument, and Terragrunt then resolved it as the command name.
+
+For example, `terragrunt run --all --working-dir queue-include-dir --queue-include-dir foo -- plan` ran against a command called `queue-include-dir` instead of `plan`, because `queue-include-dir` is also the name of a flag. Directory names that match a flag name are now parsed as the values they are.

--- a/internal/clihelper/command.go
+++ b/internal/clihelper/command.go
@@ -274,8 +274,8 @@ func (cmd *Command) flagSetParse(
 		}
 
 		// cut off the args
-		flagArg, rest, notFoundMatch := cutAtUndefinedFlag(args, undefArg)
-		if notFoundMatch {
+		flagArg, rest, found := cutAtUndefinedFlag(args, undefArg)
+		if found {
 			undefArgs = append(undefArgs, flagArg)
 			args = rest
 		}
@@ -286,7 +286,7 @@ func (cmd *Command) flagSetParse(
 
 		// This should be an impossible to reach code path, but in case the arg
 		// splitting failed to happen, this will prevent infinite loops
-		if !notFoundMatch {
+		if !found {
 			return nil, err
 		}
 	}

--- a/internal/clihelper/command.go
+++ b/internal/clihelper/command.go
@@ -274,28 +274,10 @@ func (cmd *Command) flagSetParse(
 		}
 
 		// cut off the args
-		var notFoundMatch bool
-
-		for i, arg := range args {
-			// Only a flag can be the undefined flag. Without this check a *value* that
-			// happens to read like the undefined flag name matches first, and the args are
-			// cut short of the flag they were meant to be cut at, which leaves that value
-			// behind as a positional argument. `--working-dir queue-include-dir
-			// --queue-include-dir foo` used to resolve the command name to
-			// `queue-include-dir`.
-			if !strings.HasPrefix(arg, "-") {
-				continue
-			}
-
-			// `--var=input=from_env` trims to `var`
-			trimmed, _, _ := strings.Cut(strings.Trim(arg, "-"), "=")
-			if trimmed == undefArg {
-				undefArgs = append(undefArgs, arg)
-				notFoundMatch = true
-				args = args[i+1:]
-
-				break
-			}
+		flagArg, rest, notFoundMatch := cutAtUndefinedFlag(args, undefArg)
+		if notFoundMatch {
+			undefArgs = append(undefArgs, flagArg)
+			args = rest
 		}
 
 		if !cmd.DisabledErrorOnUndefinedFlag && !ctx.shellComplete {
@@ -312,6 +294,30 @@ func (cmd *Command) flagSetParse(
 	undefArgs = append(undefArgs, flagSet.Args()...)
 
 	return undefArgs, err
+}
+
+// cutAtUndefinedFlag finds the arg that spells `undefArg` and returns it along with the args
+// that follow it, so that the next parse round starts past the flag that was rejected.
+//
+// Only a dash-prefixed arg is considered, because that is the only shape
+// `flag.FlagSet.Parse` reports as undefined. A *value* spelled like the undefined flag would
+// otherwise match first, since it comes earlier in the args, and the cut would land a token
+// early: the value is taken for the flag and the flag itself is left to be re-parsed as a
+// positional argument.
+func cutAtUndefinedFlag(args Args, undefArg string) (string, Args, bool) {
+	for i, arg := range args {
+		if !strings.HasPrefix(arg, "-") {
+			continue
+		}
+
+		// `--var=input=from_env` trims to `var`
+		trimmed := strings.SplitN(strings.Trim(arg, "-"), "=", 2)[0] //nolint:mnd
+		if trimmed == undefArg {
+			return arg, args[i+1:], true
+		}
+	}
+
+	return "", args, false
 }
 
 func (cmd *Command) WrapAction(

--- a/internal/clihelper/command.go
+++ b/internal/clihelper/command.go
@@ -277,6 +277,16 @@ func (cmd *Command) flagSetParse(
 		var notFoundMatch bool
 
 		for i, arg := range args {
+			// Only a flag can be the undefined flag. Without this check a *value* that
+			// happens to read like the undefined flag name matches first, and the args are
+			// cut short of the flag they were meant to be cut at, which leaves that value
+			// behind as a positional argument. `--working-dir queue-include-dir
+			// --queue-include-dir foo` used to resolve the command name to
+			// `queue-include-dir`.
+			if !strings.HasPrefix(arg, "-") {
+				continue
+			}
+
 			// `--var=input=from_env` trims to `var`
 			trimmed, _, _ := strings.Cut(strings.Trim(arg, "-"), "=")
 			if trimmed == undefArg {

--- a/internal/clihelper/command_test.go
+++ b/internal/clihelper/command_test.go
@@ -352,3 +352,88 @@ func TestCommandVisibleSubcommand(t *testing.T) {
 		})
 	}
 }
+
+// A flag value is not a flag. `flagSet.Parse` only reports a dash-prefixed token as
+// undefined, so the args must be cut at that token and not at an earlier positional that
+// happens to read the same way -- otherwise the value is left behind and resolves as the
+// command name. https://github.com/gruntwork-io/terragrunt/issues/4966
+func TestCommandRunUndefinedFlagIsNotMatchedByAnotherFlagsValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		expectedGlobal string
+		expectedScoped string
+		args           []string
+	}{
+		// The value of the global flag is spelled exactly like the subcommand's own flag.
+		{
+			args:           []string{"cmd-bar", "--foo", "bar", "--bar", "value"},
+			expectedGlobal: "bar",
+			expectedScoped: "value",
+		},
+		// The same, with the global flag given before the subcommand.
+		{
+			args:           []string{"--foo", "bar", "cmd-bar", "--bar", "value"},
+			expectedGlobal: "bar",
+			expectedScoped: "value",
+		},
+		// `--flag=value` form: the value is not a separate arg and never was affected.
+		{
+			args:           []string{"cmd-bar", "--foo=bar", "--bar", "value"},
+			expectedGlobal: "bar",
+			expectedScoped: "value",
+		},
+		// A value spelled like the global flag itself.
+		{
+			args:           []string{"cmd-bar", "--bar", "foo", "--foo", "value"},
+			expectedGlobal: "value",
+			expectedScoped: "foo",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			var actualGlobal, actualScoped string
+
+			var actualArgs []string
+
+			cmd := clihelper.Command{
+				Flags: clihelper.Flags{
+					&clihelper.GenericFlag[string]{Name: "foo", Destination: &actualGlobal},
+				},
+				Subcommands: clihelper.Commands{
+					&clihelper.Command{
+						Name: "cmd-bar",
+						Flags: clihelper.Flags{
+							&clihelper.GenericFlag[string]{
+								Name:        "bar",
+								Destination: &actualScoped,
+							},
+						},
+						Action: func(ctx context.Context, cliCtx *clihelper.Context) error {
+							actualArgs = cliCtx.Args().Slice()
+							return nil
+						},
+						DisabledErrorOnUndefinedFlag: true,
+					},
+				},
+				DisabledErrorOnUndefinedFlag: true,
+			}
+
+			app := &clihelper.App{
+				App: &urfaveCli.App{Writer: io.Discard},
+				Env: map[string]string{},
+			}
+			cliCtx := clihelper.NewAppContext(app, tc.args)
+
+			err := cmd.Run(t.Context(), cliCtx, tc.args)
+			require.NoError(t, err, tc)
+
+			assert.Equal(t, tc.expectedGlobal, actualGlobal, tc)
+			assert.Equal(t, tc.expectedScoped, actualScoped, tc)
+			assert.Empty(t, actualArgs, "no flag value may be left behind as an argument")
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes #4966.

`flagSetParse` cuts the remaining args at the flag `flag.FlagSet.Parse` reported as undefined, so that the next parse round starts after it. It located that flag by comparing every arg's dash-trimmed text to the reported name:

```go
for i, arg := range args {
	// `--var=input=from_env` trims to `var`
	trimmed := strings.SplitN(strings.Trim(arg, "-"), "=", 2)[0]
	if trimmed == undefArg {
```

`strings.Trim(arg, "-")` is a no-op on an arg with no dashes, so a **value** that happens to read like the undefined flag matches too — and matches first, because it comes earlier in the args.

When it matched a value, the cut landed one token too early. The value was appended to the undefined args, and the flag it actually belonged to was left in the stream to be re-parsed as a positional. So in the issue's command, `queue-include-dir` — the value of `--working-dir` — was taken for the `--queue-include-dir` flag.

Only a dash-prefixed arg can be the undefined flag, since that is the only shape `flag.FlagSet.Parse` reports as `flag provided but not defined`. This skips the rest.

## Effect

Built both binaries from this repo, with a `tofu` on `PATH` that echoes its argv, against `queue-include-dir/{foo,bar}`:

```
$ terragrunt run --all --non-interactive --working-dir queue-include-dir --queue-include-dir foo -- plan
```

**Before** — `bar` runs even though the queue was filtered to `foo`, and the command handed to OpenTofu is the leaked value plus the real one:

```
INFO   [bar] tofu: STUB-TOFU-INVOKED: init
INFO   [foo] tofu: STUB-TOFU-INVOKED: init
STDOUT [bar] tofu: STUB-TOFU-INVOKED: queue-include-dir foo plan
STDOUT [foo] tofu: STUB-TOFU-INVOKED: queue-include-dir foo plan
```

**After** — `foo` only, `plan` only:

```
INFO   [foo] tofu: STUB-TOFU-INVOKED: init
STDOUT [foo] tofu: STUB-TOFU-INVOKED: plan -input=false
```

So the issue's report that the command-specific flag "is not parsed correctly" understates it slightly: `--queue-include-dir` was dropped entirely, and the value was also forwarded to OpenTofu as part of the command.

## Tests

`TestCommandRunUndefinedFlagIsNotMatchedByAnotherFlagsValue` in `internal/clihelper/command_test.go`, four cases. To be straight about what they buy: **case 0 is the regression** — it fails on `main` on the `assert.Empty(t, actualArgs)` line and passes here. The other three pass either way and are there to pin the adjacent forms (flag given before the subcommand, `--flag=value`, and the mirror case where the value reads like the *global* flag) so a later change to the cut cannot quietly break them.

`go test ./internal/clihelper/... ./internal/cli/...` — 23 packages, all ok.

## TODOs

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license — n/a, no dependency change
- [ ] Update the docs. — n/a, no documented behaviour changes; this only makes the documented behaviour correct
- [x] Update the changelog in the docs. — `docs/src/data/changelog/v1.1.4/global-flag-value-shadowing-command-flag.mdx`
- [x] Run the relevant tests successfully, including pre-commit checks. — `gofmt` clean; I could not run `golangci-lint` here, so please let CI have the last word on lint
- [x] This change is backwards compatible. — the only arguments whose handling changes are ones that were being parsed as the wrong thing
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag. — n/a, bug fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected command-line parsing when global or scoped flag values resemble command-specific flag names.
  - Flag values are now assigned correctly instead of being interpreted as command names or undefined flags.
  - Supports both separated values and `--flag=value` syntax without leaving unintended positional arguments.
  - Commands now execute successfully in these scenarios.

- **Documentation**
  - Added a changelog entry describing the parsing fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

*Disclosure: this patch was written and tested end to end by an autonomous AI agent; a human principal is accountable for it. [What this account is](https://github.com/sujeito-operator). Ask me anything about how it was produced and I will answer.*