### PR TITLE
fix: Updating `render --write` file permissions

### DIFF
--- a/docs/src/data/changelog/v1.1.4/generated-file-permissions.mdx
+++ b/docs/src/data/changelog/v1.1.4/generated-file-permissions.mdx
@@ -10,5 +10,6 @@ Terragrunt created several files and directories that other users on the same ma
 - The CLI config Terragrunt writes for OpenTofu/Terraform when the [Provider Cache Server](/features/caching/provider-cache-server) is enabled, and the directory holding it.
 - The JSON plan files written to [`--json-out-dir`](/reference/cli/commands/run#json-out-dir), and that directory.
 - The directories holding the plan files written to [`--out-dir`](/reference/cli/commands/run#out-dir).
+- The config written by [`render --write`](/reference/cli/commands/render#write), which holds the resolved values of `inputs`, `locals`, and `dependency` outputs.
 
 Terragrunt now creates those files as `0600` and those directories as `0700`.

--- a/internal/cli/commands/render/render.go
+++ b/internal/cli/commands/render/render.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 
 	"errors"
@@ -185,8 +186,13 @@ func writeRendered(l log.Logger, fsys vfs.FS, opts *Options, data []byte) error 
 
 	l.Debugf("Rendering config %s to %s", opts.TerragruntConfigPath, outPath)
 
-	const ownerWriteGlobalReadPerms = 0644
-	if err := vfs.WriteFile(fsys, outPath, data, ownerWriteGlobalReadPerms); err != nil {
+	if err := fsys.Remove(outPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+
+	const ownerReadWritePerms = 0o600
+
+	if err := vfs.WriteFile(fsys, outPath, data, ownerReadWritePerms); err != nil {
 		return err
 	}
 

--- a/internal/cli/commands/render/render_test.go
+++ b/internal/cli/commands/render/render_test.go
@@ -164,6 +164,82 @@ func TestRenderWriteWithoutOutputPath(t *testing.T) {
 	}
 }
 
+func TestRenderWriteFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("Windows does not enforce POSIX file permissions")
+	}
+
+	testCases := []struct {
+		name   string
+		format string
+	}{
+		{
+			name:   "hcl",
+			format: render.FormatHCL,
+		},
+		{
+			name:   "json",
+			format: render.FormatJSON,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			outputPath := filepath.Join(helpers.TmpDirWOSymlinks(t), "rendered")
+
+			assert.Equal(t, os.FileMode(0600), renderToFilePerm(t, tc.format, outputPath))
+		})
+	}
+}
+
+func TestRenderWriteReplacesLooserPermissions(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("Windows does not enforce POSIX file permissions")
+	}
+
+	outputPath := filepath.Join(helpers.TmpDirWOSymlinks(t), "rendered")
+	require.NoError(t, os.WriteFile(outputPath, []byte("stale"), 0644))
+
+	assert.Equal(t, os.FileMode(0600), renderToFilePerm(t, render.FormatJSON, outputPath))
+
+	content, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	var result map[string]any
+
+	require.NoError(t, json.Unmarshal(content, &result))
+	validateRenderedJSON(t, result, false)
+}
+
+// renderToFilePerm renders a config and returns the permissions of the file it writes.
+func renderToFilePerm(t *testing.T, format, outputPath string) os.FileMode {
+	t.Helper()
+
+	opts, _ := setupTest(t, testTerragruntConfigFixture)
+	opts.Format = format
+	opts.Write = true
+	opts.OutputPath = outputPath
+
+	err := render.Run(
+		t.Context(),
+		logger.CreateLogger(),
+		venvtest.NewOSWithEmptyEnv().WithWriter(io.Discard),
+		opts,
+	)
+	require.NoError(t, err)
+
+	info, err := os.Stat(outputPath)
+	require.NoError(t, err)
+
+	return info.Mode().Perm()
+}
+
 func TestRenderJSON_InvalidFormat(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Updates the file permissions used for files generated by `render --write`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Rendered configuration files are now restricted to the invoking user, with owner-only read and write access.
  * Existing files receive the same secure permissions when regenerated.

* **Documentation**
  * Added documentation describing the updated permissions for generated configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->