### PR TITLE
chore: Isolate `TestDependencyOutputSkipDependencyOutputsFlag` fixtures

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -993,12 +993,20 @@ func TestDependencyOutputSkipDependencyOutputsFlag(t *testing.T) {
 	t.Parallel()
 
 	helpers.CleanupTerraformFolder(t, testFixtureGetOutput)
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGetOutput)
-	noOutputPath := filepath.Join(tmpEnvPath, testFixtureGetOutput, "integration", "skip-dependency-outputs")
+
+	// The subtests all drive the same unit, so each one needs its own copy of the
+	// fixture. Sharing a working directory makes them race for its state lock.
+	noOutputPath := func(t *testing.T) string {
+		t.Helper()
+
+		tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGetOutput)
+
+		return filepath.Join(tmpEnvPath, testFixtureGetOutput, "integration", "skip-dependency-outputs")
+	}
 
 	t.Run("plan without flag fails", func(t *testing.T) {
 		t.Parallel()
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan --non-interactive --working-dir "+noOutputPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt plan --non-interactive --working-dir "+noOutputPath(t))
 		require.ErrorContains(t, err, "resolving dependency \"app1\" outputs")
 	})
 
@@ -1009,14 +1017,14 @@ func TestDependencyOutputSkipDependencyOutputsFlag(t *testing.T) {
 			t.Skip("Skipping: TG_EXPERIMENT_MODE forces the optional-dependency-outputs experiment on, so its disabled-state error can't be verified")
 		}
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt init --no-dependency-outputs --non-interactive --working-dir "+noOutputPath)
+		_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt init --no-dependency-outputs --non-interactive --working-dir "+noOutputPath(t))
 		require.ErrorContains(t, err, "--no-dependency-outputs requires the 'optional-dependency-outputs' experiment")
 	})
 
 	for _, cmd := range []string{"init", "validate", "plan"} {
 		t.Run(cmd+" succeeds with flag", func(t *testing.T) {
 			t.Parallel()
-			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt "+cmd+" --experiment optional-dependency-outputs --no-dependency-outputs --non-interactive --working-dir "+noOutputPath)
+			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt "+cmd+" --experiment optional-dependency-outputs --no-dependency-outputs --non-interactive --working-dir "+noOutputPath(t))
 			require.NoError(t, err)
 		})
 	}
@@ -1024,7 +1032,7 @@ func TestDependencyOutputSkipDependencyOutputsFlag(t *testing.T) {
 	for _, cmd := range []string{"init", "validate", "plan"} {
 		t.Run("run --all "+cmd+" succeeds with flag", func(t *testing.T) {
 			t.Parallel()
-			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --experiment optional-dependency-outputs "+cmd+" --no-dependency-outputs --non-interactive --working-dir "+noOutputPath)
+			_, _, err := helpers.RunTerragruntCommandWithOutput(t, "terragrunt run --all --experiment optional-dependency-outputs "+cmd+" --no-dependency-outputs --non-interactive --working-dir "+noOutputPath(t))
 			require.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Makes `TestDependencyOutputSkipDependencyOutputsFlag` more reliable.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test isolation by giving each parallel test its own independent fixture and working directory.
  * Prevented shared state and lock conflicts during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->