### PR TITLE
ci(coverage): added support for test suppressions in weekly test report

### DIFF
--- a/.github/scripts/coverage/coverage-report.sh
+++ b/.github/scripts/coverage/coverage-report.sh
@@ -16,7 +16,8 @@ set -euo pipefail
 #   timing <events.ndjson> <out.json>  Roll `go test -json` events into per-package /
 #                                    per-test wall-time JSON.
 #   compare-coverage <cur> <prev> [out]  Diff two coverage summaries -> report JSON + HTML.
-#   compare-timing <cur> <prev> [out]    Diff two timing summaries -> report JSON.
+#   compare-timing <cur> <prev> [out]    Diff two timing summaries -> report JSON;
+#                                    entries in report-suppressions.json are omitted.
 #   render <cov-report> <timing-report>  Render the combined Markdown report to
 #                                    $GITHUB_STEP_SUMMARY (or stdout).
 #   notify <cov-report> <timing-report>  Post the combined report to Slack.
@@ -306,6 +307,31 @@ count_lines() {
 	done <<<"$list"
 
 	echo "$count"
+}
+
+# Read report suppressions as normalized JSON
+read_report_suppressions() {
+	local suppressions_file="${REPORT_SUPPRESSIONS_FILE:-${SELF%/*}/report-suppressions.json}"
+
+	if [[ ! -f "$suppressions_file" ]]; then
+		echo '{"packages":[],"tests":[]}'
+
+		return 0
+	fi
+
+	jq '
+		def string_array($name):
+			(.[$name] // []) as $values
+			| if ($values | type) != "array" or any($values[]; type != "string")
+				then error($name + " must be an array of strings")
+				else ($values | unique)
+			end;
+
+		{
+			packages: string_array("packages"),
+			tests: string_array("tests")
+		}
+	' "$suppressions_file"
 }
 
 # Replay the captured output of each selected "package<TAB>test" key
@@ -675,21 +701,35 @@ cmd_compare_timing() {
 		exit 1
 	fi
 
+	local suppressions
+	suppressions=$(read_report_suppressions)
+
 	if [[ ! -s "$previous" ]]; then
 		echo "No previous timing data found - emitting current-only report."
-		jq '{
+		jq --argjson suppressions "$suppressions" '
+		def matches_suppression($name; $entries):
+			any($entries[];
+				. as $entry
+				| $name == $entry or ($name | startswith($entry + "/"))
+			);
+		def without_suppressed_tests:
+			with_entries(select(.key as $name | matches_suppression($name; $suppressions.tests) | not));
+
+		{
 			baseline: true,
 			current_total_sec: ((.total_sec * 10 | round) / 10),
 			previous_total_sec: null,
 			total_delta_sec: null,
 			slow_packages: (
-				.packages | to_entries | sort_by(-.value.wall_sec) | .[:5] | map({
+				.packages | to_entries
+				| map(select(.key as $name | matches_suppression($name; $suppressions.packages) | not))
+				| sort_by(-.value.wall_sec) | .[:5] | map({
 					package: .key,
 					current_sec: .value.wall_sec,
 					previous_sec: null,
 					delta_sec: null,
 					top_tests: (
-						.value.tests | to_entries | sort_by(-.value) | .[:5] | map({
+						.value.tests | without_suppressed_tests | to_entries | sort_by(-.value) | .[:5] | map({
 							name: .key,
 							current_sec: .value,
 							previous_sec: null,
@@ -704,9 +744,18 @@ cmd_compare_timing() {
 	fi
 
 	jq -n \
+		--argjson suppressions "$suppressions" \
 		--slurpfile curr "$current" \
 		--slurpfile prev "$previous" \
 		'
+		def matches_suppression($name; $entries):
+			any($entries[];
+				. as $entry
+				| $name == $entry or ($name | startswith($entry + "/"))
+			);
+		def without_suppressed_tests:
+			with_entries(select(.key as $name | matches_suppression($name; $suppressions.tests) | not));
+
 		($curr[0]) as $c |
 		($prev[0]) as $p |
 		($c.packages) as $cp |
@@ -727,12 +776,16 @@ cmd_compare_timing() {
 					then (($cs - $ps) * 10 | round / 10)
 					else null end
 				),
-				current_tests: ($cp[$pkg].tests // {}),
-				previous_tests: ($pp[$pkg].tests // {})
+				current_tests: (($cp[$pkg].tests // {}) | without_suppressed_tests),
+				previous_tests: (($pp[$pkg].tests // {}) | without_suppressed_tests)
 			}
 		)) as $pkg_diff |
 
-		([$pkg_diff[] | select(.current_sec != null)] | sort_by(-.current_sec) | .[:5] | map(
+		($pkg_diff
+		 | map(select(.package as $name | matches_suppression($name; $suppressions.packages) | not))
+		) as $visible_pkg_diff |
+
+		([$visible_pkg_diff[] | select(.current_sec != null)] | sort_by(-.current_sec) | .[:5] | map(
 			. as $row |
 			{
 				package: $row.package,
@@ -757,7 +810,7 @@ cmd_compare_timing() {
 			}
 		)) as $slow_packages |
 
-		([$pkg_diff[] | select(.delta_sec != null and .delta_sec > 0)]
+		([$visible_pkg_diff[] | select(.delta_sec != null and .delta_sec > 0)]
 		 | sort_by(-.delta_sec) | .[:5] | map({
 			package: .package,
 			current_sec: .current_sec,

--- a/.github/scripts/coverage/report-suppressions.json
+++ b/.github/scripts/coverage/report-suppressions.json
@@ -1,0 +1,9 @@
+{
+  "packages": [],
+  "tests": [
+    "TestCAS_CloneRepoWithNestedSubmodules",
+    "TestExitCodeUnix",
+    "TestFileManifestCleanRejectsTooManyReferencedManifests",
+    "TestNewSignalsForwarderWaitUnix"
+  ]
+}

--- a/.github/scripts/coverage/report-suppressions.json
+++ b/.github/scripts/coverage/report-suppressions.json
@@ -1,9 +1,6 @@
 {
   "packages": [],
   "tests": [
-    "TestCAS_CloneRepoWithNestedSubmodules",
-    "TestExitCodeUnix",
-    "TestFileManifestCleanRejectsTooManyReferencedManifests",
-    "TestNewSignalsForwarderWaitUnix"
+    "TestCAS_CloneRepoWithNestedSubmodules"
   ]
 }

--- a/.github/scripts/coverage/tests/timing.bats
+++ b/.github/scripts/coverage/tests/timing.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+
+setup() {
+	SCRIPT="${BATS_TEST_DIRNAME}/../coverage-report.sh"
+	CURRENT="${BATS_TEST_TMPDIR}/current.json"
+	PREVIOUS="${BATS_TEST_TMPDIR}/previous.json"
+	REPORT="${BATS_TEST_TMPDIR}/report.json"
+	SUPPRESSIONS="${BATS_TEST_TMPDIR}/report-suppressions.json"
+
+	cat >"$CURRENT" <<'EOF'
+{
+  "total_sec": 50,
+  "packages": {
+    "example.com/a": {
+      "wall_sec": 10,
+      "tests": {
+        "TestCAS_CloneRepoWithNestedSubmodules": 9,
+        "TestCAS_CloneRepoWithNestedSubmodules/child": 8,
+        "TestCAS_CloneRepoWithNestedSubmodulesSlow": 7,
+        "TestOther": 6
+      }
+    },
+    "example.com/ignored": {
+      "wall_sec": 20,
+      "tests": {
+        "TestIgnored": 19
+      }
+    },
+    "example.com/ignored/child": {
+      "wall_sec": 18,
+      "tests": {
+        "TestIgnoredChild": 17
+      }
+    }
+  }
+}
+EOF
+
+	cat >"$PREVIOUS" <<'EOF'
+{
+  "total_sec": 35,
+  "packages": {
+    "example.com/a": {
+      "wall_sec": 8,
+      "tests": {
+        "TestCAS_CloneRepoWithNestedSubmodules": 7,
+        "TestCAS_CloneRepoWithNestedSubmodules/child": 6,
+        "TestCAS_CloneRepoWithNestedSubmodulesSlow": 5,
+        "TestOther": 4
+      }
+    },
+    "example.com/ignored": {
+      "wall_sec": 15,
+      "tests": {
+        "TestIgnored": 14
+      }
+    },
+    "example.com/ignored/child": {
+      "wall_sec": 12,
+      "tests": {
+        "TestIgnoredChild": 11
+      }
+    }
+  }
+}
+EOF
+}
+
+@test "suppresses configured tests and packages from timing diffs" {
+	cat >"$SUPPRESSIONS" <<'EOF'
+{
+  "tests": ["TestCAS_CloneRepoWithNestedSubmodules"],
+  "packages": ["example.com/ignored"]
+}
+EOF
+
+	REPORT_SUPPRESSIONS_FILE="$SUPPRESSIONS" run "$SCRIPT" compare-timing "$CURRENT" "$PREVIOUS" "$REPORT"
+	[ "$status" -eq 0 ]
+
+	run jq -e '.slow_packages | map(.package) == ["example.com/a"]' "$REPORT"
+	[ "$status" -eq 0 ]
+
+	run jq -e '.slow_packages[0].top_tests | map(.name) == [
+    "TestCAS_CloneRepoWithNestedSubmodulesSlow",
+    "TestOther"
+  ]' "$REPORT"
+	[ "$status" -eq 0 ]
+
+	run jq -e '.top_regressions | map(.package) == ["example.com/a"]' "$REPORT"
+	[ "$status" -eq 0 ]
+
+	run jq -r '[.current_total_sec, .previous_total_sec, .slow_packages[0].current_sec] | @tsv' "$REPORT"
+	[ "$output" = $'50\t35\t10' ]
+}
+
+@test "uses no report suppressions when the config is missing" {
+	REPORT_SUPPRESSIONS_FILE="${BATS_TEST_TMPDIR}/missing.json" run "$SCRIPT" compare-timing "$CURRENT" "$PREVIOUS" "$REPORT"
+	[ "$status" -eq 0 ]
+
+	run jq -r '.slow_packages[].package' "$REPORT"
+	[[ "$output" == *"example.com/ignored"* ]]
+
+	run jq -r '.slow_packages[].top_tests[].name' "$REPORT"
+	[[ "$output" == *"TestCAS_CloneRepoWithNestedSubmodules"* ]]
+}
+
+@test "uses the repository report suppression config by default" {
+	run "$SCRIPT" compare-timing "$CURRENT" "$PREVIOUS" "$REPORT"
+	[ "$status" -eq 0 ]
+
+	run jq -e '[.slow_packages[].top_tests[].name] | index("TestCAS_CloneRepoWithNestedSubmodules") == null' "$REPORT"
+	[ "$status" -eq 0 ]
+
+	run jq -e '.slow_packages | map(.package) | index("example.com/ignored") != null' "$REPORT"
+	[ "$status" -eq 0 ]
+}
+
+@test "suppresses configured tests and packages from baseline reports" {
+	cat >"$SUPPRESSIONS" <<'EOF'
+{
+  "tests": ["TestCAS_CloneRepoWithNestedSubmodules"],
+  "packages": ["example.com/ignored"]
+}
+EOF
+
+	REPORT_SUPPRESSIONS_FILE="$SUPPRESSIONS" run "$SCRIPT" compare-timing "$CURRENT" "${BATS_TEST_TMPDIR}/missing-previous.json" "$REPORT"
+	[ "$status" -eq 0 ]
+
+	run jq -e '.slow_packages | map(.package) == ["example.com/a"]' "$REPORT"
+	[ "$status" -eq 0 ]
+
+	run jq -e '.slow_packages[0].top_tests | map(.name) == [
+    "TestCAS_CloneRepoWithNestedSubmodulesSlow",
+    "TestOther"
+  ]' "$REPORT"
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for suppressing selected packages and tests from coverage timing comparisons.
  - Added a configurable suppression list with sensible defaults when no configuration is provided.
  - Updated comparison help text to explain suppression behavior.

- **Bug Fixes**
  - Ensured suppression filtering works consistently with and without a previous baseline report.

- **Tests**
  - Added coverage tests for configured, default, missing, and baseline-unavailable suppression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->