### PR TITLE
perf: Streaming buffered output

### DIFF
--- a/docs/src/data/changelog/v1.1.5/lower-memory-during-run-all.mdx
+++ b/docs/src/data/changelog/v1.1.5/lower-memory-during-run-all.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.5"
+category: "performance-improvements"
+---
+
+#### Lower memory use during `run --all`
+
+When you set [`--json-out-dir`](/reference/cli/commands/run#json-out-dir), Terragrunt saves a JSON plan for every unit it runs. It used to build each of those documents in memory in full before writing any of it to disk, so a unit with a 64 MB plan needed roughly 168 MB to save it, and every unit running in parallel needed its own. Terragrunt now writes the document as it arrives. That same plan needs about 300 KB, roughly 550x less, and saving it finishes about 18% faster.
+
+Two other places held on to more than they needed. During `run --all plan`, Terragrunt kept every unit's error output until the run finished so it could check it for a single message at the end, and it now checks that as the output streams. Responses from a provider registry were read twice on the way in, and are now read once, which uses about 19% less memory per request.
+
+JSON plans are also replaced atomically now. A run that fails part way through leaves the previous file in place instead of truncating it.

--- a/internal/runner/json_output.go
+++ b/internal/runner/json_output.go
@@ -1,0 +1,68 @@
+package runner
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"path/filepath"
+
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+)
+
+const (
+	jsonOutputDirPerms  = 0o700
+	jsonOutputFilePerms = 0o600
+
+	// jsonOutputBufferSize coalesces the small chunks arriving from `show -json`
+	// into fewer, larger writes. Without it, streaming trades one large allocation
+	// for a write syscall per chunk and runs slower than the buffering it replaced.
+	// Every unit running concurrently holds one, so it stays fixed rather than
+	// scaling with the document.
+	jsonOutputBufferSize = 256 << 10
+
+	jsonOutputTempPattern = ".*.tmp"
+)
+
+// WriteJSONOutput streams whatever fn writes into the file at path, creating the
+// parent directory first. Plan JSON runs to tens of megabytes on large units and
+// every unit in a `run --all` produces its own, so the writer is handed straight
+// to fn rather than accumulating the document in memory.
+//
+// The document lands in a temporary file that replaces path only once fn returns
+// cleanly. A failed run therefore leaves whatever was already at path untouched,
+// and no reader observes a half-written plan.
+func WriteJSONOutput(fsys vfs.FS, path string, fn func(w io.Writer) error) error {
+	if err := fsys.MkdirAll(filepath.Dir(path), jsonOutputDirPerms); err != nil {
+		return err
+	}
+
+	// Writers can aim at one path concurrently, so the scratch file cannot be named
+	// after it.
+	file, err := vfs.CreateTemp(fsys, filepath.Dir(path), filepath.Base(path)+jsonOutputTempPattern)
+	if err != nil {
+		return err
+	}
+
+	tmpPath := file.Name()
+
+	// The rename carries this mode onto the published plan.
+	if err := fsys.Chmod(tmpPath, jsonOutputFilePerms); err != nil {
+		return errors.Join(err, file.Close(), fsys.Remove(tmpPath))
+	}
+
+	buffered := bufio.NewWriterSize(file, jsonOutputBufferSize)
+
+	if err := fn(buffered); err != nil {
+		return errors.Join(err, file.Close(), fsys.Remove(tmpPath))
+	}
+
+	if err := errors.Join(buffered.Flush(), file.Close()); err != nil {
+		return errors.Join(err, fsys.Remove(tmpPath))
+	}
+
+	if err := fsys.Rename(tmpPath, path); err != nil {
+		return errors.Join(err, fsys.Remove(tmpPath))
+	}
+
+	return nil
+}

--- a/internal/runner/json_output.go
+++ b/internal/runner/json_output.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"io"
+	"io/fs"
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
@@ -31,7 +32,7 @@ const (
 // The document lands in a temporary file that replaces path only once fn returns
 // cleanly. A failed run therefore leaves whatever was already at path untouched,
 // and no reader observes a half-written plan.
-func WriteJSONOutput(fsys vfs.FS, path string, fn func(w io.Writer) error) error {
+func WriteJSONOutput(fsys vfs.FS, path string, fn func(w io.Writer) error) (err error) {
 	if err := fsys.MkdirAll(filepath.Dir(path), jsonOutputDirPerms); err != nil {
 		return err
 	}
@@ -45,24 +46,43 @@ func WriteJSONOutput(fsys vfs.FS, path string, fn func(w io.Writer) error) error
 
 	tmpPath := file.Name()
 
+	closed := false
+	closeFile := func() error {
+		if closed {
+			return nil
+		}
+
+		closed = true
+
+		return file.Close()
+	}
+
+	defer func() {
+		// Windows refuses to remove an open file.
+		closeErr := closeFile()
+
+		rmErr := fsys.Remove(tmpPath)
+		if errors.Is(rmErr, fs.ErrNotExist) {
+			rmErr = nil
+		}
+
+		err = errors.Join(err, closeErr, rmErr)
+	}()
+
 	// The rename carries this mode onto the published plan.
 	if err := fsys.Chmod(tmpPath, jsonOutputFilePerms); err != nil {
-		return errors.Join(err, file.Close(), fsys.Remove(tmpPath))
+		return err
 	}
 
 	buffered := bufio.NewWriterSize(file, jsonOutputBufferSize)
 
 	if err := fn(buffered); err != nil {
-		return errors.Join(err, file.Close(), fsys.Remove(tmpPath))
+		return err
 	}
 
-	if err := errors.Join(buffered.Flush(), file.Close()); err != nil {
-		return errors.Join(err, fsys.Remove(tmpPath))
+	if err := errors.Join(buffered.Flush(), closeFile()); err != nil {
+		return err
 	}
 
-	if err := fsys.Rename(tmpPath, path); err != nil {
-		return errors.Join(err, fsys.Remove(tmpPath))
-	}
-
-	return nil
+	return fsys.Rename(tmpPath, path)
 }

--- a/internal/runner/json_output_racing_test.go
+++ b/internal/runner/json_output_racing_test.go
@@ -1,0 +1,93 @@
+package runner_test
+
+import (
+	"io"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/runner"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestWriteJSONOutputSamePathConcurrentWithRacing pins that the published plan is
+// exactly one writer's output when several write to the same path at once, which is
+// what two commands sharing a --json-out-dir do.
+func TestWriteJSONOutputSamePathConcurrentWithRacing(t *testing.T) {
+	t.Parallel()
+
+	const (
+		writers = 8
+		// Enough 33-byte lines to run past the write buffer, so the writers overlap
+		// instead of each landing in a single flush.
+		lines    = 10000
+		fillLine = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	fsys := vfs.NewOSFS()
+	path := filepath.Join(t.TempDir(), "plan.json")
+
+	bodies := make([]string, writers)
+	for i := range bodies {
+		bodies[i] = strings.Repeat(strconv.Itoa(i)+fillLine+"\n", lines)
+	}
+
+	group, _ := errgroup.WithContext(t.Context())
+
+	for i := range writers {
+		group.Go(func() error {
+			return runner.WriteJSONOutput(fsys, path, func(w io.Writer) error {
+				_, err := io.WriteString(w, bodies[i])
+
+				return err
+			})
+		})
+	}
+
+	require.NoError(t, group.Wait())
+
+	contents, err := vfs.ReadFile(fsys, path)
+	require.NoError(t, err)
+
+	assert.Contains(
+		t,
+		bodies,
+		string(contents),
+		"the published plan is a mixture rather than any single writer's output",
+	)
+}
+
+// TestWriteJSONOutputLeavesNoScratchFiles pins that scratch files are removed on
+// both the success and failure paths. Their names are random, so a leaked one
+// accumulates rather than being overwritten by the next run.
+func TestWriteJSONOutputLeavesNoScratchFiles(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	dir := t.TempDir()
+
+	require.NoError(t, runner.WriteJSONOutput(fsys, filepath.Join(dir, "ok.json"), func(w io.Writer) error {
+		_, err := io.WriteString(w, `{"ok":true}`)
+
+		return err
+	}))
+
+	err := runner.WriteJSONOutput(fsys, filepath.Join(dir, "bad.json"), func(w io.Writer) error {
+		return io.ErrClosedPipe
+	})
+	require.Error(t, err)
+
+	entries, err := vfs.ReadDir(fsys, dir)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+
+	assert.ElementsMatch(t, []string{"ok.json"}, names)
+}

--- a/internal/runner/json_output_test.go
+++ b/internal/runner/json_output_test.go
@@ -1,0 +1,194 @@
+package runner_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/runner"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteJSONOutput(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	path := filepath.Join(t.TempDir(), "nested", "plan.json")
+
+	err := runner.WriteJSONOutput(fsys, path, func(w io.Writer) error {
+		_, err := io.WriteString(w, `{"format_version":"1.2"}`)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	contents, err := vfs.ReadFile(fsys, path)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"format_version":"1.2"}`, string(contents))
+}
+
+func TestWriteJSONOutputLeavesNoFileWhenRunFails(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	path := filepath.Join(t.TempDir(), "plan.json")
+	sentinel := errors.New("show failed")
+
+	err := runner.WriteJSONOutput(fsys, path, func(w io.Writer) error {
+		if _, err := io.WriteString(w, `{"format_ver`); err != nil {
+			return err
+		}
+
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+
+	assert.False(
+		t,
+		vfs.Exists(fsys, path),
+		"a failed run must not leave a partial plan behind",
+	)
+}
+
+func TestWriteJSONOutputKeepsPreviousPlanWhenRunFails(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	path := filepath.Join(t.TempDir(), "plan.json")
+
+	require.NoError(t, runner.WriteJSONOutput(fsys, path, func(w io.Writer) error {
+		_, err := io.WriteString(w, `{"run":"first"}`)
+
+		return err
+	}))
+
+	err := runner.WriteJSONOutput(fsys, path, func(w io.Writer) error {
+		if _, err := io.WriteString(w, `{"run":"sec`); err != nil {
+			return err
+		}
+
+		return errors.New("show failed")
+	})
+	require.Error(t, err)
+
+	contents, err := vfs.ReadFile(fsys, path)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"run":"first"}`, string(contents))
+}
+
+func TestWriteJSONOutputTruncatesExistingFile(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	path := filepath.Join(t.TempDir(), "plan.json")
+
+	require.NoError(t, runner.WriteJSONOutput(fsys, path, func(w io.Writer) error {
+		_, err := io.WriteString(w, `{"stale":true,"padding":"aaaaaaaaaaaaaaaa"}`)
+
+		return err
+	}))
+
+	require.NoError(t, runner.WriteJSONOutput(fsys, path, func(w io.Writer) error {
+		_, err := io.WriteString(w, `{"fresh":true}`)
+
+		return err
+	}))
+
+	contents, err := vfs.ReadFile(fsys, path)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"fresh":true}`, string(contents))
+}
+
+// planJSONChunk is one pipe-sized read of a plan document, so the benchmark feeds
+// the writer in chunks the way a real run does rather than in one large write.
+func planJSONChunk() []byte {
+	const chunkSize = 32 << 10
+
+	line := []byte(
+		`{"address":"module.vpc.aws_subnet.private[0]","mode":"managed",` +
+			`"type":"aws_subnet","change":{"actions":["create"]}},`,
+	)
+
+	return bytes.Repeat(line, chunkSize/len(line)+1)
+}
+
+func showJSON(w io.Writer, size int) error {
+	chunk := planJSONChunk()
+
+	for written := 0; written < size; written += len(chunk) {
+		if _, err := w.Write(chunk); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeJSONOutputBuffered is the strategy the unit runner used before. It stays
+// here as the baseline the streaming numbers are read against, since the code it
+// mirrors is gone.
+func writeJSONOutputBuffered(fsys vfs.FS, path string, fn func(w io.Writer) error) error {
+	const (
+		dirPerms  = 0o700
+		filePerms = 0o600
+	)
+
+	var buf bytes.Buffer
+
+	if err := fn(&buf); err != nil {
+		return err
+	}
+
+	if err := fsys.MkdirAll(filepath.Dir(path), dirPerms); err != nil {
+		return err
+	}
+
+	return vfs.WriteFile(fsys, path, buf.Bytes(), filePerms)
+}
+
+// BenchmarkWriteJSONOutput contrasts streaming a plan document to disk against
+// buffering it first. Read the bytes-per-operation column. Under `run --all` every
+// unit running concurrently pays that figure at the same time.
+func BenchmarkWriteJSONOutput(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{name: "1MiB", size: 1 << 20},
+		{name: "16MiB", size: 16 << 20},
+		{name: "64MiB", size: 64 << 20},
+	}
+
+	strategies := []struct {
+		write func(vfs.FS, string, func(io.Writer) error) error
+		name  string
+	}{
+		{write: runner.WriteJSONOutput, name: "stream"},
+		{write: writeJSONOutputBuffered, name: "buffered"},
+	}
+
+	for _, strategy := range strategies {
+		for _, size := range sizes {
+			b.Run(strategy.name+"/"+size.name, func(b *testing.B) {
+				fsys := vfs.NewOSFS()
+				path := filepath.Join(b.TempDir(), "plan.json")
+
+				b.ReportAllocs()
+				b.SetBytes(int64(size.size))
+
+				for b.Loop() {
+					err := strategy.write(fsys, path, func(w io.Writer) error {
+						return showJSON(w, size.size)
+					})
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/runner/json_output_test.go
+++ b/internal/runner/json_output_test.go
@@ -54,6 +54,33 @@ func TestWriteJSONOutputLeavesNoFileWhenRunFails(t *testing.T) {
 	)
 }
 
+// TestWriteJSONOutputLeavesNoFileWhenRunPanics pins the cleanup against a
+// panic, which unwinds past every return in the function. The scratch file
+// holds a plan, so one left behind under a name nothing looks for outlives the
+// process that wrote it.
+func TestWriteJSONOutputLeavesNoFileWhenRunPanics(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plan.json")
+
+	require.PanicsWithValue(t, "show exploded", func() {
+		err := runner.WriteJSONOutput(fsys, path, func(w io.Writer) error {
+			if _, err := io.WriteString(w, `{"format_ver`); err != nil {
+				return err
+			}
+
+			panic("show exploded")
+		})
+		require.NoError(t, err)
+	})
+
+	entries, err := vfs.ReadDir(fsys, dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "a panic must leave no scratch file behind")
+}
+
 func TestWriteJSONOutputKeepsPreviousPlanWhenRunFails(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3,7 +3,6 @@
 package runner
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -35,6 +34,14 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+)
+
+// Seen together in a unit's plan stderr, these mean the unit failed because a
+// terraform_remote_state data source had nothing to read yet, which points the
+// user at applying dependencies first.
+const (
+	planRemoteStateErrorPrefix   = "Error running plan:"
+	planRemoteStateErrorResource = ": Resource 'data.terraform_remote_state."
 )
 
 // Runner executes the units of a discovered stack.
@@ -384,14 +391,17 @@ func (rnr *Runner) Run(
 		needsCliSync = true
 	}
 
-	var planErrorBuffers map[string]*bytes.Buffer
+	var planErrorScanners map[string]*SubstringScanner
 	if isPlan {
-		planErrorBuffers = make(map[string]*bytes.Buffer, len(rnr.Stack.Units))
+		planErrorScanners = make(map[string]*SubstringScanner, len(rnr.Stack.Units))
 		for _, u := range rnr.Stack.Units {
-			planErrorBuffers[u.Path()] = &bytes.Buffer{}
+			planErrorScanners[u.Path()] = NewSubstringScanner(
+				planRemoteStateErrorPrefix,
+				planRemoteStateErrorResource,
+			)
 		}
 
-		defer rnr.summarizePlanAllErrors(l, planErrorBuffers)
+		defer rnr.summarizePlanAllErrors(l, planErrorScanners)
 	}
 
 	// Emit report entries for excluded units that haven't been reported yet.
@@ -452,13 +462,11 @@ func (rnr *Runner) Run(
 			syncUnitCliArgs(l, stackOpts, unitOpts, u)
 		}
 
-		// Wrap ErrWriter with plan error buffer for plan commands. The
-		// wrapped writer is materialized on the per-unit venv below.
 		var unitErrWriterWrap io.Writer
 
 		if isPlan {
-			if buf := planErrorBuffers[u.Path()]; buf != nil {
-				unitErrWriterWrap = io.MultiWriter(buf, v.Writers.ErrWriter)
+			if scanner := planErrorScanners[u.Path()]; scanner != nil {
+				unitErrWriterWrap = io.MultiWriter(scanner, v.Writers.ErrWriter)
 			}
 		}
 
@@ -836,42 +844,32 @@ func (rnr *Runner) ListStackDependentUnits() map[string][]string {
 }
 
 // summarizePlanAllErrors summarizes all errors encountered during the plan phase across all units in the stack.
-func (rnr *Runner) summarizePlanAllErrors(l log.Logger, errorStreams map[string]*bytes.Buffer) {
+func (rnr *Runner) summarizePlanAllErrors(l log.Logger, errorScanners map[string]*SubstringScanner) {
 	for _, unit := range rnr.Stack.Units {
-		buf := errorStreams[unit.Path()]
-		if buf == nil {
+		scanner := errorScanners[unit.Path()]
+		if scanner == nil || !scanner.FoundAll() {
 			continue
 		}
 
-		output := buf.String()
+		var dependenciesMsg string
 
-		if len(output) == 0 {
-			// An empty buffer means the unit's plan wrote nothing to stderr.
-			continue
-		}
-
-		if strings.Contains(output, "Error running plan:") &&
-			strings.Contains(output, ": Resource 'data.terraform_remote_state.") {
-			var dependenciesMsg string
-
-			if len(unit.Dependencies()) > 0 {
-				cfg := unit.Config()
-				if cfg != nil && cfg.Dependencies != nil && len(cfg.Dependencies.Paths) > 0 {
-					dependenciesMsg = fmt.Sprintf(
-						" contains dependencies to %v and",
-						cfg.Dependencies.Paths,
-					)
-				} else {
-					dependenciesMsg = " contains dependencies and"
-				}
+		if len(unit.Dependencies()) > 0 {
+			cfg := unit.Config()
+			if cfg != nil && cfg.Dependencies != nil && len(cfg.Dependencies.Paths) > 0 {
+				dependenciesMsg = fmt.Sprintf(
+					" contains dependencies to %v and",
+					cfg.Dependencies.Paths,
+				)
+			} else {
+				dependenciesMsg = " contains dependencies and"
 			}
-
-			l.Infof("%v%v refers to remote State "+
-				"you may have to apply your changes in the dependencies prior running terragrunt run --all plan.\n",
-				unit.Path(),
-				dependenciesMsg,
-			)
 		}
+
+		l.Infof("%v%v refers to remote State "+
+			"you may have to apply your changes in the dependencies before running terragrunt run --all plan.\n",
+			unit.Path(),
+			dependenciesMsg,
+		)
 	}
 }
 

--- a/internal/runner/scanner.go
+++ b/internal/runner/scanner.go
@@ -1,0 +1,99 @@
+package runner
+
+import "bytes"
+
+// SubstringScanner reports whether every one of its needles has appeared in the
+// stream written to it.
+//
+// The longest needle bounds what it retains, not the length of the stream, so
+// watching a unit's stderr for the whole of a `run --all` costs a fixed amount of
+// memory. A scanner with no needles reports [SubstringScanner.FoundAll] straight
+// away. It is not safe for concurrent use.
+type SubstringScanner struct {
+	needles [][]byte
+	found   []bool
+	tail    []byte
+	seam    []byte
+	overlap int
+}
+
+// NewSubstringScanner returns a scanner watching for every needle in needles.
+// Empty needles are dropped, since every stream trivially contains them.
+func NewSubstringScanner(needles ...string) *SubstringScanner {
+	scanner := &SubstringScanner{}
+
+	for _, needle := range needles {
+		if needle == "" {
+			continue
+		}
+
+		scanner.needles = append(scanner.needles, []byte(needle))
+
+		if overlap := len(needle) - 1; overlap > scanner.overlap {
+			scanner.overlap = overlap
+		}
+	}
+
+	scanner.found = make([]bool, len(scanner.needles))
+
+	return scanner
+}
+
+// Write implements [io.Writer] and never reports an error.
+func (scanner *SubstringScanner) Write(p []byte) (int, error) {
+	if scanner.FoundAll() {
+		return len(p), nil
+	}
+
+	// A needle can straddle two writes, so search the seam between the retained
+	// tail and the head of p before searching p itself. The longest needle bounds
+	// both regions, which is what keeps memory independent of how much a unit
+	// writes.
+	if len(scanner.tail) > 0 {
+		head := p[:min(len(p), scanner.overlap)]
+		scanner.seam = append(append(scanner.seam[:0], scanner.tail...), head...)
+
+		scanner.search(scanner.seam)
+	}
+
+	scanner.search(p)
+	scanner.retain(p)
+
+	return len(p), nil
+}
+
+// FoundAll reports whether every needle has been seen.
+func (scanner *SubstringScanner) FoundAll() bool {
+	for _, found := range scanner.found {
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (scanner *SubstringScanner) search(b []byte) {
+	for i, needle := range scanner.needles {
+		if !scanner.found[i] && bytes.Contains(b, needle) {
+			scanner.found[i] = true
+		}
+	}
+}
+
+// retain keeps the trailing bytes a later write might need to complete a needle.
+// Writes shorter than a needle accumulate, so a needle arriving a byte at a time
+// still matches.
+func (scanner *SubstringScanner) retain(p []byte) {
+	if len(p) >= scanner.overlap {
+		scanner.tail = append(scanner.tail[:0], p[len(p)-scanner.overlap:]...)
+
+		return
+	}
+
+	scanner.tail = append(scanner.tail, p...)
+
+	if len(scanner.tail) > scanner.overlap {
+		scanner.tail = append(scanner.tail[:0], scanner.tail[len(scanner.tail)-scanner.overlap:]...)
+	}
+}

--- a/internal/runner/scanner_test.go
+++ b/internal/runner/scanner_test.go
@@ -1,0 +1,194 @@
+package runner_test
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/runner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubstringScanner(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name    string
+		needles []string
+		writes  []string
+		want    bool
+	}{
+		{
+			name:    "both needles in one write",
+			needles: []string{"alpha", "beta"},
+			writes:  []string{"xx alpha yy beta zz"},
+			want:    true,
+		},
+		{
+			name:    "needles arrive in separate writes",
+			needles: []string{"alpha", "beta"},
+			writes:  []string{"xx alpha ", "yy beta zz"},
+			want:    true,
+		},
+		{
+			name:    "needle straddles a write boundary",
+			needles: []string{"alpha"},
+			writes:  []string{"xx al", "pha yy"},
+			want:    true,
+		},
+		{
+			name:    "needle arrives one byte per write",
+			needles: []string{"alpha"},
+			writes:  []string{"a", "l", "p", "h", "a"},
+			want:    true,
+		},
+		{
+			name:    "needle straddles many writes with filler between",
+			needles: []string{"alpha"},
+			writes:  []string{"filler al", "p", "ha"},
+			want:    true,
+		},
+		{
+			name:    "one needle never appears",
+			needles: []string{"alpha", "beta"},
+			writes:  []string{"xx alpha yy"},
+			want:    false,
+		},
+		{
+			name:    "nothing written",
+			needles: []string{"alpha"},
+			writes:  nil,
+			want:    false,
+		},
+		{
+			name:    "empty needles are dropped",
+			needles: []string{"", "alpha"},
+			writes:  []string{"alpha"},
+			want:    true,
+		},
+		{
+			name:    "a scanner with no needles has nothing left to find",
+			needles: nil,
+			writes:  []string{"anything"},
+			want:    true,
+		},
+		{
+			name:    "single byte needle cannot straddle a boundary",
+			needles: []string{"x"},
+			writes:  []string{"aaa", "bxb"},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			scanner := runner.NewSubstringScanner(tt.needles...)
+
+			for _, write := range tt.writes {
+				n, err := scanner.Write([]byte(write))
+				require.NoError(t, err)
+				assert.Equal(t, len(write), n)
+			}
+
+			assert.Equal(t, tt.want, scanner.FoundAll())
+		})
+	}
+}
+
+func TestSubstringScannerMatchesAfterLongStream(t *testing.T) {
+	t.Parallel()
+
+	scanner := runner.NewSubstringScanner("alpha")
+
+	chunk := []byte("filler filler filler")
+	for range 1000 {
+		_, err := scanner.Write(chunk)
+		require.NoError(t, err)
+	}
+
+	// A needle arriving only after a long run of unrelated output still matches,
+	// which is the property the fixed-size retention has to preserve.
+	_, err := scanner.Write([]byte("alpha"))
+	require.NoError(t, err)
+	assert.True(t, scanner.FoundAll())
+}
+
+// The markers a unit's plan stderr is watched for. Their length decides how much
+// the scanner has to retain between writes.
+const (
+	benchNeedlePrefix   = "Error running plan:"
+	benchNeedleResource = ": Resource 'data.terraform_remote_state."
+)
+
+// planStderrChunk mimics one read from a unit's stderr during a plan. The lines
+// are warnings and progress, so none of them match either marker.
+func planStderrChunk(lines int) []byte {
+	var sb strings.Builder
+
+	for i := range lines {
+		sb.WriteString("Warning: Argument is deprecated on main.tf line ")
+		sb.WriteString(strconv.Itoa(i))
+		sb.WriteString(", in resource \"aws_s3_bucket\" \"logs\"\n")
+	}
+
+	return []byte(sb.String())
+}
+
+// BenchmarkPlanErrorScan contrasts scanning a unit's stderr as it streams against
+// accumulating the stream and testing it once at the end, which is what the runner
+// did before. Read the bytes-per-operation column. The scanner's figure holds
+// steady as the stream grows.
+func BenchmarkPlanErrorScan(b *testing.B) {
+	chunk := planStderrChunk(32)
+
+	for _, chunks := range []int{16, 256, 4096} {
+		total := int64(len(chunk) * chunks)
+
+		b.Run("scanner/"+strconv.Itoa(chunks)+"chunks", func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(total)
+
+			for b.Loop() {
+				scanner := runner.NewSubstringScanner(
+					benchNeedlePrefix,
+					benchNeedleResource,
+				)
+
+				for range chunks {
+					if _, err := scanner.Write(chunk); err != nil {
+						b.Fatal(err)
+					}
+				}
+
+				if scanner.FoundAll() {
+					b.Fatal("benchmark input should not match")
+				}
+			}
+		})
+
+		b.Run("buffered/"+strconv.Itoa(chunks)+"chunks", func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(total)
+
+			for b.Loop() {
+				buf := &bytes.Buffer{}
+
+				for range chunks {
+					if _, err := buf.Write(chunk); err != nil {
+						b.Fatal(err)
+					}
+				}
+
+				output := buf.String()
+				if strings.Contains(output, benchNeedlePrefix) &&
+					strings.Contains(output, benchNeedleResource) {
+					b.Fatal("benchmark input should not match")
+				}
+			}
+		})
+	}
+}

--- a/internal/runner/unit_runner.go
+++ b/internal/runner/unit_runner.go
@@ -1,8 +1,8 @@
 package runner
 
 import (
-	"bytes"
 	"context"
+	"io"
 	"path/filepath"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
@@ -15,7 +15,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
@@ -160,7 +159,6 @@ func (runner *UnitRunner) Run(
 			return err
 		}
 
-		stdout := bytes.Buffer{}
 		jsonOptions.ForwardTFStdout = true
 		jsonOptions.JSONLogFormat = false
 		jsonOptions.TerraformCommand = tf.CommandNameShow
@@ -172,34 +170,20 @@ func (runner *UnitRunner) Run(
 		// Use an ad-hoc report to avoid polluting the main report
 		adhocReport := report.NewReport()
 
-		jsonV := v.WithWriter(&stdout)
-
 		runOpts := configbridge.NewRunOptions(jsonOptions)
-		if err := run.Run(
-			ctx,
-			jsonLogger,
-			jsonV,
-			runOpts,
-			adhocReport,
-			cfg,
-			credsGetter,
-		); err != nil {
-			return err
-		}
-
 		outputFile := runner.Unit.OutputJSONFile(opts.RootWorkingDir, opts.JSONOutputFolder)
-		jsonDir := filepath.Dir(outputFile)
 
-		const (
-			ownerReadWriteExecutePerms = 0o700
-			ownerReadWritePerms        = 0o600
-		)
-
-		if err := v.FS.MkdirAll(jsonDir, ownerReadWriteExecutePerms); err != nil {
-			return err
-		}
-
-		if err := vfs.WriteFile(v.FS, outputFile, stdout.Bytes(), ownerReadWritePerms); err != nil {
+		if err := WriteJSONOutput(v.FS, outputFile, func(w io.Writer) error {
+			return run.Run(
+				ctx,
+				jsonLogger,
+				v.WithWriter(w),
+				runOpts,
+				adhocReport,
+				cfg,
+				credsGetter,
+			)
+		}); err != nil {
 			return err
 		}
 	}

--- a/internal/tf/cache/helpers/client.go
+++ b/internal/tf/cache/helpers/client.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 
@@ -11,6 +12,11 @@ import (
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/puzpuzpuz/xsync/v4"
 )
+
+// maxPreallocBody bounds how much memory a response's Content-Length is trusted
+// to reserve before any of the body has arrived. Registry metadata sits orders of
+// magnitude below it, so a larger value buys nothing and costs a header's word.
+const maxPreallocBody = 32 << 20
 
 // Client is the cache server's outbound HTTP client. It wraps a
 // [vhttp.Client] with registry credential injection and a per-URL response
@@ -83,17 +89,33 @@ func decodeResponse(resp *http.Response) ([]byte, error) {
 		return nil, nil
 	}
 
-	buffer, err := ResponseBuffer(resp)
+	reader, err := ResponseReader(resp)
 	if err != nil {
 		return nil, err
 	}
 
-	bodyBytes, err := io.ReadAll(buffer)
-	if err != nil {
+	body, readErr := readBody(reader, resp.ContentLength)
+	if err := errors.Join(readErr, reader.Close()); err != nil {
 		return nil, err
 	}
 
-	resp.Body = io.NopCloser(buffer)
+	return body, nil
+}
 
-	return bodyBytes, nil
+// readBody reads r to completion. A positive size, which [ResponseReader] clears
+// when it unwraps a gzip stream, is the body's exact length, so the read needs one
+// allocation rather than [io.ReadAll]'s repeated doubling. Anything above
+// maxPreallocBody falls back to [io.ReadAll], so a registry advertising a bogus
+// Content-Length cannot make Terragrunt reserve that memory up front.
+func readBody(r io.Reader, size int64) ([]byte, error) {
+	if size <= 0 || size > maxPreallocBody {
+		return io.ReadAll(r)
+	}
+
+	body := make([]byte, size)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return nil, err
+	}
+
+	return body, nil
 }

--- a/internal/tf/cache/helpers/client.go
+++ b/internal/tf/cache/helpers/client.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -13,10 +14,8 @@ import (
 	"github.com/puzpuzpuz/xsync/v4"
 )
 
-// maxPreallocBody bounds how much memory a response's Content-Length is trusted
-// to reserve before any of the body has arrived. Registry metadata sits orders of
-// magnitude below it, so a larger value buys nothing and costs a header's word.
-const maxPreallocBody = 32 << 20
+// maxResponseBody bounds a registry response body length.
+const maxResponseBody = 32 << 20
 
 // Client is the cache server's outbound HTTP client. It wraps a
 // [vhttp.Client] with registry credential injection and a per-URL response
@@ -39,7 +38,7 @@ func NewClient(c vhttp.Client, credsSource *cliconfig.CredentialsSource) *Client
 }
 
 // Do sends an HTTP request and decodes an HTTP response to the given `value`.
-func (client *Client) Do(ctx context.Context, method, reqURL string, value any) error {
+func (client *Client) Do(ctx context.Context, method, reqURL string, value any) (err error) {
 	if bodyBytes, ok := client.cache.Load(reqURL); ok {
 		return unmarshalBody(bodyBytes, value)
 	}
@@ -60,7 +59,10 @@ func (client *Client) Do(ctx context.Context, method, reqURL string, value any) 
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close() //nolint:errcheck // best-effort close of the response body
+
+	defer func() {
+		err = errors.Join(err, resp.Body.Close())
+	}()
 
 	bodyBytes, err := decodeResponse(resp)
 	if err != nil {
@@ -70,6 +72,28 @@ func (client *Client) Do(ctx context.Context, method, reqURL string, value any) 
 	client.cache.Store(reqURL, bodyBytes)
 
 	return unmarshalBody(bodyBytes, value)
+}
+
+// ReadBody reads r into memory, refusing a body past limit with
+// [ResponseTooLargeError] rather than decoding part of one.
+func ReadBody(r io.Reader, hint, limit int64) ([]byte, error) {
+	limited := io.LimitReader(r, limit+1)
+
+	buf := &bytes.Buffer{}
+	if hint > 0 && hint <= limit {
+		buf.Grow(int(hint))
+	}
+
+	n, err := buf.ReadFrom(limited)
+	if err != nil {
+		return nil, err
+	}
+
+	if n > limit {
+		return nil, ResponseTooLargeError{Limit: limit}
+	}
+
+	return buf.Bytes(), nil
 }
 
 func unmarshalBody(data []byte, value any) error {
@@ -94,26 +118,8 @@ func decodeResponse(resp *http.Response) ([]byte, error) {
 		return nil, err
 	}
 
-	body, readErr := readBody(reader, resp.ContentLength)
+	body, readErr := ReadBody(reader, resp.ContentLength, maxResponseBody)
 	if err := errors.Join(readErr, reader.Close()); err != nil {
-		return nil, err
-	}
-
-	return body, nil
-}
-
-// readBody reads r to completion. A positive size, which [ResponseReader] clears
-// when it unwraps a gzip stream, is the body's exact length, so the read needs one
-// allocation rather than [io.ReadAll]'s repeated doubling. Anything above
-// maxPreallocBody falls back to [io.ReadAll], so a registry advertising a bogus
-// Content-Length cannot make Terragrunt reserve that memory up front.
-func readBody(r io.Reader, size int64) ([]byte, error) {
-	if size <= 0 || size > maxPreallocBody {
-		return io.ReadAll(r)
-	}
-
-	body := make([]byte, size)
-	if _, err := io.ReadFull(r, body); err != nil {
 		return nil, err
 	}
 

--- a/internal/tf/cache/helpers/client_bench_test.go
+++ b/internal/tf/cache/helpers/client_bench_test.go
@@ -1,0 +1,90 @@
+package helpers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache/helpers"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+)
+
+// providerVersionsJSON approximates a registry's provider versions listing, which
+// grows with the number of published versions and the platforms each one targets.
+// Its size is what the decoding cost scales with.
+func providerVersionsJSON(tb testing.TB, versions int) []byte {
+	tb.Helper()
+
+	type platform struct {
+		OS   string `json:"os"`
+		Arch string `json:"arch"`
+	}
+
+	type version struct {
+		Version   string     `json:"version"`
+		Protocols []string   `json:"protocols"`
+		Platforms []platform `json:"platforms"`
+	}
+
+	oses := []string{"darwin", "linux", "windows"}
+	arches := []string{"amd64", "arm64"}
+
+	body := struct {
+		Versions []version `json:"versions"`
+	}{Versions: make([]version, 0, versions)}
+
+	for i := range versions {
+		v := version{
+			Version:   "5." + strconv.Itoa(i) + ".0",
+			Protocols: []string{"5.0", "6.0"},
+		}
+
+		for _, os := range oses {
+			for _, arch := range arches {
+				v.Platforms = append(v.Platforms, platform{OS: os, Arch: arch})
+			}
+		}
+
+		body.Versions = append(body.Versions, v)
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	return data
+}
+
+// BenchmarkClientDo measures a cache miss, where the response is read off the
+// wire and decoded. A fresh client per iteration keeps every iteration a miss
+// without letting the per-URL cache grow for the length of the run.
+func BenchmarkClientDo(b *testing.B) {
+	for _, versions := range []int{10, 200, 2000} {
+		b.Run(strconv.Itoa(versions)+"versions", func(b *testing.B) {
+			body := providerVersionsJSON(b, versions)
+
+			c := vhttp.NewMemClient(
+				func(_ context.Context, _ *http.Request) (*http.Response, error) {
+					return vhttp.Respond(http.StatusOK, body, nil), nil
+				},
+			)
+
+			ctx := b.Context()
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(body)))
+
+			for b.Loop() {
+				var value map[string]any
+
+				client := helpers.NewClient(c, nil)
+				if err := client.Do(ctx, http.MethodGet, "https://registry.test/v1/providers/hashicorp/aws/versions", &value); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/tf/cache/helpers/client_test.go
+++ b/internal/tf/cache/helpers/client_test.go
@@ -1,0 +1,137 @@
+package helpers_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache/helpers"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const versionsListing = `{"versions":[{"version":"5.0.0"},{"version":"5.1.0"}]}`
+
+// testLimit stands in for the real body limit, which a test would otherwise
+// have to allocate megabytes to reach.
+const testLimit = 64
+
+// TestReadBodyIgnoresTheHint pins that the body decides what comes back. A
+// Content-Length is the hint's usual source and a registry picks that freely,
+// so reading only as far as the hint would let one truncate a listing into a
+// shorter listing that still parses.
+func TestReadBodyIgnoresTheHint(t *testing.T) {
+	t.Parallel()
+
+	body := versionsListing
+
+	for name, hint := range map[string]int64{
+		"unknown length": -1,
+		"declared empty": 0,
+		"understated":    int64(len(body) / 2),
+		"exact":          int64(len(body)),
+		"overstated":     int64(len(body) * 2),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := helpers.ReadBody(strings.NewReader(body), hint, testLimit)
+			require.NoError(t, err)
+			assert.Equal(t, body, string(got))
+		})
+	}
+}
+
+// TestReadBodyRefusesABodyPastTheLimit pins that the limit bounds the read
+// itself. A registry declaring nothing, or gzipping its response, arrives with
+// no usable hint and would otherwise be read without a bound.
+func TestReadBodyRefusesABodyPastTheLimit(t *testing.T) {
+	t.Parallel()
+
+	body := bytes.Repeat([]byte("x"), testLimit+1)
+
+	_, err := helpers.ReadBody(bytes.NewReader(body), -1, testLimit)
+
+	var tooLarge helpers.ResponseTooLargeError
+
+	require.ErrorAs(t, err, &tooLarge)
+	assert.Equal(t, int64(testLimit), tooLarge.Limit)
+}
+
+// TestReadBodyKeepsABodyOnTheLimit pins the boundary, so the limit is the
+// largest body accepted rather than one byte below it.
+func TestReadBodyKeepsABodyOnTheLimit(t *testing.T) {
+	t.Parallel()
+
+	body := bytes.Repeat([]byte("x"), testLimit)
+
+	got, err := helpers.ReadBody(bytes.NewReader(body), testLimit, testLimit)
+	require.NoError(t, err)
+	assert.Len(t, got, testLimit)
+}
+
+// TestReadBodySurfacesATruncatedTransfer pins that a read ending early fails
+// the call. The bytes that did arrive can parse as a shorter document, which
+// would answer with versions the registry never published.
+func TestReadBodySurfacesATruncatedTransfer(t *testing.T) {
+	t.Parallel()
+
+	cut := errors.New("connection reset")
+
+	_, err := helpers.ReadBody(errAfter(versionsListing[:10], cut), -1, testLimit)
+	require.ErrorIs(t, err, cut)
+}
+
+// TestClientDoDecodesAResponseItsContentLengthUnderstates pins the whole path
+// for a header a registry can understate at will.
+func TestClientDoDecodesAResponseItsContentLengthUnderstates(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(versionsListing)
+
+	c := vhttp.NewMemClient(func(_ context.Context, _ *http.Request) (*http.Response, error) {
+		resp := vhttp.Respond(http.StatusOK, body, nil)
+		resp.ContentLength = int64(len(body) / 2)
+
+		return resp, nil
+	})
+
+	var value struct {
+		Versions []struct {
+			Version string `json:"version"`
+		} `json:"versions"`
+	}
+
+	client := helpers.NewClient(c, nil)
+	require.NoError(t, client.Do(
+		t.Context(),
+		http.MethodGet,
+		"https://registry.test/v1/providers/hashicorp/aws/versions",
+		&value,
+	))
+
+	assert.Len(t, value.Versions, 2)
+}
+
+// errAfter returns a reader that yields prefix and then fails, standing in for
+// a transfer the transport reports as cut short.
+func errAfter(prefix string, err error) *truncatedReader {
+	return &truncatedReader{prefix: strings.NewReader(prefix), err: err}
+}
+
+type truncatedReader struct {
+	prefix *strings.Reader
+	err    error
+}
+
+func (r *truncatedReader) Read(p []byte) (int, error) {
+	if r.prefix.Len() > 0 {
+		return r.prefix.Read(p)
+	}
+
+	return 0, r.err
+}

--- a/pkg/log/writer/writer.go
+++ b/pkg/log/writer/writer.go
@@ -42,40 +42,51 @@ func (writer *Writer) SetOption(opts ...Option) {
 
 // Write implements `io.Writer` interface.
 func (writer *Writer) Write(p []byte) (n int, err error) {
-	var (
-		str  = string(p)
-		strs = []string{str}
-	)
+	str := string(p)
 
-	if writer.msgSeparator != "" {
-		strs = strings.Split(str, writer.msgSeparator)
-	}
-
-	for _, str := range strs {
-		if len(str) == 0 {
-			continue
-		}
-
-		msg, time, level, err := writer.parseFunc(str)
-		if err != nil {
+	if writer.msgSeparator == "" {
+		if err := writer.logRecord(str); err != nil {
 			return 0, err
 		}
 
-		// Reset ANSI styles at the end of a line so that the new line does not inherit them
-		msg = log.ResetASCISeq(msg)
+		return len(p), nil
+	}
 
-		logger := writer.logger
-
-		if time != nil {
-			logger = logger.WithTime(*time)
+	// Every byte of tofu output crosses this writer, so range over the records as
+	// they are split instead of collecting them into a slice first.
+	for record := range strings.SplitSeq(str, writer.msgSeparator) {
+		if err := writer.logRecord(record); err != nil {
+			return 0, err
 		}
-
-		if level == nil {
-			level = &writer.defaultLevel
-		}
-
-		logger.Log(*level, msg)
 	}
 
 	return len(p), nil
+}
+
+func (writer *Writer) logRecord(str string) error {
+	if len(str) == 0 {
+		return nil
+	}
+
+	msg, time, level, err := writer.parseFunc(str)
+	if err != nil {
+		return err
+	}
+
+	// Reset ANSI styles at the end of a line so that the new line does not inherit them
+	msg = log.ResetASCISeq(msg)
+
+	logger := writer.logger
+
+	if time != nil {
+		logger = logger.WithTime(*time)
+	}
+
+	if level == nil {
+		level = &writer.defaultLevel
+	}
+
+	logger.Log(*level, msg)
+
+	return nil
 }

--- a/pkg/log/writer/writer_bench_test.go
+++ b/pkg/log/writer/writer_bench_test.go
@@ -1,0 +1,44 @@
+package writer_test
+
+import (
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/pkg/log/writer"
+)
+
+// tfOutputChunk mimics one read from a tofu process's stdout pipe, where many
+// newline separated records arrive in a single Write.
+func tfOutputChunk(lines int) []byte {
+	var sb strings.Builder
+
+	for i := range lines {
+		sb.WriteString("module.vpc.aws_subnet.private[")
+		sb.WriteString(strconv.Itoa(i))
+		sb.WriteString("]: Refreshing state... [id=subnet-0a1b2c3d4e5f6a7b8]\n")
+	}
+
+	return []byte(sb.String())
+}
+
+func BenchmarkWriterWrite(b *testing.B) {
+	for _, lines := range []int{1, 16, 256} {
+		b.Run(strconv.Itoa(lines)+"lines", func(b *testing.B) {
+			l := log.New(log.WithLevel(log.InfoLevel), log.WithOutput(io.Discard))
+			w := writer.New(writer.WithLogger(l), writer.WithMsgSeparator("\n"))
+			chunk := tfOutputChunk(lines)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(chunk)))
+
+			for b.Loop() {
+				if _, err := w.Write(chunk); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Streams output in a couple places where we were previously buffering all the content in memory before it got to its final destination. Dramatically reduces memory consumption in some places as consequence.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced memory usage when running all plans, including large outputs.
  - Improved handling of provider responses and streamed log output.

- **Reliability**
  - Plan files are written safely and atomically, preserving previous files when runs fail.
  - Improved detection of plan errors as output is received.
  - Temporary files are cleaned up after successful or failed writes.
  - Oversized provider responses are rejected safely.

- **Documentation**
  - Added a changelog entry describing the reduced-memory improvements in v1.1.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->