### PR TITLE
fix: Fixing `render --json` expansion logic

### DIFF
--- a/docs/src/data/changelog/v1.1.5/render-json-expansion.mdx
+++ b/docs/src/data/changelog/v1.1.5/render-json-expansion.mdx
@@ -1,0 +1,54 @@
+---
+version: "v1.1.5"
+category: "experiments-updated"
+---
+
+#### `render` previews an expanded `dependency` block written in JSON
+
+With the [`block-iteration`](/reference/experiments/active#block-iteration) experiment enabled, a configuration written in JSON now renders the same way an HCL one does. It has no HCL to quote, so Terragrunt writes the block as the HCL that means the same thing and previews the elements underneath it:
+
+```bash
+$ cat terragrunt.hcl.json
+{"dependency": {"shard": {
+  "expansion": {"count": 2},
+  "config_path": "../shard-${count.index}"
+}}}
+
+$ terragrunt render --experiment block-iteration
+dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  config_path = "../shard-${count.index}"
+}
+
+# Expands to:
+#
+# dependency "shard" {
+#   config_path = "../shard-0"
+# }
+#
+# dependency "shard" {
+#   config_path = "../shard-1"
+# }
+```
+
+Previously the elements rendered as ordinary blocks, which repeated one label. Terragrunt warns about that and rejects it under the `duplicate-dependency-labels` [strict control](/reference/strict-controls/active#duplicate-dependency-labels), so the rendered file did not read back.
+
+`--format json` no longer drops the elements either. Its `dependency` map is keyed by label, which every element shares, so it kept whichever element came last. JSON has no comment to preview the elements in, so it now emits the block as it was written, references and all:
+
+```bash
+$ terragrunt render --format json --experiment block-iteration
+{
+  "dependency": {
+    "shard": {
+      "expansion": { "count": 2 },
+      "config_path": "../shard-${count.index}",
+      "skip_outputs": true
+    }
+  }
+}
+```
+
+Whichever syntax you write and whichever format you ask for, rendering the output again returns it unchanged.

--- a/docs/src/data/commands/render.mdx
+++ b/docs/src/data/commands/render.mdx
@@ -151,3 +151,55 @@ The expanded blocks are in comments because they are not a valid Terragrunt conf
 A `dependency` block with no `expansion` block renders as it always has.
 
 </Since>
+
+<Since version="1.1.5">
+
+A configuration written in JSON reads the same way. It has no HCL to quote, so `render` writes the block as the HCL that means the same thing and previews the elements underneath it:
+
+```bash
+$ cat terragrunt.hcl.json
+{"dependency": {"shard": {
+  "expansion": {"count": 2},
+  "config_path": "../shard-${count.index}"
+}}}
+
+$ terragrunt render --experiment block-iteration
+dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  config_path = "../shard-${count.index}"
+}
+
+# Expands to:
+#
+# dependency "shard" {
+#   config_path = "../shard-0"
+# }
+#
+# dependency "shard" {
+#   config_path = "../shard-1"
+# }
+```
+
+`--format json` has no comment to preview the elements in, and its `dependency` map is keyed by label, which every element shares. It emits the block as it was written, references and all:
+
+```bash
+$ terragrunt render --format json --experiment block-iteration
+{
+  "dependency": {
+    "shard": {
+      "expansion": { "count": 2 },
+      "config_path": "../shard-${count.index}",
+      "skip_outputs": true
+    }
+  }
+}
+```
+
+An expanded block uses the names the configuration writes, such as `skip_outputs`, rather than the resolved names an unexpanded block gets, such as `skip`. Nothing about it has been resolved, so it appears as declared.
+
+Whichever syntax you write and whichever format you ask for, rendering the output again returns it unchanged.
+
+</Since>

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -732,8 +732,8 @@ func appendRootAttributes(body *hclwrite.Body, cfg *TerragruntConfig, asCty cty.
 }
 
 // dependencyGroup is the decoded dependencies one written block produced. source is nil
-// for a block that declared no expansion, and for one whose text could not be recovered,
-// which leaves deps holding the elements alone.
+// for a block that declared no expansion, and for one decoded outside the expanding
+// decoder, which leaves deps holding a single dependency.
 type dependencyGroup struct {
 	source *hclparse.SourceBlock
 	deps   []*Dependency
@@ -775,8 +775,13 @@ func groupExpandedDependencies(deps Dependencies) []dependencyGroup {
 // [validateUniqueDependencies] warns about and, under its strict control, rejects.
 // Rendering them as configuration would produce a file that reads back as one dependency.
 func appendExpansionPreview(body *hclwrite.Body, group dependencyGroup) error {
+	text, err := group.source.Body()
+	if err != nil {
+		return err
+	}
+
 	source, diags := hclwrite.ParseConfig(
-		[]byte(group.source.Text),
+		[]byte(text),
 		group.source.Range.Filename,
 		group.source.Range.Start,
 	)

--- a/pkg/config/config_as_cty.go
+++ b/pkg/config/config_as_cty.go
@@ -680,16 +680,33 @@ func RemoteStateAsCty(remote *remotestate.RemoteState) (cty.Value, error) {
 }
 
 // Serialize the list of dependency blocks to a cty Value as a map that maps the block names to the cty representation.
+//
+// Every element of an expanded block carries its label, and this map is keyed by label, so
+// serializing the elements would keep only the last. Unlike the HCL render, JSON has no comment
+// to preview them in.
 func dependencyBlocksAsCty(dependencyBlocks Dependencies) (cty.Value, error) {
 	out := map[string]cty.Value{}
 
-	for _, block := range dependencyBlocks {
-		blockCty, err := GoTypeToCty(block)
-		if err != nil {
-			return cty.NilVal, err
+	for _, group := range groupExpandedDependencies(dependencyBlocks) {
+		if group.source != nil {
+			blockCty, err := group.source.BodyAsCty()
+			if err != nil {
+				return cty.NilVal, err
+			}
+
+			out[group.deps[0].Name] = blockCty
+
+			continue
 		}
 
-		out[block.Name] = blockCty
+		for _, dep := range group.deps {
+			blockCty, err := GoTypeToCty(*dep)
+			if err != nil {
+				return cty.NilVal, err
+			}
+
+			out[dep.Name] = blockCty
+		}
 	}
 
 	return ConvertValuesMapToCtyVal(out)

--- a/pkg/config/config_as_cty.go
+++ b/pkg/config/config_as_cty.go
@@ -293,31 +293,44 @@ func TerragruntConfigAsCtyWithMetadata(config *TerragruntConfig) (cty.Value, err
 	if config.TerragruntDependencies != nil {
 		var dependenciesMap = map[string]cty.Value{}
 
-		for _, block := range config.TerragruntDependencies {
-			ctyValue, err := GoTypeToCty(block)
-			if err != nil {
+		for _, group := range groupExpandedDependencies(config.TerragruntDependencies) {
+			// This map is keyed by label too, so serialize the block that produced the
+			// elements rather than the elements themselves.
+			if group.source != nil {
+				blockCty, err := group.source.BodyAsCty()
+				if err != nil {
+					return cty.NilVal, err
+				}
+
+				name := group.deps[0].Name
+
+				value, err := dependencyWithMetadata(config, name, blockCty)
+				if err != nil {
+					continue
+				}
+
+				dependenciesMap[name] = value
+
 				continue
 			}
 
-			if ctyValue == cty.NilVal {
-				continue
+			for _, dep := range group.deps {
+				ctyValue, err := GoTypeToCty(*dep)
+				if err != nil {
+					continue
+				}
+
+				if ctyValue == cty.NilVal {
+					continue
+				}
+
+				value, err := dependencyWithMetadata(config, dep.Name, ctyValue)
+				if err != nil {
+					continue
+				}
+
+				dependenciesMap[dep.Name] = value
 			}
-
-			var content = ValueWithMetadata{
-
-				Value: ctyValue}
-
-			metadata, found := config.GetMapFieldMetadata(MetadataDependency, block.Name)
-			if found {
-				content.Metadata = metadata
-			}
-
-			value, err := GoTypeToCty(content)
-			if err != nil {
-				continue
-			}
-
-			dependenciesMap[block.Name] = value
 		}
 
 		if len(dependenciesMap) > 0 {
@@ -677,6 +690,21 @@ func RemoteStateAsCty(remote *remotestate.RemoteState) (cty.Value, error) {
 	output["encryption"] = ctyJSONVal
 
 	return ConvertValuesMapToCtyVal(output)
+}
+
+// dependencyWithMetadata wraps a serialized dependency in the metadata recorded for its label.
+func dependencyWithMetadata(
+	config *TerragruntConfig,
+	name string,
+	value cty.Value,
+) (cty.Value, error) {
+	content := ValueWithMetadata{Value: value}
+
+	if metadata, found := config.GetMapFieldMetadata(MetadataDependency, name); found {
+		content.Metadata = metadata
+	}
+
+	return GoTypeToCty(content)
 }
 
 // Serialize the list of dependency blocks to a cty Value as a map that maps the block names to the cty representation.

--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -1546,13 +1546,25 @@ func parseDependencyJSONString(
 func parseStackString(tb testing.TB, cfg string) (*config.StackConfig, error) {
 	tb.Helper()
 
-	ctx, pctx := newExpansionParsingContext(tb, venvtest.New(), config.DefaultStackFile)
+	return parseStackStringAt(tb, config.DefaultStackFile, cfg)
+}
+
+func parseStackJSONString(tb testing.TB, cfg string) (*config.StackConfig, error) {
+	tb.Helper()
+
+	return parseStackStringAt(tb, config.DefaultStackFile+".json", cfg)
+}
+
+func parseStackStringAt(tb testing.TB, path, cfg string) (*config.StackConfig, error) {
+	tb.Helper()
+
+	ctx, pctx := newExpansionParsingContext(tb, venvtest.New(), path)
 
 	return config.ReadStackConfigString(
 		ctx,
 		logger.CreateLogger(),
 		pctx,
-		config.DefaultStackFile,
+		path,
 		cfg,
 		nil,
 	)
@@ -1586,4 +1598,37 @@ func parseHCLString(tb testing.TB, cfg, configPath string) *hclparse.File {
 	require.NoError(tb, err)
 
 	return file
+}
+
+// TestUnitExpandsInJSONStackFile pins that a stack file written in JSON expands the same way an
+// HCL one does, including a unit block written as an array. Nothing reads the HCL a unit block is
+// quoted back into, so the unexpanded unit here carries a property no HCL argument can spell: a
+// stack file must not fail on text that only an expanded block would ever need.
+func TestUnitExpandsInJSONStackFile(t *testing.T) {
+	t.Parallel()
+
+	stackCfg, err := parseStackJSONString(t, `{
+  "unit": {
+    "app": [{
+      "expansion": {"count": 2},
+      "source": "./modules/app",
+      "path": "app-${count.index}"
+    }],
+    "vpc": {
+      "//": "the network",
+      "source": "./modules/vpc",
+      "path": "vpc",
+      "not an identifier": "a unit block accepts properties it does not declare"
+    }
+  }
+}`)
+	require.NoError(t, err)
+	require.Len(t, stackCfg.Units, 3)
+
+	paths := make([]string, 0, len(stackCfg.Units))
+	for _, unit := range stackCfg.Units {
+		paths = append(paths, unit.Path)
+	}
+
+	assert.ElementsMatch(t, []string{"app-0", "app-1", "vpc"}, paths)
 }

--- a/pkg/config/hclparse/blockcty.go
+++ b/pkg/config/hclparse/blockcty.go
@@ -1,0 +1,168 @@
+package hclparse
+
+import (
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// BodyAsCty renders the block's body the way a JSON config writes it. An expression that cannot
+// be evaluated on its own, which is every reference to the iteration a block expands over,
+// becomes the template a JSON config spells it with.
+func (src *SourceBlock) BodyAsCty() (cty.Value, error) {
+	source, err := src.Body()
+	if err != nil {
+		return cty.NilVal, err
+	}
+
+	text := []byte(source)
+
+	file, diags := hclsyntax.ParseConfig(text, src.Range.Filename, hcl.InitialPos)
+	if diags.HasErrors() {
+		return cty.NilVal, diags
+	}
+
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok || len(body.Blocks) != 1 {
+		return cty.NilVal, UnquotableBlockError{Subject: &src.Range}
+	}
+
+	return bodyAsCty(body.Blocks[0].Body, text)
+}
+
+func bodyAsCty(body *hclsyntax.Body, text []byte) (cty.Value, error) {
+	out := map[string]cty.Value{}
+
+	for name, attr := range body.Attributes {
+		value, err := exprAsCty(attr.Expr, text)
+		if err != nil {
+			return cty.NilVal, err
+		}
+
+		out[name] = value
+	}
+
+	for _, block := range body.Blocks {
+		if len(block.Labels) > 0 {
+			blockRange := block.DefRange()
+
+			return cty.NilVal, UnquotableBlockError{Subject: &blockRange}
+		}
+
+		value, err := bodyAsCty(block.Body, text)
+		if err != nil {
+			return cty.NilVal, err
+		}
+
+		out[block.Type] = value
+	}
+
+	return cty.ObjectVal(out), nil
+}
+
+func exprAsCty(expr hclsyntax.Expression, text []byte) (cty.Value, error) {
+	switch expr := expr.(type) {
+	case *hclsyntax.TemplateExpr:
+		rendered, err := templateAsString(expr, text)
+		if err != nil {
+			return cty.NilVal, err
+		}
+
+		return cty.StringVal(rendered), nil
+	case *hclsyntax.TemplateWrapExpr:
+		// Wrapping this again would nest a string in a string and turn what it evaluates to
+		// into text.
+		return cty.StringVal("${" + exprText(expr.Wrapped, text) + "}"), nil
+	case *hclsyntax.ObjectConsExpr:
+		return objectConsAsCty(expr, text)
+	case *hclsyntax.TupleConsExpr:
+		return tupleConsAsCty(expr, text)
+	}
+
+	if value, diags := expr.Value(nil); !diags.HasErrors() && value.IsWhollyKnown() {
+		return value, nil
+	}
+
+	// JSON reads a string as a template, and a template that is a single interpolation keeps the
+	// type of whatever that interpolation evaluates to.
+	return cty.StringVal("${" + exprText(expr, text) + "}"), nil
+}
+
+// objectConsAsCty renders an object one key at a time, so a reference in one value does not turn
+// the whole object into a string.
+func objectConsAsCty(expr *hclsyntax.ObjectConsExpr, text []byte) (cty.Value, error) {
+	out := map[string]cty.Value{}
+
+	for _, item := range expr.Items {
+		key, diags := item.KeyExpr.Value(nil)
+		if diags.HasErrors() || key.Type() != cty.String || !key.IsKnown() {
+			// A key JSON cannot spell, such as one computed from the iteration. The object goes
+			// back whole, as the one interpolation that rebuilds it.
+			return cty.StringVal("${" + exprText(expr, text) + "}"), nil
+		}
+
+		value, err := exprAsCty(item.ValueExpr, text)
+		if err != nil {
+			return cty.NilVal, err
+		}
+
+		out[key.AsString()] = value
+	}
+
+	return cty.ObjectVal(out), nil
+}
+
+func tupleConsAsCty(expr *hclsyntax.TupleConsExpr, text []byte) (cty.Value, error) {
+	out := make([]cty.Value, 0, len(expr.Exprs))
+
+	for _, element := range expr.Exprs {
+		value, err := exprAsCty(element, text)
+		if err != nil {
+			return cty.NilVal, err
+		}
+
+		out = append(out, value)
+	}
+
+	return cty.TupleVal(out), nil
+}
+
+// templateAsString rebuilds a template from its own source, unevaluated.
+func templateAsString(template *hclsyntax.TemplateExpr, text []byte) (string, error) {
+	var sb strings.Builder
+
+	for _, part := range template.Parts {
+		literal, ok := part.(*hclsyntax.LiteralValueExpr)
+		if !ok {
+			source := exprText(part, text)
+
+			// A directive is already written in template syntax and spans its own markers, so
+			// an interpolation around it would be read as part of the expression it controls.
+			if strings.HasPrefix(source, "%{") {
+				sb.WriteString(source)
+
+				continue
+			}
+
+			sb.WriteString("${" + source + "}")
+
+			continue
+		}
+
+		if literal.Val.Type() != cty.String {
+			return "", UnquotableBlockError{Subject: &template.SrcRange}
+		}
+
+		sb.WriteString(escapeTemplateMarkers(literal.Val.AsString()))
+	}
+
+	return sb.String(), nil
+}
+
+func exprText(expr hclsyntax.Expression, text []byte) string {
+	rng := expr.Range()
+
+	return string(text[rng.Start.Byte:rng.End.Byte])
+}

--- a/pkg/config/hclparse/blockcty_test.go
+++ b/pkg/config/hclparse/blockcty_test.go
@@ -1,0 +1,127 @@
+package hclparse_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
+)
+
+// sourceBlock builds a SourceBlock over text the way [hclparse.File.ExpandBlocks] would.
+func sourceBlock(text string) *hclparse.SourceBlock {
+	return hclparse.NewSourceBlock(text, hcl.Range{Filename: "terragrunt.hcl"})
+}
+
+// assertCty compares by value. A cty number carries big.Float state that a deep compare reads as
+// a difference even when the two numbers are the same.
+func assertCty(t *testing.T, want, got cty.Value) {
+	t.Helper()
+
+	assert.True(t, want.RawEquals(got), "want %#v, got %#v", want, got)
+}
+
+// TestBodyAsCtyRejectsLabeledNestedBlock pins a guard nothing reaches today, since no
+// dependency, unit or stack block declares a labeled nested block. JSON nests such a block once
+// per label, so writing it as one object would claim a config the caller never wrote.
+func TestBodyAsCtyRejectsLabeledNestedBlock(t *testing.T) {
+	t.Parallel()
+
+	_, err := sourceBlock(`dependency "aurora" {
+  generate "backend" {
+    path = "backend.tf"
+  }
+}`).BodyAsCty()
+
+	var typed hclparse.UnquotableBlockError
+	require.ErrorAs(t, err, &typed)
+}
+
+// TestBodyAsCtyRejectsUnparseableText pins that text which is not one block is refused rather
+// than serialized into something a config would read differently.
+func TestBodyAsCtyRejectsUnparseableText(t *testing.T) {
+	t.Parallel()
+
+	for name, text := range map[string]string{
+		"two blocks":  "dependency \"a\" {}\ndependency \"b\" {}",
+		"no block":    "config_path = \"../a\"",
+		"not hcl":     "{\"dependency\": {}}",
+		"empty input": "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := sourceBlock(text).BodyAsCty()
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestBodyAsCtyKeepsEmptyCollections pins that an empty object comes back as an empty object
+// and an empty list as an empty list, rather than as the template a value would fall back to.
+func TestBodyAsCtyKeepsEmptyCollections(t *testing.T) {
+	t.Parallel()
+
+	value, err := sourceBlock(`dependency "aurora" {
+  expansion {
+    count = 1
+  }
+
+  config_path  = "../a-${count.index}"
+  mock_outputs = {
+    nothing = {}
+    none    = []
+  }
+}`).BodyAsCty()
+	require.NoError(t, err)
+
+	mocks := value.GetAttr("mock_outputs")
+	assertCty(t, cty.EmptyObjectVal, mocks.GetAttr("nothing"))
+	assertCty(t, cty.EmptyTupleVal, mocks.GetAttr("none"))
+
+	assertCty(t, cty.NumberIntVal(1), value.GetAttr("expansion").GetAttr("count"))
+	assertCty(t, cty.StringVal("../a-${count.index}"), value.GetAttr("config_path"))
+}
+
+// TestBodyAsCtyKeepsEscapedTemplateMarkers pins that a marker the config escaped comes back
+// escaped, so the rendered configuration still reads as the literal text it was written as.
+func TestBodyAsCtyKeepsEscapedTemplateMarkers(t *testing.T) {
+	t.Parallel()
+
+	value, err := sourceBlock(`dependency "aurora" {
+  expansion {
+    count = 1
+  }
+
+  config_path  = "../a-${count.index}"
+  mock_outputs = {
+    literal = "$${not an interpolation}"
+    nested  = ["%%{not a directive}"]
+  }
+}`).BodyAsCty()
+	require.NoError(t, err)
+
+	mocks := value.GetAttr("mock_outputs")
+	assertCty(t, cty.StringVal("$${not an interpolation}"), mocks.GetAttr("literal"))
+	assertCty(t, cty.StringVal("%%{not a directive}"), mocks.GetAttr("nested").Index(cty.NumberIntVal(0)))
+}
+
+// TestBodyAsCtyKeepsDirectives pins that a directive comes back as the directive rather than as
+// the branch it takes.
+func TestBodyAsCtyKeepsDirectives(t *testing.T) {
+	t.Parallel()
+
+	value, err := sourceBlock(`dependency "aurora" {
+  expansion {
+    count = 1
+  }
+
+  config_path = "../a-%{ if true }one%{ else }two%{ endif }"
+}`).BodyAsCty()
+	require.NoError(t, err)
+
+	assertCty(t, cty.StringVal("../a-%{ if true }one%{ else }two%{ endif }"), value.GetAttr("config_path"))
+}

--- a/pkg/config/hclparse/errors.go
+++ b/pkg/config/hclparse/errors.go
@@ -173,3 +173,62 @@ func (err UnsupportedForEachKeyTypeError) Error() string {
 		err.Type,
 	)
 }
+
+// JSONBlockSourceError is returned when a block written in JSON cannot be rendered back as the
+// HCL that means the same thing.
+type JSONBlockSourceError struct {
+	Subject *hcl.Range
+	Err     error
+}
+
+func (err JSONBlockSourceError) Error() string {
+	return fmt.Sprintf(
+		"%s: `render` cannot rewrite this JSON block as HCL: %v. The configuration is fine. "+
+			"This is a bug in Terragrunt, so please open an issue at "+
+			"https://github.com/gruntwork-io/terragrunt/issues",
+		err.Subject,
+		err.Err,
+	)
+}
+
+func (err JSONBlockSourceError) Unwrap() error {
+	return err.Err
+}
+
+// UnsupportedJSONBlockError is returned for a nested block that JSON writes as one object per
+// label, which does not map onto a single HCL block.
+type UnsupportedJSONBlockError struct {
+	BlockType string
+}
+
+func (err UnsupportedJSONBlockError) Error() string {
+	return "the " + err.BlockType + " block takes labels, which cannot be recovered from JSON"
+}
+
+// UnquotableBlockError is returned when a block cannot be written back out as the object a
+// JSON config would hold it in.
+type UnquotableBlockError struct {
+	Subject *hcl.Range
+}
+
+func (err UnquotableBlockError) Error() string {
+	return fmt.Sprintf("%s: cannot render this block as JSON", err.Subject)
+}
+
+// UnsupportedJSONValueError is returned for JSON that is not the object, array, string, number,
+// boolean or null the decoder expected.
+type UnsupportedJSONValueError struct {
+	Value string
+}
+
+func (err UnsupportedJSONValueError) Error() string {
+	return "unsupported JSON value: " + err.Value
+}
+
+// UnlocatableJSONBlockError is returned when the array a JSON config wrote a block in holds no
+// element ending where the block's body does, leaving no text to render the block from.
+type UnlocatableJSONBlockError struct{}
+
+func (err UnlocatableJSONBlockError) Error() string {
+	return "no element of the array holding this block ends where its body does"
+}

--- a/pkg/config/hclparse/expansion.go
+++ b/pkg/config/hclparse/expansion.go
@@ -74,16 +74,26 @@ type ExpansionBlock struct {
 	InstanceKey
 }
 
-// SourceBlock is a block as it was written, before expansion decoded it once per
-// element. Every instance of one block points at the same SourceBlock, so a caller can
-// group instances back together by [SourceBlock.Range].
+// SourceBlock is the HCL text of a block, before expansion decoded it once per element. Every
+// instance of one block points at the same SourceBlock, so a caller can group instances back
+// together by [SourceBlock.Range].
 //
-// Only [ExpandBlocks] fills it in, and only for native HCL syntax: a block handed to
-// [ExpandBlock] on its own carries no file to slice, and a JSON config has no HCL text
-// to quote back.
+// Only [ExpandBlocks] fills it in, and only for a block that expansion split into elements. A
+// block handed to [ExpandBlock] on its own carries no file to read it out of.
 type SourceBlock struct {
-	Text  string
+	err   error
+	text  string
 	Range hcl.Range
+}
+
+// NewSourceBlock builds a block over text that was not read out of a file.
+func NewSourceBlock(text string, rng hcl.Range) *SourceBlock {
+	return &SourceBlock{text: text, Range: rng}
+}
+
+// Body returns the block's HCL text, or the error that stopped Terragrunt from recovering it.
+func (src *SourceBlock) Body() (string, error) {
+	return src.text, src.err
 }
 
 // InstanceKey identifies which expansion element produced a decoded block. It carries
@@ -162,10 +172,7 @@ func (file *File) ExpandBlocks(
 
 		expanded, err := ExpandBlock(block, out, ctx, opts...)
 		if err == nil {
-			source := blockSource(file.Bytes, block)
-			for i := range expanded {
-				expanded[i].Source = source
-			}
+			attachSource(file.Bytes, block, out, expanded)
 
 			instances = append(instances, expanded...)
 
@@ -254,13 +261,36 @@ func skipBlock(block *hcl.Block, skipLabels map[string]struct{}) bool {
 	return err == nil && expansion == nil
 }
 
+// attachSource records the text of a block that expansion split into elements, so a caller can
+// quote the block rather than the elements it produced.
+//
+// A block that expanded into nothing, and one that never declared expansion, has no elements to
+// group and gets no text. Recovering the text of a block written in JSON means transcoding it,
+// and blocks that would throw the text away stay off that path.
+func attachSource(src []byte, block *hcl.Block, out any, instances []Instance) {
+	if len(instances) == 0 || !instances[0].Expanded() {
+		return
+	}
+
+	source, err := blockSource(src, block, out)
+	if err != nil {
+		// Only render reads this text, so the failure rides along on the block rather than
+		// failing the parse that every command performs.
+		source = &SourceBlock{err: err, Range: block.DefRange}
+	}
+
+	for i := range instances {
+		instances[i].Source = source
+	}
+}
+
 // blockSource slices block back out of the file it was parsed from, so a caller can quote
-// the block as written rather than as decoded. A body that is not native HCL syntax has
-// no such text and yields nil.
-func blockSource(src []byte, block *hcl.Block) *SourceBlock {
+// the block as written rather than as decoded. A block written in JSON becomes the equivalent
+// HCL instead, since the preview of its elements has to hang off a block.
+func blockSource(src []byte, block *hcl.Block, out any) (*SourceBlock, error) {
 	body, ok := block.Body.(*hclsyntax.Body)
 	if !ok {
-		return nil
+		return jsonBlockSource(src, block, out)
 	}
 
 	rng := hcl.Range{
@@ -270,9 +300,9 @@ func blockSource(src []byte, block *hcl.Block) *SourceBlock {
 	}
 
 	return &SourceBlock{
-		Text:  string(src[rng.Start.Byte:rng.End.Byte]),
+		text:  string(src[rng.Start.Byte:rng.End.Byte]),
 		Range: rng,
-	}
+	}, nil
 }
 
 // ExpandBlock decodes block once per iteration element, returning one Instance per

--- a/pkg/config/hclparse/jsonsource.go
+++ b/pkg/config/hclparse/jsonsource.go
@@ -1,0 +1,531 @@
+package hclparse
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+const blockTagKind = "block"
+
+// jsonCommentKey is the property hcl reads as a comment on a body rather than as part of it.
+const jsonCommentKey = "//"
+
+// firstPrintable is the lowest rune HCL accepts in a quoted string without an escape.
+const firstPrintable = 0x20
+
+// jsonMember is one property of a JSON object, kept in source order so the rendered HCL reads
+// in the same order as the config it came from.
+type jsonMember struct {
+	name  string
+	value json.RawMessage
+}
+
+// jsonBlockSource renders a block written in JSON as the equivalent HCL, so a caller can quote
+// it like any other block.
+func jsonBlockSource(src []byte, block *hcl.Block, out any) (*SourceBlock, error) {
+	rng := jsonBlockRange(block)
+
+	members, err := jsonBlockMembers(src, block)
+	if err != nil {
+		return nil, JSONBlockSourceError{Subject: &rng, Err: err}
+	}
+
+	var sb strings.Builder
+
+	if err := writeJSONBlock(&sb, block.Type, block.Labels, members, reflect.TypeOf(out).Elem()); err != nil {
+		return nil, JSONBlockSourceError{Subject: &rng, Err: err}
+	}
+
+	text := hclwrite.Format([]byte(sb.String()))
+
+	// This HCL is quoted into a config that has to parse. Nothing downstream would catch a
+	// transcoding bug before it reached a rendered file, so parse it here.
+	if _, diags := hclsyntax.ParseConfig(text, block.TypeRange.Filename, hcl.InitialPos); diags.HasErrors() {
+		return nil, JSONBlockSourceError{Subject: &rng, Err: diags}
+	}
+
+	return &SourceBlock{
+		text:  strings.TrimRight(string(text), "\n"),
+		Range: rng,
+	}, nil
+}
+
+// jsonBlockRange returns the range that identifies one block. hcl gives every instance a JSON
+// config wrote in an array the range of that array, so a caller grouping blocks by range would
+// fold them into one.
+func jsonBlockRange(block *hcl.Block) hcl.Range {
+	return hcl.RangeBetween(block.DefRange, block.Body.MissingItemRange())
+}
+
+// jsonBlockMembers reads the properties of the object holding the block's body.
+func jsonBlockMembers(src []byte, block *hcl.Block) ([]jsonMember, error) {
+	// DefRange opens the block's value, so this starts at the object, or at the array of them.
+	value := src[block.DefRange.Start.Byte:]
+	if !bytes.HasPrefix(value, []byte("[")) {
+		return decodeJSONObject(value)
+	}
+
+	end := block.Body.MissingItemRange().End.Byte - block.DefRange.Start.Byte
+
+	element, err := jsonArrayElementEndingAt(value, int64(end))
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeJSONObject(element)
+}
+
+// jsonArrayElementEndingAt returns the element of the array at the start of src that ends offset
+// bytes into it.
+func jsonArrayElementEndingAt(src []byte, offset int64) (json.RawMessage, error) {
+	dec := json.NewDecoder(bytes.NewReader(src))
+
+	if err := expectDelim(dec, '['); err != nil {
+		return nil, err
+	}
+
+	for dec.More() {
+		var element json.RawMessage
+		if err := dec.Decode(&element); err != nil {
+			return nil, err
+		}
+
+		if dec.InputOffset() == offset {
+			return element, nil
+		}
+	}
+
+	return nil, UnlocatableJSONBlockError{}
+}
+
+// writeJSONBlock writes a block header and its body. Labels are quoted rather than written
+// bare, since a JSON block label is whatever string the property name held.
+func writeJSONBlock(
+	sb *strings.Builder,
+	blockType string,
+	labels []string,
+	members []jsonMember,
+	structType reflect.Type,
+) error {
+	sb.WriteString(blockType)
+
+	for _, label := range labels {
+		sb.WriteString(" " + hclStringLiteral(label))
+	}
+
+	sb.WriteString(" {\n")
+
+	if err := writeJSONBody(sb, members, structType); err != nil {
+		return err
+	}
+
+	sb.WriteString("}\n")
+
+	return nil
+}
+
+// writeJSONBody writes the properties of one JSON object as the attributes and nested blocks
+// of an HCL body.
+func writeJSONBody(sb *strings.Builder, members []jsonMember, structType reflect.Type) error {
+	blocks := blockFields(structType)
+	members = bodyMembers(members)
+
+	for i, member := range members {
+		nestedType, isBlock := blocks[member.name]
+		if !isBlock {
+			value, err := jsonValueHCL(member.value)
+			if err != nil {
+				return err
+			}
+
+			sb.WriteString(member.name + " = " + value + "\n")
+
+			continue
+		}
+
+		if labels := labelFields(nestedType); len(labels) > 0 {
+			return UnsupportedJSONBlockError{BlockType: member.name}
+		}
+
+		bodies, err := nestedJSONBlocks(member.value)
+		if err != nil {
+			return err
+		}
+
+		for _, nested := range bodies {
+			if err := writeJSONBlock(sb, member.name, nil, nested, nestedType); err != nil {
+				return err
+			}
+		}
+
+		// An expansion block written in HCL is conventionally set off from the body it
+		// iterates, so the quoted block matches. A null property wrote no block to set off.
+		if len(bodies) > 0 && i < len(members)-1 {
+			sb.WriteString("\n")
+		}
+	}
+
+	return nil
+}
+
+// bodyMembers drops the properties hcl does not read as part of a body, so a rendered block
+// holds only what the config set.
+func bodyMembers(members []jsonMember) []jsonMember {
+	kept := make([]jsonMember, 0, len(members))
+
+	for _, member := range members {
+		if member.name == jsonCommentKey {
+			continue
+		}
+
+		kept = append(kept, member)
+	}
+
+	return kept
+}
+
+// nestedJSONBlocks reads the bodies of the nested blocks one property holds. JSON writes
+// repeated blocks of one type as an array and no block at all as null, so a property naming a
+// block type stands for any number of them.
+func nestedJSONBlocks(raw json.RawMessage) ([][]jsonMember, error) {
+	trimmed := bytes.TrimSpace(raw)
+
+	switch {
+	case string(trimmed) == "null":
+		return nil, nil
+	case bytes.HasPrefix(trimmed, []byte("[")):
+		elements, err := decodeJSONArray(trimmed)
+		if err != nil {
+			return nil, err
+		}
+
+		bodies := make([][]jsonMember, 0, len(elements))
+
+		for _, element := range elements {
+			members, err := decodeJSONObject(element)
+			if err != nil {
+				return nil, err
+			}
+
+			bodies = append(bodies, members)
+		}
+
+		return bodies, nil
+	}
+
+	members, err := decodeJSONObject(trimmed)
+	if err != nil {
+		return nil, err
+	}
+
+	return [][]jsonMember{members}, nil
+}
+
+// jsonValueHCL renders one JSON value as the HCL expression that means the same thing.
+//
+// Numbers, booleans and null are spelled the same in both. Objects and arrays are written in a
+// syntax HCL also accepts, but they are still rebuilt rather than quoted through. A string
+// anywhere inside them has to be re-escaped, since JSON allows escapes such as \/ that HCL
+// rejects.
+func jsonValueHCL(raw json.RawMessage) (string, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return "", UnsupportedJSONValueError{Value: string(raw)}
+	}
+
+	switch trimmed[0] {
+	case '{':
+		members, err := decodeJSONObject(trimmed)
+		if err != nil {
+			return "", err
+		}
+
+		parts := make([]string, 0, len(members))
+
+		for _, member := range members {
+			value, err := jsonValueHCL(member.value)
+			if err != nil {
+				return "", err
+			}
+
+			parts = append(parts, objectKey(member.name)+" = "+value)
+		}
+
+		if len(parts) == 0 {
+			return "{}", nil
+		}
+
+		// One key per line, the way hclwrite renders the same value in the preview below the
+		// block. Formatting aligns them once the whole block is written.
+		return "{\n" + strings.Join(parts, "\n") + "\n}", nil
+	case '[':
+		elements, err := decodeJSONArray(trimmed)
+		if err != nil {
+			return "", err
+		}
+
+		parts := make([]string, 0, len(elements))
+
+		for _, element := range elements {
+			value, err := jsonValueHCL(element)
+			if err != nil {
+				return "", err
+			}
+
+			parts = append(parts, value)
+		}
+
+		return "[" + strings.Join(parts, ", ") + "]", nil
+	case '"':
+		var text string
+		if err := json.Unmarshal(trimmed, &text); err != nil {
+			return "", err
+		}
+
+		return hclTemplateLiteral(text), nil
+	default:
+		return string(trimmed), nil
+	}
+}
+
+// objectKey writes a JSON property name as an HCL object key, quoting only the names that
+// cannot be written bare.
+func objectKey(name string) string {
+	if hclsyntax.ValidIdentifier(name) {
+		return name
+	}
+
+	return hclStringLiteral(name)
+}
+
+// hclTemplateLiteral quotes text as an HCL string, leaving the interpolations and directives it
+// contains as written. HCL reads a JSON string value as a template too, so a config_path written
+// as "../aurora-${count.index}" means the same thing in both syntaxes. Quoting it back
+// unevaluated lets the rendered block stand in for the one the config declared.
+//
+// Only the text around those sequences is escaped. HCL parses what is inside ${ } as an
+// expression, where a quote opens a string of its own and an escaped quote does not parse. JSON
+// escapes every quote in the string it holds. The two disagree on exactly the text that carries
+// a reference, so escaping follows the template rather than the string.
+func hclTemplateLiteral(text string) string {
+	var sb strings.Builder
+
+	sb.WriteByte('"')
+
+	for i := 0; i < len(text); {
+		switch {
+		case strings.HasPrefix(text[i:], `$${`), strings.HasPrefix(text[i:], `%%{`):
+			// Already the escaped form, which HCL reads as text.
+			sb.WriteString(text[i : i+len(`$${`)])
+			i += len(`$${`)
+		case strings.HasPrefix(text[i:], `${`), strings.HasPrefix(text[i:], `%{`):
+			end := templateSequenceEnd(text, i)
+			sb.WriteString(text[i:end])
+			i = end
+		default:
+			char, size := utf8.DecodeRuneInString(text[i:])
+			writeEscapedRune(&sb, char)
+
+			i += size
+		}
+	}
+
+	sb.WriteByte('"')
+
+	return sb.String()
+}
+
+// hclStringLiteral quotes text as an HCL string that reads back as exactly that text. Any
+// template marker in it is escaped, so HCL reads it rather than evaluating it.
+func hclStringLiteral(text string) string {
+	var sb strings.Builder
+
+	sb.WriteByte('"')
+
+	for _, char := range escapeTemplateMarkers(text) {
+		writeEscapedRune(&sb, char)
+	}
+
+	sb.WriteByte('"')
+
+	return sb.String()
+}
+
+// escapeTemplateMarkers spells the sequences that open a template so HCL reads them as text
+// rather than evaluating them.
+func escapeTemplateMarkers(text string) string {
+	replaced := strings.ReplaceAll(text, `${`, `$${`)
+
+	return strings.ReplaceAll(replaced, `%{`, `%%{`)
+}
+
+func writeEscapedRune(sb *strings.Builder, char rune) {
+	switch char {
+	case '\\':
+		sb.WriteString(`\\`)
+	case '"':
+		sb.WriteString(`\"`)
+	case '\n':
+		sb.WriteString(`\n`)
+	case '\r':
+		sb.WriteString(`\r`)
+	case '\t':
+		sb.WriteString(`\t`)
+	default:
+		if char < firstPrintable {
+			fmt.Fprintf(sb, `\u%04x`, char)
+
+			return
+		}
+
+		sb.WriteRune(char)
+	}
+}
+
+// templateSequenceEnd returns the index just past the brace closing the template sequence that
+// opens at start, or the end of text when nothing closes it.
+func templateSequenceEnd(text string, start int) int {
+	depth := 0
+
+	for i := start + 1; i < len(text); {
+		switch text[i] {
+		case '{':
+			depth++
+
+			i++
+		case '}':
+			depth--
+
+			i++
+
+			if depth == 0 {
+				return i
+			}
+		case '"':
+			i = quotedEnd(text, i)
+		default:
+			i++
+		}
+	}
+
+	return len(text)
+}
+
+// quotedEnd returns the index just past the string opening at start, so that a brace written
+// inside it does not close the template sequence around it.
+func quotedEnd(text string, start int) int {
+	for i := start + 1; i < len(text); i++ {
+		switch text[i] {
+		case '\\':
+			i++
+		case '"':
+			return i + 1
+		}
+	}
+
+	return len(text)
+}
+
+// decodeJSONObject reads the object at the start of src, keeping its properties in order. It
+// ignores trailing content, so it can read one block out of a whole config file.
+func decodeJSONObject(src []byte) ([]jsonMember, error) {
+	dec := json.NewDecoder(bytes.NewReader(src))
+
+	if err := expectDelim(dec, '{'); err != nil {
+		return nil, err
+	}
+
+	var members []jsonMember
+
+	for dec.More() {
+		token, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		name, ok := token.(string)
+		if !ok {
+			return nil, UnsupportedJSONValueError{Value: fmt.Sprint(token)}
+		}
+
+		var value json.RawMessage
+		if err := dec.Decode(&value); err != nil {
+			return nil, err
+		}
+
+		members = append(members, jsonMember{name: name, value: value})
+	}
+
+	return members, nil
+}
+
+// decodeJSONArray reads the array at the start of src, keeping its elements in order.
+func decodeJSONArray(src []byte) ([]json.RawMessage, error) {
+	dec := json.NewDecoder(bytes.NewReader(src))
+
+	if err := expectDelim(dec, '['); err != nil {
+		return nil, err
+	}
+
+	var elements []json.RawMessage
+
+	for dec.More() {
+		var element json.RawMessage
+		if err := dec.Decode(&element); err != nil {
+			return nil, err
+		}
+
+		elements = append(elements, element)
+	}
+
+	return elements, nil
+}
+
+func expectDelim(dec *json.Decoder, want json.Delim) error {
+	token, err := dec.Token()
+	if err != nil {
+		return err
+	}
+
+	if delim, ok := token.(json.Delim); !ok || delim != want {
+		return UnsupportedJSONValueError{Value: fmt.Sprint(token)}
+	}
+
+	return nil
+}
+
+// blockFields returns the `hcl:"name,block"` fields of a block struct, keyed by the name the
+// config writes. JSON gives no other way to tell a nested block from an attribute, and gohcl
+// reads the same tags, so the two cannot drift.
+func blockFields(structType reflect.Type) map[string]reflect.Type {
+	fields := map[string]reflect.Type{}
+
+	for i := range structType.NumField() {
+		name, kind, found := strings.Cut(structType.Field(i).Tag.Get("hcl"), ",")
+		if !found || kind != blockTagKind {
+			continue
+		}
+
+		fields[name] = elementType(structType.Field(i).Type)
+	}
+
+	return fields
+}
+
+// elementType unwraps the pointers and slices a block field is declared with, down to the
+// struct it decodes into.
+func elementType(fieldType reflect.Type) reflect.Type {
+	for fieldType.Kind() == reflect.Pointer || fieldType.Kind() == reflect.Slice {
+		fieldType = fieldType.Elem()
+	}
+
+	return fieldType
+}

--- a/pkg/config/hclparse/jsonsource.go
+++ b/pkg/config/hclparse/jsonsource.go
@@ -508,13 +508,13 @@ func expectDelim(dec *json.Decoder, want json.Delim) error {
 func blockFields(structType reflect.Type) map[string]reflect.Type {
 	fields := map[string]reflect.Type{}
 
-	for i := range structType.NumField() {
-		name, kind, found := strings.Cut(structType.Field(i).Tag.Get("hcl"), ",")
+	for field := range structType.Fields() {
+		name, kind, found := strings.Cut(field.Tag.Get("hcl"), ",")
 		if !found || kind != blockTagKind {
 			continue
 		}
 
-		fields[name] = elementType(structType.Field(i).Type)
+		fields[name] = elementType(field.Type)
 	}
 
 	return fields

--- a/pkg/config/hclparse/jsonsource_test.go
+++ b/pkg/config/hclparse/jsonsource_test.go
@@ -1,0 +1,195 @@
+package hclparse_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
+)
+
+// jsonBlock is what the JSON source tests decode into. Untyped attributes let a fuzzed string
+// land anywhere in a body without the decode rejecting it first.
+type jsonBlock struct {
+	Expansion *hclparse.ExpansionBlock `hcl:"expansion,block"`
+	Value     *cty.Value               `hcl:"value,attr"`
+	Path      *cty.Value               `hcl:"path,attr"`
+	Name      string                   `hcl:",label"`
+}
+
+// jsonSource renders the single dependency block src declares as the HCL that means the same
+// thing, the way the render command quotes it.
+func jsonSource(tb testing.TB, src string) (*hclparse.SourceBlock, *jsonBlock, error) {
+	tb.Helper()
+
+	file, err := hclparse.NewParser().ParseFromString(src, "terragrunt.hcl.json")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	instances, err := file.ExpandBlocks("dependency", new(jsonBlock), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	require.Len(tb, instances, 1)
+	require.NotNil(tb, instances[0].Source, "src must declare an expansion block to get a source")
+
+	return instances[0].Source, instances[0].Value.(*jsonBlock), nil
+}
+
+// TestJSONBlockSourceDropsCommentProperty pins that the "//" property hcl reads as a comment on
+// a body stays out of the rendered block. Writing it back as an argument spelled "//" leaves a
+// line HCL reads as a comment, so nothing downstream reports it.
+func TestJSONBlockSourceDropsCommentProperty(t *testing.T) {
+	t.Parallel()
+
+	source, _, err := jsonSource(t, `{"dependency": {"vpc": {
+  "//": "the network",
+  "expansion": {"count": 1},
+  "path": "../vpc",
+  "value": {"//": "kept, since this one is not a body"}
+}}}`)
+	require.NoError(t, err)
+
+	text, err := source.Body()
+	require.NoError(t, err)
+
+	assert.NotContains(t, text, "the network")
+	assert.Contains(t, text, `"//" = "kept, since this one is not a body"`)
+}
+
+// FuzzJSONBlockSourceRoundTrips pins that a JSON block renders as HCL that reads back as the
+// same block. The two syntaxes disagree on which characters an escape may spell and on which
+// names a key may be written bare, so this walks the strings a table cannot enumerate.
+func FuzzJSONBlockSourceRoundTrips(f *testing.F) {
+	seeds := []string{
+		"",
+		"plain",
+		`a"b`,
+		`a\b`,
+		`a\/b`,
+		"a\tb",
+		"a\nb",
+		"a\x01b",
+		"ünïcode",
+		"emoji \U0001F600",
+		"${count.index}",
+		"$${count.index}",
+		"%{ if true }a%{ endif }",
+		`${lower("A\"B")}`,
+		"//",
+		"not an identifier",
+		"${",
+		"}",
+	}
+
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, text string) {
+		if !utf8.ValidString(text) {
+			t.Skip("JSON cannot carry a string that is not UTF-8, so this never reaches a config")
+		}
+
+		quoted, err := json.Marshal(text)
+		require.NoError(t, err)
+
+		// Only an expanded block is quoted back, so the block declares an expansion it does not
+		// otherwise use.
+		src := `{"dependency": {` + string(quoted) + `: {` +
+			`"expansion": {"count": 1},` +
+			`"path": ` + string(quoted) + `,` +
+			`"value": {` + string(quoted) + `: [` + string(quoted) + `]}}}}`
+
+		source, block, err := jsonSource(t, src)
+		if err != nil {
+			// A ${ that opens no expression is not a template, and hcl rejects the config
+			// before there is anything to render.
+			return
+		}
+
+		assert.Equal(t, text, block.Name, "the label survives the render")
+
+		if strings.Contains(text, "${") || strings.Contains(text, "%{") {
+			// Formatting normalizes the spacing inside a template, so what a template renders
+			// to is not the text it was written as. TestBodyAsCtyKeepsEscapedTemplateMarkers
+			// and TestBodyAsCtyKeepsDirectives pin those.
+			return
+		}
+
+		// BodyAsCty reads the rendered HCL the way `render --format json` serializes it, so this
+		// compares the block against the config it was rendered from.
+		body, err := source.BodyAsCty()
+		require.NoError(t, err)
+
+		wantValue := cty.ObjectVal(map[string]cty.Value{
+			text: cty.TupleVal([]cty.Value{cty.StringVal(text)}),
+		})
+
+		assert.True(t, cty.StringVal(text).RawEquals(body.GetAttr("path")),
+			"path: want %#v, got %#v", text, body.GetAttr("path"))
+		assert.True(t, wantValue.RawEquals(body.GetAttr("value")),
+			"value: want %#v, got %#v", wantValue, body.GetAttr("value"))
+	})
+}
+
+// remainBlock mirrors the unit and stack blocks, which accept properties they do not declare.
+type remainBlock struct {
+	Remain    hcl.Body                 `hcl:",remain"`
+	Expansion *hclparse.ExpansionBlock `hcl:"expansion,block"`
+	Path      *cty.Value               `hcl:"path,attr"`
+	Name      string                   `hcl:",label"`
+}
+
+// TestExpandBlocksTranscodesOnlyExpandedJSONBlocks pins that a block declaring no expansion is
+// never transcoded. Only an expanded block is quoted back, and every command parses these blocks,
+// so a property no HCL argument can spell must not fail a config that needs no quoted text.
+func TestExpandBlocksTranscodesOnlyExpandedJSONBlocks(t *testing.T) {
+	t.Parallel()
+
+	const unrenderable = `"path": "../vpc", "not an identifier": 1`
+
+	file, err := hclparse.NewParser().ParseFromString(
+		`{"dependency": {"vpc": {`+unrenderable+`}}}`,
+		"terragrunt.hcl.json",
+	)
+	require.NoError(t, err)
+
+	instances, err := file.ExpandBlocks("dependency", new(remainBlock), nil)
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+	assert.Nil(t, instances[0].Source)
+
+	// The same body under an expansion block still cannot be quoted back, since an HCL argument
+	// name cannot be written in quotes. Parsing succeeds anyway: the failure rides along on the
+	// block and reaches whoever asks for the text.
+	expanded, err := hclparse.NewParser().ParseFromString(
+		`{"dependency": {"vpc": {"expansion": {"count": 1}, `+unrenderable+`}}}`,
+		"terragrunt.hcl.json",
+	)
+	require.NoError(t, err)
+
+	withExpansion, err := expanded.ExpandBlocks("dependency", new(remainBlock), nil)
+	require.NoError(t, err, "a block Terragrunt cannot quote must not fail the parse")
+	require.Len(t, withExpansion, 1)
+
+	source := withExpansion[0].Source
+	require.NotNil(t, source)
+
+	text, err := source.Body()
+	assert.Empty(t, text)
+
+	var typed hclparse.JSONBlockSourceError
+	require.ErrorAs(t, err, &typed)
+
+	_, err = source.BodyAsCty()
+	require.ErrorAs(t, err, &typed)
+}

--- a/pkg/config/render_expansion_test.go
+++ b/pkg/config/render_expansion_test.go
@@ -2,12 +2,14 @@ package config_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 // renderConfig renders cfg the way `terragrunt render` does.
@@ -129,10 +131,10 @@ dependency "vpc" {
 	assert.NotContains(t, rendered, "#")
 }
 
-// TestRenderJSONExpansionOmitsPreview pins what a JSON config renders as. Its blocks carry
-// no HCL text to quote back, so the elements render as configuration, which is the one
-// case where render repeats a label outside a comment.
-func TestRenderJSONExpansionOmitsPreview(t *testing.T) {
+// TestRenderJSONExpansionQuotesBlockAsHCL pins that a JSON config renders the same way an HCL
+// one does. The block comes back as the HCL that means the same thing, references unresolved,
+// and the elements follow as comments.
+func TestRenderJSONExpansionQuotesBlockAsHCL(t *testing.T) {
 	t.Parallel()
 
 	cfg, err := parseDependencyJSONString(t, jsonDependencyWithExpansion)
@@ -140,8 +142,475 @@ func TestRenderJSONExpansionOmitsPreview(t *testing.T) {
 
 	rendered := renderConfig(t, cfg)
 
-	assert.NotContains(t, rendered, "Expands to")
-	assert.Contains(t, rendered, `"../aurora-0"`)
-	assert.Contains(t, rendered, `"../aurora-1"`)
-	assert.Equal(t, 2, blocksOpening(rendered, `"aurora"`))
+	assert.Contains(t, rendered, `dependency "aurora" {
+  expansion {
+    count = 2
+  }
+
+  config_path = "../aurora-${count.index}"
+}`)
+
+	assert.Contains(t, rendered, `# Expands to:
+#
+# dependency "aurora" {
+#   config_path = "../aurora-0"
+# }
+#
+# dependency "aurora" {
+#   config_path = "../aurora-1"
+# }`)
+
+	assert.Equal(t, 1, blocksOpening(rendered, `"aurora"`), "only the written block renders as configuration")
+}
+
+// TestRenderJSONExpansionRendersFixedPoint pins that rendering a JSON config produces a
+// configuration that renders back to itself. Quoting the elements instead would repeat one
+// label, and that would not read back at all.
+func TestRenderJSONExpansionRendersFixedPoint(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyJSONString(t, jsonDependencyWithExpansion)
+	require.NoError(t, err)
+
+	first := renderConfig(t, cfg)
+
+	reparsed, err := parseDependencyStringStrict(t, first)
+	require.NoError(t, err)
+
+	assert.Equal(t, first, renderConfig(t, reparsed))
+}
+
+// TestRenderJSONExpansionGroupsEachBlockSeparately pins that two expanded blocks in one JSON
+// config each get a block and a preview of their own, rather than folding into one.
+func TestRenderJSONExpansionGroupsEachBlockSeparately(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyJSONString(t, `
+{"dependency": {
+  "aurora": {"expansion": {"count": 1}, "config_path": "../aurora-${count.index}"},
+  "shard": {"expansion": {"count": 1}, "config_path": "../shard-${count.index}"}
+}}
+`)
+	require.NoError(t, err)
+
+	rendered := renderConfig(t, cfg)
+
+	assert.Equal(t, 1, blocksOpening(rendered, `"aurora"`))
+	assert.Equal(t, 1, blocksOpening(rendered, `"shard"`))
+
+	assert.Contains(t, rendered, `  config_path = "../aurora-${count.index}"`)
+	assert.Contains(t, rendered, `  config_path = "../shard-${count.index}"`)
+	assert.Equal(t, 2, strings.Count(rendered, "# Expands to:"))
+}
+
+// TestRenderJSONExpansionQuotesValuesAsHCL pins the value spellings that differ between the two
+// syntaxes. JSON allows the escape \/, which HCL rejects, and writes objects with colons.
+func TestRenderJSONExpansionQuotesValuesAsHCL(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyJSONString(t, `
+{"dependency": {"aurora": {
+  "expansion": {"count": 1},
+  "config_path": "../aurora-${count.index}",
+  "mock_outputs": {
+    "url": "https:\/\/example.com\/${count.index}",
+    "tags": ["a", "b"],
+    "nested": {"on": false, "none": null, "size": 3},
+    "quote": "say \"hi\"",
+    "unicode": "café"
+  }
+}}}
+`)
+	require.NoError(t, err)
+
+	rendered := renderConfig(t, cfg)
+
+	assert.Contains(t, rendered, `  mock_outputs = {
+    url  = "https://example.com/${count.index}"
+    tags = ["a", "b"]
+    nested = {
+      on   = false
+      none = null
+      size = 3
+    }
+    quote   = "say \"hi\""
+    unicode = "café"
+  }`)
+}
+
+// renderJSONDependencies renders cfg's dependency blocks the way `render --format json` does.
+func renderJSONDependencies(t *testing.T, cfg *config.TerragruntConfig) map[string]any {
+	t.Helper()
+
+	asCty, err := config.TerragruntConfigAsCty(cfg)
+	require.NoError(t, err)
+
+	encoded, err := ctyjson.Marshal(asCty, asCty.Type())
+	require.NoError(t, err)
+
+	var rendered struct {
+		Dependency map[string]any `json:"dependency"`
+	}
+
+	require.NoError(t, json.Unmarshal(encoded, &rendered))
+
+	return rendered.Dependency
+}
+
+// TestRenderJSONFormatKeepsExpansionUnexpanded pins that the JSON format serializes the block
+// that was written rather than the elements it expanded into. The map is keyed by label, which
+// every element shares, so serializing the elements would keep only the last of them.
+func TestRenderJSONFormatKeepsExpansionUnexpanded(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyString(t, `
+dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  config_path  = "../shard-${count.index}"
+  skip_outputs = true
+}
+`)
+	require.NoError(t, err)
+
+	deps := renderJSONDependencies(t, cfg)
+	require.Contains(t, deps, "shard")
+
+	assert.Equal(t, map[string]any{
+		"config_path":  "../shard-${count.index}",
+		"expansion":    map[string]any{"count": float64(2)},
+		"skip_outputs": true,
+	}, deps["shard"])
+}
+
+// TestRenderJSONFormatKeepsForEachExpression pins that a for_each is written back as the call
+// that built it. Serializing the set it evaluated to would emit a JSON array, which for_each
+// rejects, so the output would no longer read back.
+func TestRenderJSONFormatKeepsForEachExpression(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyString(t, `
+dependency "region" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  config_path = "../${each.key}"
+}
+`)
+	require.NoError(t, err)
+
+	deps := renderJSONDependencies(t, cfg)
+	require.Contains(t, deps, "region")
+
+	assert.Equal(t, map[string]any{
+		"config_path": "../${each.key}",
+		"expansion":   map[string]any{"for_each": `${toset(["web", "api"])}`},
+	}, deps["region"])
+}
+
+// TestRenderJSONFormatLeavesUnexpandedBlocksAlone pins that a block that declares no expansion
+// serializes as it always has, resolved and under the names the rest of the format uses.
+func TestRenderJSONFormatLeavesUnexpandedBlocksAlone(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyString(t, `
+dependency "vpc" {
+  config_path  = "../vpc"
+  skip_outputs = true
+}
+`)
+	require.NoError(t, err)
+
+	deps := renderJSONDependencies(t, cfg)
+	require.Contains(t, deps, "vpc")
+
+	vpc, ok := deps["vpc"].(map[string]any)
+	require.True(t, ok)
+
+	assert.Equal(t, "../vpc", vpc["config_path"])
+	assert.Equal(t, true, vpc["skip"])
+	assert.Equal(t, "vpc", vpc["name"])
+}
+
+// TestRenderJSONExpansionQuotesInterpolationsAsWritten pins the escaping around a quote inside
+// an interpolation. JSON escapes every quote in a string, and HCL reads what is inside ${ } as
+// an expression, where an escaped quote does not parse.
+func TestRenderJSONExpansionQuotesInterpolationsAsWritten(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyJSONString(t, `
+{"dependency": {"shard": {
+  "expansion": {"count": 1},
+  "config_path": "../${lower(\"SHARD\")}-${count.index}",
+  "mock_outputs": {"literal": "costs $${100}", "quoted": "say \"hi\""}
+}}}
+`)
+	require.NoError(t, err)
+
+	rendered := renderConfig(t, cfg)
+
+	assert.Contains(t, rendered, `config_path = "../${lower("SHARD")}-${count.index}"`)
+	assert.Contains(t, rendered, `literal = "costs $${100}"`)
+	assert.Contains(t, rendered, `quoted  = "say \"hi\""`)
+
+	reparsed, err := parseDependencyStringStrict(t, rendered)
+	require.NoError(t, err)
+
+	assert.Equal(t, rendered, renderConfig(t, reparsed))
+}
+
+// TestRenderJSONFormatKeepsExpressionsWhereTheyAre pins the shapes that a single interpolation
+// around the whole value would get wrong. A collection keeps its shape, and only the values
+// holding a reference become templates. An expression already written as one interpolation is
+// not wrapped in another. A directive stays in the template syntax it is already written in.
+func TestRenderJSONFormatKeepsExpressionsWhereTheyAre(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyString(t, `
+locals {
+  on = true
+}
+
+dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  config_path = "../shard-${count.index}"
+  enabled     = "${local.on}"
+  mock_outputs = {
+    directive = "%{if local.on}yes%{else}no%{endif}"
+    wrapped   = "${count.index}"
+    settled   = "plain"
+    tags      = ["a", "${count.index}"]
+  }
+}
+`)
+	require.NoError(t, err)
+
+	deps := renderJSONDependencies(t, cfg)
+	require.Contains(t, deps, "shard")
+
+	assert.Equal(t, map[string]any{
+		"config_path": "../shard-${count.index}",
+		"enabled":     "${local.on}",
+		"expansion":   map[string]any{"count": float64(2)},
+		"mock_outputs": map[string]any{
+			"directive": "%{if local.on}yes%{else}no%{endif}",
+			"wrapped":   "${count.index}",
+			"settled":   "plain",
+			"tags":      []any{"a", "${count.index}"},
+		},
+	}, deps["shard"])
+}
+
+// TestRenderJSONExpansionEscapesValuesForHCL pins the characters the two syntaxes spell
+// differently, and the keys HCL cannot write bare. A miss here renders a block that no longer
+// parses, so the round-trip at the end is the assertion that matters most.
+func TestRenderJSONExpansionEscapesValuesForHCL(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyJSONString(t, `
+{"dependency": {"shard": {
+  "expansion": {"count": 1},
+  "config_path": "../shard-${count.index}",
+  "mock_outputs": {
+    "backslash": "a\\b",
+    "tab": "a\tb",
+    "newline": "a\nb",
+    "control": "a\u0001b",
+    "quote-in-call": "${lower(\"A\\\"B\")}",
+    "not an identifier": 1,
+    "empty_object": {},
+    "empty_list": []
+  }
+}}}
+`)
+	require.NoError(t, err)
+
+	rendered := renderConfig(t, cfg)
+
+	assert.Contains(t, rendered, `  mock_outputs = {
+    backslash           = "a\\b"
+    tab                 = "a\tb"
+    newline             = "a\nb"
+    control             = "a\u0001b"
+    quote-in-call       = "${lower("A\"B")}"
+    "not an identifier" = 1
+    empty_object        = {}
+    empty_list          = []
+  }`)
+
+	reparsed, err := parseDependencyStringStrict(t, rendered)
+	require.NoError(t, err)
+
+	assert.Equal(t, rendered, renderConfig(t, reparsed))
+}
+
+// TestRenderExpansionKeepsComputedObjectKeys pins a key JSON has no way to spell, such as one
+// computed from the iteration. The object goes back whole as one interpolation rather than
+// failing the render. The HCL format depends on this too, since it builds the same cty value
+// even though it quotes the block from source.
+func TestRenderExpansionKeepsComputedObjectKeys(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyString(t, `
+dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  config_path = "../shard-${count.index}"
+  mock_outputs = {
+    (count.index) = "keyed by iteration"
+  }
+}
+`)
+	require.NoError(t, err)
+
+	rendered := renderConfig(t, cfg)
+
+	assert.Contains(t, rendered, `  mock_outputs = {
+    (count.index) = "keyed by iteration"
+  }`)
+
+	reparsed, err := parseDependencyStringStrict(t, rendered)
+	require.NoError(t, err)
+	assert.Equal(t, rendered, renderConfig(t, reparsed))
+
+	shard, ok := renderJSONDependencies(t, cfg)["shard"].(map[string]any)
+	require.True(t, ok)
+
+	mocks, ok := shard["mock_outputs"].(string)
+	require.True(t, ok, "a computed key leaves the object as one interpolation")
+
+	assert.Contains(t, mocks, `(count.index) = "keyed by iteration"`)
+	assert.True(t, strings.HasPrefix(mocks, "${"))
+}
+
+// TestRenderJSONArrayBlockRendersEachElement pins that a block a JSON config wrote as an array
+// of objects renders as one HCL block per element. JSON has no way to repeat a property, so an
+// array is how it writes a block once or several times over.
+func TestRenderJSONArrayBlockRendersEachElement(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyJSONString(t, `
+{"dependency": {
+  "vpc": [{"config_path": "../vpc", "skip_outputs": true}],
+  "shard": [
+    {"config_path": "../shard-a"},
+    {"config_path": "../shard-b"}
+  ]
+}}
+`)
+	require.NoError(t, err)
+
+	rendered := renderConfig(t, cfg)
+
+	assert.Contains(t, rendered, `dependency "vpc" {
+  config_path  = "../vpc"
+  skip_outputs = true
+}`)
+
+	assert.Contains(t, rendered, `config_path = "../shard-a"`)
+	assert.Contains(t, rendered, `config_path = "../shard-b"`)
+	assert.Equal(t, 2, blocksOpening(rendered, `"shard"`))
+}
+
+// TestRenderJSONFormatReadsArrayBlocks pins that the JSON format serializes a block written as
+// an array too, rather than failing the render.
+func TestRenderJSONFormatReadsArrayBlocks(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyJSONString(t, `
+{"dependency": {"shard": [{
+  "//": "one of several",
+  "expansion": {"count": 2},
+  "config_path": "../shard-${count.index}",
+  "skip_outputs": true
+}]}}
+`)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{
+		"config_path":  "../shard-${count.index}",
+		"expansion":    map[string]any{"count": float64(2)},
+		"skip_outputs": true,
+	}, renderJSONDependencies(t, cfg)["shard"])
+}
+
+// TestRenderJSONArrayBlockPreviewsEachElementSeparately pins that two expanded blocks written in
+// one array each get a block and a preview of their own, rather than folding into one.
+func TestRenderJSONArrayBlockPreviewsEachElementSeparately(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyJSONString(t, `
+{"dependency": {"shard": [
+  {"expansion": {"count": 1}, "config_path": "../a-${count.index}"},
+  {"expansion": {"count": 1}, "config_path": "../b-${count.index}"}
+]}}
+`)
+	require.NoError(t, err)
+
+	rendered := renderConfig(t, cfg)
+
+	assert.Contains(t, rendered, `  config_path = "../a-${count.index}"`)
+	assert.Contains(t, rendered, `  config_path = "../b-${count.index}"`)
+
+	assert.Contains(t, rendered, `# dependency "shard" {
+#   config_path = "../a-0"
+# }`)
+	assert.Contains(t, rendered, `# dependency "shard" {
+#   config_path = "../b-0"
+# }`)
+
+	assert.Equal(t, 2, blocksOpening(rendered, `"shard"`))
+	assert.Equal(t, 2, strings.Count(rendered, "# Expands to:"))
+}
+
+// TestRenderJSONNestedBlockArray pins that a nested block written as an array renders the same
+// way the object form does, since one element is one block.
+func TestRenderJSONNestedBlockArray(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyJSONString(t, `
+{"dependency": {"shard": {
+  "expansion": [{"count": 2}],
+  "config_path": "../shard-${count.index}"
+}}}
+`)
+	require.NoError(t, err)
+
+	rendered := renderConfig(t, cfg)
+
+	assert.Contains(t, rendered, `dependency "shard" {
+  expansion {
+    count = 2
+  }
+
+  config_path = "../shard-${count.index}"
+}`)
+
+	assert.Contains(t, rendered, `#   config_path = "../shard-1"`)
+}
+
+// TestRenderJSONNullNestedBlockRendersNothing pins that a nested block written as null renders
+// as no block at all, which is how HCL reads it.
+func TestRenderJSONNullNestedBlockRendersNothing(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyJSONString(t, `
+{"dependency": {"vpc": {"expansion": null, "config_path": "../vpc"}}}
+`)
+	require.NoError(t, err)
+
+	rendered := renderConfig(t, cfg)
+
+	assert.Contains(t, rendered, `dependency "vpc" {
+  config_path = "../vpc"
+}`)
+	assert.NotContains(t, rendered, "expansion")
 }

--- a/test/fixtures/render-expansion/json-app/terragrunt.hcl.json
+++ b/test/fixtures/render-expansion/json-app/terragrunt.hcl.json
@@ -1,0 +1,15 @@
+{
+  "dependency": {
+    "aurora": {
+      "expansion": {"count": 2},
+      "config_path": "../aurora-${count.index}",
+      "skip_outputs": true
+    },
+    "vpc": [
+      {
+        "config_path": "../vpc",
+        "skip_outputs": true
+      }
+    ]
+  }
+}

--- a/test/integration_render_expansion_test.go
+++ b/test/integration_render_expansion_test.go
@@ -1,6 +1,8 @@
 package test_test
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -76,4 +78,110 @@ func TestRenderPreviewsExpandedDependencies(t *testing.T) {
   config_path  = "../vpc"
   skip_outputs = true
 }`)
+}
+
+// TestRenderPreviewsExpandedJSONDependencies pins that a JSON config previews the same way an
+// HCL one does, and that the file render writes reads back. Rendering the elements as
+// configuration instead would repeat one label, which Terragrunt rejects under the strict
+// control.
+func TestRenderPreviewsExpandedJSONDependencies(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureRenderExpansion)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRenderExpansion)
+	appPath := filepath.Join(tmpEnvPath, testFixtureRenderExpansion, "json-app")
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt render --format hcl --write --experiment block-iteration"+
+			" --non-interactive --working-dir "+appPath,
+	)
+	require.NoError(t, err)
+
+	rendered, err := os.ReadFile(filepath.Join(appPath, "terragrunt.rendered.hcl"))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), `dependency "aurora" {
+  expansion {
+    count = 2
+  }
+
+  config_path  = "../aurora-${count.index}"
+  skip_outputs = true
+}
+
+# Expands to:
+#
+# dependency "aurora" {
+#   config_path  = "../aurora-0"
+#   skip_outputs = true
+# }
+#
+# dependency "aurora" {
+#   config_path  = "../aurora-1"
+#   skip_outputs = true
+# }`)
+
+	// JSON writes repeated blocks of one type as an array, so a block written as a single-element
+	// array is the same block as one written as an object.
+	assert.Contains(t, string(rendered), `dependency "vpc" {
+  config_path  = "../vpc"
+  skip_outputs = true
+}`)
+
+	reparsePath := filepath.Join(tmpEnvPath, testFixtureRenderExpansion, "reparse")
+	require.NoError(t, os.MkdirAll(reparsePath, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(reparsePath, "terragrunt.hcl"), rendered, 0644))
+
+	// Without the strict control a repeated label is only a warning, so the read-back would
+	// pass on output that no future version of Terragrunt will accept.
+	reparsed, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt render --format hcl --experiment block-iteration"+
+			" --strict-control duplicate-dependency-labels"+
+			" --non-interactive --working-dir "+reparsePath,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(rendered), reparsed, "rendering the rendered config returns it unchanged")
+}
+
+// TestRenderJSONFormatKeepsExpandedDependenciesWhole pins that the JSON format serializes the
+// block that was written rather than the elements it expanded into. Its dependency map is keyed
+// by label, which every element shares, and JSON has no comment to preview them in.
+func TestRenderJSONFormatKeepsExpandedDependenciesWhole(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureRenderExpansion)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRenderExpansion)
+	appPath := filepath.Join(tmpEnvPath, testFixtureRenderExpansion, "app")
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt render --format json --experiment block-iteration"+
+			" --non-interactive --working-dir "+appPath,
+	)
+	require.NoError(t, err)
+
+	var rendered struct {
+		Dependency map[string]map[string]any `json:"dependency"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(stdout), &rendered))
+
+	assert.Equal(t, map[string]any{
+		"config_path":  "../shard-${count.index}",
+		"expansion":    map[string]any{"count": float64(2)},
+		"skip_outputs": true,
+	}, rendered.Dependency["shard"])
+
+	assert.Equal(t, map[string]any{
+		"config_path":  "../aurora-${each.key}",
+		"expansion":    map[string]any{"for_each": `${toset(["web", "api"])}`},
+		"skip_outputs": true,
+	}, rendered.Dependency["aurora"])
+
+	// The unexpanded dependency serializes as it always has, resolved.
+	assert.Equal(t, "../vpc", rendered.Dependency["vpc"]["config_path"])
+	assert.Equal(t, true, rendered.Dependency["vpc"]["skip"])
 }

--- a/test/integration_render_expansion_test.go
+++ b/test/integration_render_expansion_test.go
@@ -185,3 +185,43 @@ func TestRenderJSONFormatKeepsExpandedDependenciesWhole(t *testing.T) {
 	assert.Equal(t, "../vpc", rendered.Dependency["vpc"]["config_path"])
 	assert.Equal(t, true, rendered.Dependency["vpc"]["skip"])
 }
+
+// TestRenderJSONFormatWithMetadataKeepsExpandedDependenciesWhole pins the same grouping in the
+// metadata output. It keys dependencies by label as well, so serializing every element there
+// would keep only the last one.
+func TestRenderJSONFormatWithMetadataKeepsExpandedDependenciesWhole(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureRenderExpansion)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureRenderExpansion)
+	appPath := filepath.Join(tmpEnvPath, testFixtureRenderExpansion, "app")
+
+	stdout, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt render --format json --with-metadata --experiment block-iteration"+
+			" --non-interactive --working-dir "+appPath,
+	)
+	require.NoError(t, err)
+
+	var rendered struct {
+		Dependency map[string]struct {
+			Value map[string]any `json:"value"`
+		} `json:"dependency"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(stdout), &rendered))
+
+	assert.Equal(t, map[string]any{
+		"config_path":  "../shard-${count.index}",
+		"expansion":    map[string]any{"count": float64(2)},
+		"skip_outputs": true,
+	}, rendered.Dependency["shard"].Value)
+
+	assert.Equal(t, map[string]any{
+		"config_path":  "../aurora-${each.key}",
+		"expansion":    map[string]any{"for_each": `${toset(["web", "api"])}`},
+		"skip_outputs": true,
+	}, rendered.Dependency["aurora"].Value)
+
+	assert.Equal(t, "../vpc", rendered.Dependency["vpc"].Value["config_path"])
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses feedback from #6737

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved rendering of JSON-configured dependency expansions in HCL and JSON formats.
  * Preserved expansion previews, unresolved references, expressions, computed keys, and declared settings.
  * Added stable round-trip rendering across supported input and output formats.
* **Bug Fixes**
  * Prevented expanded dependency elements from being dropped or rendered with duplicate labels.
  * Improved handling of nested blocks, collections, templates, arrays, and null values.
* **Documentation**
  * Added command documentation and changelog details for JSON dependency expansion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->