### PR TITLE
fix: Adjust fix in #6711 so that it uses the autoinclude decode order instead of ignoring errors

### DIFF
--- a/docs/src/data/changelog/v1.1.4/autoinclude-config-path-override.mdx
+++ b/docs/src/data/changelog/v1.1.4/autoinclude-config-path-override.mdx
@@ -32,3 +32,5 @@ unit "app" {
   }
 }
 ```
+
+Terragrunt no longer evaluates a replaced block, so nothing written inside it is reported. Blocks using `expansion` are an exception. The autoinclude's block sits alongside their instances instead of replacing them, so Terragrunt still evaluates them.

--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -556,7 +556,7 @@ func initialSetup(
 
 	// --- Terragrunt ConfigPath
 	if opts.TerragruntConfigPath == "" {
-		opts.TerragruntConfigPath = config.GetDefaultConfigPath(opts.WorkingDir)
+		opts.TerragruntConfigPath = config.GetDefaultConfigPath(v.FS, opts.WorkingDir)
 	} else if !filepath.IsAbs(opts.TerragruntConfigPath) &&
 		(cliCtx.Command.Name == runcmd.CommandName || slices.Contains(tf.CommandNames, cliCtx.Command.Name)) {
 		opts.TerragruntConfigPath = filepath.Join(opts.WorkingDir, opts.TerragruntConfigPath)

--- a/pkg/config/autoinclude_test.go
+++ b/pkg/config/autoinclude_test.go
@@ -2,7 +2,6 @@ package config_test
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -10,9 +9,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	inthclparse "github.com/gruntwork-io/terragrunt/internal/hclparse"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
-	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -25,20 +25,19 @@ const tfInitCommand = "init"
 func TestMergeAutoInclude_MalformedSiblingDoesNotPanic(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
 	// The parent lives in a subdirectory so the sibling autoinclude does not also apply to it.
 	parentDir := filepath.Join(tmpDir, "parent")
-	require.NoError(t, os.MkdirAll(parentDir, 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(parentDir, "root.hcl"), []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(parentDir, "root.hcl"), []byte(`
 inputs = {
   parent = "from-root"
 }
 `), 0644))
 
 	// A unit with a resolvable include so TrackInclude is set and the post-merge handleInclude branch dereferences config on a shallow merge.
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 include "root" {
   path           = "`+filepath.Join(parentDir, "root.hcl")+`"
   merge_strategy = "shallow"
@@ -51,13 +50,13 @@ inputs = {
 
 	// An autoinclude that references an undefined local so its parse fails and mergeAutoIncludeIfPresent returns (nil, err).
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 inputs = {
   broken = local.does_not_exist
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -74,14 +73,13 @@ inputs = {
 func TestFoldSiblingAutoIncludeDeps_UsesAutoIncludeOwnLocals(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
 	// The valid dependency target named by the autoinclude's own local.
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "foo"), 0755))
 	require.NoError(
 		t,
-		os.WriteFile(
+		vfs.WriteFile(v.FS,
 			filepath.Join(tmpDir, "foo", config.DefaultTerragruntConfigPath),
 			[]byte(``),
 			0644,
@@ -91,7 +89,7 @@ func TestFoldSiblingAutoIncludeDeps_UsesAutoIncludeOwnLocals(t *testing.T) {
 	const marker = "autoinclude-local-marker"
 
 	// The unit defines NO target local and reads a dependency output the autoinclude wires in.
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 remote_state {
   backend = "local"
   generate = {
@@ -106,7 +104,7 @@ remote_state {
 
 	// The autoinclude declares its own local that names the real target dir and feeds config_path.
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 locals {
   target = "./foo"
 }
@@ -121,7 +119,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -148,14 +146,13 @@ dependency "foo" {
 func TestFoldSiblingAutoIncludeDeps_FoldsIncludeInheritedDeps(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
 	// The dependency target dir.
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "foo"), 0755))
 	require.NoError(
 		t,
-		os.WriteFile(
+		vfs.WriteFile(v.FS,
 			filepath.Join(tmpDir, "foo", config.DefaultTerragruntConfigPath),
 			[]byte(``),
 			0644,
@@ -165,7 +162,7 @@ func TestFoldSiblingAutoIncludeDeps_FoldsIncludeInheritedDeps(t *testing.T) {
 	const marker = "include-inherited-dep-marker"
 
 	// The unit reads a dependency output but declares no dependency itself.
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 remote_state {
   backend = "local"
   generate = {
@@ -180,8 +177,7 @@ remote_state {
 
 	// The included base lives in its OWN dir (not beside the autoinclude) and declares the dependency
 	// the unit relies on. config_path is absolute so it resolves the same regardless of parse dir.
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "base"), 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "base", "base.hcl"), []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(tmpDir, "base", "base.hcl"), []byte(`
 dependency "foo" {
   config_path  = "`+filepath.Join(tmpDir, "foo")+`"
   skip_outputs = true
@@ -194,14 +190,14 @@ dependency "foo" {
 
 	// The autoinclude declares NO dependency of its own; it inherits "foo" through a deep include.
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 include "base" {
   path           = "`+filepath.Join(tmpDir, "base", "base.hcl")+`"
   merge_strategy = "deep"
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -227,17 +223,17 @@ include "base" {
 func TestMergeAutoInclude_SameDirIncludeDoesNotRecurse(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 inputs = {
   from_unit = "unit-value"
 }
 `), 0644))
 
 	// A sibling file in the SAME directory as the autoinclude.
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "common.hcl"), []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(tmpDir, "common.hcl"), []byte(`
 inputs = {
   from_common = "common-value"
 }
@@ -245,14 +241,14 @@ inputs = {
 
 	// The autoinclude includes that same-dir sibling, the shape that previously recursed forever.
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 include "common" {
   path           = "`+filepath.Join(tmpDir, "common.hcl")+`"
   merge_strategy = "deep"
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -280,14 +276,13 @@ include "common" {
 func TestFoldSiblingAutoIncludeDeps_PulledInFileDoesNotFoldForeignAutoInclude(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 
 	// Dependency targets for the wanted and foreign dependencies.
 	for _, name := range []string{"wanted-target", "leak-target"} {
-		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, name), 0755))
 		require.NoError(
 			t,
-			os.WriteFile(
+			vfs.WriteFile(v.FS,
 				filepath.Join(tmpDir, name, config.DefaultTerragruntConfigPath),
 				[]byte(``),
 				0644,
@@ -296,13 +291,12 @@ func TestFoldSiblingAutoIncludeDeps_PulledInFileDoesNotFoldForeignAutoInclude(t 
 	}
 
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 inputs = { from_unit = "a" }
 `), 0644))
 
 	// A's autoinclude declares a WANTED dependency and deep-includes a base file in a different dir.
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "b"), 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, config.DefaultAutoIncludeFile), []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(tmpDir, config.DefaultAutoIncludeFile), []byte(`
 dependency "wanted" {
   config_path  = "`+filepath.Join(tmpDir, "wanted-target")+`"
   skip_outputs = true
@@ -316,14 +310,14 @@ include "base" {
 }
 `), 0644))
 
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "b", "base.hcl"), []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(tmpDir, "b", "base.hcl"), []byte(`
 inputs = { from_base = "b" }
 `), 0644))
 
 	// The base directory has its OWN sibling autoinclude declaring a foreign dependency that must not leak.
 	require.NoError(
 		t,
-		os.WriteFile(filepath.Join(tmpDir, "b", config.DefaultAutoIncludeFile), []byte(`
+		vfs.WriteFile(v.FS, filepath.Join(tmpDir, "b", config.DefaultAutoIncludeFile), []byte(`
 dependency "leak" {
   config_path  = "`+filepath.Join(tmpDir, "leak-target")+`"
   skip_outputs = true
@@ -333,7 +327,7 @@ dependency "leak" {
 `), 0644),
 	)
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -364,11 +358,11 @@ dependency "leak" {
 func TestMergeAutoInclude_ExcludeAutoIncludeWinsBothParsePaths(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
 	// The unit declares an exclude with one action set.
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 exclude {
   if      = true
   actions = ["plan"]
@@ -377,7 +371,7 @@ exclude {
 
 	// The autoinclude declares a different exclude that must win.
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 exclude {
   if      = true
   actions = ["apply"]
@@ -386,7 +380,7 @@ exclude {
 
 	l := logger.CreateLogger()
 
-	ctxFull, pctxFull := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctxFull, pctxFull := newTestParsingContext(t, v, cfgPath)
 	pctxFull.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	parsedFull, err := config.ParseConfigFile(ctxFull, pctxFull, l, cfgPath, nil)
@@ -400,7 +394,7 @@ exclude {
 		"autoinclude exclude must win in full parse",
 	)
 
-	ctxPartial, pctxPartial := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctxPartial, pctxPartial := newTestParsingContext(t, v, cfgPath)
 	pctxPartial.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctxPartial = pctxPartial.WithDecodeList(config.ExcludeBlock).WithSkipOutputsResolution()
 
@@ -420,10 +414,10 @@ func TestMergeAutoInclude_NoFile(t *testing.T) {
 	t.Parallel()
 
 	// When there is no terragrunt.autoinclude.hcl, parsing should work normally.
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 terraform {
   source = "."
 }
@@ -433,7 +427,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 
 	l := logger.CreateLogger()
 
@@ -448,11 +442,11 @@ inputs = {
 func TestMergeAutoInclude_WithFile(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
 	// Unit config with some inputs
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 terraform {
   source = "."
 }
@@ -465,14 +459,14 @@ inputs = {
 
 	// Autoinclude with overlapping inputs, which should win on conflicts
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 inputs = {
   name = "from-autoinclude"
   extra = "autoinclude-value"
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 
 	l := logger.CreateLogger()
 
@@ -492,10 +486,10 @@ inputs = {
 func TestMergeAutoInclude_StackLevelFilenameNotMergedIntoUnit(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 terraform {
   source = "."
 }
@@ -507,13 +501,13 @@ inputs = {
 
 	// A sibling terragrunt.autoinclude.stack.hcl must be ignored by the unit-level merge path.
 	stackAutoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeStackFile)
-	require.NoError(t, os.WriteFile(stackAutoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, stackAutoIncludePath, []byte(`
 inputs = {
   name = "from-stack-autoinclude-must-not-merge"
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 
 	l := logger.CreateLogger()
 
@@ -533,11 +527,11 @@ inputs = {
 func TestPartialParseAutoIncludeRemoteStateDependencyPlaceholder(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
 	// Unit references a dependency output but declares no dependency block itself.
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 remote_state {
   backend = "local"
   generate = {
@@ -552,7 +546,7 @@ remote_state {
 
 	// The dependency lives only in the sibling autoinclude.
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 dependency "foo" {
   config_path = "../foo"
   mock_outputs = {
@@ -561,7 +555,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx = pctx.WithDecodeList(config.DependencyBlock, config.RemoteStateBlock).
 		WithSkipOutputsResolution()
@@ -576,14 +570,13 @@ dependency "foo" {
 func TestParseConfigAutoIncludeRemoteStateFoldsDependencyMockOutput(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
 	// A sibling target directory so the dependency config_path is valid.
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "foo"), 0755))
 	require.NoError(
 		t,
-		os.WriteFile(
+		vfs.WriteFile(v.FS,
 			filepath.Join(tmpDir, "foo", config.DefaultTerragruntConfigPath),
 			[]byte(``),
 			0644,
@@ -593,7 +586,7 @@ func TestParseConfigAutoIncludeRemoteStateFoldsDependencyMockOutput(t *testing.T
 	const marker = "autoinclude-mock-marker"
 
 	// Unit remote_state config references a dependency output but has no dependency block.
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 remote_state {
   backend = "local"
   generate = {
@@ -608,7 +601,7 @@ remote_state {
 
 	// The dependency lives only in the sibling autoinclude with a mock output.
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 dependency "foo" {
   config_path = "./foo"
   skip_outputs = true
@@ -619,7 +612,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -637,13 +630,12 @@ dependency "foo" {
 func TestParseConfigAutoIncludeFileDirectlyDoesNotRecurse(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 
 	// A sibling target directory so the dependency config_path is valid.
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "foo"), 0755))
 	require.NoError(
 		t,
-		os.WriteFile(
+		vfs.WriteFile(v.FS,
 			filepath.Join(tmpDir, "foo", config.DefaultTerragruntConfigPath),
 			[]byte(``),
 			0644,
@@ -652,7 +644,7 @@ func TestParseConfigAutoIncludeFileDirectlyDoesNotRecurse(t *testing.T) {
 
 	// Parse the autoinclude file directly.
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 dependency "foo" {
   config_path = "./foo"
   skip_outputs = true
@@ -663,7 +655,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), autoIncludePath)
+	ctx, pctx := newTestParsingContext(t, v, autoIncludePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -681,10 +673,10 @@ dependency "foo" {
 func TestMergeAutoIncludeShallowInputMerge(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 inputs = {
   tags      = { a = "1" }
   unit_only = "u"
@@ -692,14 +684,14 @@ inputs = {
 `), 0644))
 
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 inputs = {
   tags    = { b = "2" }
   ai_only = "x"
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -733,10 +725,10 @@ inputs = {
 func TestMergeAutoIncludeDirectionAutoIncludeWins(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 terraform {
   source = "from-unit"
 }
@@ -747,7 +739,7 @@ inputs = {
 `), 0644))
 
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 terraform {
   source = "from-autoinclude"
 }
@@ -759,7 +751,7 @@ inputs = {
 
 	l := logger.CreateLogger()
 
-	ctxFull, pctxFull := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctxFull, pctxFull := newTestParsingContext(t, v, cfgPath)
 	pctxFull.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	parsedFull, err := config.ParseConfigFile(ctxFull, pctxFull, l, cfgPath, nil)
@@ -780,7 +772,7 @@ inputs = {
 		"autoinclude terraform source must win in full parse",
 	)
 
-	ctxPartial, pctxPartial := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctxPartial, pctxPartial := newTestParsingContext(t, v, cfgPath)
 	pctxPartial.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctxPartial = pctxPartial.WithDecodeList(config.TerraformSource).WithSkipOutputsResolution()
 
@@ -801,18 +793,18 @@ inputs = {
 func TestPartialParseAutoIncludeEffectiveMerge(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
 	// Unit declares none of the blocks under test.
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 inputs = {
   name = "from-unit"
 }
 `), 0644))
 
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 remote_state {
   backend = "local"
   generate = {
@@ -837,7 +829,7 @@ errors {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx = pctx.WithDecodeList(
 		config.DependencyBlock,
@@ -876,20 +868,19 @@ errors {
 func TestPartialParseAutoIncludeDependencyNoDoubleCount(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "foo"), 0755))
 	require.NoError(
 		t,
-		os.WriteFile(
+		vfs.WriteFile(v.FS,
 			filepath.Join(tmpDir, "foo", config.DefaultTerragruntConfigPath),
 			[]byte(``),
 			0644,
 		),
 	)
 
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 dependency "foo" {
   config_path  = "./foo"
   skip_outputs = true
@@ -897,14 +888,14 @@ dependency "foo" {
 `), 0644))
 
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 dependency "foo" {
   config_path  = "./foo"
   skip_outputs = true
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx = pctx.WithDecodeList(config.DependencyBlock).WithSkipOutputsResolution()
 
@@ -944,13 +935,12 @@ dependency "foo" {
 func TestPartialParseConfigAutoIncludeFileDirectlyDoesNotRecurse(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 
 	// A sibling target directory so the dependency config_path is valid.
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "foo"), 0755))
 	require.NoError(
 		t,
-		os.WriteFile(
+		vfs.WriteFile(v.FS,
 			filepath.Join(tmpDir, "foo", config.DefaultTerragruntConfigPath),
 			[]byte(``),
 			0644,
@@ -958,7 +948,7 @@ func TestPartialParseConfigAutoIncludeFileDirectlyDoesNotRecurse(t *testing.T) {
 	)
 
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 dependency "foo" {
   config_path = "./foo"
   skip_outputs = true
@@ -969,7 +959,7 @@ dependency "foo" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), autoIncludePath)
+	ctx, pctx := newTestParsingContext(t, v, autoIncludePath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 	pctx = pctx.WithDecodeList(config.DependencyBlock, config.RemoteStateBlock).
@@ -987,14 +977,13 @@ dependency "foo" {
 func TestPartialParseAutoIncludeCacheNotStaleOnCreate(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
 	// A sibling target directory so the autoinclude dependency config_path is valid.
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "producer"), 0755))
 	require.NoError(
 		t,
-		os.WriteFile(
+		vfs.WriteFile(v.FS,
 			filepath.Join(tmpDir, "producer", config.DefaultTerragruntConfigPath),
 			[]byte(``),
 			0644,
@@ -1002,13 +991,13 @@ func TestPartialParseAutoIncludeCacheNotStaleOnCreate(t *testing.T) {
 	)
 
 	// The unit declares none of the blocks under test; the autoinclude supplies them.
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 inputs = {
   name = "from-unit"
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	// A shared config cache so the second parse can see (and would otherwise reuse) the first entry.
 	ctx = context.WithValue(
 		ctx,
@@ -1031,7 +1020,7 @@ inputs = {
 	// Create the autoinclude AFTER the cache was populated: a dependency plus a remote_state that
 	// references that dependency (the real generated unit-level autoinclude shape).
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 dependency "producer" {
   config_path  = "./producer"
   skip_outputs = true
@@ -1076,17 +1065,17 @@ remote_state {
 func TestPartialParseAutoIncludeCacheNotStaleOnEdit(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 inputs = {
   name = "from-unit"
 }
 `), 0644))
 
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 remote_state {
   backend = "local"
   generate = {
@@ -1099,7 +1088,7 @@ remote_state {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	// A shared config cache so the second parse can see (and would otherwise reuse) the first entry.
 	ctx = context.WithValue(
 		ctx,
@@ -1119,7 +1108,7 @@ remote_state {
 	assert.Equal(t, "first", first.RemoteState.BackendConfig["path"])
 
 	// Edit the autoinclude in-process; the changed content must change the cache key.
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 remote_state {
   backend = "local"
   generate = {
@@ -1151,12 +1140,11 @@ remote_state {
 func TestMergeAutoInclude_DependenciesBlockEdgeSurvivesDisabledDependencyOverlap(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	for _, name := range []string{"foo", "bar"} {
-		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, name), 0755))
 		require.NoError(
 			t,
-			os.WriteFile(
+			vfs.WriteFile(v.FS,
 				filepath.Join(tmpDir, name, config.DefaultTerragruntConfigPath),
 				[]byte(``),
 				0644,
@@ -1165,7 +1153,7 @@ func TestMergeAutoInclude_DependenciesBlockEdgeSurvivesDisabledDependencyOverlap
 	}
 
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 dependencies {
   paths = ["./foo"]
 }
@@ -1177,13 +1165,13 @@ dependency "foo" {
 `), 0644))
 
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 dependency "bar" {
   config_path = "./bar"
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx = pctx.WithDecodeList(config.DependenciesBlock, config.DependencyBlock).
 		WithSkipOutputsResolution()
@@ -1208,14 +1196,13 @@ dependency "bar" {
 func TestParseTerragruntConfig_ReadsStackAutoIncludeFile(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 
 	// The generated stack-level autoinclude lives beside a nested stack's terragrunt.stack.hcl.
 	stackDir := filepath.Join(tmpDir, "stack")
-	require.NoError(t, os.MkdirAll(stackDir, 0755))
 
 	autoIncludePath := filepath.Join(stackDir, config.DefaultAutoIncludeStackFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 unit "db" {
   source = "../catalog/units/db"
   path   = "db"
@@ -1228,7 +1215,7 @@ stack "networking" {
 `), 0644))
 
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -1266,13 +1253,12 @@ stack "networking" {
 func TestParseTerragruntConfig_ReadsUnitAutoIncludeFile(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 
 	// The dependency target the autoinclude's dependency block points at.
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "vpc"), 0755))
 	require.NoError(
 		t,
-		os.WriteFile(
+		vfs.WriteFile(v.FS,
 			filepath.Join(tmpDir, "vpc", config.DefaultTerragruntConfigPath),
 			[]byte(``),
 			0644,
@@ -1280,7 +1266,7 @@ func TestParseTerragruntConfig_ReadsUnitAutoIncludeFile(t *testing.T) {
 	)
 
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 dependency "vpc" {
   config_path  = "./vpc"
   skip_outputs = true
@@ -1296,7 +1282,7 @@ inputs = {
 `), 0644))
 
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -1326,10 +1312,10 @@ inputs = {
 func TestValidateStackAutoIncludes_ReportsMalformedAutoInclude(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 
 	stackPath := filepath.Join(tmpDir, config.DefaultStackFile)
-	require.NoError(t, os.WriteFile(stackPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, stackPath, []byte(`
 unit "app" {
   source = "./units/app"
   path   = "app"
@@ -1342,7 +1328,7 @@ unit "app" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackPath)
+	ctx, pctx := newTestParsingContext(t, v, stackPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -1369,11 +1355,11 @@ unit "app" {
 func TestMergeAutoInclude_ValuesPlaceholderForOverriddenInputs(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
 	// Unit references values.vpc_id (not in values file) and values.cidr (in values file).
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 inputs = {
   vpc_id = values.vpc_id
   cidr   = values.cidr
@@ -1381,19 +1367,19 @@ inputs = {
 `), 0644))
 
 	// Values file defines only cidr, not vpc_id.
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "terragrunt.values.hcl"), []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(tmpDir, "terragrunt.values.hcl"), []byte(`
 cidr = "10.0.0.0/16"
 `), 0644))
 
 	// Autoinclude overrides vpc_id with a literal (in real usage this would be dependency.*.outputs.*).
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 inputs = {
   vpc_id = "from-autoinclude"
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 
 	l := logger.CreateLogger()
@@ -1410,12 +1396,11 @@ inputs = {
 func TestFoldSiblingAutoIncludeDeps_OverridesConfigPathFromValues(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
 	// Dependency target referenced by the autoinclude override.
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "vpc"), 0755))
-	require.NoError(t, os.WriteFile(
+	require.NoError(t, vfs.WriteFile(v.FS,
 		filepath.Join(tmpDir, "vpc", config.DefaultTerragruntConfigPath),
 		[]byte(``), 0644,
 	))
@@ -1423,7 +1408,7 @@ func TestFoldSiblingAutoIncludeDeps_OverridesConfigPathFromValues(t *testing.T) 
 	const marker = "autoinclude-overrides-values-config-path"
 
 	// Unit references values.vpc_path, which does NOT exist in the values.
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 dependency "vpc" {
   config_path  = values.vpc_path
   skip_outputs = true
@@ -1440,7 +1425,7 @@ inputs = {
 
 	// Autoinclude overrides the dependency with a valid config_path.
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 dependency "vpc" {
   config_path  = "./vpc"
   skip_outputs = true
@@ -1452,11 +1437,11 @@ dependency "vpc" {
 `), 0644))
 
 	// Values that intentionally omit vpc_path.
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "terragrunt.values.hcl"), []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(tmpDir, "terragrunt.values.hcl"), []byte(`
 region = "us-east-1"
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -1477,19 +1462,18 @@ region = "us-east-1"
 func TestFoldSiblingAutoIncludeDeps_OverridesConfigPathMixedDeps(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
 	for _, sub := range []string{"vpc", "db"} {
-		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, sub), 0755))
-		require.NoError(t, os.WriteFile(
+		require.NoError(t, vfs.WriteFile(v.FS,
 			filepath.Join(tmpDir, sub, config.DefaultTerragruntConfigPath),
 			[]byte(``), 0644,
 		))
 	}
 
 	// "vpc" references an absent values.vpc_path; "db" has a valid literal path.
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 dependency "vpc" {
   config_path  = values.vpc_path
   skip_outputs = true
@@ -1516,7 +1500,7 @@ inputs = {
 
 	// Autoinclude overrides only "vpc".
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 dependency "vpc" {
   config_path  = "./vpc"
   skip_outputs = true
@@ -1527,7 +1511,7 @@ dependency "vpc" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -1549,17 +1533,16 @@ dependency "vpc" {
 func TestFoldSiblingAutoIncludeDeps_NonOverriddenFailureStillErrors(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "other"), 0755))
-	require.NoError(t, os.WriteFile(
+	require.NoError(t, vfs.WriteFile(v.FS,
 		filepath.Join(tmpDir, "other", config.DefaultTerragruntConfigPath),
 		[]byte(``), 0644,
 	))
 
 	// "vpc" references an absent values.vpc_path; no autoinclude overrides it.
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 dependency "vpc" {
   config_path  = values.vpc_path
   skip_outputs = true
@@ -1572,7 +1555,7 @@ dependency "vpc" {
 
 	// Autoinclude overrides only "other", not "vpc".
 	autoIncludePath := filepath.Join(tmpDir, config.DefaultAutoIncludeFile)
-	require.NoError(t, os.WriteFile(autoIncludePath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, autoIncludePath, []byte(`
 dependency "other" {
   config_path  = "./other"
   skip_outputs = true
@@ -1583,7 +1566,7 @@ dependency "other" {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -1602,11 +1585,11 @@ dependency "other" {
 func TestFoldSiblingAutoIncludeDeps_MissingValuesPathWithoutAutoIncludeStillErrors(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	v, tmpDir := newMemTestDir(t)
 	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
 
 	// No autoinclude file at all.
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
 dependency "vpc" {
   config_path  = values.vpc_path
   skip_outputs = true
@@ -1621,7 +1604,7 @@ inputs = {
 }
 `), 0644))
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), cfgPath)
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
 	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
 	pctx.OriginalTerraformCommand = tfInitCommand
 
@@ -1634,5 +1617,185 @@ inputs = {
 
 	_, err := config.ParseConfigFile(ctx, pctx, l, cfgPath, nil)
 	require.Error(t, err, "without autoinclude the values.vpc_path error must not be swallowed")
-	assert.Contains(t, err.Error(), "values", "error must reference the unresolvable values variable")
+
+	var diags hcl.Diagnostics
+
+	require.ErrorAs(t, err, &diags)
+	require.NotEmpty(t, diags)
+	require.NotNil(t, diags[0].Subject)
+	assert.Equal(t, cfgPath, diags[0].Subject.Filename)
+	// The config_path expression, not a downstream dependency.vpc reference.
+	assert.Equal(t, 3, diags[0].Subject.Start.Line)
+}
+
+// A dependency block the autoinclude replaces wholesale contributes nothing to the merged
+// config, so the parse never evaluates it and never reports its contents.
+func TestFoldSiblingAutoIncludeDeps_OverriddenBlockIsNeverEvaluated(t *testing.T) {
+	t.Parallel()
+
+	v, tmpDir := newMemTestDir(t)
+	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
+
+	require.NoError(t, vfs.WriteFile(v.FS,
+		filepath.Join(tmpDir, "vpc", config.DefaultTerragruntConfigPath),
+		[]byte(``), 0644,
+	))
+
+	// config_path resolves fine; mock_outputs_allowed_terraform_commands has the wrong type.
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
+dependency "vpc" {
+  config_path  = "./vpc"
+  skip_outputs = true
+  mock_outputs = {
+    id = "from-unit"
+  }
+  mock_outputs_allowed_terraform_commands = "init"
+}
+
+inputs = {
+  vpc_id = dependency.vpc.outputs.id
+}
+`), 0644))
+
+	require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(tmpDir, config.DefaultAutoIncludeFile), []byte(`
+dependency "vpc" {
+  config_path  = "./vpc"
+  skip_outputs = true
+  mock_outputs = {
+    id = "from-autoinclude"
+  }
+  mock_outputs_allowed_terraform_commands = ["init"]
+}
+`), 0644))
+
+	ctx, pctx := newTestParsingContext(t, v, cfgPath)
+	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
+	pctx.OriginalTerraformCommand = tfInitCommand
+
+	l := logger.CreateLogger()
+
+	parsed, err := config.ParseConfigFile(ctx, pctx, l, cfgPath, nil)
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	assert.Equal(t, "from-autoinclude", parsed.Inputs["vpc_id"])
+}
+
+// An expanded unit dependency is decoded even when the autoinclude declares the same name. The
+// merge keys expanded blocks per instance, so the autoinclude sits alongside them instead of
+// replacing them.
+func TestFoldSiblingAutoIncludeDeps_ExpandedUnitDepSurvivesUnexpandedOverride(t *testing.T) {
+	t.Parallel()
+
+	v, tmpDir := newMemTestDir(t)
+	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
+
+	for _, sub := range []string{"vpc", "vpc-api", "vpc-web"} {
+		require.NoError(t, vfs.WriteFile(v.FS,
+			filepath.Join(tmpDir, sub, config.DefaultTerragruntConfigPath),
+			[]byte(``), 0644,
+		))
+	}
+
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
+locals {
+  services = toset(["api", "web"])
+}
+
+dependency "vpc" {
+  expansion {
+    for_each = local.services
+  }
+
+  config_path  = "./vpc-${each.value}"
+  skip_outputs = true
+  mock_outputs = {
+    id = "unit-${each.value}"
+  }
+  mock_outputs_allowed_terraform_commands = ["init"]
+}
+`), 0644))
+
+	require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(tmpDir, config.DefaultAutoIncludeFile), []byte(`
+dependency "vpc" {
+  config_path  = "./vpc"
+  skip_outputs = true
+  mock_outputs = {
+    id = "from-autoinclude"
+  }
+  mock_outputs_allowed_terraform_commands = ["init"]
+}
+`), 0644))
+
+	ctx, pctx := newExpansionParsingContext(t, v, cfgPath)
+	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
+	pctx.OriginalTerraformCommand = tfInitCommand
+
+	l := logger.CreateLogger()
+
+	parsed, err := config.ParseConfigFile(ctx, pctx, l, cfgPath, nil)
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+
+	got := make([]string, 0, len(parsed.TerragruntDependencies))
+
+	for _, dep := range parsed.TerragruntDependencies {
+		if dep.Expansion == nil {
+			got = append(got, dep.Name)
+			continue
+		}
+
+		got = append(got, dep.Name+"["+dep.Expansion.Key()+"]")
+	}
+
+	assert.ElementsMatch(t, []string{"vpc[api]", "vpc[web]", "vpc"}, got)
+}
+
+// An expanded unit dependency the autoinclude does not replace must still report an
+// unresolvable for_each, rather than vanishing behind the same-name autoinclude block.
+func TestFoldSiblingAutoIncludeDeps_ExpandedUnitDepStillErrors(t *testing.T) {
+	t.Parallel()
+
+	v, tmpDir := newMemTestDir(t)
+	cfgPath := filepath.Join(tmpDir, config.DefaultTerragruntConfigPath)
+
+	require.NoError(t, vfs.WriteFile(v.FS,
+		filepath.Join(tmpDir, "vpc", config.DefaultTerragruntConfigPath),
+		[]byte(``), 0644,
+	))
+
+	require.NoError(t, vfs.WriteFile(v.FS, cfgPath, []byte(`
+dependency "vpc" {
+  expansion {
+    for_each = values.regions
+  }
+
+  config_path  = "./vpc-${each.value}"
+  skip_outputs = true
+}
+`), 0644))
+
+	require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(tmpDir, config.DefaultAutoIncludeFile), []byte(`
+dependency "vpc" {
+  config_path  = "./vpc"
+  skip_outputs = true
+  mock_outputs = {
+    id = "from-autoinclude"
+  }
+  mock_outputs_allowed_terraform_commands = ["init"]
+}
+`), 0644))
+
+	ctx, pctx := newExpansionParsingContext(t, v, cfgPath)
+	pctx.Experiments.EnableExperiment(experiment.StackDependencies)
+	pctx.OriginalTerraformCommand = tfInitCommand
+
+	values := cty.ObjectVal(map[string]cty.Value{
+		"region": cty.StringVal("us-east-1"),
+	})
+	pctx.Values = &values
+
+	l := logger.CreateLogger()
+
+	_, err := config.ParseConfigFile(ctx, pctx, l, cfgPath, nil)
+	require.Error(t, err)
 }

--- a/pkg/config/catalog.go
+++ b/pkg/config/catalog.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 
@@ -55,21 +54,21 @@ func (cfg *CatalogConfig) String() string {
 	)
 }
 
-func (cfg *CatalogConfig) normalize(configPath string) {
+func (cfg *CatalogConfig) normalize(fsys vfs.FS, configPath string) {
 	configDir := filepath.Dir(configPath)
 
 	// transform relative paths to absolute ones
 	for i, url := range cfg.URLs {
 		url := filepath.Join(configDir, url)
 
-		if _, err := os.Stat(url); err == nil {
+		if vfs.Exists(fsys, url) {
 			cfg.URLs[i] = url
 		}
 	}
 
 	if cfg.DefaultTemplate != "" {
 		path := filepath.Join(configDir, cfg.DefaultTemplate)
-		if _, err := os.Stat(path); err == nil {
+		if vfs.Exists(fsys, path) {
 			cfg.DefaultTemplate = path
 		}
 	}
@@ -196,7 +195,7 @@ func convertToTerragruntCatalogConfig(
 
 	if terragruntConfigFromFile.Catalog != nil {
 		terragruntConfig.Catalog = terragruntConfigFromFile.Catalog
-		terragruntConfig.Catalog.normalize(configPath)
+		terragruntConfig.Catalog.normalize(pctx.Venv.FS, configPath)
 		terragruntConfig.SetFieldMetadata(MetadataCatalog, defaultMetadata)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,7 +9,6 @@ import (
 	"io/fs"
 	"maps"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -1221,9 +1220,9 @@ func adjustSourceWithMap(
 
 // GetDefaultConfigPath returns the default path to use for the Terragrunt configuration
 // that exists within the path giving preference to `terragrunt.hcl`
-func GetDefaultConfigPath(workingDir string) string {
+func GetDefaultConfigPath(fsys vfs.FS, workingDir string) string {
 	// check if a configuration file was passed as `workingDir`.
-	if info, err := os.Stat(workingDir); err == nil && !info.IsDir() {
+	if vfs.IsFile(fsys, workingDir) {
 		return workingDir
 	}
 
@@ -1234,7 +1233,7 @@ func GetDefaultConfigPath(workingDir string) string {
 			configPath = filepath.Join(workingDir, configPath)
 		}
 
-		if _, err := os.Stat(configPath); err == nil {
+		if vfs.Exists(fsys, configPath) {
 			break
 		}
 	}
@@ -1578,7 +1577,7 @@ func ParseConfig(
 
 	// Decode the rest of the config, passing in this config's `include` block or the child's `include` block, whichever
 	// is appropriate
-	terragruntConfigFile, err := decodeAsTerragruntConfigFile(pctx, l, file, evalContext)
+	terragruntConfigFile, err := decodeAsTerragruntConfigFile(ctx, pctx, l, file, evalContext)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -1814,6 +1813,7 @@ func setIAMRole(
 }
 
 func decodeAsTerragruntConfigFile(
+	ctx context.Context,
 	pctx *ParsingContext,
 	l log.Logger,
 	file *hclparse.File,
@@ -1837,7 +1837,7 @@ func decodeAsTerragruntConfigFile(
 		l.Debugf("Deferred attribute access error to autoinclude merge: %v", diagErr)
 	}
 
-	dependencies, err := decodeDependencyBlocksWithAutoIncludeRetry(file, evalContext, pctx)
+	dependencies, err := decodeDependencyBlocksWithAutoIncludeOverrides(ctx, pctx, file, evalContext)
 	if err != nil {
 		return &terragruntConfig, err
 	}
@@ -2303,7 +2303,7 @@ func validateDependencies(ctx *ParsingContext, dependencies *ModuleDependencies)
 // Iterate over generate blocks and detect duplicate names, return error with list of duplicated names
 func validateGenerateBlocks(blocks *[]terragruntGenerateBlock) error {
 	var (
-		blockNames                   = map[string]bool{}
+		blockNames                   = map[string]struct{}{}
 		duplicatedGenerateBlockNames []string
 	)
 
@@ -2314,7 +2314,7 @@ func validateGenerateBlocks(blocks *[]terragruntGenerateBlock) error {
 			continue
 		}
 
-		blockNames[block.Name] = true
+		blockNames[block.Name] = struct{}{}
 	}
 
 	if len(duplicatedGenerateBlockNames) != 0 {
@@ -2327,8 +2327,8 @@ func validateGenerateBlocks(blocks *[]terragruntGenerateBlock) error {
 // configFileHasDependencyBlock statically checks the terrragrunt config file at the given path and checks if it has any
 // dependency or dependencies blocks defined. Note that this does not do any decoding of the blocks, as it is only meant
 // to check for block presence.
-func configFileHasDependencyBlock(configPath string) (bool, error) {
-	configBytes, err := os.ReadFile(configPath)
+func configFileHasDependencyBlock(fsys vfs.FS, configPath string) (bool, error) {
+	configBytes, err := vfs.ReadFile(fsys, configPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return false, DependencyFileNotFoundError{Path: configPath}

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -793,7 +793,7 @@ func findInParentFoldersImpl(
 			}
 		}
 
-		fileToFind := parentFileCandidate(currentDir, fileToFindParam)
+		fileToFind := parentFileCandidate(pctx.Venv.FS, currentDir, fileToFindParam)
 
 		if parentFileExists(ctx, pctx.Venv.FS, probes, fileToFind) {
 			return fileToFind, nil
@@ -813,9 +813,9 @@ func findInParentFoldersImpl(
 // the caller passed no argument and wants whichever default config name is
 // present, which costs a probe per known name, so [GetDefaultConfigPath] is
 // only consulted in that case.
-func parentFileCandidate(dir, fileName string) string {
+func parentFileCandidate(fsys vfs.FS, dir, fileName string) string {
 	if fileName == "" {
-		return GetDefaultConfigPath(dir)
+		return GetDefaultConfigPath(fsys, dir)
 	}
 
 	return filepath.Join(dir, fileName)
@@ -1212,7 +1212,7 @@ func getCleanedTargetConfigPath(fsys vfs.FS, configPath string, workingPath stri
 	}
 
 	if vfs.IsDir(fsys, targetConfig) {
-		targetConfig = GetDefaultConfigPath(targetConfig)
+		targetConfig = GetDefaultConfigPath(fsys, targetConfig)
 	}
 
 	return filepath.Clean(targetConfig)
@@ -1575,7 +1575,7 @@ func readTFVarsFileImpl(pctx *ParsingContext, l log.Logger, args []string) (stri
 	// Track that this file was read during parsing
 	pctx.FilesRead.Add(varFile)
 
-	fileContents, err := os.ReadFile(varFile)
+	fileContents, err := vfs.ReadFile(pctx.Venv.FS, varFile)
 	if err != nil {
 		return "", fmt.Errorf("could not read file %q: %w", varFile, err)
 	}

--- a/pkg/config/config_helpers_test.go
+++ b/pkg/config/config_helpers_test.go
@@ -1061,6 +1061,17 @@ func testGetTerragruntDir(t *testing.T, configPath string, expectedPath string) 
 	assert.Equal(t, expectedPath, actualPath)
 }
 
+// newMemTestDir returns an in-memory venv and a root path for a test's config tree, so a
+// test that builds one never touches the real filesystem.
+//
+// The path comes from TempDir because it is absolute on every platform, which a hand-rolled
+// "/name" is not on Windows. Nothing is written to it on disk.
+func newMemTestDir(tb testing.TB) (*venv.Venv, string) {
+	tb.Helper()
+
+	return venvtest.New(), tb.TempDir()
+}
+
 // newTestParsingContext creates a ParsingContext around v with sensible test
 // defaults. Replicates NewTerragruntOptionsForTest + configbridge.populateFromOpts.
 func newTestParsingContext(

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
@@ -735,10 +734,11 @@ func PartialParseConfig(
 			}
 
 		case DependencyBlock:
-			decodedDeps, err := decodeDependencyBlocksWithAutoIncludeRetry(
+			decodedDeps, err := decodeDependencyBlocksWithAutoIncludeOverrides(
+				ctx,
+				pctx,
 				file,
 				evalParsingContext,
-				pctx,
 			)
 			if err != nil {
 				return nil, err
@@ -1148,7 +1148,7 @@ func autoIncludeCacheKeySuffix(
 
 	// Fingerprint the sibling cheaply so a cache hit reuses the content based suffix without re-reading the file.
 	fingerprint := autoIncludePath
-	if info, statErr := os.Stat(autoIncludePath); statErr == nil {
+	if info, statErr := pctx.Venv.FS.Stat(autoIncludePath); statErr == nil {
 		fingerprint = fmt.Sprintf(
 			"%s-%d-%d",
 			autoIncludePath,

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"maps"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -29,7 +28,6 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
@@ -314,7 +312,7 @@ func decodeAndRetrieveOutputs(
 		return nil, err
 	}
 
-	dependencies, err := decodeDependencyBlocksWithAutoIncludeRetry(file, evalParsingContext, pctx)
+	dependencies, err := decodeDependencyBlocksWithAutoIncludeOverrides(ctx, pctx, file, evalParsingContext)
 	if err != nil {
 		return nil, err
 	}
@@ -2183,7 +2181,7 @@ func parseAutoIncludeFileCached(
 	pctx *ParsingContext,
 	autoIncludePath string,
 ) (*hclparse.File, error) {
-	fileInfo, err := os.Stat(autoIncludePath)
+	fileInfo, err := pctx.Venv.FS.Stat(autoIncludePath)
 	if err != nil {
 		return nil, err
 	}
@@ -2207,62 +2205,52 @@ func parseAutoIncludeFileCached(
 	return file, nil
 }
 
-// decodeDependencyBlocksWithAutoIncludeRetry decodes dependency blocks, retrying with label-skip when a sibling autoinclude overrides some of them and the first decode fails on unresolvable attributes. Used by both decodeAndRetrieveOutputs and decodeAsTerragruntConfigFile.
-func decodeDependencyBlocksWithAutoIncludeRetry(
+// decodeDependencyBlocksWithAutoIncludeOverrides decodes the file's dependency blocks, leaving
+// out the ones a sibling autoinclude replaces wholesale.
+//
+// A replaced block contributes nothing to the final config, so evaluating it can only raise
+// errors about a body that is about to be thrown away. A unit source whose config_path reads a
+// values attribute the stack stopped setting hits exactly that.
+func decodeDependencyBlocksWithAutoIncludeOverrides(
+	ctx context.Context,
+	pctx *ParsingContext,
 	file *hclparse.File,
 	evalContext *hcl.EvalContext,
-	pctx *ParsingContext,
 ) (Dependencies, error) {
-	deps, err := decodeDependencyBlocks(file, evalContext, pctx.Experiments)
-	if err != nil && hasSiblingAutoInclude(pctx) {
-		overrides := siblingAutoIncludeDepNames(pctx)
-		if len(overrides) > 0 {
-			deps, err = decodeDependencyBlocks(
-				file, evalContext, pctx.Experiments,
-				hclparse.WithSkipLabelsOnError(overrides),
-			)
-		}
+	overrides, err := siblingAutoIncludeDepOverrides(ctx, pctx)
+	if err != nil {
+		return nil, err
 	}
 
-	return deps, err
+	return decodeDependencyBlocks(
+		file,
+		evalContext,
+		pctx.Experiments,
+		hclparse.WithSkipLabels(overrides),
+	)
 }
 
-// siblingAutoIncludeDepNames extracts dependency block labels from the sibling autoinclude file via a lightweight HCL parse. Returns nil when no autoinclude is registered, the file is absent, or it cannot be parsed.
-func siblingAutoIncludeDepNames(pctx *ParsingContext) map[string]bool {
+// siblingAutoIncludeDepOverrides returns the names of the dependency blocks the sibling
+// autoinclude replaces wholesale, or nil when no autoinclude is registered.
+//
+// [mergeDependencyBlocks] keys the merge on a dependency's name, so an unexpanded autoinclude
+// block named vpc displaces the unit's unexpanded vpc outright. Expansion keys the merge per
+// instance instead, leaving both sides in the result. [hclparse.File.UnexpandedLabels]
+// reports only the unexpanded names for that reason.
+func siblingAutoIncludeDepOverrides(
+	ctx context.Context,
+	pctx *ParsingContext,
+) (map[string]struct{}, error) {
 	if !hasSiblingAutoInclude(pctx) {
-		return nil
+		return nil, nil
 	}
 
-	autoPath := pctx.TrackInclude.AutoIncludeOverride.Path
-
-	data, err := vfs.ReadFile(pctx.Venv.FS, autoPath)
+	autoFile, err := parseAutoIncludeFileCached(ctx, pctx, pctx.TrackInclude.AutoIncludeOverride.Path)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
-	file, diags := hclsyntax.ParseConfig(data, autoPath, hcl.Pos{Line: 1, Column: 1})
-	if diags.HasErrors() {
-		return nil
-	}
-
-	body, ok := file.Body.(*hclsyntax.Body)
-	if !ok {
-		return nil
-	}
-
-	names := make(map[string]bool)
-
-	for _, block := range body.Blocks {
-		if block.Type == MetadataDependency && len(block.Labels) > 0 {
-			names[block.Labels[0]] = true
-		}
-	}
-
-	if len(names) == 0 {
-		return nil
-	}
-
-	return names
+	return autoFile.UnexpandedLabels(MetadataDependency, &Dependency{})
 }
 
 // IsValidConfigPath checks if a cty.Value is a valid, usable config path.

--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -2,12 +2,12 @@ package config_test
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
@@ -207,7 +207,7 @@ func TestParseConfigStringExpansionRequiresExperiment(t *testing.T) {
 	skipInExperimentMode(t)
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultTerragruntConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.New(), config.DefaultTerragruntConfigPath)
 
 	_, err := config.ParseConfigString(
 		ctx,
@@ -253,7 +253,7 @@ func TestReadStackConfigStringExpansionRequiresExperiment(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), config.DefaultStackFile)
+			ctx, pctx := newTestParsingContext(t, venvtest.New(), config.DefaultStackFile)
 
 			_, err := config.ReadStackConfigString(
 				ctx,
@@ -297,7 +297,7 @@ include "extra" {
 `), 0o644))
 
 	l := logger.CreateLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), stackPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.New(), stackPath)
 	pctx.Venv.FS = fsys
 
 	_, err := config.ReadStackConfigFile(ctx, l, pctx, stackPath, nil)
@@ -420,7 +420,7 @@ dependency "vpc" {
 func TestDisabledExpandedDependencySkipsOutputRetrieval(t *testing.T) {
 	t.Parallel()
 
-	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newExpansionParsingContext(t, venvtest.New(), config.DefaultTerragruntConfigPath)
 
 	cfg, err := config.ParseConfigString(
 		ctx,
@@ -464,12 +464,13 @@ func TestIncludeMergeKeepsEveryExpandedInstance(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			dir := t.TempDir()
+			v, dir := newMemTestDir(t)
 
-			require.NoError(t, os.MkdirAll(filepath.Join(dir, "network"), 0o755))
-			require.NoError(t, os.MkdirAll(filepath.Join(dir, "logging"), 0o755))
+			// Both directories stay empty, so nothing else brings them into existence.
+			require.NoError(t, v.FS.MkdirAll(filepath.Join(dir, "network"), 0o755))
+			require.NoError(t, v.FS.MkdirAll(filepath.Join(dir, "logging"), 0o755))
 
-			require.NoError(t, os.WriteFile(filepath.Join(dir, "root.hcl"), []byte(`
+			require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(dir, "root.hcl"), []byte(`
 dependencies {
   paths = ["./network"]
 }
@@ -481,7 +482,7 @@ dependency "vpc" {
 `), 0o644))
 
 			configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
-			require.NoError(t, os.WriteFile(configPath, []byte(`
+			require.NoError(t, vfs.WriteFile(v.FS, configPath, []byte(`
 include "root" {
   path = "root.hcl"
   `+tc.mergeStrategy+`
@@ -501,7 +502,7 @@ dependency "shard" {
 }
 `), 0o644))
 
-			ctx, pctx := newExpansionParsingContext(t, configPath)
+			ctx, pctx := newExpansionParsingContext(t, v, configPath)
 
 			cfg, err := config.ParseConfigFile(ctx, pctx, logger.CreateLogger(), configPath, nil)
 			require.NoError(t, err)
@@ -524,7 +525,7 @@ dependency "shard" {
 func TestExpandedDependencyCarriesItsOwnOutputConfig(t *testing.T) {
 	t.Parallel()
 
-	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newExpansionParsingContext(t, venvtest.New(), config.DefaultTerragruntConfigPath)
 
 	cfg, err := config.ParseConfigString(
 		ctx,
@@ -594,7 +595,7 @@ func TestJSONExpansionRequiresExperiment(t *testing.T) {
 
 	skipInExperimentMode(t)
 
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), jsonConfigPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.New(), jsonConfigPath)
 
 	_, err := config.PartialParseConfigString(
 		ctx,
@@ -614,7 +615,7 @@ func TestJSONExpansionRequiresExperiment(t *testing.T) {
 func TestUnknownBlockRemainsRejected(t *testing.T) {
 	t.Parallel()
 
-	ctx, pctx := newExpansionParsingContext(t, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newExpansionParsingContext(t, venvtest.New(), config.DefaultTerragruntConfigPath)
 
 	_, err := config.ParseConfigString(
 		ctx,
@@ -807,7 +808,7 @@ func TestDependencyCtyShapeExcludesExpansionMetadata(t *testing.T) {
 func parseDependencyString(tb testing.TB, cfg string) (*config.TerragruntConfig, error) {
 	tb.Helper()
 
-	ctx, pctx := newExpansionParsingContext(tb, config.DefaultTerragruntConfigPath)
+	ctx, pctx := newExpansionParsingContext(tb, venvtest.New(), config.DefaultTerragruntConfigPath)
 
 	return config.PartialParseConfigString(
 		ctx,
@@ -833,7 +834,7 @@ func parseDependencyJSONString(
 ) (*config.TerragruntConfig, error) {
 	tb.Helper()
 
-	ctx, pctx := newExpansionParsingContext(tb, jsonConfigPath)
+	ctx, pctx := newExpansionParsingContext(tb, venvtest.New(), jsonConfigPath)
 
 	return config.PartialParseConfigString(
 		ctx,
@@ -848,7 +849,7 @@ func parseDependencyJSONString(
 func parseStackString(tb testing.TB, cfg string) (*config.StackConfig, error) {
 	tb.Helper()
 
-	ctx, pctx := newExpansionParsingContext(tb, config.DefaultStackFile)
+	ctx, pctx := newExpansionParsingContext(tb, venvtest.New(), config.DefaultStackFile)
 
 	return config.ReadStackConfigString(
 		ctx,
@@ -870,11 +871,12 @@ func parseStackErr(tb testing.TB, cfg string) error {
 
 func newExpansionParsingContext(
 	tb testing.TB,
+	v *venv.Venv,
 	configPath string,
 ) (context.Context, *config.ParsingContext) {
 	tb.Helper()
 
-	ctx, pctx := newTestParsingContext(tb, venvtest.NewOSWithEmptyEnv(), configPath)
+	ctx, pctx := newTestParsingContext(tb, v, configPath)
 	require.NoError(tb, pctx.Experiments.EnableExperiment(experiment.BlockIteration))
 
 	return ctx, pctx

--- a/pkg/config/external_test.go
+++ b/pkg/config/external_test.go
@@ -393,7 +393,7 @@ func TestExternalGetDefaultConfigPath(t *testing.T) {
 
 	// When given a non-existent directory, GetDefaultConfigPath returns a path
 	// ending with the default config file name.
-	result := config.GetDefaultConfigPath("/some/nonexistent/path")
+	result := config.GetDefaultConfigPath(venvtest.New().FS, "/some/nonexistent/path")
 	assert.Contains(t, result, "terragrunt.hcl")
 }
 

--- a/pkg/config/hclparse/expansion.go
+++ b/pkg/config/hclparse/expansion.go
@@ -38,8 +38,8 @@ const (
 const DefaultMaxInstances = 1_000_000
 
 type expandConfig struct {
-	skipLabelsOnError map[string]bool
-	maxInstances      int
+	skipLabels   map[string]struct{}
+	maxInstances int
 }
 
 // ExpandOption adjusts how [ExpandBlock] expands a block.
@@ -53,10 +53,12 @@ func WithMaxInstances(maxInstances int) ExpandOption {
 	}
 }
 
-// WithSkipLabelsOnError silently drops a block whose first label is in the set when its decode fails, instead of propagating the error. This lets callers skip blocks whose attributes are unresolvable because an autoinclude will replace them.
-func WithSkipLabelsOnError(labels map[string]bool) ExpandOption {
+// WithSkipLabels leaves blocks whose first label is in the set undecoded, so nothing inside
+// them is evaluated. A block declaring an expansion sub-block is decoded anyway. Expansion
+// splits one block into separately keyed instances, and a bare label does not name those.
+func WithSkipLabels(labels map[string]struct{}) ExpandOption {
 	return func(cfg *expandConfig) {
-		cfg.skipLabelsOnError = labels
+		cfg.skipLabels = labels
 	}
 }
 
@@ -124,31 +126,21 @@ func (file *File) ExpandBlocks(
 		opt(&cfg)
 	}
 
-	labels := labelFields(reflect.TypeOf(out).Elem())
-	labelNames := make([]string, 0, len(labels))
-
-	for _, label := range labels {
-		labelNames = append(labelNames, label.name)
-	}
-
-	content, _, diags := file.Body.PartialContent(&hcl.BodySchema{
-		Blocks: []hcl.BlockHeaderSchema{{Type: blockType, LabelNames: labelNames}},
-	})
-	if err := file.HandleDiagnostics(diags); err != nil {
+	content, err := file.blockContent(blockType, out)
+	if err != nil {
 		return nil, err
 	}
 
 	instances := make([]Instance, 0, len(content.Blocks))
 
 	for _, block := range content.Blocks {
-		expanded, err := ExpandBlock(block, out, ctx, opts...)
-		if err == nil {
-			instances = append(instances, expanded...)
+		if skipBlock(block, cfg.skipLabels) {
 			continue
 		}
 
-		// Drop blocks whose label matches the skip set on decode failure.
-		if cfg.skipLabelsOnError != nil && len(block.Labels) > 0 && cfg.skipLabelsOnError[block.Labels[0]] {
+		expanded, err := ExpandBlock(block, out, ctx, opts...)
+		if err == nil {
+			instances = append(instances, expanded...)
 			continue
 		}
 
@@ -163,6 +155,75 @@ func (file *File) ExpandBlocks(
 	}
 
 	return instances, nil
+}
+
+// UnexpandedLabels returns the first label of every blockType block in the file that declares
+// no expansion sub-block. Labels come off the block header, so a block whose body cannot be
+// evaluated still reports its label.
+//
+// [WithSkipLabels] also spares expanded blocks, so pairing the two never drops an expanded
+// block.
+func (file *File) UnexpandedLabels(blockType string, out any) (map[string]struct{}, error) {
+	content, err := file.blockContent(blockType, out)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := make(map[string]struct{}, len(content.Blocks))
+
+	for _, block := range content.Blocks {
+		if len(block.Labels) == 0 {
+			continue
+		}
+
+		expansion, err := expansionBlock(block)
+		if err != nil {
+			return nil, err
+		}
+
+		if expansion == nil {
+			labels[block.Labels[0]] = struct{}{}
+		}
+	}
+
+	return labels, nil
+}
+
+// blockContent returns the file's blockType blocks.
+func (file *File) blockContent(blockType string, out any) (*hcl.BodyContent, error) {
+	labels := labelFields(reflect.TypeOf(out).Elem())
+	labelNames := make([]string, 0, len(labels))
+
+	for _, label := range labels {
+		labelNames = append(labelNames, label.name)
+	}
+
+	content, _, diags := file.Body.PartialContent(&hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{{Type: blockType, LabelNames: labelNames}},
+	})
+	if err := file.HandleDiagnostics(diags); err != nil {
+		return nil, err
+	}
+
+	return content, nil
+}
+
+// skipBlock reports whether the caller named this block in [WithSkipLabels] and it can be left
+// undecoded without losing instances.
+func skipBlock(block *hcl.Block, skipLabels map[string]struct{}) bool {
+	if len(block.Labels) == 0 {
+		return false
+	}
+
+	if _, named := skipLabels[block.Labels[0]]; !named {
+		return false
+	}
+
+	expansion, err := expansionBlock(block)
+
+	// A sub-block that will not parse is a structural error. Keep the block so the decode
+	// below reports it.
+	return err == nil && expansion == nil
 }
 
 // ExpandBlock decodes block once per iteration element, returning one Instance per

--- a/pkg/config/hclparse/expansion_test.go
+++ b/pkg/config/hclparse/expansion_test.go
@@ -640,8 +640,9 @@ dependency "vpc" {
 	assert.Equal(t, "vpc", instances[0].Value.(*testBlock).Name)
 }
 
-// WithSkipLabelsOnError silently drops blocks whose label matches the skip set on decode failure.
-func TestExpandBlocksSkipLabelsOnError(t *testing.T) {
+// WithSkipLabels leaves a named block undecoded, so an unresolvable reference inside it never
+// gets evaluated.
+func TestExpandBlocksSkipLabels(t *testing.T) {
 	t.Parallel()
 
 	file, err := hclparse.NewParser().ParseFromString(`
@@ -655,14 +656,12 @@ dependency "vpc" {
 `, "terragrunt.hcl")
 	require.NoError(t, err)
 
-	// Without skip option, the broken block causes an error.
 	_, err = file.ExpandBlocks("dependency", new(testBlock), nil)
-	require.Error(t, err, "without skip option, decode must fail")
+	require.Error(t, err, "without the option, the unresolvable reference must fail the decode")
 
-	// With skip option for the broken label, it is silently dropped.
 	instances, err := file.ExpandBlocks(
 		"dependency", new(testBlock), nil,
-		hclparse.WithSkipLabelsOnError(map[string]bool{"broken": true}),
+		hclparse.WithSkipLabels(map[string]struct{}{"broken": {}}),
 	)
 	require.NoError(t, err)
 	require.Len(t, instances, 1)
@@ -670,7 +669,7 @@ dependency "vpc" {
 }
 
 // A block whose label is NOT in the skip set still fails.
-func TestExpandBlocksSkipLabelsOnErrorNonMatchingStillFails(t *testing.T) {
+func TestExpandBlocksSkipLabelsNonMatchingStillFails(t *testing.T) {
 	t.Parallel()
 
 	file, err := hclparse.NewParser().ParseFromString(`
@@ -686,9 +685,72 @@ dependency "vpc" {
 
 	_, err = file.ExpandBlocks(
 		"dependency", new(testBlock), nil,
-		hclparse.WithSkipLabelsOnError(map[string]bool{"other": true}),
+		hclparse.WithSkipLabels(map[string]struct{}{"other": {}}),
 	)
-	require.Error(t, err, "non-matching skip label must not suppress the error")
+	require.Error(t, err, "a label outside the skip set must still fail the decode")
+}
+
+// An expanded block is decoded even when its label is in the skip set. Its instances carry keys
+// the bare label cannot name.
+func TestExpandBlocksSkipLabelsKeepsExpandedBlock(t *testing.T) {
+	t.Parallel()
+
+	file, err := hclparse.NewParser().ParseFromString(`
+dependency "vpc" {
+  expansion {
+    for_each = local.services
+  }
+
+  path = "../vpc-${each.value}"
+}
+`, "terragrunt.hcl")
+	require.NoError(t, err)
+
+	evalCtx := &hcl.EvalContext{
+		Variables: map[string]cty.Value{
+			"local": cty.ObjectVal(map[string]cty.Value{
+				"services": cty.SetVal([]cty.Value{cty.StringVal("api"), cty.StringVal("web")}),
+			}),
+		},
+	}
+
+	instances, err := file.ExpandBlocks(
+		"dependency", new(testBlock), evalCtx,
+		hclparse.WithSkipLabels(map[string]struct{}{"vpc": {}}),
+	)
+	require.NoError(t, err)
+	require.Len(t, instances, 2)
+	assert.Equal(t, "../vpc-api", instances[0].Value.(*testBlock).Path)
+	assert.Equal(t, "../vpc-web", instances[1].Value.(*testBlock).Path)
+}
+
+// UnexpandedLabels reads labels off the block header, so a block whose body cannot be
+// evaluated still reports its label. An expanded block does not.
+func TestUnexpandedLabels(t *testing.T) {
+	t.Parallel()
+
+	file, err := hclparse.NewParser().ParseFromString(`
+dependency "broken" {
+  path = local.undefined
+}
+
+dependency "vpc" {
+  path = "../vpc"
+}
+
+dependency "shard" {
+  expansion {
+    for_each = local.services
+  }
+
+  path = "../shard-${each.value}"
+}
+`, "terragrunt.hcl")
+	require.NoError(t, err)
+
+	labels, err := file.UnexpandedLabels("dependency", new(testBlock))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]struct{}{"broken": {}, "vpc": {}}, labels)
 }
 
 func expand(

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -84,7 +84,7 @@ func parseIncludedConfig(
 	// NOTE: To make the logic easier to implement, we implement the inverse here, where we check whether the included
 	// config has a dependency block, and if we are in the middle of a partial parse, we perform a partial parse of the
 	// included config.
-	hasDependency, err := configFileHasDependencyBlock(includePath)
+	hasDependency, err := configFileHasDependencyBlock(pctx.Venv.FS, includePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -247,7 +247,7 @@ func resolveStackAutoIncludes(
 	}
 
 	// stackSrcBytes is read separately for the autoinclude parser, which slices expression byte ranges from the original file when generating terragrunt.autoinclude.hcl.
-	stackSrcBytes, err := os.ReadFile(stackFilePath)
+	stackSrcBytes, err := vfs.ReadFile(pctx.Venv.FS, stackFilePath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read stack file bytes %s: %w", stackFilePath, err)
 	}
@@ -598,6 +598,7 @@ func resolveDestPath(cmp *componentToGenerate, opts *generateOpts) (string, erro
 // validateGeneratedComponent validates the generated component directory contains the expected config file.
 func validateGeneratedComponent(
 	l log.Logger,
+	fsys vfs.FS,
 	cmp *componentToGenerate,
 	opts *generateOpts,
 	dest string,
@@ -625,7 +626,7 @@ func validateGeneratedComponent(
 		expectedFile = DefaultStackFile
 	}
 
-	if err := validateTargetDir(kindStr, cmp.name, dest, expectedFile); err != nil {
+	if err := validateTargetDir(fsys, kindStr, cmp.name, dest, expectedFile); err != nil {
 		if opts.noStackValidate {
 			l.Warnf(
 				"Suppressing validation error for %s %s at path %s: expected %s to generate with %s file at root of generated directory.",
@@ -735,7 +736,7 @@ func generateComponent(
 		}
 	}
 
-	if err := validateGeneratedComponent(l, cmp, opts, dest); err != nil {
+	if err := validateGeneratedComponent(l, v.FS, cmp, opts, dest); err != nil {
 		return err
 	}
 
@@ -785,7 +786,7 @@ func fetchComponentSource(
 			)
 		}
 
-		if err := os.MkdirAll(dest, os.ModePerm); err != nil {
+		if err := v.FS.MkdirAll(dest, os.ModePerm); err != nil {
 			return fmt.Errorf("failed to create directory %s for %s %w", dest, cmp.name, err)
 		}
 
@@ -1851,11 +1852,11 @@ func processLocals(
 	return nil
 }
 
-// validateTargetDir target destination directory.
-func validateTargetDir(kind, name, destDir, expectedFile string) error {
+// validateTargetDir errors unless destDir holds expectedFile as a regular file.
+func validateTargetDir(fsys vfs.FS, kind, name, destDir, expectedFile string) error {
 	expectedPath := filepath.Join(destDir, expectedFile)
 
-	info, err := os.Stat(expectedPath)
+	info, err := fsys.Stat(expectedPath)
 	if err != nil {
 		return fmt.Errorf(
 			"%s '%s': expected file '%s' not found in target directory '%s': %w",


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adjusts the logic in #6711 so that it uses the autoinclude decode order instead of ignoring errors.

Also migrates a bunch of stuff over to vfs.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
