### PR TITLE
fix(test): pass config fixture to setupTest lint

### DIFF
--- a/internal/cli/commands/render/render_test.go
+++ b/internal/cli/commands/render/render_test.go
@@ -144,7 +144,7 @@ func TestRenderWriteWithoutOutputPath(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts, configPath := setupTest(t)
+			opts, configPath := setupTest(t, testTerragruntConfigFixture)
 			opts.Format = tc.format
 			opts.Write = true
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated render command test setup to use the standard configuration fixture, improving test consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->