### PR TITLE
feat: Adding render preview for expansion

### DIFF
--- a/docs/src/data/changelog/v1.1.4/duplicate-dependency-labels.mdx
+++ b/docs/src/data/changelog/v1.1.4/duplicate-dependency-labels.mdx
@@ -1,0 +1,35 @@
+---
+version: "v1.1.4"
+category: "new-features"
+---
+
+#### `duplicate-dependency-labels` strict control
+
+Declaring two `dependency` blocks with the same label in one `terragrunt.hcl` configuration file parsed without error, and then quietly resolved every reference to that label to whichever block came last. The blocks before it were silently overridden:
+
+```hcl
+dependency "vpc" {
+  config_path = "../vpc-us-east-1"
+}
+
+dependency "vpc" {
+  config_path = "../vpc-us-west-2"
+}
+
+inputs = {
+  # Reads ../vpc-us-west-2.
+  vpc_id = dependency.vpc.outputs.vpc_id
+}
+```
+
+Terragrunt now warns when it finds this. With the new [`duplicate-dependency-labels`](/reference/strict-controls/active#duplicate-dependency-labels) strict control enabled, the warning becomes an error naming the address the blocks share:
+
+```bash
+terragrunt run plan --strict-control duplicate-dependency-labels
+```
+
+```text
+/path/to/terragrunt.hcl: dependency vpc is declared more than once; every dependency needs an address of its own
+```
+
+Give each block a label of its own. A configuration that was relying on the shadowing to pick the last block should keep only that block.

--- a/docs/src/data/changelog/v1.1.4/render-expansion-preview.mdx
+++ b/docs/src/data/changelog/v1.1.4/render-expansion-preview.mdx
@@ -1,0 +1,31 @@
+---
+version: "v1.1.4"
+category: "experiments-updated"
+---
+
+#### `render` previews what an expanded `dependency` block expanded to
+
+With the [`block-iteration`](/reference/experiments/active#block-iteration) experiment enabled, a `dependency` block that carries an `expansion` block now renders as it was written, followed by the elements it expanded into, commented out and with their bodies resolved:
+
+```bash
+$ terragrunt render --experiment block-iteration
+dependency "aurora" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  config_path = "../aurora-${each.key}"
+}
+
+# Expands to:
+#
+# dependency "aurora" {
+#   config_path = "../aurora-api"
+# }
+#
+# dependency "aurora" {
+#   config_path = "../aurora-web"
+# }
+```
+
+The elements are comments because they aren't valid Terragrunt HCL configurations (you are not allowed to use the same dependency label twice in Terragrunt configurations), the previews are there to help you understand how expansion will resolve.

--- a/docs/src/data/commands/render.mdx
+++ b/docs/src/data/commands/render.mdx
@@ -18,6 +18,8 @@ flags:
   - render-all
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 Render the Terragrunt configuration in the current working directory, with as much work done as possible beforehand (that is, with all includes merged, dependencies resolved/interpolated, function calls executed, etc).
 
 The only supported format at the moment is JSON, but support for HCL will be added in a future version.
@@ -83,3 +85,59 @@ terragrunt render --all --json -w
 ```
 
 This will render all configurations discovered from the current working directory and write the rendered configurations to `terragrunt.rendered.json` files adjacent to the configurations they are derived from.
+
+## Expanded dependencies
+
+<Aside type="tip" title="Experimental">
+Expanding a `dependency` block over a `count` or `for_each` is gated behind the [`block-iteration`](/reference/experiments/active#block-iteration) experiment. Enable it with `--experiment=block-iteration` or `TG_EXPERIMENT=block-iteration`.
+</Aside>
+
+A `dependency` block that carries an `expansion` block renders as it was written, references and all, followed by the elements it expanded into. Each element is commented out, with its body resolved against the iteration it came from:
+
+```bash
+$ terragrunt render --experiment block-iteration
+dependency "aurora" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  config_path = "../aurora-${each.key}"
+}
+
+# Expands to:
+#
+# dependency "aurora" {
+#   config_path = "../aurora-api"
+# }
+#
+# dependency "aurora" {
+#   config_path = "../aurora-web"
+# }
+```
+
+`count` reads the same way:
+
+```bash
+$ terragrunt render --experiment block-iteration
+dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  config_path = "../shard-${count.index}"
+}
+
+# Expands to:
+#
+# dependency "shard" {
+#   config_path = "../shard-0"
+# }
+#
+# dependency "shard" {
+#   config_path = "../shard-1"
+# }
+```
+
+The expanded blocks are in comments because expanded blocks are not valid HCL configurations (Terragrunt disallows having multiple `dependency` blocks with the same label). They are present as comments to help you predict how Terragrunt will expand the block with an `expansion` block.
+
+A `dependency` block with no `expansion` block renders as it always has.

--- a/docs/src/data/commands/render.mdx
+++ b/docs/src/data/commands/render.mdx
@@ -19,6 +19,8 @@ flags:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import Before from '@components/Before.astro';
+import Since from '@components/Since.astro';
 
 Render the Terragrunt configuration in the current working directory, with as much work done as possible beforehand (that is, with all includes merged, dependencies resolved/interpolated, function calls executed, etc).
 
@@ -88,6 +90,12 @@ This will render all configurations discovered from the current working director
 
 ## Expanded dependencies
 
+<Before version="1.1.4">
+Previewing how a `dependency` block expands will be supported in v1.1.4.
+</Before>
+
+<Since version="1.1.4">
+
 <Aside type="tip" title="Experimental">
 Expanding a `dependency` block over a `count` or `for_each` is gated behind the [`block-iteration`](/reference/experiments/active#block-iteration) experiment. Enable it with `--experiment=block-iteration` or `TG_EXPERIMENT=block-iteration`.
 </Aside>
@@ -141,3 +149,5 @@ dependency "shard" {
 The expanded blocks are in comments because they are not a valid Terragrunt configuration: they all carry one label, and only the last block with a given label can be referenced. Terragrunt warns about that, and rejects it outright under the `duplicate-dependency-labels` [strict control](/reference/strict-controls/active#duplicate-dependency-labels). They are present as comments to help you predict how Terragrunt will expand the block with an `expansion` block.
 
 A `dependency` block with no `expansion` block renders as it always has.
+
+</Since>

--- a/docs/src/data/commands/render.mdx
+++ b/docs/src/data/commands/render.mdx
@@ -138,6 +138,6 @@ dependency "shard" {
 # }
 ```
 
-The expanded blocks are in comments because expanded blocks are not valid HCL configurations (Terragrunt disallows having multiple `dependency` blocks with the same label). They are present as comments to help you predict how Terragrunt will expand the block with an `expansion` block.
+The expanded blocks are in comments because they are not a valid Terragrunt configuration: they all carry one label, and only the last block with a given label can be referenced. Terragrunt warns about that, and rejects it outright under the `duplicate-dependency-labels` [strict control](/reference/strict-controls/active#duplicate-dependency-labels). They are present as comments to help you predict how Terragrunt will expand the block with an `expansion` block.
 
 A `dependency` block with no `expansion` block renders as it always has.

--- a/docs/src/data/strict-controls/duplicate-dependency-labels.mdx
+++ b/docs/src/data/strict-controls/duplicate-dependency-labels.mdx
@@ -1,6 +1,7 @@
 ---
 name: duplicate-dependency-labels
 status: active
+since: "1.1.4"
 ---
 
 Throw an error when two `dependency` blocks in one configuration claim the same address.

--- a/docs/src/data/strict-controls/duplicate-dependency-labels.mdx
+++ b/docs/src/data/strict-controls/duplicate-dependency-labels.mdx
@@ -1,0 +1,35 @@
+---
+name: duplicate-dependency-labels
+status: active
+---
+
+Throw an error when two `dependency` blocks in one configuration claim the same address.
+
+### `duplicate-dependency-labels` - Reason
+
+Two `dependency` blocks written with the same label both parse, and Terragrunt then resolves every reference to that label to whichever block came last. The blocks before it are unreachable, with nothing to say so:
+
+```hcl
+dependency "vpc" {
+  config_path = "../vpc-us-east-1"
+}
+
+dependency "vpc" {
+  config_path = "../vpc-us-west-2"
+}
+
+inputs = {
+  # Reads ../vpc-us-west-2. The first block may as well not be there.
+  vpc_id = dependency.vpc.outputs.vpc_id
+}
+```
+
+Terragrunt warns about this by default. Enabling the control turns it into an error naming the address the blocks share:
+
+```text
+/path/to/terragrunt.hcl: dependency vpc is declared more than once; every dependency needs an address of its own
+```
+
+Give each block a label of its own. A configuration that was relying on the shadowing to pick the last block should keep only that block.
+
+Blocks are compared by the address they resolve to rather than by label alone, so the elements of a block expanded with the [`block-iteration`](/reference/experiments/active#block-iteration) experiment, which all carry the label the block was written with, remain valid.

--- a/internal/strict/controls/controls.go
+++ b/internal/strict/controls/controls.go
@@ -94,6 +94,10 @@ const (
 	LegacyGCSPublicPrefix = "legacy-gcs-public-prefix"
 
 	OptionalHooks = "optional-hooks"
+
+	// DuplicateDependencyLabels is the control that prevents two `dependency` blocks in one
+	// configuration from claiming the same address.
+	DuplicateDependencyLabels = "duplicate-dependency-labels"
 )
 
 // LegacyGCSDeprecationWarning is the warning text emitted when a plain
@@ -232,6 +236,15 @@ func New() strict.Controls {
 				"Using an `include` block without a label is deprecated. Please use the `include` block with a label instead.",
 			),
 			Warning: "Using an `include` block without a label is deprecated. Please use the `include` block with a label instead. For more information, see https://docs.terragrunt.com/migrate/bare-include/",
+		},
+
+		&Control{
+			Name:        DuplicateDependencyLabels,
+			Description: "Prevents two `dependency` blocks in one configuration from claiming the same address.",
+			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+				"Two `dependency` blocks address the same dependency. Give each block a label of its own.",
+			),
+			Warning: "Two `dependency` blocks address the same dependency, so only the last of them can be referenced and the rest are unreachable. Give each block a label of its own. In a future version of Terragrunt, this will result in an error.",
 		},
 
 		&Control{

--- a/internal/strict/controls/controls_test.go
+++ b/internal/strict/controls/controls_test.go
@@ -248,3 +248,16 @@ func TestControlEvaluate(t *testing.T) {
 		require.ErrorIs(t, err, bootErr)
 	})
 }
+
+// TestDuplicateDependencyLabelsControlIsRegistered pins that the control the dependency
+// decoder looks up by name is one the registry hands back.
+func TestDuplicateDependencyLabelsControlIsRegistered(t *testing.T) {
+	t.Parallel()
+
+	ctrl := controls.New().Find(controls.DuplicateDependencyLabels)
+
+	if assert.NotNil(t, ctrl, "duplicate-dependency-labels must be registered") {
+		assert.Equal(t, strict.ActiveStatus, ctrl.GetStatus())
+		assert.Error(t, ctrl.(*controls.Control).Error)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -453,39 +453,23 @@ func (cfg *TerragruntConfig) WriteTo(w io.Writer) (int64, error) {
 	}
 
 	// Handle dependency blocks
-	for _, dep := range cfg.TerragruntDependencies {
-		depBlock := hclwrite.NewBlock("dependency", []string{dep.Name})
-		depBody := depBlock.Body()
-		depAsCty := cfgAsCty.GetAttr("dependency").GetAttr(dep.Name)
-		depBody.SetAttributeValue("config_path", depAsCty.GetAttr("config_path"))
+	for _, group := range groupExpandedDependencies(cfg.TerragruntDependencies) {
+		if group.source == nil {
+			for _, dep := range group.deps {
+				depBlock, err := dependencyBlock(dep)
+				if err != nil {
+					return 0, err
+				}
 
-		if dep.Enabled != nil {
-			depBody.SetAttributeValue("enabled", goboolToCty(*dep.Enabled))
+				rootBody.AppendBlock(depBlock)
+			}
+
+			continue
 		}
 
-		if dep.SkipOutputs != nil {
-			depBody.SetAttributeValue("skip_outputs", goboolToCty(*dep.SkipOutputs))
+		if err := appendExpansionPreview(rootBody, group); err != nil {
+			return 0, err
 		}
-
-		if dep.MockOutputs != nil {
-			depBody.SetAttributeValue("mock_outputs", depAsCty.GetAttr("mock_outputs"))
-		}
-
-		if dep.MockOutputsAllowedTerraformCommands != nil {
-			depBody.SetAttributeValue(
-				"mock_outputs_allowed_terraform_commands",
-				depAsCty.GetAttr("mock_outputs_allowed_terraform_commands"),
-			)
-		}
-
-		if dep.MockOutputsMergeStrategyWithState != nil {
-			depBody.SetAttributeValue(
-				"mock_outputs_merge_strategy_with_state",
-				depAsCty.GetAttr("mock_outputs_merge_strategy_with_state"),
-			)
-		}
-
-		rootBody.AppendBlock(depBlock)
 	}
 
 	// Handle generate blocks
@@ -732,6 +716,165 @@ func (cfg *TerragruntConfig) WriteTo(w io.Writer) (int64, error) {
 	}
 
 	return f.WriteTo(w)
+}
+
+// dependencyGroup is the decoded dependencies one written block produced. source is nil
+// for a block that declared no expansion, and for one whose text could not be recovered,
+// which leaves deps holding the elements alone.
+type dependencyGroup struct {
+	source *hclparse.SourceBlock
+	deps   []*Dependency
+}
+
+// groupExpandedDependencies gathers the elements of each expanded block back under the
+// block that produced them, in the order the elements were decoded. Dependencies that
+// share no source block each get a group of their own.
+func groupExpandedDependencies(deps Dependencies) []dependencyGroup {
+	groups := make([]dependencyGroup, 0, len(deps))
+	byRange := map[hcl.Range]int{}
+
+	for i := range deps {
+		dep := &deps[i]
+
+		if dep.Expansion == nil || dep.Expansion.Source == nil {
+			groups = append(groups, dependencyGroup{deps: []*Dependency{dep}})
+			continue
+		}
+
+		source := dep.Expansion.Source
+
+		if at, ok := byRange[source.Range]; ok {
+			groups[at].deps = append(groups[at].deps, dep)
+			continue
+		}
+
+		byRange[source.Range] = len(groups)
+		groups = append(groups, dependencyGroup{source: source, deps: []*Dependency{dep}})
+	}
+
+	return groups
+}
+
+// appendExpansionPreview writes an expanded block as it was written, followed by the
+// elements it expanded into, commented out and with every reference resolved.
+//
+// The elements stay comments because they all repeat the block's label. Terragrunt reads
+// repeated labels without complaint, but every reference to one resolves to the last
+// block carrying it, so uncommented elements would render a config that quietly drops all
+// but one of them.
+func appendExpansionPreview(body *hclwrite.Body, group dependencyGroup) error {
+	source, diags := hclwrite.ParseConfig(
+		[]byte(group.source.Text),
+		group.source.Range.Filename,
+		group.source.Range.Start,
+	)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	for _, block := range source.Body().Blocks() {
+		body.AppendBlock(block)
+	}
+
+	lines, err := expansionPreviewLines(group.deps)
+	if err != nil {
+		return err
+	}
+
+	// The quoted source ends at its closing brace, so the first newline ends that line
+	// and the second sets the preview off from the block it describes.
+	body.AppendNewline()
+	body.AppendNewline()
+	body.AppendUnstructuredTokens(commentTokens(lines))
+	body.AppendNewline()
+
+	return nil
+}
+
+// expansionPreviewLines renders the elements of one expanded block, blank line separated,
+// as the lines of the preview comment.
+func expansionPreviewLines(deps []*Dependency) ([]string, error) {
+	lines := []string{"Expands to:", ""}
+
+	for i, dep := range deps {
+		if i > 0 {
+			lines = append(lines, "")
+		}
+
+		block, err := dependencyBlock(dep)
+		if err != nil {
+			return nil, err
+		}
+
+		rendered := hclwrite.NewEmptyFile()
+		rendered.Body().AppendBlock(block)
+
+		lines = append(lines, strings.Split(strings.TrimRight(string(rendered.Bytes()), "\n"), "\n")...)
+	}
+
+	return lines, nil
+}
+
+// commentTokens renders lines as consecutive comment lines, blank ones included so a
+// comment can be paragraphed.
+func commentTokens(lines []string) hclwrite.Tokens {
+	tokens := make(hclwrite.Tokens, 0, len(lines))
+
+	for _, line := range lines {
+		text := "#\n"
+		if line != "" {
+			text = "# " + line + "\n"
+		}
+
+		tokens = append(tokens, &hclwrite.Token{
+			Type:  hclsyntax.TokenComment,
+			Bytes: []byte(text),
+		})
+	}
+
+	return tokens
+}
+
+// dependencyBlock renders one decoded dependency, with the references in its body already
+// resolved to the values this instance decoded against.
+func dependencyBlock(dep *Dependency) (*hclwrite.Block, error) {
+	depAsCty, err := GoTypeToCty(*dep)
+	if err != nil {
+		return nil, err
+	}
+
+	depBlock := hclwrite.NewBlock("dependency", []string{dep.Name})
+	depBody := depBlock.Body()
+
+	depBody.SetAttributeValue("config_path", depAsCty.GetAttr("config_path"))
+
+	if dep.Enabled != nil {
+		depBody.SetAttributeValue("enabled", goboolToCty(*dep.Enabled))
+	}
+
+	if dep.SkipOutputs != nil {
+		depBody.SetAttributeValue("skip_outputs", goboolToCty(*dep.SkipOutputs))
+	}
+
+	if dep.MockOutputs != nil {
+		depBody.SetAttributeValue("mock_outputs", depAsCty.GetAttr("mock_outputs"))
+	}
+
+	if dep.MockOutputsAllowedTerraformCommands != nil {
+		depBody.SetAttributeValue(
+			"mock_outputs_allowed_terraform_commands",
+			depAsCty.GetAttr("mock_outputs_allowed_terraform_commands"),
+		)
+	}
+
+	if dep.MockOutputsMergeStrategyWithState != nil {
+		depBody.SetAttributeValue(
+			"mock_outputs_merge_strategy_with_state",
+			depAsCty.GetAttr("mock_outputs_merge_strategy_with_state"),
+		)
+	}
+
+	return depBlock, nil
 }
 
 // terragruntConfigFile represents the configuration supported in a Terragrunt configuration file (i.e.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -767,10 +767,9 @@ func groupExpandedDependencies(deps Dependencies) []dependencyGroup {
 // appendExpansionPreview writes an expanded block as it was written, followed by the
 // elements it expanded into, commented out and with every reference resolved.
 //
-// The elements stay comments because they all repeat the block's label. Terragrunt reads
-// repeated labels without complaint, but every reference to one resolves to the last
-// block carrying it, so uncommented elements would render a config that quietly drops all
-// but one of them.
+// The elements stay comments because they all repeat the block's label, which
+// [validateUniqueDependencies] warns about and, under its strict control, rejects.
+// Rendering them as configuration would produce a file that reads back as one dependency.
 func appendExpansionPreview(body *hclwrite.Body, group dependencyGroup) error {
 	source, diags := hclwrite.ParseConfig(
 		[]byte(group.source.Text),
@@ -1731,7 +1730,7 @@ func ParseConfig(
 
 	// Decode the rest of the config, passing in this config's `include` block or the child's `include` block, whichever
 	// is appropriate
-	terragruntConfigFile, err := decodeAsTerragruntConfigFile(pctx, l, file, evalContext)
+	terragruntConfigFile, err := decodeAsTerragruntConfigFile(ctx, pctx, l, file, evalContext)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -1978,6 +1977,7 @@ func setIAMRole(
 }
 
 func decodeAsTerragruntConfigFile(
+	ctx context.Context,
 	pctx *ParsingContext,
 	l log.Logger,
 	file *hclparse.File,
@@ -2001,7 +2001,7 @@ func decodeAsTerragruntConfigFile(
 		l.Debugf("Deferred attribute access error to autoinclude merge: %v", diagErr)
 	}
 
-	dependencies, err := decodeDependencyBlocks(file, evalContext, pctx.Experiments)
+	dependencies, err := decodeDependencyBlocks(ctx, pctx, l, file, evalContext)
 	if err != nil {
 		return &terragruntConfig, err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -256,466 +256,475 @@ func (cfg *TerragruntConfig) WriteTo(w io.Writer) (int64, error) {
 	f := hclwrite.NewFile()
 	rootBody := f.Body()
 
-	// Handle blocks first
 	if len(cfg.Locals) > 0 {
-		localsBlock := hclwrite.NewBlock("locals", nil)
-		localsBody := localsBlock.Body()
-
-		localsAsCty := cfgAsCty.GetAttr("locals")
-
-		for k := range cfg.Locals {
-			localsBody.SetAttributeValue(k, localsAsCty.GetAttr(k))
-		}
-
-		rootBody.AppendBlock(localsBlock)
+		rootBody.AppendBlock(localsBlock(cfg.Locals, cfgAsCty.GetAttr("locals")))
 	}
 
 	if cfg.Terraform != nil {
-		terraformBlock := hclwrite.NewBlock("terraform", nil)
-		terraformBody := terraformBlock.Body()
-		terraformAsCty := cfgAsCty.GetAttr("terraform")
-
-		// Handle source
-		if cfg.Terraform.Source != nil {
-			terraformBody.SetAttributeValue("source", terraformAsCty.GetAttr("source"))
-		}
-
-		if cfg.Terraform.UpdateSourceWithCAS != nil {
-			terraformBody.SetAttributeValue(
-				"update_source_with_cas",
-				terraformAsCty.GetAttr("update_source_with_cas"),
-			)
-		}
-
-		if cfg.Terraform.Mutable != nil {
-			terraformBody.SetAttributeValue("mutable", terraformAsCty.GetAttr("mutable"))
-		}
-
-		// Handle extra_arguments blocks
-		if len(cfg.Terraform.ExtraArgs) > 0 {
-			extraArgsAsCty := terraformAsCty.GetAttr("extra_arguments").AsValueMap()
-
-			for _, arg := range cfg.Terraform.ExtraArgs {
-				extraArgBlock := hclwrite.NewBlock("extra_arguments", []string{arg.Name})
-				extraArgBody := extraArgBlock.Body()
-				argCty := extraArgsAsCty[arg.Name]
-
-				if arg.Commands != nil {
-					extraArgBody.SetAttributeValue("commands", argCty.GetAttr("commands"))
-				}
-
-				if arg.Arguments != nil {
-					extraArgBody.SetAttributeValue("arguments", argCty.GetAttr("arguments"))
-				}
-
-				if arg.RequiredVarFiles != nil {
-					extraArgBody.SetAttributeValue(
-						"required_var_files",
-						argCty.GetAttr("required_var_files"),
-					)
-				}
-
-				if arg.OptionalVarFiles != nil {
-					extraArgBody.SetAttributeValue(
-						"optional_var_files",
-						argCty.GetAttr("optional_var_files"),
-					)
-				}
-
-				if arg.EnvVars != nil {
-					extraArgBody.SetAttributeValue("env_vars", argCty.GetAttr("env_vars"))
-				}
-
-				terraformBody.AppendBlock(extraArgBlock)
-			}
-		}
-
-		// Handle hooks
-		for _, beforeHook := range cfg.Terraform.BeforeHooks { //nolint:dupl
-			beforeHookBlock := hclwrite.NewBlock("before_hook", []string{beforeHook.Name})
-			beforeHookBody := beforeHookBlock.Body()
-
-			beforeHookAsCty := terraformAsCty.GetAttr("before_hook").AsValueMap()[beforeHook.Name]
-
-			if beforeHook.If != nil {
-				beforeHookBody.SetAttributeValue("if", beforeHookAsCty.GetAttr("if"))
-			}
-
-			if beforeHook.RunOnError != nil {
-				beforeHookBody.SetAttributeValue(
-					"run_on_error",
-					beforeHookAsCty.GetAttr("run_on_error"),
-				)
-			}
-
-			beforeHookBody.SetAttributeValue("commands", beforeHookAsCty.GetAttr("commands"))
-			beforeHookBody.SetAttributeValue("execute", beforeHookAsCty.GetAttr("execute"))
-
-			if beforeHook.WorkingDir != nil {
-				beforeHookBody.SetAttributeValue(
-					"working_dir",
-					beforeHookAsCty.GetAttr("working_dir"),
-				)
-			}
-
-			terraformBody.AppendBlock(beforeHookBlock)
-		}
-
-		for _, afterHook := range cfg.Terraform.AfterHooks { //nolint:dupl
-			afterHookBlock := hclwrite.NewBlock("after_hook", []string{afterHook.Name})
-			afterHookBody := afterHookBlock.Body()
-
-			afterHookAsCty := terraformAsCty.GetAttr("after_hook").AsValueMap()[afterHook.Name]
-
-			if afterHook.If != nil {
-				afterHookBody.SetAttributeValue("if", afterHookAsCty.GetAttr("if"))
-			}
-
-			if afterHook.RunOnError != nil {
-				afterHookBody.SetAttributeValue(
-					"run_on_error",
-					afterHookAsCty.GetAttr("run_on_error"),
-				)
-			}
-
-			afterHookBody.SetAttributeValue("commands", afterHookAsCty.GetAttr("commands"))
-			afterHookBody.SetAttributeValue("execute", afterHookAsCty.GetAttr("execute"))
-
-			if afterHook.WorkingDir != nil {
-				afterHookBody.SetAttributeValue(
-					"working_dir",
-					afterHookAsCty.GetAttr("working_dir"),
-				)
-			}
-
-			terraformBody.AppendBlock(afterHookBlock)
-		}
-
-		for _, errorHook := range cfg.Terraform.ErrorHooks {
-			errorHookBlock := hclwrite.NewBlock("error_hook", []string{errorHook.Name})
-			errorHookBody := errorHookBlock.Body()
-
-			errorHookAsCty := terraformAsCty.GetAttr("error_hook").AsValueMap()[errorHook.Name]
-
-			errorHookBody.SetAttributeValue("commands", errorHookAsCty.GetAttr("commands"))
-			errorHookBody.SetAttributeValue("execute", errorHookAsCty.GetAttr("execute"))
-			errorHookBody.SetAttributeValue("on_errors", errorHookAsCty.GetAttr("on_errors"))
-
-			if errorHook.WorkingDir != nil {
-				errorHookBody.SetAttributeValue(
-					"working_dir",
-					errorHookAsCty.GetAttr("working_dir"),
-				)
-			}
-
-			terraformBody.AppendBlock(errorHookBlock)
-		}
-
-		rootBody.AppendBlock(terraformBlock)
+		rootBody.AppendBlock(terraformBlock(cfg.Terraform, cfgAsCty.GetAttr("terraform")))
 	}
 
 	if cfg.RemoteState != nil {
-		remoteStateBlock := hclwrite.NewBlock("remote_state", nil)
-		remoteStateBody := remoteStateBlock.Body()
-		remoteStateAsCty := cfgAsCty.GetAttr("remote_state")
-
-		remoteStateBody.SetAttributeValue("backend", remoteStateAsCty.GetAttr("backend"))
-
-		if cfg.RemoteState.DisableInit {
-			remoteStateBody.SetAttributeValue(
-				"disable_init",
-				remoteStateAsCty.GetAttr("disable_init"),
-			)
-		}
-
-		if cfg.RemoteState.DisableDependencyOptimization {
-			remoteStateBody.SetAttributeValue(
-				"disable_dependency_optimization",
-				remoteStateAsCty.GetAttr("disable_dependency_optimization"),
-			)
-		}
-
-		if cfg.RemoteState.BackendConfig != nil {
-			remoteStateBody.SetAttributeValue("config", remoteStateAsCty.GetAttr("config"))
-		}
-
-		rootBody.AppendBlock(remoteStateBlock)
+		rootBody.AppendBlock(remoteStateBlock(cfg.RemoteState, cfgAsCty.GetAttr("remote_state")))
 	}
 
 	if cfg.Dependencies != nil && len(cfg.Dependencies.Paths) > 0 {
-		dependenciesBlock := hclwrite.NewBlock("dependencies", nil)
-		dependenciesBody := dependenciesBlock.Body()
-
-		dependenciesAsCty := cfgAsCty.GetAttr("dependencies")
-
-		dependenciesBody.SetAttributeValue("paths", dependenciesAsCty.GetAttr("paths"))
-		rootBody.AppendBlock(dependenciesBlock)
+		rootBody.AppendBlock(dependenciesBlock(cfgAsCty.GetAttr("dependencies")))
 	}
 
-	// Handle dependency blocks
-	for _, group := range groupExpandedDependencies(cfg.TerragruntDependencies) {
+	if err := appendDependencyBlocks(rootBody, cfg.TerragruntDependencies); err != nil {
+		return 0, err
+	}
+
+	for name, gen := range cfg.GenerateConfigs {
+		rootBody.AppendBlock(generateBlock(name, &gen))
+	}
+
+	for _, flag := range cfg.FeatureFlags {
+		rootBody.AppendBlock(featureBlock(flag, cfgAsCty.GetAttr("feature").GetAttr(flag.Name)))
+	}
+
+	if cfg.Engine != nil {
+		rootBody.AppendBlock(engineBlock(cfg.Engine, cfgAsCty.GetAttr("engine")))
+	}
+
+	if cfg.Exclude != nil {
+		rootBody.AppendBlock(excludeBlock(cfg.Exclude, cfgAsCty.GetAttr("exclude")))
+	}
+
+	if cfg.Errors != nil {
+		rootBody.AppendBlock(errorsBlock(cfg.Errors))
+	}
+
+	if cfg.Catalog != nil {
+		rootBody.AppendBlock(catalogBlock(cfg.Catalog, cfgAsCty.GetAttr("catalog")))
+	}
+
+	appendRootAttributes(rootBody, cfg, cfgAsCty)
+
+	return f.WriteTo(w)
+}
+
+// localsBlock renders the evaluated locals.
+func localsBlock(locals map[string]any, asCty cty.Value) *hclwrite.Block {
+	block := hclwrite.NewBlock("locals", nil)
+	body := block.Body()
+
+	for name := range locals {
+		body.SetAttributeValue(name, asCty.GetAttr(name))
+	}
+
+	return block
+}
+
+// terraformBlock renders the terraform block along with the extra arguments and hooks
+// nested in it.
+func terraformBlock(terraform *TerraformConfig, asCty cty.Value) *hclwrite.Block {
+	block := hclwrite.NewBlock("terraform", nil)
+	body := block.Body()
+
+	if terraform.Source != nil {
+		body.SetAttributeValue("source", asCty.GetAttr("source"))
+	}
+
+	if terraform.UpdateSourceWithCAS != nil {
+		body.SetAttributeValue("update_source_with_cas", asCty.GetAttr("update_source_with_cas"))
+	}
+
+	if terraform.Mutable != nil {
+		body.SetAttributeValue("mutable", asCty.GetAttr("mutable"))
+	}
+
+	if len(terraform.ExtraArgs) > 0 {
+		extraArgsAsCty := asCty.GetAttr("extra_arguments").AsValueMap()
+
+		for i := range terraform.ExtraArgs {
+			arg := &terraform.ExtraArgs[i]
+			body.AppendBlock(extraArgumentsBlock(arg, extraArgsAsCty[arg.Name]))
+		}
+	}
+
+	for i := range terraform.BeforeHooks {
+		hook := &terraform.BeforeHooks[i]
+		body.AppendBlock(
+			hookBlock("before_hook", hook, asCty.GetAttr("before_hook").AsValueMap()[hook.Name]),
+		)
+	}
+
+	for i := range terraform.AfterHooks {
+		hook := &terraform.AfterHooks[i]
+		body.AppendBlock(
+			hookBlock("after_hook", hook, asCty.GetAttr("after_hook").AsValueMap()[hook.Name]),
+		)
+	}
+
+	for i := range terraform.ErrorHooks {
+		hook := &terraform.ErrorHooks[i]
+		body.AppendBlock(errorHookBlock(hook, asCty.GetAttr("error_hook").AsValueMap()[hook.Name]))
+	}
+
+	return block
+}
+
+// extraArgumentsBlock renders one extra_arguments block of a terraform block.
+func extraArgumentsBlock(arg *TerraformExtraArguments, asCty cty.Value) *hclwrite.Block {
+	block := hclwrite.NewBlock("extra_arguments", []string{arg.Name})
+	body := block.Body()
+
+	if arg.Commands != nil {
+		body.SetAttributeValue("commands", asCty.GetAttr("commands"))
+	}
+
+	if arg.Arguments != nil {
+		body.SetAttributeValue("arguments", asCty.GetAttr("arguments"))
+	}
+
+	if arg.RequiredVarFiles != nil {
+		body.SetAttributeValue("required_var_files", asCty.GetAttr("required_var_files"))
+	}
+
+	if arg.OptionalVarFiles != nil {
+		body.SetAttributeValue("optional_var_files", asCty.GetAttr("optional_var_files"))
+	}
+
+	if arg.EnvVars != nil {
+		body.SetAttributeValue("env_vars", asCty.GetAttr("env_vars"))
+	}
+
+	return block
+}
+
+// hookBlock renders one before_hook or after_hook block, which share a shape.
+func hookBlock(blockType string, hook *Hook, asCty cty.Value) *hclwrite.Block {
+	block := hclwrite.NewBlock(blockType, []string{hook.Name})
+	body := block.Body()
+
+	if hook.If != nil {
+		body.SetAttributeValue("if", asCty.GetAttr("if"))
+	}
+
+	if hook.RunOnError != nil {
+		body.SetAttributeValue("run_on_error", asCty.GetAttr("run_on_error"))
+	}
+
+	body.SetAttributeValue("commands", asCty.GetAttr("commands"))
+	body.SetAttributeValue("execute", asCty.GetAttr("execute"))
+
+	if hook.WorkingDir != nil {
+		body.SetAttributeValue("working_dir", asCty.GetAttr("working_dir"))
+	}
+
+	return block
+}
+
+// errorHookBlock renders one error_hook block. It runs on the errors it names rather than
+// on a command, so it carries neither the if nor the run_on_error the other hooks do.
+func errorHookBlock(hook *ErrorHook, asCty cty.Value) *hclwrite.Block {
+	block := hclwrite.NewBlock("error_hook", []string{hook.Name})
+	body := block.Body()
+
+	body.SetAttributeValue("commands", asCty.GetAttr("commands"))
+	body.SetAttributeValue("execute", asCty.GetAttr("execute"))
+	body.SetAttributeValue("on_errors", asCty.GetAttr("on_errors"))
+
+	if hook.WorkingDir != nil {
+		body.SetAttributeValue("working_dir", asCty.GetAttr("working_dir"))
+	}
+
+	return block
+}
+
+// remoteStateBlock renders the remote_state block.
+func remoteStateBlock(state *remotestate.RemoteState, asCty cty.Value) *hclwrite.Block {
+	block := hclwrite.NewBlock("remote_state", nil)
+	body := block.Body()
+
+	body.SetAttributeValue("backend", asCty.GetAttr("backend"))
+
+	if state.DisableInit {
+		body.SetAttributeValue("disable_init", asCty.GetAttr("disable_init"))
+	}
+
+	if state.DisableDependencyOptimization {
+		body.SetAttributeValue(
+			"disable_dependency_optimization",
+			asCty.GetAttr("disable_dependency_optimization"),
+		)
+	}
+
+	if state.BackendConfig != nil {
+		body.SetAttributeValue("config", asCty.GetAttr("config"))
+	}
+
+	return block
+}
+
+// dependenciesBlock renders the dependencies block listing bare paths.
+func dependenciesBlock(asCty cty.Value) *hclwrite.Block {
+	block := hclwrite.NewBlock("dependencies", nil)
+	block.Body().SetAttributeValue("paths", asCty.GetAttr("paths"))
+
+	return block
+}
+
+// appendDependencyBlocks renders the dependency blocks, previewing the ones that expanded.
+func appendDependencyBlocks(body *hclwrite.Body, deps Dependencies) error {
+	for _, group := range groupExpandedDependencies(deps) {
 		if group.source == nil {
 			for _, dep := range group.deps {
 				depBlock, err := dependencyBlock(dep)
 				if err != nil {
-					return 0, err
+					return err
 				}
 
-				rootBody.AppendBlock(depBlock)
+				body.AppendBlock(depBlock)
 			}
 
 			continue
 		}
 
-		if err := appendExpansionPreview(rootBody, group); err != nil {
-			return 0, err
+		if err := appendExpansionPreview(body, group); err != nil {
+			return err
 		}
 	}
 
-	// Handle generate blocks
-	for name, gen := range cfg.GenerateConfigs {
-		genBlock := hclwrite.NewBlock("generate", []string{name})
-		genBody := genBlock.Body()
-		genBody.SetAttributeValue("path", gostringToCty(gen.Path))
-		genBody.SetAttributeValue("if_exists", gostringToCty(gen.IfExistsStr))
-		genBody.SetAttributeValue("if_disabled", gostringToCty(gen.IfDisabledStr))
-		genBody.SetAttributeValue("contents", gostringToCty(gen.Contents))
+	return nil
+}
 
-		if gen.CommentPrefix != codegen.DefaultCommentPrefix {
-			genBody.SetAttributeValue("comment_prefix", gostringToCty(gen.CommentPrefix))
-		}
+// generateBlock renders one generate block.
+func generateBlock(name string, gen *codegen.GenerateConfig) *hclwrite.Block {
+	block := hclwrite.NewBlock("generate", []string{name})
+	body := block.Body()
 
-		if gen.DisableSignature {
-			genBody.SetAttributeValue("disable_signature", goboolToCty(gen.DisableSignature))
-		}
+	body.SetAttributeValue("path", gostringToCty(gen.Path))
+	body.SetAttributeValue("if_exists", gostringToCty(gen.IfExistsStr))
+	body.SetAttributeValue("if_disabled", gostringToCty(gen.IfDisabledStr))
+	body.SetAttributeValue("contents", gostringToCty(gen.Contents))
 
-		if gen.Disable {
-			genBody.SetAttributeValue("disable", goboolToCty(gen.Disable))
-		}
-
-		if gen.HclFmt != nil {
-			genBody.SetAttributeValue("hcl_fmt", goboolToCty(*gen.HclFmt))
-		}
-
-		if gen.Mutable != nil {
-			genBody.SetAttributeValue("mutable", goboolToCty(*gen.Mutable))
-		}
-
-		rootBody.AppendBlock(genBlock)
+	if gen.CommentPrefix != codegen.DefaultCommentPrefix {
+		body.SetAttributeValue("comment_prefix", gostringToCty(gen.CommentPrefix))
 	}
 
-	// Handle feature flags
-	for _, flag := range cfg.FeatureFlags {
-		flagBlock := hclwrite.NewBlock("feature", []string{flag.Name})
-		flagBody := flagBlock.Body()
-		flagAsCty := cfgAsCty.GetAttr("feature").GetAttr(flag.Name)
-
-		if flag.Default != nil {
-			flagBody.SetAttributeValue("default", flagAsCty.GetAttr("default"))
-		}
-
-		rootBody.AppendBlock(flagBlock)
+	if gen.DisableSignature {
+		body.SetAttributeValue("disable_signature", goboolToCty(gen.DisableSignature))
 	}
 
-	// Handle engine block
-	if cfg.Engine != nil {
-		engineBlock := hclwrite.NewBlock("engine", nil)
-		engineBody := engineBlock.Body()
-		engineAsCty := cfgAsCty.GetAttr("engine")
-
-		if cfg.Engine.Source != "" {
-			engineBody.SetAttributeValue("source", engineAsCty.GetAttr("source"))
-		}
-
-		if cfg.Engine.Version != nil {
-			engineBody.SetAttributeValue("version", engineAsCty.GetAttr("version"))
-		}
-
-		if cfg.Engine.Type != nil {
-			engineBody.SetAttributeValue("type", engineAsCty.GetAttr("type"))
-		}
-
-		if cfg.Engine.Meta != nil {
-			engineBody.SetAttributeValue("meta", engineAsCty.GetAttr("meta"))
-		}
-
-		rootBody.AppendBlock(engineBlock)
+	if gen.Disable {
+		body.SetAttributeValue("disable", goboolToCty(gen.Disable))
 	}
 
-	// Handle exclude block
-	if cfg.Exclude != nil {
-		excludeBlock := hclwrite.NewBlock("exclude", nil)
-		excludeBody := excludeBlock.Body()
-		excludeAsCty := cfgAsCty.GetAttr("exclude")
-
-		if cfg.Exclude.ExcludeDependencies != nil {
-			excludeBody.SetAttributeValue(
-				"exclude_dependencies",
-				excludeAsCty.GetAttr("exclude_dependencies"),
-			)
-		}
-
-		if len(cfg.Exclude.Actions) > 0 {
-			excludeBody.SetAttributeValue("actions", excludeAsCty.GetAttr("actions"))
-		}
-
-		if cfg.Exclude.NoRun != nil {
-			excludeBody.SetAttributeValue("no_run", excludeAsCty.GetAttr("no_run"))
-		}
-
-		excludeBody.SetAttributeValue("if", excludeAsCty.GetAttr("if"))
-
-		rootBody.AppendBlock(excludeBlock)
+	if gen.HclFmt != nil {
+		body.SetAttributeValue("hcl_fmt", goboolToCty(*gen.HclFmt))
 	}
 
-	// Handle errors block
-	if cfg.Errors != nil {
-		errorsBlock := hclwrite.NewBlock("errors", nil)
-		errorsBody := errorsBlock.Body()
-
-		// Handle retry blocks
-		if len(cfg.Errors.Retry) > 0 {
-			for _, retryConfig := range cfg.Errors.Retry {
-				retryBlock := hclwrite.NewBlock("retry", []string{retryConfig.Label})
-				retryBody := retryBlock.Body()
-
-				if retryConfig.MaxAttempts > 0 {
-					retryBody.SetAttributeValue(
-						"max_attempts",
-						cty.NumberIntVal(int64(retryConfig.MaxAttempts)),
-					)
-				}
-
-				if retryConfig.SleepIntervalSec > 0 {
-					retryBody.SetAttributeValue(
-						"sleep_interval_sec",
-						cty.NumberIntVal(int64(retryConfig.SleepIntervalSec)),
-					)
-				}
-
-				if len(retryConfig.RetryableErrors) > 0 {
-					retryableErrors := make([]cty.Value, len(retryConfig.RetryableErrors))
-
-					for i, err := range retryConfig.RetryableErrors {
-						retryableErrors[i] = cty.StringVal(err)
-					}
-
-					retryBody.SetAttributeValue("retryable_errors", cty.ListVal(retryableErrors))
-				}
-
-				errorsBody.AppendBlock(retryBlock)
-			}
-		}
-
-		// Handle ignore blocks
-		if len(cfg.Errors.Ignore) > 0 {
-			for _, ignoreConfig := range cfg.Errors.Ignore {
-				ignoreBlock := hclwrite.NewBlock("ignore", []string{ignoreConfig.Label})
-				ignoreBody := ignoreBlock.Body()
-
-				if len(ignoreConfig.IgnorableErrors) > 0 {
-					ignorableErrors := make([]cty.Value, len(ignoreConfig.IgnorableErrors))
-
-					for i, err := range ignoreConfig.IgnorableErrors {
-						ignorableErrors[i] = cty.StringVal(err)
-					}
-
-					ignoreBody.SetAttributeValue("ignorable_errors", cty.ListVal(ignorableErrors))
-				}
-
-				if ignoreConfig.Message != "" {
-					ignoreBody.SetAttributeValue("message", cty.StringVal(ignoreConfig.Message))
-				}
-
-				if ignoreConfig.Signals != nil {
-					ignoreBody.SetAttributeValue("signals", cty.MapVal(ignoreConfig.Signals))
-				}
-
-				errorsBody.AppendBlock(ignoreBlock)
-			}
-		}
-
-		rootBody.AppendBlock(errorsBlock)
+	if gen.Mutable != nil {
+		body.SetAttributeValue("mutable", goboolToCty(*gen.Mutable))
 	}
 
-	// Handle catalog block
-	if cfg.Catalog != nil {
-		catalogBlock := hclwrite.NewBlock("catalog", nil)
-		catalogBody := catalogBlock.Body()
-		catalogAsCty := cfgAsCty.GetAttr("catalog")
+	return block
+}
 
-		if cfg.Catalog.DefaultTemplate != "" {
-			catalogBody.SetAttributeValue(
-				"default_template",
-				catalogAsCty.GetAttr("default_template"),
-			)
-		}
+// featureBlock renders one feature block.
+func featureBlock(flag *FeatureFlag, asCty cty.Value) *hclwrite.Block {
+	block := hclwrite.NewBlock("feature", []string{flag.Name})
 
-		if len(cfg.Catalog.URLs) > 0 {
-			catalogBody.SetAttributeValue("urls", catalogAsCty.GetAttr("urls"))
-		}
-
-		if cfg.Catalog.NoShell != nil {
-			catalogBody.SetAttributeValue("no_shell", catalogAsCty.GetAttr("no_shell"))
-		}
-
-		if cfg.Catalog.NoHooks != nil {
-			catalogBody.SetAttributeValue("no_hooks", catalogAsCty.GetAttr("no_hooks"))
-		}
-
-		rootBody.AppendBlock(catalogBlock)
+	if flag.Default != nil {
+		block.Body().SetAttributeValue("default", asCty.GetAttr("default"))
 	}
 
-	// Handle attributes
+	return block
+}
+
+// engineBlock renders the engine block.
+func engineBlock(engine *EngineConfig, asCty cty.Value) *hclwrite.Block {
+	block := hclwrite.NewBlock("engine", nil)
+	body := block.Body()
+
+	if engine.Source != "" {
+		body.SetAttributeValue("source", asCty.GetAttr("source"))
+	}
+
+	if engine.Version != nil {
+		body.SetAttributeValue("version", asCty.GetAttr("version"))
+	}
+
+	if engine.Type != nil {
+		body.SetAttributeValue("type", asCty.GetAttr("type"))
+	}
+
+	if engine.Meta != nil {
+		body.SetAttributeValue("meta", asCty.GetAttr("meta"))
+	}
+
+	return block
+}
+
+// excludeBlock renders the exclude block.
+func excludeBlock(exclude *ExcludeConfig, asCty cty.Value) *hclwrite.Block {
+	block := hclwrite.NewBlock("exclude", nil)
+	body := block.Body()
+
+	if exclude.ExcludeDependencies != nil {
+		body.SetAttributeValue("exclude_dependencies", asCty.GetAttr("exclude_dependencies"))
+	}
+
+	if len(exclude.Actions) > 0 {
+		body.SetAttributeValue("actions", asCty.GetAttr("actions"))
+	}
+
+	if exclude.NoRun != nil {
+		body.SetAttributeValue("no_run", asCty.GetAttr("no_run"))
+	}
+
+	body.SetAttributeValue("if", asCty.GetAttr("if"))
+
+	return block
+}
+
+// errorsBlock renders the errors block along with the retry and ignore blocks nested in
+// it. It reads the config directly, which is where the retry and ignore values live.
+func errorsBlock(errs *ErrorsConfig) *hclwrite.Block {
+	block := hclwrite.NewBlock("errors", nil)
+	body := block.Body()
+
+	for _, retry := range errs.Retry {
+		body.AppendBlock(retryBlock(retry))
+	}
+
+	for _, ignore := range errs.Ignore {
+		body.AppendBlock(ignoreBlock(ignore))
+	}
+
+	return block
+}
+
+// errorPatterns renders the error patterns a retry or ignore block matches on.
+func errorPatterns(patterns []string) cty.Value {
+	rendered := make([]cty.Value, len(patterns))
+	for i, pattern := range patterns {
+		rendered[i] = cty.StringVal(pattern)
+	}
+
+	return cty.ListVal(rendered)
+}
+
+// retryBlock renders one retry block of an errors block.
+func retryBlock(retry *RetryBlock) *hclwrite.Block {
+	block := hclwrite.NewBlock("retry", []string{retry.Label})
+	body := block.Body()
+
+	if retry.MaxAttempts > 0 {
+		body.SetAttributeValue("max_attempts", cty.NumberIntVal(int64(retry.MaxAttempts)))
+	}
+
+	if retry.SleepIntervalSec > 0 {
+		body.SetAttributeValue(
+			"sleep_interval_sec",
+			cty.NumberIntVal(int64(retry.SleepIntervalSec)),
+		)
+	}
+
+	if len(retry.RetryableErrors) > 0 {
+		body.SetAttributeValue("retryable_errors", errorPatterns(retry.RetryableErrors))
+	}
+
+	return block
+}
+
+// ignoreBlock renders one ignore block of an errors block.
+func ignoreBlock(ignore *IgnoreBlock) *hclwrite.Block {
+	block := hclwrite.NewBlock("ignore", []string{ignore.Label})
+	body := block.Body()
+
+	if len(ignore.IgnorableErrors) > 0 {
+		body.SetAttributeValue("ignorable_errors", errorPatterns(ignore.IgnorableErrors))
+	}
+
+	if ignore.Message != "" {
+		body.SetAttributeValue("message", cty.StringVal(ignore.Message))
+	}
+
+	if ignore.Signals != nil {
+		body.SetAttributeValue("signals", cty.MapVal(ignore.Signals))
+	}
+
+	return block
+}
+
+// catalogBlock renders the catalog block.
+func catalogBlock(catalog *CatalogConfig, asCty cty.Value) *hclwrite.Block {
+	block := hclwrite.NewBlock("catalog", nil)
+	body := block.Body()
+
+	if catalog.DefaultTemplate != "" {
+		body.SetAttributeValue("default_template", asCty.GetAttr("default_template"))
+	}
+
+	if len(catalog.URLs) > 0 {
+		body.SetAttributeValue("urls", asCty.GetAttr("urls"))
+	}
+
+	if catalog.NoShell != nil {
+		body.SetAttributeValue("no_shell", asCty.GetAttr("no_shell"))
+	}
+
+	if catalog.NoHooks != nil {
+		body.SetAttributeValue("no_hooks", asCty.GetAttr("no_hooks"))
+	}
+
+	return block
+}
+
+// appendRootAttributes renders the attributes set at the top level of the config, which
+// follow its blocks in the rendered output.
+func appendRootAttributes(body *hclwrite.Body, cfg *TerragruntConfig, asCty cty.Value) {
 	if cfg.TerraformBinary != "" {
-		rootBody.SetAttributeValue("terraform_binary", cfgAsCty.GetAttr("terraform_binary"))
+		body.SetAttributeValue("terraform_binary", asCty.GetAttr("terraform_binary"))
 	}
 
 	if cfg.TerraformVersionConstraint != "" {
-		rootBody.SetAttributeValue(
+		body.SetAttributeValue(
 			"terraform_version_constraint",
-			cfgAsCty.GetAttr("terraform_version_constraint"),
+			asCty.GetAttr("terraform_version_constraint"),
 		)
 	}
 
 	if cfg.TerragruntVersionConstraint != "" {
-		rootBody.SetAttributeValue(
+		body.SetAttributeValue(
 			"terragrunt_version_constraint",
-			cfgAsCty.GetAttr("terragrunt_version_constraint"),
+			asCty.GetAttr("terragrunt_version_constraint"),
 		)
 	}
 
 	if cfg.DownloadDir != "" {
-		rootBody.SetAttributeValue("download_dir", cfgAsCty.GetAttr("download_dir"))
+		body.SetAttributeValue("download_dir", asCty.GetAttr("download_dir"))
 	}
 
 	if cfg.PreventDestroy != nil {
-		rootBody.SetAttributeValue("prevent_destroy", cfgAsCty.GetAttr("prevent_destroy"))
+		body.SetAttributeValue("prevent_destroy", asCty.GetAttr("prevent_destroy"))
 	}
 
 	if cfg.IamRole != "" {
-		rootBody.SetAttributeValue("iam_role", cfgAsCty.GetAttr("iam_role"))
+		body.SetAttributeValue("iam_role", asCty.GetAttr("iam_role"))
 	}
 
 	if cfg.IamAssumeRoleDuration != nil {
-		rootBody.SetAttributeValue(
+		body.SetAttributeValue(
 			"iam_assume_role_duration",
-			cfgAsCty.GetAttr("iam_assume_role_duration"),
+			asCty.GetAttr("iam_assume_role_duration"),
 		)
 	}
 
 	if cfg.IamAssumeRoleSessionName != "" {
-		rootBody.SetAttributeValue(
+		body.SetAttributeValue(
 			"iam_assume_role_session_name",
-			cfgAsCty.GetAttr("iam_assume_role_session_name"),
+			asCty.GetAttr("iam_assume_role_session_name"),
 		)
 	}
 
 	if len(cfg.Inputs) > 0 {
-		rootBody.SetAttributeValue("inputs", cfgAsCty.GetAttr("inputs"))
+		body.SetAttributeValue("inputs", asCty.GetAttr("inputs"))
 	}
-
-	return f.WriteTo(w)
 }
 
 // dependencyGroup is the decoded dependencies one written block produced. source is nil

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -735,9 +735,11 @@ func PartialParseConfig(
 
 		case DependencyBlock:
 			decodedDeps, err := decodeDependencyBlocks(
+				ctx,
+				pctx,
+				l,
 				file,
 				evalParsingContext,
-				pctx.Experiments,
 			)
 			if err != nil {
 				return nil, err

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
+	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
 	s3backend "github.com/gruntwork-io/terragrunt/internal/remotestate/backend/s3"
@@ -270,10 +271,14 @@ func outputLocksFromContext(ctx context.Context) *util.KeyLocks {
 // decodeDependencyBlocks decodes a config's dependency blocks, returning one Dependency
 // per iteration element. A block that declares no expansion yields a single Dependency.
 func decodeDependencyBlocks(
+	ctx context.Context,
+	pctx *ParsingContext,
+	l log.Logger,
 	file *hclparse.File,
 	evalContext *hcl.EvalContext,
-	experiments experiment.Experiments,
 ) (Dependencies, error) {
+	experiments := pctx.Experiments
+
 	instances, err := file.ExpandBlocks(MetadataDependency, &Dependency{}, evalContext)
 	if err != nil {
 		return nil, err
@@ -303,7 +308,61 @@ func decodeDependencyBlocks(
 		dependencies = append(dependencies, *dep)
 	}
 
+	if err := validateUniqueDependencies(ctx, pctx, l, file.ConfigPath, dependencies); err != nil {
+		return nil, err
+	}
+
 	return dependencies, nil
+}
+
+// validateUniqueDependencies reports two dependency blocks in one config that address the
+// same dependency. HCL allows the repeated label, and nothing downstream reports it: the
+// dependency map is keyed by address, so the last block silently wins and the ones before
+// it become unreachable.
+//
+// Whether that is an error or a warning is left to the duplicate-dependency-labels strict
+// control, since configs carrying a shadowed block have always run.
+func validateUniqueDependencies(
+	ctx context.Context,
+	pctx *ParsingContext,
+	l log.Logger,
+	configPath string,
+	deps Dependencies,
+) error {
+	address, found := duplicateDependencyAddress(deps)
+	if !found {
+		return nil
+	}
+
+	control := pctx.StrictControls.Find(controls.DuplicateDependencyLabels)
+	if control == nil {
+		return errors.New("failed to find control " + controls.DuplicateDependencyLabels)
+	}
+
+	if control.GetEnabled() {
+		return DuplicateDependencyError{ConfigPath: configPath, Address: address}
+	}
+
+	return control.Evaluate(log.ContextWithLogger(ctx, l))
+}
+
+// duplicateDependencyAddress returns the first address that two dependency blocks both
+// claim. Blocks are compared by address rather than by label, so the elements of an
+// expanded block, which all carry the label the block was written with, stay distinct.
+func duplicateDependencyAddress(deps Dependencies) (string, bool) {
+	seen := make(map[string]struct{}, len(deps))
+
+	for i := range deps {
+		address := deps[i].mergeKey()
+
+		if _, duplicate := seen[address]; duplicate {
+			return address, true
+		}
+
+		seen[address] = struct{}{}
+	}
+
+	return "", false
 }
 
 // Decode the dependency blocks from the file, and then retrieve all the outputs from the remote state. Then encode the
@@ -323,7 +382,7 @@ func decodeAndRetrieveOutputs(
 		return nil, err
 	}
 
-	dependencies, err := decodeDependencyBlocks(file, evalParsingContext, pctx.Experiments)
+	dependencies, err := decodeDependencyBlocks(ctx, pctx, l, file, evalParsingContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -297,6 +297,7 @@ func decodeDependencyBlocks(
 			}
 
 			dep.Expansion.InstanceKey = instance.InstanceKey
+			dep.Expansion.Source = instance.Source
 		}
 
 		dependencies = append(dependencies, *dep)

--- a/pkg/config/dependency_test.go
+++ b/pkg/config/dependency_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -358,4 +359,106 @@ func TestDependencyDeepMergeExpansion(t *testing.T) {
 			assert.Equal(t, tc.expected, dep.Expansion)
 		})
 	}
+}
+
+// parseDependencyStringStrict parses cfg with the duplicate-dependency-labels strict
+// control enabled.
+func parseDependencyStringStrict(tb testing.TB, cfg string) (*config.TerragruntConfig, error) {
+	tb.Helper()
+
+	ctx, pctx := newExpansionParsingContext(tb, config.DefaultTerragruntConfigPath)
+
+	control := pctx.StrictControls.Find(controls.DuplicateDependencyLabels)
+	require.NotNil(tb, control)
+	control.Enable()
+
+	return config.PartialParseConfigString(
+		ctx,
+		pctx.WithDecodeList(config.DependencyBlock),
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		cfg,
+		nil,
+	)
+}
+
+const duplicateDependencyLabels = `
+dependency "foo" {
+  config_path = "../a"
+}
+
+dependency "foo" {
+  config_path = "../b"
+}
+`
+
+// TestDuplicateDependencyLabelsWarnByDefault pins that a config whose blocks shadow each
+// other still parses, since such configs have always run.
+func TestDuplicateDependencyLabelsWarnByDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyString(t, duplicateDependencyLabels)
+
+	require.NoError(t, err)
+	assert.Len(t, cfg.TerragruntDependencies, 2)
+}
+
+// TestDuplicateDependencyLabelsRejectedWhenStrict pins that the strict control turns the
+// shadowing into a parse failure naming the address two blocks claim.
+func TestDuplicateDependencyLabelsRejectedWhenStrict(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseDependencyStringStrict(t, duplicateDependencyLabels)
+
+	var typed config.DuplicateDependencyError
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, "foo", typed.Address)
+}
+
+// TestExpandedDependencyLabelsAccepted pins that the elements of one expanded block, which
+// all carry the label the block was written with, are not read as duplicates even under
+// the strict control.
+func TestExpandedDependencyLabelsAccepted(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyStringStrict(t, `
+dependency "foo" {
+  expansion {
+    for_each = toset(["a", "b"])
+  }
+
+  config_path = "../${each.key}"
+}
+`)
+
+	require.NoError(t, err)
+	assert.Len(t, cfg.TerragruntDependencies, 2)
+}
+
+// TestExpandedDependencyLabelCollisionRejectedWhenStrict pins that two expanded blocks
+// sharing a label collide on the elements whose keys they both produce.
+func TestExpandedDependencyLabelCollisionRejectedWhenStrict(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseDependencyStringStrict(t, `
+dependency "foo" {
+  expansion {
+    for_each = toset(["a"])
+  }
+
+  config_path = "../first-${each.key}"
+}
+
+dependency "foo" {
+  expansion {
+    for_each = toset(["a"])
+  }
+
+  config_path = "../second-${each.key}"
+}
+`)
+
+	var typed config.DuplicateDependencyError
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, "foo[a]", typed.Address)
 }

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -362,6 +362,21 @@ func (err DependencyLabelCollisionError) Error() string {
 	)
 }
 
+// DuplicateDependencyError is returned when two dependency blocks in one config claim the
+// same address, which leaves no way to reference either but the last.
+type DuplicateDependencyError struct {
+	ConfigPath string
+	Address    string
+}
+
+func (err DuplicateDependencyError) Error() string {
+	return fmt.Sprintf(
+		"%s: dependency %s is declared more than once; every dependency needs an address of its own",
+		err.ConfigPath,
+		err.Address,
+	)
+}
+
 type TerragruntOutputListEncodingError struct {
 	Err   error
 	Paths []string

--- a/pkg/config/hclparse/expansion.go
+++ b/pkg/config/hclparse/expansion.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 )
@@ -58,7 +59,21 @@ type ExpansionBlock struct {
 	ForEach *cty.Value `hcl:"for_each,attr"`
 	Count   *cty.Value `hcl:"count,attr"`
 
+	Source *SourceBlock
+
 	InstanceKey
+}
+
+// SourceBlock is a block as it was written, before expansion decoded it once per
+// element. Every instance of one block points at the same SourceBlock, so a caller can
+// group instances back together by [SourceBlock.Range].
+//
+// Only [ExpandBlocks] fills it in, and only for native HCL syntax: a block handed to
+// [ExpandBlock] on its own carries no file to slice, and a JSON config has no HCL text
+// to quote back.
+type SourceBlock struct {
+	Text  string
+	Range hcl.Range
 }
 
 // InstanceKey identifies which expansion element produced a decoded block. It carries
@@ -95,7 +110,8 @@ func (key InstanceKey) Expanded() bool {
 // Instance is one decoded product of expanding a block. A block with no expansion
 // block yields a single Instance with both keys nil.
 type Instance struct {
-	Value any
+	Value  any
+	Source *SourceBlock
 	InstanceKey
 }
 
@@ -136,7 +152,13 @@ func (file *File) ExpandBlocks(
 	for _, block := range content.Blocks {
 		expanded, err := ExpandBlock(block, out, ctx, opts...)
 		if err == nil {
+			source := blockSource(file.Bytes, block)
+			for i := range expanded {
+				expanded[i].Source = source
+			}
+
 			instances = append(instances, expanded...)
+
 			continue
 		}
 
@@ -151,6 +173,27 @@ func (file *File) ExpandBlocks(
 	}
 
 	return instances, nil
+}
+
+// blockSource slices block back out of the file it was parsed from, so a caller can quote
+// the block as written rather than as decoded. A body that is not native HCL syntax has
+// no such text and yields nil.
+func blockSource(src []byte, block *hcl.Block) *SourceBlock {
+	body, ok := block.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil
+	}
+
+	rng := hcl.Range{
+		Filename: block.TypeRange.Filename,
+		Start:    block.TypeRange.Start,
+		End:      body.SrcRange.End,
+	}
+
+	return &SourceBlock{
+		Text:  string(src[rng.Start.Byte:rng.End.Byte]),
+		Range: rng,
+	}
 }
 
 // ExpandBlock decodes block once per iteration element, returning one Instance per

--- a/pkg/config/render_expansion_test.go
+++ b/pkg/config/render_expansion_test.go
@@ -1,0 +1,147 @@
+package config_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// renderConfig renders cfg the way `terragrunt render` does.
+func renderConfig(t *testing.T, cfg *config.TerragruntConfig) string {
+	t.Helper()
+
+	rendered := &bytes.Buffer{}
+	_, err := cfg.WriteTo(rendered)
+	require.NoError(t, err)
+
+	return rendered.String()
+}
+
+// renderDependencies parses cfgHCL and renders it back out.
+func renderDependencies(t *testing.T, cfgHCL string) string {
+	t.Helper()
+
+	cfg, err := parseDependencyString(t, cfgHCL)
+	require.NoError(t, err)
+
+	return renderConfig(t, cfg)
+}
+
+// blocksOpening counts the dependency blocks rendered as configuration, so a test can tell
+// the block that was written from the elements previewing what it expanded to.
+func blocksOpening(rendered, label string) int {
+	opening := "dependency " + label + " {"
+	count := 0
+
+	for line := range strings.SplitSeq(rendered, "\n") {
+		if line == opening {
+			count++
+		}
+	}
+
+	return count
+}
+
+// TestRenderPreviewsForEachExpansion pins the preview shape for for_each: the block as it
+// was written, its references still unresolved, followed by one commented element per
+// iteration with its body resolved.
+func TestRenderPreviewsForEachExpansion(t *testing.T) {
+	t.Parallel()
+
+	rendered := renderDependencies(t, `
+dependency "region" {
+  expansion {
+    for_each = {
+      use1 = "us-east-1"
+      usw2 = "us-west-2"
+    }
+  }
+
+  config_path = "../${each.value}"
+}
+`)
+
+	assert.Contains(t, rendered, `for_each = {`, "the block keeps the collection it was written with")
+	assert.Contains(t, rendered, `config_path = "../${each.value}"`, "the block keeps its unresolved body")
+
+	assert.Contains(t, rendered, `# Expands to:
+#
+# dependency "region" {
+#   config_path = "../us-east-1"
+# }
+#
+# dependency "region" {
+#   config_path = "../us-west-2"
+# }`)
+
+	assert.Equal(t, 1, blocksOpening(rendered, `"region"`), "only the written block renders as configuration")
+}
+
+// TestRenderPreviewsCountExpansion pins the preview shape for count.
+func TestRenderPreviewsCountExpansion(t *testing.T) {
+	t.Parallel()
+
+	rendered := renderDependencies(t, `
+dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  config_path = "../shard-${count.index}"
+}
+`)
+
+	assert.Contains(t, rendered, "count = 2", "the block keeps the count it was written with")
+	assert.Contains(t, rendered, `config_path = "../shard-${count.index}"`)
+
+	assert.Contains(t, rendered, `# Expands to:
+#
+# dependency "shard" {
+#   config_path = "../shard-0"
+# }
+#
+# dependency "shard" {
+#   config_path = "../shard-1"
+# }`)
+
+	assert.Equal(t, 1, blocksOpening(rendered, `"shard"`))
+}
+
+// TestRenderLeavesUnexpandedBlocksAlone pins that a block that declares no expansion
+// renders exactly as it did before previews existed, with no comment bolted on.
+func TestRenderLeavesUnexpandedBlocksAlone(t *testing.T) {
+	t.Parallel()
+
+	rendered := renderDependencies(t, `
+dependency "vpc" {
+  config_path  = "../vpc"
+  skip_outputs = true
+}
+`)
+
+	assert.Contains(t, rendered, `"../vpc"`)
+	assert.Contains(t, rendered, "skip_outputs = true")
+	assert.NotContains(t, rendered, "expansion")
+	assert.NotContains(t, rendered, "#")
+}
+
+// TestRenderJSONExpansionOmitsPreview pins what a JSON config renders as. Its blocks carry
+// no HCL text to quote back, so the elements render as configuration, which is the one
+// case where render repeats a label outside a comment.
+func TestRenderJSONExpansionOmitsPreview(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyJSONString(t, jsonDependencyWithExpansion)
+	require.NoError(t, err)
+
+	rendered := renderConfig(t, cfg)
+
+	assert.NotContains(t, rendered, "Expands to")
+	assert.Contains(t, rendered, `"../aurora-0"`)
+	assert.Contains(t, rendered, `"../aurora-1"`)
+	assert.Equal(t, 2, blocksOpening(rendered, `"aurora"`))
+}

--- a/test/fixtures/render-expansion/app/terragrunt.hcl
+++ b/test/fixtures/render-expansion/app/terragrunt.hcl
@@ -1,0 +1,26 @@
+dependency "vpc" {
+  config_path  = "../vpc"
+  skip_outputs = true
+}
+
+dependency "aurora" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  config_path  = "../aurora-${each.key}"
+  skip_outputs = true
+}
+
+dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  config_path  = "../shard-${count.index}"
+  skip_outputs = true
+}
+
+inputs = {
+  name = "app"
+}

--- a/test/integration_render_expansion_test.go
+++ b/test/integration_render_expansion_test.go
@@ -1,0 +1,79 @@
+package test_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+)
+
+const testFixtureRenderExpansion = "fixtures/render-expansion"
+
+// TestRenderPreviewsExpandedDependencies pins the preview the render command prints for a
+// config whose dependencies expand: each block as it was written, followed by the elements
+// it expanded into, commented out and resolved.
+func TestRenderPreviewsExpandedDependencies(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureRenderExpansion)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRenderExpansion)
+	appPath := filepath.Join(tmpEnvPath, testFixtureRenderExpansion, "app")
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt render --format hcl --experiment block-iteration"+
+			" --non-interactive --working-dir "+appPath,
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, `dependency "aurora" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  config_path  = "../aurora-${each.key}"
+  skip_outputs = true
+}
+
+# Expands to:
+#
+# dependency "aurora" {
+#   config_path  = "../aurora-api"
+#   skip_outputs = true
+# }
+#
+# dependency "aurora" {
+#   config_path  = "../aurora-web"
+#   skip_outputs = true
+# }`)
+
+	assert.Contains(t, stdout, `dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  config_path  = "../shard-${count.index}"
+  skip_outputs = true
+}
+
+# Expands to:
+#
+# dependency "shard" {
+#   config_path  = "../shard-0"
+#   skip_outputs = true
+# }
+#
+# dependency "shard" {
+#   config_path  = "../shard-1"
+#   skip_outputs = true
+# }`)
+
+	// The unexpanded dependency renders on its own, with no preview attached.
+	assert.Contains(t, stdout, `dependency "vpc" {
+  config_path  = "../vpc"
+  skip_outputs = true
+}`)
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds `render` expansion previews as comments below HCL blocks with `expansion` blocks.

As part of adding this, I realized we never landed the plane on duplicate dependency labels, as discussed in #4504. This PR adds the `duplicate-dependency-labels` strict control, which warns by default and errors when enabled if duplicate dependency labels are discovered.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added previews for expanded `dependency` blocks when using `terragrunt render --experiment block-iteration`.
  * Preview output shows resolved `for_each` and `count` instances while preserving the original configuration.
  * Added detection for duplicate dependency addresses.
  * Added the `duplicate-dependency-labels` strict control to convert duplicate-label warnings into errors.

* **Documentation**
  * Added command, strict-control, and changelog documentation for dependency expansion previews and duplicate labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->