### PR TITLE
fix: Normalize paths using `ToSlash` to hande old/new prefix appropriately

### DIFF
--- a/internal/cli/commands/hcl/format/bytes_diff_test.go
+++ b/internal/cli/commands/hcl/format/bytes_diff_test.go
@@ -2,6 +2,7 @@
 package format
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,7 +42,7 @@ func TestBytesDiff(t *testing.T) {
 		"path is prefixed with old/ and new/ labels": {
 			before: "a\n",
 			after:  "b\n",
-			path:   "nested/dir/file.hcl",
+			path:   filepath.Join("nested", "dir", "file.hcl"),
 			wantHeader: []string{
 				"--- old/nested/dir/file.hcl",
 				"+++ new/nested/dir/file.hcl",

--- a/internal/cli/commands/hcl/format/format.go
+++ b/internal/cli/commands/hcl/format/format.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"path"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -320,6 +321,10 @@ func checkErrors(l log.Logger, v *venv.Venv, contents []byte, tgHclFile string) 
 }
 
 // bytesDiff returns a unified diff between the original and formatted HCL contents.
-func bytesDiff(b1, b2 []byte, path string) []byte {
-	return diff.Diff(filepath.Join("old", path), b1, filepath.Join("new", path), b2)
+func bytesDiff(b1, b2 []byte, name string) []byte {
+	// Diff labels are slash separated on every platform, so that consumers of the diff don't have to
+	// handle a Windows-specific spelling of the same label.
+	name = filepath.ToSlash(name)
+
+	return diff.Diff(path.Join("old", name), b1, path.Join("new", name), b2)
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses review feedback from #6726.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized file paths in formatting differences to ensure consistent output across operating systems.
* **Tests**
  * Updated path-related test coverage to work reliably across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->