### PR TITLE
chore: Adding sandboxed unit tests in CI

### DIFF
--- a/.github/scripts/ci/no-network-exec.sh
+++ b/.github/scripts/ci/no-network-exec.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run a command with no network reach beyond loopback.
+#
+# Written for `go test -exec`, which splits the flag value on spaces, so this
+# has to be a single path taking the test binary and its arguments:
+#
+#   go test -exec "$PWD/.github/scripts/ci/no-network-exec.sh" ./...
+#
+# Loopback stays reachable so tests can stand up httptest servers. Everything
+# else is refused, which turns any unvirtualized network call in the unit suite
+# into a test failure.
+#
+# With --check, confirm the sandbox is actually in force.
+PROFILE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/no-network.sb"
+
+run_sandboxed() {
+	case "$(uname -s)" in
+	Darwin)
+		exec sandbox-exec -f "$PROFILE" "$@"
+		;;
+	Linux)
+		# A fresh network namespace starts with `lo` down, so bring it up before
+		# handing over to the real command.
+		exec unshare --map-root-user --net -- \
+			sh -c 'ip link set lo up && exec "$@"' sh "$@"
+		;;
+	*)
+		echo "no-network-exec.sh: no sandbox mechanism for $(uname -s)" >&2
+		exit 1
+		;;
+	esac
+}
+
+run_check() {
+	local script="${BASH_SOURCE[0]}"
+
+	if ! command -v curl >/dev/null 2>&1; then
+		echo "no-network-exec.sh: --check needs curl" >&2
+		exit 1
+	fi
+
+	# A sandbox that cannot start makes every command under it fail, which would
+	# otherwise read as "egress is blocked" below and hand back a green run.
+	if ! "$script" true; then
+		echo "no-network-exec.sh: check failed, the sandbox cannot run a command at all" >&2
+		exit 1
+	fi
+
+	if "$script" curl --silent --show-error --max-time 15 --output /dev/null https://example.com; then
+		echo "no-network-exec.sh: check failed, https://example.com is still reachable inside the sandbox" >&2
+		exit 1
+	fi
+
+	echo "no-network-exec.sh: check passed, egress is blocked"
+}
+
+if [[ "${1:-}" == "--check" ]]; then
+	run_check
+	exit 0
+fi
+
+run_sandboxed "$@"

--- a/.github/scripts/ci/no-network-exec.sh
+++ b/.github/scripts/ci/no-network-exec.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 # into a test failure.
 #
 # With --check, confirm the sandbox is actually in force.
+
 PROFILE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/no-network.sb"
 
 run_sandboxed() {

--- a/.github/scripts/ci/no-network.sb
+++ b/.github/scripts/ci/no-network.sb
@@ -1,0 +1,14 @@
+;; macOS seatbelt profile that denies a process (and everything it spawns) any
+;; network reach beyond loopback. Loopback stays open so tests can stand up
+;; httptest servers and talk to them; every other socket operation is refused.
+;;
+;; Unix domain sockets stay open because the platform reaches system daemons
+;; (mDNSResponder, notifyd) through them. Name resolution therefore still
+;; succeeds; connecting to what it resolves does not.
+(version 1)
+(allow default)
+(deny network*)
+(allow network-bind (local ip "localhost:*"))
+(allow network-inbound (local ip "localhost:*"))
+(allow network-outbound (remote ip "localhost:*"))
+(allow network-outbound (remote unix-socket))

--- a/.github/scripts/ci/no-network.sb
+++ b/.github/scripts/ci/no-network.sb
@@ -1,10 +1,10 @@
-;; macOS seatbelt profile that denies a process (and everything it spawns) any
+;; macOS seatbelt profile that denies a process, and everything it spawns, any
 ;; network reach beyond loopback. Loopback stays open so tests can stand up
-;; httptest servers and talk to them; every other socket operation is refused.
+;; httptest servers. Every other socket operation is refused.
 ;;
 ;; Unix domain sockets stay open because the platform reaches system daemons
-;; (mDNSResponder, notifyd) through them. Name resolution therefore still
-;; succeeds; connecting to what it resolves does not.
+;; (mDNSResponder, notifyd) through them. Name resolution still succeeds as a
+;; result. Connecting to what it resolves does not.
 (version 1)
 (allow default)
 (deny network*)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,13 @@ jobs:
       checks: write
     secrets: inherit
 
+  sandboxed_tests:
+    needs: [lint, precommit, go_mod_tidy_check]
+    uses: ./.github/workflows/sandboxed-test.yml
+    permissions:
+      contents: read
+    secrets: inherit
+
   build:
     needs: [lint, precommit, go_mod_tidy_check]
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/sandboxed-test.yml
+++ b/.github/workflows/sandboxed-test.yml
@@ -1,0 +1,73 @@
+name: Sandboxed Tests
+
+on:
+  workflow_call:
+
+# Run the suite with every socket except loopback closed. Terragrunt virtualizes
+# its side effects through the venv bundle, so a test that reaches the network is
+# either exercising an unvirtualized code path or is an integration test hiding in
+# the untagged suite. Both are worth catching here rather than as a flake on a day
+# the registry is slow.
+jobs:
+  test:
+    name: Sandboxed Test
+    runs-on: ubuntu-latest
+    env:
+      GOGC: "400"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          fetch-depth: 1
+
+      - name: Use mise to install dependencies
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.5.12
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: go-cache-paths
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Go Build Cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}-ubuntu-amd64
+          restore-keys: |
+            ${{ runner.os }}-go-build-
+
+      - name: Go Mod Cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}-ubuntu-amd64
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+
+      # Ubuntu 24.04 confines unprivileged user namespaces with AppArmor, which is
+      # what `unshare --map-root-user --net` needs. The check below is what
+      # actually gates the run, so a runner image that never restricted them is
+      # free to ignore this.
+      - name: Permit unprivileged user namespaces
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+        shell: bash
+
+      # `go test` compiles outside the sandbox, so warm the module cache first and
+      # keep the sandbox scoped to what the test binaries do.
+      - name: Warm build cache
+        run: go build ./... && go mod download
+        shell: bash
+
+      - name: Verify the sandbox blocks egress
+        run: ./.github/scripts/ci/no-network-exec.sh --check
+        shell: bash
+
+      - name: Run Tests
+        run: go test -exec "$PWD/.github/scripts/ci/no-network-exec.sh" -timeout 45m ./...
+        shell: bash

--- a/.github/workflows/sandboxed-test.yml
+++ b/.github/workflows/sandboxed-test.yml
@@ -4,8 +4,8 @@ on:
   workflow_call:
 
 # Run the suite with every socket except loopback closed. Terragrunt virtualizes
-# its side effects through the venv bundle, so a test that reaches the network is
-# either exercising an unvirtualized code path or is an integration test hiding in
+# its side effects through the venv bundle, so a test that reaches the network
+# either exercises an unvirtualized code path or is an integration test hiding in
 # the untagged suite. Both are worth catching here rather than as a flake on a day
 # the registry is slow.
 jobs:

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -11,7 +11,7 @@
         "@astrojs/sitemap": "3.7.3",
         "@astrojs/starlight": "0.41.3",
         "@astrojs/starlight-tailwind": "5.0.0",
-        "@astrojs/vercel": "11.0.0",
+        "@astrojs/vercel": "11.0.3",
         "@tailwindcss/vite": "^4.3.2",
         "astro": "7.1.0",
         "astro-d2": "^0.11.0",
@@ -81,7 +81,7 @@
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.3", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "package-manager-detector": "^1.6.0" } }, "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ=="],
 
-    "@astrojs/vercel": ["@astrojs/vercel@11.0.0", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.0", "@vercel/analytics": "^1.6.1", "@vercel/functions": "^3.4.3", "@vercel/nft": "^1.3.2", "@vercel/routing-utils": "^5.3.3", "esbuild": "^0.28.0", "tinyglobby": "^0.2.15" }, "peerDependencies": { "astro": "^7.0.0-alpha.0" } }, "sha512-Ii2o/45JaTdy0MULwzQQM8A4K7gkTTxQtj6b4ZghvTLdESBc0kGEIvd2ldAswYzbbSUqrspRgxOg/mu3D5qAAg=="],
+    "@astrojs/vercel": ["@astrojs/vercel@11.0.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@vercel/analytics": "^1.6.1", "@vercel/functions": "^3.4.3", "@vercel/nft": "^1.3.2", "@vercel/routing-utils": "^5.3.3", "esbuild": "^0.28.0", "tinyglobby": "^0.2.15" }, "peerDependencies": { "astro": "^7.0.0" } }, "sha512-UMhcZ/lWB0/B2l1L8BJh6QxysjZt8SLS9e40xRfBdVhfi3Y6SIDw+99rY/+OGW/yem/S7sBRkvqvto8neevO2A=="],
 
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
@@ -1275,8 +1275,6 @@
 
     "@astrojs/markdown-satteri/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.0", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.1.1", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw=="],
 
-    "@astrojs/vercel/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.0", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.1.1", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw=="],
-
     "@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@emnapi/core/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -1332,8 +1330,6 @@
     "vite/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "@astrojs/markdown-satteri/@astrojs/internal-helpers/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
-
-    "@astrojs/vercel/@astrojs/internal-helpers/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "@emnapi/core/@emnapi/wasi-threads/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/docs/src/content/docs/05-community/01-contributing.mdx
+++ b/docs/src/content/docs/05-community/01-contributing.mdx
@@ -335,7 +335,7 @@ The convention we use for race tests is to prefix them with `WithRacing`. The Te
 
 #### Sandboxed tests
 
-Terragrunt routes its side effects through a virtualized environment, so tests can drive filesystem, subprocess and HTTP behavior without touching the real thing. A test that still reaches the network is either exercising a code path that bypasses that environment, or is an integration test sitting in the untagged suite. Either way, it makes the unit suite slower and flakier. Every run pays for the round trip, and a slow registry or a rate-limited git host turns into a red build that has nothing to do with the change under review.
+Terragrunt routes its side effects through a virtualized environment, so tests can drive filesystem, subprocess and HTTP behavior without touching the real thing. A test that still reaches the network either exercises a code path that bypasses that environment or is an integration test sitting in the untagged suite. Either way, it makes the unit suite slower and flakier. Every run pays for the round trip, and a slow registry or a rate-limited git host turns into a red build that has nothing to do with the change under review.
 
 To check for that, run the suite with every socket except loopback closed:
 
@@ -349,7 +349,7 @@ Before reading anything into a passing run, confirm the sandbox took effect:
 ./.github/scripts/ci/no-network-exec.sh --check
 ```
 
-Loopback stays reachable, so tests that stand up an `httptest` server keep working, and compilation happens outside the sandbox, so module downloads are unaffected. How the sandbox itself is built differs by platform:
+Loopback stays reachable, so tests that stand up an `httptest` server keep working. Compilation happens outside the sandbox, so module downloads are unaffected. How the sandbox is built differs by platform:
 
 <Tabs syncKey="operating-systems">
   <TabItem label="Linux">

--- a/docs/src/content/docs/05-community/01-contributing.mdx
+++ b/docs/src/content/docs/05-community/01-contributing.mdx
@@ -6,7 +6,7 @@ sidebar:
   order: 1
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## Contribution Guidelines
 
@@ -332,6 +332,41 @@ In general, when encountering a bug caused by a race condition in the wild, we e
 We can do a better job of finding candidates for additional testing here, so if you are interested in helping out, please open an issue to discuss it.
 
 The convention we use for race tests is to prefix them with `WithRacing`. The Terragrunt Continuous Integration workflow will run these tests with the `-race` flag as part of the test suite.
+
+#### Sandboxed tests
+
+Terragrunt routes its side effects through a virtualized environment, so tests can drive filesystem, subprocess and HTTP behavior without touching the real thing. A test that still reaches the network is either exercising a code path that bypasses that environment, or is an integration test sitting in the untagged suite. Either way, it makes the unit suite slower and flakier. Every run pays for the round trip, and a slow registry or a rate-limited git host turns into a red build that has nothing to do with the change under review.
+
+To check for that, run the suite with every socket except loopback closed:
+
+```bash
+go test -exec "$PWD/.github/scripts/ci/no-network-exec.sh" ./...
+```
+
+Before reading anything into a passing run, confirm the sandbox took effect:
+
+```bash
+./.github/scripts/ci/no-network-exec.sh --check
+```
+
+Loopback stays reachable, so tests that stand up an `httptest` server keep working, and compilation happens outside the sandbox, so module downloads are unaffected. How the sandbox itself is built differs by platform:
+
+<Tabs syncKey="operating-systems">
+  <TabItem label="Linux">
+    Each test binary runs in its own network namespace, created with `unshare`.
+
+    Ubuntu 24.04 and later confine unprivileged user namespaces with AppArmor, which stops `unshare` from creating that namespace. If the check reports that the sandbox cannot run a command at all, lift the restriction:
+
+    ```bash
+    sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+    ```
+  </TabItem>
+  <TabItem label="macOS">
+    Each test binary runs under the seatbelt profile at `.github/scripts/ci/no-network.sb`, applied with `sandbox-exec`.
+
+    Nothing to set up. `sandbox-exec` ships with macOS.
+  </TabItem>
+</Tabs>
 
 #### Benchmark tests
 

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/go-getter/v2"
 
+	"github.com/gruntwork-io/terragrunt/internal/detect"
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
@@ -27,7 +28,7 @@ import (
 var RemoteSourceDetectors = []getter.Detector{
 	new(getter.GitHubDetector),
 	new(getter.GitDetector),
-	new(getter.BitBucketDetector),
+	new(detect.BitBucket),
 	new(getter.GitLabDetector),
 }
 

--- a/internal/detect/bitbucket.go
+++ b/internal/detect/bitbucket.go
@@ -1,0 +1,39 @@
+// Package detect holds the go-getter source detectors Terragrunt owns rather
+// than taking from go-getter itself.
+package detect
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const bitBucketPrefix = "bitbucket.org/"
+
+// BitBucket rewrites "bitbucket.org/owner/repo" shorthand into a URL the git
+// getter understands.
+//
+// go-getter/v2's BitBucketDetector asks the BitBucket API whether a repository
+// is Git or Mercurial before rewriting. BitBucket dropped Mercurial in July
+// 2021, and that detector already turns every non-git answer into an error, so
+// the request confirms the one answer it still accepts. It also goes through
+// the package-level http.Get, which no test can redirect.
+type BitBucket struct{}
+
+// Detect implements go-getter's Detector.
+func (d *BitBucket) Detect(src, _ string) (string, bool, error) {
+	if !strings.HasPrefix(src, bitBucketPrefix) {
+		return "", false, nil
+	}
+
+	u, err := url.Parse("https://" + src)
+	if err != nil {
+		return "", true, fmt.Errorf("error parsing BitBucket URL: %w", err)
+	}
+
+	if !strings.HasSuffix(u.Path, ".git") {
+		u.Path += ".git"
+	}
+
+	return "git::" + u.String(), true, nil
+}

--- a/internal/detect/bitbucket_test.go
+++ b/internal/detect/bitbucket_test.go
@@ -1,0 +1,91 @@
+package detect_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/detect"
+)
+
+func TestBitBucketIgnoresNonBitBucketSources(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		src  string
+	}{
+		{name: "empty", src: ""},
+		{name: "github shorthand", src: "github.com/gruntwork-io/terragrunt"},
+		{name: "local path", src: "/abs/path/to/module"},
+		{name: "host is a bitbucket suffix", src: "notbitbucket.org/owner/repo"},
+		{name: "bare host without a path", src: "bitbucket.org"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, ok, err := new(detect.BitBucket).Detect(tc.src, "")
+			require.NoError(t, err)
+			assert.False(t, ok)
+			assert.Empty(t, out)
+		})
+	}
+}
+
+func TestBitBucketRewritesShorthandToForcedGitURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		src         string
+		expectedURL string
+	}{
+		{
+			name:        "adds the .git suffix",
+			src:         "bitbucket.org/atlassian/aws-ecr-push-image",
+			expectedURL: "git::https://bitbucket.org/atlassian/aws-ecr-push-image.git",
+		},
+		{
+			name:        "keeps an existing .git suffix",
+			src:         "bitbucket.org/atlassian/aws-ecr-push-image.git",
+			expectedURL: "git::https://bitbucket.org/atlassian/aws-ecr-push-image.git",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, ok, err := new(detect.BitBucket).Detect(tc.src, "")
+			require.NoError(t, err)
+			assert.True(t, ok)
+			assert.Equal(t, tc.expectedURL, out)
+		})
+	}
+}
+
+// TestBitBucketMatchesUpstreamRewrite pins the rewrite against go-getter's.
+// Dropping that detector's API probe was only safe because the rewrite around
+// it is unconditional, so the two have to stay identical.
+func TestBitBucketMatchesUpstreamRewrite(t *testing.T) {
+	t.Parallel()
+
+	// Every shape upstream's detectHTTP puts through url.Parse and its .git
+	// suffix check.
+	sources := []string{
+		"bitbucket.org/owner/repo",
+		"bitbucket.org/owner/repo.git",
+		"bitbucket.org/owner/repo/deep/path",
+	}
+
+	for _, src := range sources {
+		out, ok, err := new(detect.BitBucket).Detect(src, "")
+		require.NoError(t, err, "src=%s", src)
+		require.True(t, ok, "src=%s", src)
+		assert.Equal(t, "git::https://"+strings.TrimSuffix(src, ".git")+".git", out)
+	}
+}

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -13,6 +13,7 @@ import (
 	getter "github.com/hashicorp/go-getter/v2"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/detect"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
@@ -140,7 +141,7 @@ func NewCASGetter(
 		Detectors: []Detector{
 			new(GitHubDetector),
 			new(GitDetector),
-			new(BitBucketDetector),
+			new(detect.BitBucket),
 			new(GitLabDetector),
 			new(FileDetector),
 		},

--- a/internal/getter/detect.go
+++ b/internal/getter/detect.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/gruntwork-io/terragrunt/internal/detect"
 	getter "github.com/hashicorp/go-getter/v2"
 	urlhelper "github.com/hashicorp/go-getter/v2/helper/url"
 )
@@ -162,7 +163,7 @@ func defaultDetectors() []Detector {
 	return []Detector{
 		new(GitHubDetector),
 		new(GitDetector),
-		new(BitBucketDetector),
+		new(detect.BitBucket),
 		new(GitLabDetector),
 		prefixedDetector{Detector: new(GCSDetector), prefix: "gcs"},
 		prefixedDetector{Detector: new(S3Detector), prefix: "s3"},

--- a/internal/getter/git.go
+++ b/internal/getter/git.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 
+	"github.com/gruntwork-io/terragrunt/internal/detect"
 	getter "github.com/hashicorp/go-getter/v2"
 )
 
@@ -12,7 +13,7 @@ func defaultGitDetectors() []Detector {
 	return []Detector{
 		new(GitHubDetector),
 		new(GitDetector),
-		new(BitBucketDetector),
+		new(detect.BitBucket),
 		new(GitLabDetector),
 	}
 }

--- a/internal/getter/types.go
+++ b/internal/getter/types.go
@@ -28,14 +28,15 @@ const (
 
 // Detector type aliases for the concrete detectors used by callers that
 // build their own detector chain (e.g. internal/tf for normalizeSourceURL).
+// BitBucketDetector is deliberately absent. Chains use [detect.BitBucket],
+// which documents why.
 type (
-	GitHubDetector    = getter.GitHubDetector
-	GitDetector       = getter.GitDetector
-	BitBucketDetector = getter.BitBucketDetector
-	GitLabDetector    = getter.GitLabDetector
-	FileDetector      = getter.FileDetector
-	S3Detector        = s3.Detector
-	GCSDetector       = gcs.Detector
+	GitHubDetector = getter.GitHubDetector
+	GitDetector    = getter.GitDetector
+	GitLabDetector = getter.GitLabDetector
+	FileDetector   = getter.FileDetector
+	S3Detector     = s3.Detector
+	GCSDetector    = gcs.Detector
 )
 
 // Concrete getter type aliases for callers that need to assert on the

--- a/internal/tf/source.go
+++ b/internal/tf/source.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 
+	"github.com/gruntwork-io/terragrunt/internal/detect"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/strict"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
@@ -337,7 +338,7 @@ func normalizeSourceURL(source string, workingDir string) (string, error) {
 		new(getter.GitHubDetector),
 		new(getter.GitLabDetector),
 		new(getter.GitDetector),
-		new(getter.BitBucketDetector),
+		new(detect.BitBucket),
 	}
 
 	for _, detector := range detectors {

--- a/test/fixtures/catalog/local-catalog/README.md
+++ b/test/fixtures/catalog/local-catalog/README.md
@@ -1,0 +1,14 @@
+# Local Catalog
+
+`helpers.LocalGitRemote` serves this directory as a git remote, so the catalog
+tests never clone from a git host.
+
+The catalog counts every directory under `modules/` holding at least one `.tf`
+file as a module, so this tree holds four. Each is named for what it covers:
+
+| Module | Covers |
+| --- | --- |
+| `modules/with-variables` | a module with inputs, which the scaffold tests generate a configuration from |
+| `modules/without-variables` | a module the catalog lists but has no inputs to scaffold |
+| `modules/nested/with-readme` | discovery below the first level, with a README supplying the title |
+| `modules/nested/without-readme` | the same, with no README, so the title falls back to the directory name |

--- a/test/fixtures/catalog/local-catalog/modules/nested/with-readme/README.md
+++ b/test/fixtures/catalog/local-catalog/modules/nested/with-readme/README.md
@@ -1,0 +1,3 @@
+# Nested Module With Readme
+
+The catalog reads this heading as the module title.

--- a/test/fixtures/catalog/local-catalog/modules/nested/with-readme/main.tf
+++ b/test/fixtures/catalog/local-catalog/modules/nested/with-readme/main.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = "nested/with-readme"
+}

--- a/test/fixtures/catalog/local-catalog/modules/nested/without-readme/main.tf
+++ b/test/fixtures/catalog/local-catalog/modules/nested/without-readme/main.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = "nested/without-readme"
+}

--- a/test/fixtures/catalog/local-catalog/modules/with-variables/README.md
+++ b/test/fixtures/catalog/local-catalog/modules/with-variables/README.md
@@ -1,0 +1,3 @@
+# Module With Variables
+
+The catalog reads this heading as the module title.

--- a/test/fixtures/catalog/local-catalog/modules/with-variables/main.tf
+++ b/test/fixtures/catalog/local-catalog/modules/with-variables/main.tf
@@ -1,0 +1,3 @@
+output "required_input" {
+  value = var.required_input
+}

--- a/test/fixtures/catalog/local-catalog/modules/with-variables/variables.tf
+++ b/test/fixtures/catalog/local-catalog/modules/with-variables/variables.tf
@@ -1,0 +1,11 @@
+# required_input is the only variable without a default, so it is the only
+# input the scaffold test expects in the generated configuration.
+variable "required_input" {
+  type        = string
+  description = "An input the caller has to supply"
+}
+
+variable "optional_input" {
+  type    = string
+  default = "a default the caller can leave alone"
+}

--- a/test/fixtures/catalog/local-catalog/modules/without-variables/README.md
+++ b/test/fixtures/catalog/local-catalog/modules/without-variables/README.md
@@ -1,0 +1,3 @@
+# Module Without Variables
+
+The catalog reads this heading as the module title.

--- a/test/fixtures/catalog/local-catalog/modules/without-variables/main.tf
+++ b/test/fixtures/catalog/local-catalog/modules/without-variables/main.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = "without-variables"
+}

--- a/test/helpers/test_helpers.go
+++ b/test/helpers/test_helpers.go
@@ -483,3 +483,22 @@ func FindCachedFile(t *testing.T, unitDir, filename string) string {
 
 	return matches[0]
 }
+
+// LocalGitRemote copies the fixture tree at fixturePath into a throwaway git
+// repository and returns a file:// URL for it, so tests that need a real clone
+// can have one without reaching a hosting provider.
+//
+// The URL keeps its file:// scheme. A bare directory path reads as an
+// already-checked-out local repo and skips the clone, which is the step these
+// tests exercise.
+func LocalGitRemote(t *testing.T, fixturePath string) string {
+	t.Helper()
+
+	repoDir := TmpDirWOSymlinks(t)
+
+	require.NoError(t, os.CopyFS(repoDir, os.DirFS(MustAbs(t, fixturePath))))
+
+	InitGitRepoWithBranchRef(t, repoDir, "main")
+
+	return "file://" + filepath.ToSlash(repoDir)
+}

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -40,6 +40,7 @@ import (
 
 const (
 	testFixtureCatalogLocalTemplate = "fixtures/catalog/local-template"
+	testFixtureLocalCatalog         = "fixtures/catalog/local-catalog"
 
 	// catalogPipeWorkDirEnv carries the working directory the catalog pipe
 	// child process renders, and marks the process as that child.
@@ -61,13 +62,14 @@ func TestCatalogGitRepoUpdate(t *testing.T) {
 	ctx := t.Context()
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
+	cloneURL := helpers.LocalGitRemote(t, testFixtureLocalCatalog)
 
 	_, err := module.NewRepo(
 		ctx,
 		logger.CreateLogger(),
 		venv.OSVenv(),
 		&module.RepoOpts{
-			CloneURL: "github.com/gruntwork-io/terraform-fake-modules.git",
+			CloneURL: cloneURL,
 			Path:     tempDir,
 		},
 	)
@@ -78,7 +80,7 @@ func TestCatalogGitRepoUpdate(t *testing.T) {
 		logger.CreateLogger(),
 		venv.OSVenv(),
 		&module.RepoOpts{
-			CloneURL: "github.com/gruntwork-io/terraform-fake-modules.git",
+			CloneURL: cloneURL,
 			Path:     tempDir,
 		},
 	)
@@ -91,13 +93,14 @@ func TestScaffoldGitRepo(t *testing.T) {
 	ctx := t.Context()
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
+	cloneURL := helpers.LocalGitRemote(t, testFixtureLocalCatalog)
 
 	repo, err := module.NewRepo(
 		ctx,
 		logger.CreateLogger(),
 		venv.OSVenv(),
 		&module.RepoOpts{
-			CloneURL: "github.com/gruntwork-io/terraform-fake-modules.git",
+			CloneURL: cloneURL,
 			Path:     tempDir,
 		},
 	)
@@ -114,13 +117,14 @@ func TestScaffoldGitModule(t *testing.T) {
 	ctx := t.Context()
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
+	cloneURL := helpers.LocalGitRemote(t, testFixtureLocalCatalog)
 
 	repo, err := module.NewRepo(
 		ctx,
 		logger.CreateLogger(),
 		venv.OSVenv(),
 		&module.RepoOpts{
-			CloneURL: "https://github.com/gruntwork-io/terraform-fake-modules.git",
+			CloneURL: cloneURL,
 			Path:     tempDir,
 		},
 	)
@@ -129,15 +133,15 @@ func TestScaffoldGitModule(t *testing.T) {
 	modules, err := repo.FindModules(ctx, logger.CreateLogger(), vfs.NewOSFS())
 	require.NoError(t, err)
 
-	var auroraModule *module.Module
+	var moduleWithVariables *module.Module
 
 	for _, m := range modules {
-		if m.Title() == "Terraform Fake AWS Aurora Module" {
-			auroraModule = m
+		if m.Title() == "Module With Variables" {
+			moduleWithVariables = m
 		}
 	}
 
-	assert.NotNil(t, auroraModule)
+	assert.NotNil(t, moduleWithVariables)
 
 	testPath := helpers.TmpDirWOSymlinks(t)
 	opts, err := options.NewTerragruntOptionsForTest(testPath)
@@ -150,7 +154,7 @@ func TestScaffoldGitModule(t *testing.T) {
 		createLogger(),
 		venv.OSVenv(),
 		opts,
-		auroraModule.TerraformSourcePath(),
+		moduleWithVariables.TerraformSourcePath(),
 		"",
 	)
 	require.NoError(t, err)
@@ -158,13 +162,9 @@ func TestScaffoldGitModule(t *testing.T) {
 	cfg := readConfig(t, opts)
 	assert.NotEmpty(t, cfg.Inputs)
 	assert.Len(t, cfg.Inputs, 1)
-	_, found := cfg.Inputs["vpc_id"]
+	_, found := cfg.Inputs["required_input"]
 	assert.True(t, found)
-	assert.Contains(
-		t,
-		*cfg.Terraform.Source,
-		"git::https://github.com/gruntwork-io/terraform-fake-modules.git//modules/aws/aurora",
-	)
+	assert.Contains(t, *cfg.Terraform.Source, cloneURL+"//modules/with-variables")
 }
 
 func TestCatalogWithLocalDefaultTemplate(t *testing.T) {

--- a/test/integration_provider_cache_lockfile_tf_test.go
+++ b/test/integration_provider_cache_lockfile_tf_test.go
@@ -1,0 +1,137 @@
+//go:build tf
+
+package test_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+)
+
+// TestTFTerragruntFullLockfile asserts that a single `terragrunt init` (no
+// `providers lock -platform=...` and no preexisting lock file) populates
+// `.terraform.lock.hcl` with `h1:` hashes for multiple platforms, both with
+// and without the Terragrunt provider cache server enabled.
+//
+// The OpenTofu provider registry returns pre-computed `h1:` hashes for every
+// supported platform via the `packages` field on its per-platform download
+// endpoint. With the cache server enabled, the Terragrunt-side lockfile writer
+// (internal/tf/getproviders/lock.go) consumes that field via
+// ProviderCache.RegistryHashes(), so this subtest passes on any OpenTofu
+// version. Without the cache server, OpenTofu itself must read the field, and
+// only the 1.12 binary onward does so, hence the version gate below.
+func TestTFTerragruntFullLockfile(t *testing.T) {
+	t.Parallel()
+
+	if !helpers.IsOpenTofu112OrHigher(t) {
+		t.Skip("requires OpenTofu 1.12 or higher")
+		return
+	}
+
+	testCases := []struct {
+		name           string
+		providerSource string
+		minPlatforms   int
+		runWithCache   bool
+	}{
+		{
+			name:           "without provider cache",
+			providerSource: "registry.opentofu.org/hashicorp/null",
+			minPlatforms:   2,
+			runWithCache:   false,
+		},
+		{
+			name:           "with provider cache",
+			providerSource: "registry.opentofu.org/hashicorp/null",
+			minPlatforms:   2,
+			runWithCache:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			helpers.CleanupTerraformFolder(t, testFixtureProviderCacheFullLockfile)
+			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureProviderCacheFullLockfile)
+			rootPath := filepath.Join(tmpEnvPath, testFixtureProviderCacheFullLockfile)
+
+			cmd := "terragrunt init --non-interactive --working-dir " + rootPath
+
+			if tc.runWithCache {
+				providerCacheDir := helpers.TmpDirWOSymlinks(t)
+				cmd = fmt.Sprintf(
+					"terragrunt init --provider-cache --provider-cache-dir %s --non-interactive --working-dir %s",
+					providerCacheDir,
+					rootPath,
+				)
+			} else {
+				// Without the provider cache server, OpenTofu drives the install. If
+				// `~/.terraform.d/plugins` exists, OpenTofu treats it as an implicit
+				// filesystem mirror, skips the registry trust chain, and writes only
+				// a single-platform `h1:` hash, which defeats what this test asserts.
+				homeDir, err := os.UserHomeDir()
+				require.NoError(t, err)
+
+				userPluginDir := filepath.Join(homeDir, ".terraform.d", "plugins")
+				require.NoFileExists(
+					t,
+					userPluginDir,
+					"this subtest requires %s to not exist so OpenTofu uses the direct registry path; remove or rename it before running",
+					userPluginDir,
+				)
+			}
+
+			helpers.RunTerragrunt(t, cmd)
+
+			lockfilePath := filepath.Join(rootPath, ".terraform.lock.hcl")
+			require.FileExists(
+				t,
+				lockfilePath,
+				"expected lock file to exist at %s",
+				lockfilePath,
+			)
+
+			lockfileContent, err := os.ReadFile(lockfilePath)
+			require.NoError(t, err)
+
+			lockfile, diags := hclwrite.ParseConfig(
+				lockfileContent,
+				lockfilePath,
+				hcl.Pos{Line: 1, Column: 1},
+			)
+			require.False(t, diags.HasErrors(), "diagnostics: %s", diags.Error())
+			require.NotNil(t, lockfile)
+
+			providerBlock := lockfile.Body().
+				FirstMatchingBlock("provider", []string{tc.providerSource})
+			require.NotNil(
+				t,
+				providerBlock,
+				"lock file is missing block for %s; contents:\n%s",
+				tc.providerSource,
+				string(lockfileContent),
+			)
+
+			hashesAttr := providerBlock.Body().GetAttribute("hashes")
+			require.NotNil(t, hashesAttr, "provider block has no hashes attribute")
+
+			hashesText := string(hashesAttr.Expr().BuildTokens(nil).Bytes())
+			h1Count := strings.Count(hashesText, `"h1:`)
+
+			assert.GreaterOrEqualf(t, h1Count, tc.minPlatforms,
+				"expected at least %d h1 hashes (one per platform) but found %d in:\n%s",
+				tc.minPlatforms, h1Count, hashesText,
+			)
+		})
+	}
+}

--- a/test/integration_scaffold_test.go
+++ b/test/integration_scaffold_test.go
@@ -16,7 +16,6 @@ import (
 const (
 	testScaffoldLocalModulePath     = "fixtures/scaffold/scaffold-module"
 	testScaffoldWithRootHCL         = "fixtures/scaffold/root-hcl"
-	testScaffold3rdPartyModulePath  = "git::https://github.com/Azure/terraform-azurerm-avm-res-compute-virtualmachine.git//.?ref=v0.15.0"
 	testScaffoldNoDependencyPrompt  = "fixtures/scaffold/dependency-prompt-template"
 	testScaffoldLocalTofuModulePath = "fixtures/scaffold/scaffold-module-tofu"
 	testScaffoldCopyableUnitPath    = "fixtures/scaffold/copyable/units/app"
@@ -29,6 +28,15 @@ func scaffoldModuleURL(m *helpers.GitServer) string {
 	m.AddFixtures("test/fixtures/scaffold/scaffold-module")
 
 	return m.SourceURL("/test/fixtures/scaffold/scaffold-module", "")
+}
+
+// scaffoldModulePinnedURL is scaffoldModuleURL carrying a "?ref=" query. The
+// server creates every tag in [helpers.TerragruntMirrorTags] at HEAD, so which
+// one it names does not matter.
+func scaffoldModulePinnedURL(m *helpers.GitServer) string {
+	m.AddFixtures("test/fixtures/scaffold/scaffold-module")
+
+	return m.SourceURL("/test/fixtures/scaffold/scaffold-module", "v0.99.1")
 }
 
 // scaffoldInputsURL returns the inputs fixture source on the local
@@ -309,8 +317,12 @@ func localScaffoldSource(t *testing.T, fixturePath string) string {
 	return fmt.Sprintf("%s//%s", workingDir, fixturePath)
 }
 
-func TestScaffold3rdPartyModule(t *testing.T) {
+// TestScaffoldRemoteGitModuleAtRef scaffolds from a git source pinned with a
+// "?ref=" query, the shape that surfaced #3269.
+func TestScaffoldRemoteGitModuleAtRef(t *testing.T) {
 	t.Parallel()
+
+	mirror := helpers.NewGitServer(t)
 
 	tmpRoot := helpers.TmpDirWOSymlinks(t)
 
@@ -327,7 +339,7 @@ func TestScaffold3rdPartyModule(t *testing.T) {
 		fmt.Sprintf(
 			"terragrunt scaffold --non-interactive --working-dir %s %s",
 			tmpEnvPath,
-			testScaffold3rdPartyModulePath,
+			scaffoldModulePinnedURL(mirror),
 		),
 	)
 	require.NoError(t, err)
@@ -339,6 +351,13 @@ func TestScaffold3rdPartyModule(t *testing.T) {
 		"terragrunt hcl validate --non-interactive --working-dir "+tmpEnvPath,
 	)
 	require.NoError(t, err)
+
+	// Both halves of the heredoc description have to survive. Emitting them
+	// unescaped is what produced unparseable HCL.
+	content, err := vfs.ReadFileAsString(vfs.NewOSFS(), filepath.Join(tmpEnvPath, "terragrunt.hcl"))
+	require.NoError(t, err)
+	assert.Contains(t, content, "Port to be opened in the security group")
+	assert.Contains(t, content, "Can be a single port or a range")
 }
 
 func TestScaffoldOutputFolderFlag(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -362,125 +361,6 @@ func TestHclvalidateInvalidConfigPath(t *testing.T) {
 		}
 
 		assert.Truef(t, found, "expected a path ending with %q in %v", rel, actualPaths)
-	}
-}
-
-// TestTerragruntFullLockfile asserts that a single `terragrunt init` (no
-// `providers lock -platform=...` and no preexisting lock file) populates
-// `.terraform.lock.hcl` with `h1:` hashes for multiple platforms, both with
-// and without the Terragrunt provider cache server enabled.
-//
-// The OpenTofu provider registry returns pre-computed `h1:` hashes for every
-// supported platform via the `packages` field on its per-platform download
-// endpoint. With the cache server enabled, the Terragrunt-side lockfile writer
-// (internal/tf/getproviders/lock.go) consumes that field via
-// ProviderCache.RegistryHashes(), so this subtest passes on any OpenTofu
-// version. Without the cache server, OpenTofu itself must read the field, and
-// only the 1.12 binary onward does so, hence the version gate below.
-func TestTerragruntFullLockfile(t *testing.T) {
-	t.Parallel()
-
-	if !helpers.IsOpenTofu112OrHigher(t) {
-		t.Skip("requires OpenTofu 1.12 or higher")
-		return
-	}
-
-	testCases := []struct {
-		name           string
-		providerSource string
-		minPlatforms   int
-		runWithCache   bool
-	}{
-		{
-			name:           "without provider cache",
-			providerSource: "registry.opentofu.org/hashicorp/null",
-			minPlatforms:   2,
-			runWithCache:   false,
-		},
-		{
-			name:           "with provider cache",
-			providerSource: "registry.opentofu.org/hashicorp/null",
-			minPlatforms:   2,
-			runWithCache:   true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			helpers.CleanupTerraformFolder(t, testFixtureProviderCacheFullLockfile)
-			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureProviderCacheFullLockfile)
-			rootPath := filepath.Join(tmpEnvPath, testFixtureProviderCacheFullLockfile)
-
-			cmd := "terragrunt init --non-interactive --working-dir " + rootPath
-
-			if tc.runWithCache {
-				providerCacheDir := helpers.TmpDirWOSymlinks(t)
-				cmd = fmt.Sprintf(
-					"terragrunt init --provider-cache --provider-cache-dir %s --non-interactive --working-dir %s",
-					providerCacheDir,
-					rootPath,
-				)
-			} else {
-				// Without the provider cache server, OpenTofu drives the install. If
-				// `~/.terraform.d/plugins` exists, OpenTofu treats it as an implicit
-				// filesystem mirror, skips the registry trust chain, and writes only
-				// a single-platform `h1:` hash, which defeats what this test asserts.
-				homeDir, err := os.UserHomeDir()
-				require.NoError(t, err)
-
-				userPluginDir := filepath.Join(homeDir, ".terraform.d", "plugins")
-				require.NoFileExists(
-					t,
-					userPluginDir,
-					"this subtest requires %s to not exist so OpenTofu uses the direct registry path; remove or rename it before running",
-					userPluginDir,
-				)
-			}
-
-			helpers.RunTerragrunt(t, cmd)
-
-			lockfilePath := filepath.Join(rootPath, ".terraform.lock.hcl")
-			require.FileExists(
-				t,
-				lockfilePath,
-				"expected lock file to exist at %s",
-				lockfilePath,
-			)
-
-			lockfileContent, err := os.ReadFile(lockfilePath)
-			require.NoError(t, err)
-
-			lockfile, diags := hclwrite.ParseConfig(
-				lockfileContent,
-				lockfilePath,
-				hcl.Pos{Line: 1, Column: 1},
-			)
-			require.False(t, diags.HasErrors(), "diagnostics: %s", diags.Error())
-			require.NotNil(t, lockfile)
-
-			providerBlock := lockfile.Body().
-				FirstMatchingBlock("provider", []string{tc.providerSource})
-			require.NotNil(
-				t,
-				providerBlock,
-				"lock file is missing block for %s; contents:\n%s",
-				tc.providerSource,
-				string(lockfileContent),
-			)
-
-			hashesAttr := providerBlock.Body().GetAttribute("hashes")
-			require.NotNil(t, hashesAttr, "provider block has no hashes attribute")
-
-			hashesText := string(hashesAttr.Expr().BuildTokens(nil).Bytes())
-			h1Count := strings.Count(hashesText, `"h1:`)
-
-			assert.GreaterOrEqualf(t, h1Count, tc.minPlatforms,
-				"expected at least %d h1 hashes (one per platform) but found %d in:\n%s",
-				tc.minPlatforms, h1Count, hashesText,
-			)
-		})
 	}
 }
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds a test in CI that verifies the HTTP venv coverage is good, and closes the remaining gaps to achieve unit tests with no external network connectivity.

Required implementing our own BitBucket `go-getter` `Detector`. Also required updating some catalog tests that were operating against a remote catalog to ones that operated against a local Git server, and build tagging some OpenTofu/Terraform tests.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Bitbucket source handling, including shorthand URLs, HTTPS normalization, and automatic `.git` suffix support.
  - Added local catalog and Git-based test coverage for module discovery, titles, variables, and scaffolding.
  - Added provider lockfile validation across multiple platforms and cache configurations.

- **Documentation**
  - Expanded contributor guidance for running tests without network access on macOS and Linux.

- **Chores**
  - Added network-isolated CI testing to improve build and test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->