### PR TITLE
docs: Clean-up for v1.1.4 changelog

### DIFF
--- a/docs/src/data/changelog/v1.1.4/cas-depth-query-param.mdx
+++ b/docs/src/data/changelog/v1.1.4/cas-depth-query-param.mdx
@@ -3,8 +3,8 @@ version: "v1.1.4"
 category: "bug-fixes"
 ---
 
-#### Fixed Git sources that combine a `depth` query parameter with a `ref`
+#### Fixed Git sources with a `depth` query parameter
 
-A `terraform.source` (or stack source) URL carrying both the go-getter `depth` query parameter and a `ref`, such as `...vpc.git?depth=1&ref=v5.21.0`, failed to download since v1.1.0, when the CAS became the default path for Git sources. Terragrunt lifted `ref` out of the URL but left `depth` in place, so `git` received `...vpc.git?depth=1` and rejected it as an invalid repository name.
+A `terraform.source` (or stack source) URL carrying the go-getter `depth` query parameter, such as `...vpc.git?depth=1&ref=v5.21.0`, failed to download since v1.1.0, when the CAS became the default path for Git sources. Terragrunt lifted `ref` out of the URL but left `depth` in place, so `git` received `...vpc.git?depth=1` and rejected it as an invalid repository name. A URL with `depth` and no `ref` hit the same failure.
 
-Terragrunt now strips `depth` alongside `ref` before invoking `git`, so these sources download again. The clone depth itself always comes from [`--cas-clone-depth`](/reference/cli/commands/run#cas-clone-depth), which defaults to `1`; a `depth` on a source URL is never applied.
+Terragrunt now strips `depth`, with or without a `ref`, before invoking `git`, so these sources download again. The clone depth itself always comes from [`--cas-clone-depth`](/reference/cli/commands/run#cas-clone-depth), which defaults to `1`; a `depth` on a source URL is never applied for CAS clones.

--- a/docs/src/data/changelog/v1.1.4/cas-local-source-cache-dirs.mdx
+++ b/docs/src/data/changelog/v1.1.4/cas-local-source-cache-dirs.mdx
@@ -3,8 +3,10 @@ version: "v1.1.4"
 category: "bug-fixes"
 ---
 
-#### CAS no longer falls back on sources that have been initialized
+#### CAS handles local sources that have already been initialized
 
-With CAS enabled, reading a local source that had already been initialized failed and fell back to the slower standard copy. Generating a stack from such a unit logged `CAS processing failed ... source escapes repository root`. Provider caching, whether through the [provider cache server](/features/caching/provider-cache-server) or the [automatic provider cache dir](/features/caching/auto-provider-cache-dir), leaves the plugins under `.terraform` pointing into a shared cache outside the source, and CAS read those links as the source reaching outside itself.
+With CAS enabled, reading a local source that had already been initialized failed and fell back to the slower standard copy. Generating a stack from such a unit logged `CAS processing failed ... source escapes repository root`.
 
-CAS now leaves `.terraform` and `.terragrunt-cache` out of local sources, keeping `.terraform.lock.hcl` and everything else. Both directories hold working state that OpenTofu, Terraform, and Terragrunt rebuild on demand, so units and stacks stop being handed a stale copy of either, and running `tofu init` in a source directory stops changing the CAS key of source that hasn't changed.
+Provider caching was the cause. Both the [Provider Cache Server](/features/caching/provider-cache-server) and the [Automatic Provider Cache Dir](/features/caching/auto-provider-cache-dir) leave the plugins under `.terraform` pointing into a shared cache outside the source. CAS read those links as the source reaching outside itself and refused to copy the link for safety.
+
+CAS now leaves `.terraform` and `.terragrunt-cache` out of local sources, keeping `.terraform.lock.hcl` and everything else. OpenTofu, Terraform, and Terragrunt rebuild both directories on demand, so units and stacks no longer receive a stale copy of either. Running `tofu init` in a source directory no longer changes that source's CAS key.

--- a/docs/src/data/changelog/v1.1.4/extreme-number-literals.mdx
+++ b/docs/src/data/changelog/v1.1.4/extreme-number-literals.mdx
@@ -5,7 +5,7 @@ category: "bug-fixes"
 
 #### Numbers with extreme exponents fail fast instead of stalling
 
-A number literal such as `9E9999999` in `inputs`, `locals`, or a `dependency` block's `mock_outputs` used to cost minutes of CPU on a single unit. Written out in decimal that number is ten million digits long, and `terragrunt render --format=json` spent over a minute producing it before failing with a ten megabyte error message.
+A number literal such as `9E9999999` in `inputs`, `locals`, or a `dependency` block's `mock_outputs` used to cost over a minute of CPU on a single unit. Written out in decimal that number is ten million digits long, and `terragrunt render --format=json` produced every digit before failing with a ten megabyte error message.
 
 Terragrunt now rejects numbers larger than `1e4096`, and non-zero numbers smaller than `1e-4096`, before it tries to write them out, and names the attribute holding the value:
 

--- a/docs/src/data/changelog/v1.1.4/generated-cli-config-credentials.mdx
+++ b/docs/src/data/changelog/v1.1.4/generated-cli-config-credentials.mdx
@@ -10,3 +10,5 @@ When the [Provider Cache Server](/features/caching/provider-cache-server) is ena
 Those copies were never read. For a routed registry, Terragrunt sets the matching `TF_TOKEN_<hostname>` environment variable, which takes precedence over a `credentials` block, and the cache server presents your real credentials when it contacts the registry on your behalf. The generated file now leaves the block out for those registries, so your token stays in the CLI config you put it in instead of being duplicated somewhere it had no effect.
 
 Credentials for hosts the cache server does not route are unchanged, since OpenTofu/Terraform contacts those directly and still reads them from the generated config.
+
+Upgrading does not rewrite the files an earlier version already generated. Each is named `.terraformrc` and sits in a unit's working directory, which is under `.terragrunt-cache` for remote sources. Delete those files, or clear the cache, to get the copied credentials off disk.

--- a/docs/src/data/changelog/v1.1.4/generated-file-permissions.mdx
+++ b/docs/src/data/changelog/v1.1.4/generated-file-permissions.mdx
@@ -1,0 +1,14 @@
+---
+version: "v1.1.4"
+category: "bug-fixes"
+---
+
+#### Generated files are readable only by the user who ran Terragrunt
+
+Terragrunt created several files and directories that other users on the same machine could read:
+
+- The CLI config Terragrunt writes for OpenTofu/Terraform when the [Provider Cache Server](/features/caching/provider-cache-server) is enabled, and the directory holding it.
+- The JSON plan files written to [`--json-out-dir`](/reference/cli/commands/run#json-out-dir), and that directory.
+- The directories holding the plan files written to [`--out-dir`](/reference/cli/commands/run#out-dir).
+
+Terragrunt now creates those files as `0600` and those directories as `0700`.

--- a/docs/src/data/changelog/v1.1.4/opentelemetry-1-45-0.mdx
+++ b/docs/src/data/changelog/v1.1.4/opentelemetry-1-45-0.mdx
@@ -7,4 +7,4 @@ category: "process-updates"
 
 Terragrunt's OpenTelemetry tracing and metrics dependencies have been updated from `v1.44.0` to `v1.45.0`. The logging packages and exporters have also been updated to their compatible releases, and Terragrunt now uses the `v1.43.0` semantic conventions.
 
-Telemetry behavior remains unchanged, with additional coverage for collection, context propagation, exporter output, errors, and shutdown.
+Telemetry behavior is unchanged.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Cleans up changelog for v1.1.4

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated provider cache configuration and plan files now use secure permissions, with restricted access for their containing directories.
  * Extreme numeric values are rejected before serialization, with the relevant attribute identified.
  * Git and stack source depth handling is now documented, including safer clone-depth behavior.

* **Documentation**
  * Clarified local-source cache behavior and credential cleanup requirements.
  * Updated telemetry documentation to reflect unchanged behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->