### PR TITLE
feat: Adding `tg-login` experiment

### DIFF
--- a/docs/src/data/changelog/v1.1.5/tg-login.mdx
+++ b/docs/src/data/changelog/v1.1.5/tg-login.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.5"
+category: "experiments-added"
+---
+
+#### `tg-login` reserved for signing in to the Gruntwork Developer Portal
+
+The `tg-login` experiment has been added as the gate for `terragrunt login`, a command for signing in to the Gruntwork Developer Portal. Once it lands, signing in lets `terragrunt catalog` read the repositories your organization selected in the portal rather than a `catalog` block you maintain yourself.
+
+In this release the flag is reserved only. Enabling it has no effect, and no command reads it.
+
+See the [experiment documentation](/reference/experiments/active#tg-login) for what is planned and what has to land before it stabilizes.

--- a/docs/src/data/experiments/tg-login.mdx
+++ b/docs/src/data/experiments/tg-login.mdx
@@ -1,0 +1,40 @@
+---
+name: tg-login
+since: "1.1.5"
+---
+
+Signing in to the Gruntwork Developer Portal from the CLI, so an admin can define a catalog in the portal instead of local HCL.
+
+### `tg-login` - What it does
+
+Nothing yet. The flag is reserved, and no command reads it.
+
+Once the command lands, `terragrunt login` will sign you in through your browser using the OAuth 2.0 Device Authorization Grant ([RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628)). The CLI shows a short code, your browser opens to a page where you confirm that code and grant access, and the CLI receives a token scoped to your organization. `terragrunt catalog` then reads the repositories an admin selected in the portal, so there is no `catalog` block to write or maintain.
+
+A `catalog` block in your configuration keeps working whether or not you are signed in.
+
+### `tg-login` - How to enable it
+
+```bash
+# Via CLI flag
+terragrunt --experiment tg-login login
+
+# Via environment variable
+export TG_EXPERIMENT=tg-login
+terragrunt login
+```
+
+`terragrunt login` does not exist yet, so both forms currently set a flag that nothing reads.
+
+### `tg-login` - Criteria for stabilization
+
+To transition the `tg-login` feature to a stable release, the following must be addressed, at a minimum:
+
+- [ ] `terragrunt login` completes the device flow and reports the signed-in user and organization.
+- [ ] On a headless or SSH session, the CLI prints the URL and code to open on another device, and login still completes.
+- [ ] The CLI stores the token so it survives between commands and expires on its own.
+- [ ] `terragrunt catalog` browses and scaffolds from the portal-defined catalog as it does from a local one.
+- [ ] A user who is not signed in still gets a catalog from local configuration.
+- [ ] A user with no catalog configured anywhere gets guidance on setting one up.
+- [ ] Test coverage for login and catalog that does not need a live portal.
+- [ ] Documentation for login and catalog setup.

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -111,6 +111,11 @@ const (
 	// OptionalDependencyOutputs gates the --no-dependency-outputs flag that skips
 	// all dependency output resolution during a run.
 	OptionalDependencyOutputs = "optional-dependency-outputs"
+	// TGLogin reserves the experiment flag for signing in to the Gruntwork
+	// Developer Portal from the CLI, so an admin can define a catalog in the
+	// portal instead of local HCL. Nothing is gated on it yet; the login
+	// command and the portal-defined catalog land in follow-up PRs.
+	TGLogin = "tg-login"
 )
 
 const (
@@ -228,6 +233,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: OptionalDependencyOutputs,
+		},
+		{
+			Name: TGLogin,
 		},
 	}
 }

--- a/internal/portal/deviceauth.go
+++ b/internal/portal/deviceauth.go
@@ -1,0 +1,207 @@
+package portal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+)
+
+const (
+	deviceAuthorizationPath = "/api/v1/oauth/device/authorize"
+
+	formContentType = "application/x-www-form-urlencoded"
+	jsonContentType = "application/json"
+
+	// defaultPollInterval is the wait RFC 8628 §3.2 assigns a response that
+	// names no interval of its own.
+	defaultPollInterval = 5 * time.Second
+
+	// maxResponseBytes caps what is read from the portal, so a response that
+	// never ends cannot hold a login open indefinitely.
+	maxResponseBytes = 1 << 20
+)
+
+// DeviceAuthorization is the login request the portal created, waiting for the
+// user to approve it in a browser (RFC 8628 §3.2).
+type DeviceAuthorization struct {
+	DeviceCode              Secret
+	UserCode                string
+	VerificationURI         string
+	VerificationURIComplete string
+	ExpiresIn               time.Duration
+	Interval                time.Duration
+}
+
+// deviceAuthorizationBody is the success shape of RFC 8628 §3.2.
+type deviceAuthorizationBody struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int64  `json:"expires_in"`
+	Interval                int64  `json:"interval"`
+}
+
+// AuthorizeDevice asks the portal at baseURL to create a login request the user
+// can approve in a browser (RFC 8628 §3.1). A portal that refuses answers with
+// an [Error] carrying the [ErrorCode] it named.
+func AuthorizeDevice(
+	ctx context.Context,
+	l log.Logger,
+	c vhttp.Client,
+	baseURL string,
+) (*DeviceAuthorization, error) {
+	endpoint, err := url.JoinPath(baseURL, deviceAuthorizationPath)
+	if err != nil {
+		return nil, fmt.Errorf("building the portal device authorization URL from %q: %w", baseURL, err)
+	}
+
+	form := url.Values{
+		"client_id": {ClientID},
+		"scope":     {ScopeCatalogRead},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("building the portal device authorization request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", formContentType)
+	req.Header.Set("Accept", jsonContentType)
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("requesting device authorization from the portal: %w", err)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			l.Warnf("Error closing response body: %v", err)
+		}
+	}()
+
+	body := io.LimitReader(resp.Body, maxResponseBytes)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, newError(resp, body)
+	}
+
+	return parseDeviceAuthorization(body)
+}
+
+// parseDeviceAuthorization reads a device authorization the portal reported as
+// successful. Every field login goes on to use is required here, so a response
+// missing one fails now rather than as an empty prompt or an unexchangeable
+// code later.
+func parseDeviceAuthorization(r io.Reader) (*DeviceAuthorization, error) {
+	body := &bodyReader{r: r}
+
+	var raw json.RawMessage
+	if err := json.NewDecoder(body).Decode(&raw); err != nil {
+		return nil, body.wrap(err)
+	}
+
+	if raw[0] != '{' {
+		return nil, ErrResponseNotObject
+	}
+
+	var parsed deviceAuthorizationBody
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrMalformedResponse, err)
+	}
+
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "device_code", value: parsed.DeviceCode},
+		{name: "user_code", value: parsed.UserCode},
+		{name: "verification_uri", value: parsed.VerificationURI},
+	} {
+		if field.value == "" {
+			return nil, &MissingFieldError{Field: field.name}
+		}
+	}
+
+	if parsed.ExpiresIn <= 0 {
+		return nil, fmt.Errorf("%w: unusable expires_in of %d", ErrMalformedResponse, parsed.ExpiresIn)
+	}
+
+	if err := checkBrowsable(parsed.VerificationURI); err != nil {
+		return nil, err
+	}
+
+	// RFC 8628 §3.2 makes the pre-filled URL optional, so its absence is not a
+	// failure.
+	if parsed.VerificationURIComplete != "" {
+		if err := checkBrowsable(parsed.VerificationURIComplete); err != nil {
+			return nil, err
+		}
+	}
+
+	interval := time.Duration(parsed.Interval) * time.Second
+	if interval <= 0 {
+		interval = defaultPollInterval
+	}
+
+	return &DeviceAuthorization{
+		DeviceCode:              Secret(parsed.DeviceCode),
+		UserCode:                parsed.UserCode,
+		VerificationURI:         parsed.VerificationURI,
+		VerificationURIComplete: parsed.VerificationURIComplete,
+		ExpiresIn:               time.Duration(parsed.ExpiresIn) * time.Second,
+		Interval:                interval,
+	}, nil
+}
+
+// bodyReader records the last transport failure, so a connection that drops
+// partway through is not reported as a response the portal got wrong. The
+// decoder sees a truncated document either way and cannot tell the two apart.
+type bodyReader struct {
+	r       io.Reader
+	readErr error
+}
+
+func (b *bodyReader) Read(p []byte) (int, error) {
+	n, err := b.r.Read(p)
+	if err != nil && !errors.Is(err, io.EOF) {
+		b.readErr = err
+	}
+
+	return n, err
+}
+
+// wrap reports a decode failure as the transport failure behind it, when there
+// was one.
+func (b *bodyReader) wrap(err error) error {
+	if b.readErr != nil {
+		return fmt.Errorf("reading the portal response: %w", b.readErr)
+	}
+
+	return fmt.Errorf("%w: %w", ErrMalformedResponse, err)
+}
+
+// checkBrowsable rejects a verification URL a browser must not open. Login
+// opens these directly, so a file: or javascript: scheme would turn a
+// compromised or misconfigured portal into local code execution.
+func checkBrowsable(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("%w: unparseable verification URL %q: %w", ErrMalformedResponse, rawURL, err)
+	}
+
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return fmt.Errorf("%w: verification URL %q is not an HTTP URL", ErrMalformedResponse, rawURL)
+	}
+
+	return nil
+}

--- a/internal/portal/deviceauth_test.go
+++ b/internal/portal/deviceauth_test.go
@@ -1,0 +1,449 @@
+package portal_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/portal"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const authorizationBody = `{
+	"device_code": "fake-device-code",
+	"user_code": "FAKE-CODE",
+	"verification_uri": "https://portal.example.com/auth/device",
+	"verification_uri_complete": "https://portal.example.com/auth/device?user_code=FAKE-CODE",
+	"expires_in": 600,
+	"interval": 5
+}`
+
+// respondJSON builds a client that answers every request with status and body,
+// recording the request it answered.
+func respondJSON(recorded **http.Request, status int, body string, header http.Header) vhttp.Client {
+	return vhttp.NewMemClient(func(_ context.Context, req *http.Request) (*http.Response, error) {
+		if recorded != nil {
+			*recorded = req
+		}
+
+		if header == nil {
+			header = http.Header{}
+		}
+
+		header.Set("Content-Type", "application/json")
+
+		return vhttp.Respond(status, []byte(body), header), nil
+	})
+}
+
+func TestAuthorizeDeviceRequest(t *testing.T) {
+	t.Parallel()
+
+	var got *http.Request
+
+	c := respondJSON(&got, http.StatusOK, authorizationBody, nil)
+
+	_, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "https://portal.example.com/")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Equal(t, http.MethodPost, got.Method)
+	assert.Equal(t, "https://portal.example.com/api/v1/oauth/device/authorize", got.URL.String())
+	assert.Equal(t, "application/x-www-form-urlencoded", got.Header.Get("Content-Type"))
+	assert.Equal(t, "application/json", got.Header.Get("Accept"))
+
+	body, err := io.ReadAll(got.Body)
+	require.NoError(t, err)
+
+	form, err := url.ParseQuery(string(body))
+	require.NoError(t, err)
+
+	assert.Equal(t, "terragrunt-cli", form.Get("client_id"))
+	assert.Equal(t, "catalog:read", form.Get("scope"))
+}
+
+func TestAuthorizeDeviceResponse(t *testing.T) {
+	t.Parallel()
+
+	c := respondJSON(nil, http.StatusOK, authorizationBody, nil)
+
+	auth, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "https://portal.example.com")
+	require.NoError(t, err)
+
+	assert.Equal(t, "fake-device-code", auth.DeviceCode.Reveal())
+	assert.Equal(t, "FAKE-CODE", auth.UserCode)
+	assert.Equal(t, "https://portal.example.com/auth/device", auth.VerificationURI)
+	assert.Equal(
+		t,
+		"https://portal.example.com/auth/device?user_code=FAKE-CODE",
+		auth.VerificationURIComplete,
+	)
+	assert.Equal(t, 600*time.Second, auth.ExpiresIn)
+	assert.Equal(t, 5*time.Second, auth.Interval)
+}
+
+// TestAuthorizeDeviceDefaultsInterval pins the five-second wait RFC 8628 §3.2
+// assigns a response that names no polling interval.
+func TestAuthorizeDeviceDefaultsInterval(t *testing.T) {
+	t.Parallel()
+
+	body := `{
+		"device_code": "fake-device-code",
+		"user_code": "FAKE-CODE",
+		"verification_uri": "https://portal.example.com/auth/device",
+		"expires_in": 600
+	}`
+
+	c := respondJSON(nil, http.StatusOK, body, nil)
+
+	auth, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "https://portal.example.com")
+	require.NoError(t, err)
+
+	assert.Equal(t, 5*time.Second, auth.Interval)
+	assert.Empty(t, auth.VerificationURIComplete)
+}
+
+func TestAuthorizeDeviceRejectsUnusableResponse(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name string
+		body string
+	}{
+		{name: "not json", body: `<html>hello</html>`},
+		{name: "wrong field type", body: `{"device_code":"fake-device-code","user_code":"FAKE-CODE",` +
+			`"verification_uri":"https://p.example.com/d","expires_in":"600"}`},
+		{
+			name: "already expired",
+			body: `{"device_code":"fake-device-code","user_code":"FAKE-CODE","verification_uri":"https://p.example.com/d"}`,
+		},
+		{
+			name: "unbrowsable verification uri",
+			body: `{"device_code":"fake-device-code","user_code":"FAKE-CODE","verification_uri":"javascript:fake-script","expires_in":600}`,
+		},
+		{
+			name: "unbrowsable complete verification uri",
+			body: `{"device_code":"fake-device-code","user_code":"FAKE-CODE","verification_uri":"https://p.example.com/d",` +
+				`"verification_uri_complete":"file:///fake/path","expires_in":600}`,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := respondJSON(nil, http.StatusOK, tt.body, nil)
+
+			auth, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "https://portal.example.com")
+			require.ErrorIs(t, err, portal.ErrMalformedResponse)
+			assert.Nil(t, auth)
+		})
+	}
+}
+
+// TestAuthorizeDeviceRejectsMissingField pins which field each check rejects.
+// Matching only the malformed-response class cannot tell them apart, because a
+// field left unchecked fails later for a different reason.
+func TestAuthorizeDeviceRejectsMissingField(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		field string
+		body  string
+	}{
+		{
+			field: "device_code",
+			body:  `{"user_code":"FAKE-CODE","verification_uri":"https://p.example.com/d","expires_in":600}`,
+		},
+		{
+			field: "user_code",
+			body:  `{"device_code":"fake-device-code","verification_uri":"https://p.example.com/d","expires_in":600}`,
+		},
+		{
+			field: "verification_uri",
+			body:  `{"device_code":"fake-device-code","user_code":"FAKE-CODE","expires_in":600}`,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.field, func(t *testing.T) {
+			t.Parallel()
+
+			c := respondJSON(nil, http.StatusOK, tt.body, nil)
+
+			_, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "https://portal.example.com")
+
+			var missing *portal.MissingFieldError
+			require.ErrorAs(t, err, &missing)
+			assert.Equal(t, tt.field, missing.Field)
+			require.ErrorIs(t, err, portal.ErrMalformedResponse)
+		})
+	}
+}
+
+// TestAuthorizeDeviceRejectsNonObjectResponse pins the message for a response
+// that is valid JSON but not an object. A JSON null unmarshals into the struct
+// without error, so it would otherwise be reported as a missing field, and the
+// rest would be reported by naming a Go type the user has no use for.
+func TestAuthorizeDeviceRejectsNonObjectResponse(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range []string{`null`, `[1,2,3]`, `"hello"`, `42`} {
+		t.Run(body, func(t *testing.T) {
+			t.Parallel()
+
+			c := respondJSON(nil, http.StatusOK, body, nil)
+
+			_, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "https://portal.example.com")
+			require.ErrorIs(t, err, portal.ErrResponseNotObject)
+		})
+	}
+}
+
+func TestAuthorizeDeviceReportsRefusal(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name            string
+		body            string
+		wantDescription string
+		header          http.Header
+		wantCode        portal.ErrorCode
+		status          int
+		wantRetryAfter  time.Duration
+	}{
+		{
+			name:            "unknown client",
+			status:          http.StatusBadRequest,
+			body:            `{"error":"invalid_client","error_description":"Unknown OAuth client."}`,
+			wantCode:        portal.ErrorCodeInvalidClient,
+			wantDescription: "Unknown OAuth client.",
+		},
+		{
+			name:            "disallowed scope",
+			status:          http.StatusBadRequest,
+			body:            `{"error":"invalid_scope","error_description":"The scope is not permitted."}`,
+			wantCode:        portal.ErrorCodeInvalidScope,
+			wantDescription: "The scope is not permitted.",
+		},
+		{
+			name:            "rate limited",
+			status:          http.StatusTooManyRequests,
+			body:            `{"error":"slow_down","error_description":"Too many login requests."}`,
+			header:          http.Header{"Retry-After": {"37"}},
+			wantCode:        portal.ErrorCodeSlowDown,
+			wantDescription: "Too many login requests.",
+			wantRetryAfter:  37 * time.Second,
+		},
+		{
+			name:            "portal failure",
+			status:          http.StatusInternalServerError,
+			body:            `{"error":"server_error","error_description":"Internal server error."}`,
+			wantCode:        portal.ErrorCodeServerError,
+			wantDescription: "Internal server error.",
+		},
+		{
+			name:   "intermediary standing in",
+			status: http.StatusBadGateway,
+			body:   `<html>502 Bad Gateway</html>`,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := respondJSON(nil, tt.status, tt.body, tt.header)
+
+			_, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "https://portal.example.com")
+
+			var portalErr *portal.Error
+			require.ErrorAs(t, err, &portalErr)
+
+			assert.Equal(t, tt.wantCode, portalErr.Code)
+			assert.Equal(t, tt.wantDescription, portalErr.Description)
+			assert.Equal(t, tt.status, portalErr.StatusCode)
+			assert.Equal(t, tt.wantRetryAfter, portalErr.RetryAfter)
+		})
+	}
+}
+
+// TestAuthorizeDeviceIgnoresUnreadableRetryAfter pins that the HTTP-date form of
+// Retry-After, which the portal does not send, reads as no advice rather than as
+// an immediate retry.
+func TestAuthorizeDeviceIgnoresUnreadableRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	c := respondJSON(
+		nil,
+		http.StatusTooManyRequests,
+		`{"error":"slow_down"}`,
+		http.Header{"Retry-After": {"Wed, 21 Oct 2026 07:28:00 GMT"}},
+	)
+
+	_, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "https://portal.example.com")
+
+	var portalErr *portal.Error
+	require.ErrorAs(t, err, &portalErr)
+
+	assert.Zero(t, portalErr.RetryAfter)
+}
+
+// truncatedReader serves prefix and then fails, standing in for a connection
+// that drops partway through a response.
+type truncatedReader struct {
+	err    error
+	prefix []byte
+	read   int
+}
+
+func (r *truncatedReader) Read(p []byte) (int, error) {
+	if r.read >= len(r.prefix) {
+		return 0, r.err
+	}
+
+	n := copy(p, r.prefix[r.read:])
+	r.read += n
+
+	return n, nil
+}
+
+// TestAuthorizeDeviceReportsTruncatedBodyAsRead pins that a connection dropping
+// partway through a response is reported as the read failure it is. The decoder
+// sees the same truncated document either way, so without the distinction a
+// dropped connection reads as a portal sending malformed JSON.
+func TestAuthorizeDeviceReportsTruncatedBodyAsRead(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("connection reset by peer")
+
+	c := vhttp.NewMemClient(func(_ context.Context, _ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body: io.NopCloser(&truncatedReader{
+				prefix: []byte(`{"device_code":"fake-device-code",`),
+				err:    sentinel,
+			}),
+		}, nil
+	})
+
+	_, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "https://portal.example.com")
+	require.ErrorIs(t, err, sentinel)
+	require.NotErrorIs(t, err, portal.ErrMalformedResponse)
+}
+
+func TestAuthorizeDevicePropagatesTransportFailure(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("dial failed")
+
+	c := vhttp.NewMemClient(func(_ context.Context, _ *http.Request) (*http.Response, error) {
+		return nil, sentinel
+	})
+
+	_, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "https://portal.example.com")
+	require.ErrorIs(t, err, sentinel)
+}
+
+// TestAuthorizeDeviceCarriesContext pins that the caller's context reaches the
+// request, so a cancelled login abandons an in-flight call instead of waiting
+// out the client's timeout.
+func TestAuthorizeDeviceCarriesContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	c := vhttp.NewMemClient(func(reqCtx context.Context, _ *http.Request) (*http.Response, error) {
+		return nil, reqCtx.Err()
+	})
+
+	_, err := portal.AuthorizeDevice(ctx, logger.CreateLogger(), c, "https://portal.example.com")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestAuthorizeDeviceRejectsUnusableBaseURL(t *testing.T) {
+	t.Parallel()
+
+	c := respondJSON(nil, http.StatusOK, authorizationBody, nil)
+
+	_, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "://portal.example.com")
+	require.Error(t, err)
+}
+
+// TestSecretDoesNotReachLogOutput pins what [portal.Secret] exists for: a
+// device authorization rendered through Terragrunt's own logger carries the
+// user code and not the device code. Going through the real formatter rather
+// than fmt covers the formatter, which is free to render a value however it
+// likes.
+//
+// This guards accidental rendering. A deliberate [portal.Secret.Reveal] prints
+// the credential by design, and covering everything the login command writes
+// needs the command itself.
+func TestSecretDoesNotReachLogOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	l := logger.CreateLogger().WithOptions(log.WithOutput(&buf))
+
+	auth := &portal.DeviceAuthorization{
+		DeviceCode: portal.Secret("fake-device-code"),
+		UserCode:   "FAKE-CODE",
+	}
+
+	l.Infof("device authorization: %v", auth)
+	l.Infof("device authorization: %+v", auth)
+
+	assert.NotContains(t, buf.String(), "fake-device-code")
+	assert.Contains(t, buf.String(), "FAKE-CODE", "the user code is meant to be shown")
+
+	// %#v does not consult String, so GoString is what keeps a struct dump from
+	// carrying the code.
+	assert.NotContains(t, fmt.Sprintf("%#v", auth), "fake-device-code")
+}
+
+func TestErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name string
+		err  *portal.Error
+		want string
+	}{
+		{
+			name: "code and description",
+			err:  &portal.Error{Code: portal.ErrorCodeInvalidScope, Description: "Not permitted.", StatusCode: 400},
+			want: "portal rejected the request: invalid_scope: Not permitted.",
+		},
+		{
+			name: "code alone",
+			err:  &portal.Error{Code: portal.ErrorCodeSlowDown, StatusCode: 429},
+			want: "portal rejected the request: slow_down",
+		},
+		{
+			name: "status alone",
+			err:  &portal.Error{StatusCode: 502},
+			want: "portal responded with unexpected status 502",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, tt.err.Error())
+		})
+	}
+}

--- a/internal/portal/errors.go
+++ b/internal/portal/errors.go
@@ -1,0 +1,116 @@
+package portal
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// ErrMalformedResponse reports a response the portal did not refuse but that
+// cannot be read as the expected shape. It is distinct from
+// a failure to read the response at all, which names the transport error
+// instead, and from an [Error], which is the portal refusing on purpose.
+var ErrMalformedResponse = errors.New("malformed portal response")
+
+// ErrResponseNotObject reports a response body that is well-formed JSON but not
+// an object.
+var ErrResponseNotObject = fmt.Errorf("%w: not a JSON object", ErrMalformedResponse)
+
+// MissingFieldError reports a response that left out a field the CLI needs. It
+// unwraps to [ErrMalformedResponse], so a caller that does not care which field
+// was missing can match the class instead.
+type MissingFieldError struct {
+	Field string
+}
+
+func (e *MissingFieldError) Error() string {
+	return ErrMalformedResponse.Error() + ": missing " + e.Field
+}
+
+func (e *MissingFieldError) Unwrap() error {
+	return ErrMalformedResponse
+}
+
+// ErrorCode names a failure the portal describes in its response body. Callers
+// reach it by unwrapping an [Error] out of the returned error.
+type ErrorCode string
+
+const (
+	// ErrorCodeInvalidRequest reports a request body the portal could not read.
+	ErrorCodeInvalidRequest ErrorCode = "invalid_request"
+
+	// ErrorCodeInvalidClient reports a client the portal has no registration for.
+	ErrorCodeInvalidClient ErrorCode = "invalid_client"
+
+	// ErrorCodeInvalidScope reports a scope that was missing, unknown, or not
+	// permitted for the client.
+	ErrorCodeInvalidScope ErrorCode = "invalid_scope"
+
+	// ErrorCodeSlowDown reports a rate limit. [Error.RetryAfter] carries how
+	// long the portal asked the caller to wait.
+	ErrorCodeSlowDown ErrorCode = "slow_down"
+
+	// ErrorCodeServerError reports an unexpected failure inside the portal.
+	ErrorCodeServerError ErrorCode = "server_error"
+)
+
+// Error reports a request the portal refused.
+type Error struct {
+	Code        ErrorCode
+	Description string
+	RetryAfter  time.Duration
+	StatusCode  int
+}
+
+func (e *Error) Error() string {
+	if e.Code == "" {
+		return "portal responded with unexpected status " + strconv.Itoa(e.StatusCode)
+	}
+
+	msg := "portal rejected the request: " + string(e.Code)
+	if e.Description != "" {
+		msg += ": " + e.Description
+	}
+
+	return msg
+}
+
+// errorBody is the failure shape of RFC 6749 §5.2.
+type errorBody struct {
+	Code        ErrorCode `json:"error"`
+	Description string    `json:"error_description"`
+}
+
+// newError reads what the portal said about a refusal. A body that is not the
+// documented shape leaves Code empty. A gateway answering in the portal's place
+// uses a format of its own, so only its status identifies the failure.
+func newError(resp *http.Response, body io.Reader) *Error {
+	err := &Error{
+		StatusCode: resp.StatusCode,
+		RetryAfter: retryAfter(resp.Header),
+	}
+
+	var parsed errorBody
+	if json.NewDecoder(body).Decode(&parsed) == nil {
+		err.Code = parsed.Code
+		err.Description = parsed.Description
+	}
+
+	return err
+}
+
+// retryAfter reads the delta-seconds form of Retry-After (RFC 9110 §10.2.3),
+// which is what the portal sends. An HTTP-date, or a header the portal omitted,
+// reads as no advice.
+func retryAfter(header http.Header) time.Duration {
+	seconds, err := strconv.Atoi(header.Get("Retry-After"))
+	if err != nil || seconds < 0 {
+		return 0
+	}
+
+	return time.Duration(seconds) * time.Second
+}

--- a/internal/portal/portal.go
+++ b/internal/portal/portal.go
@@ -1,0 +1,57 @@
+// Package portal talks to the Gruntwork Developer Portal, the authorization
+// server and catalog API that back `terragrunt login` and a portal-defined
+// `terragrunt catalog`.
+//
+// Login follows the OAuth 2.0 Device Authorization Grant ([RFC 8628]). The CLI
+// is a public client: it holds no client secret and registers no redirect URI,
+// so the device code the portal issues is the only credential in the exchange,
+// and [Secret] keeps it out of terminal output and log lines.
+//
+// The device-authorization request is built here rather than through
+// golang.org/x/oauth2. Its Config.DeviceAuth sends a request carrying no
+// context, so a cancelled login cannot abandon a call already in flight.
+//
+// [RFC 8628]: https://datatracker.ietf.org/doc/html/rfc8628
+package portal
+
+const (
+	// DefaultBaseURL addresses the production Gruntwork Developer Portal. A
+	// preview or local deployment answers on its own host, so every URL in a
+	// response is read from that response rather than assembled from this one.
+	DefaultBaseURL = "https://app.gruntwork.io"
+
+	// ClientID identifies the Terragrunt CLI to the portal's authorization
+	// server, which matches it against a registration in the portal's source.
+	// The string travels verbatim, so changing it here breaks every released
+	// CLI until the portal's registration changes with it.
+	ClientID = "terragrunt-cli"
+
+	// ScopeCatalogRead requests read access to the org's portal-defined
+	// catalog. The portal rejects any scope it does not recognize, and rejects
+	// a request that names none at all.
+	ScopeCatalogRead = "catalog:read"
+)
+
+// secretPlaceholder stands in for a credential wherever one would be rendered.
+const secretPlaceholder = "[REDACTED]"
+
+// Secret carries a credential that must never reach a terminal or a log file.
+// Formatting one yields a placeholder, so the value it holds leaves only
+// through [Secret.Reveal].
+type Secret string
+
+// String renders the placeholder instead of the credential.
+func (s Secret) String() string {
+	return secretPlaceholder
+}
+
+// GoString renders the placeholder instead of the credential, covering the %#v
+// verb, which does not consult [Secret.String].
+func (s Secret) GoString() string {
+	return secretPlaceholder
+}
+
+// Reveal returns the credential, for the request that has to carry it.
+func (s Secret) Reveal() string {
+	return string(s)
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds the `tg-login` experiment placeholder, and the initial logic for the login handshake that's going to be done with the Gruntwork developer portal.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foundational support for secure device authorization through the Developer Portal.
  * Added portal error handling, credential masking, request validation, polling defaults, and safe verification URL handling.
  * Reserved the `tg-login` experiment for future browser-based `terragrunt login` access.

* **Documentation**
  * Documented the `tg-login` experiment, configuration options, planned capabilities, and stabilization criteria.
  * Added a v1.1.5 changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->