### PR TITLE
feat(azure): assign blob data role on bootstrap in Azure

### DIFF
--- a/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
+++ b/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
@@ -456,6 +456,7 @@ The following config options are only valid for the `azurerm` backend and are us
 - `soft_delete_retention_days` - Soft delete retention in days, 1 to 365. Defaults to 7 when unset; values outside 1 to 365 are clamped to 7 at bootstrap (a warning is logged).
 - `allow_blob_public_access` - When `true`, allow containers on the account to permit anonymous access. Defaults to `false`.
 - `msi_resource_id` - Resource ID of a user-assigned managed identity to use with `use_msi`.
+- `environment` - Azure cloud partition: `public` (default), `usgovernment` (Azure Government), or `china`. Also accepted via `ARM_ENVIRONMENT`.
 <Since version="1.1.5">
 - `assign_blob_data_role` - When `true`, bootstrap grants **Storage Blob Data Contributor** on the storage account to `principal_id` (or to the identity Terragrunt authenticated as when unset). Opt-in because it requires `Microsoft.Authorization/roleAssignments/write`.
 - `principal_id` - Microsoft Entra object id that receives the data-plane role when `assign_blob_data_role` is `true`. Defaults to the caller resolved from the access token.
@@ -470,9 +471,26 @@ to any values not set in the config:
 5. OIDC / workload identity (`use_oidc`, `oidc_token_file_path`)
 6. Azure AD (`use_azuread_auth`, or the default credential chain, which honors `az login`)
 
-The `environment` key selects the Azure cloud: `public` (the default), `usgovernment`, or `china`.
-Built-in role definition IDs (including **Storage Blob Data Contributor**) are the same across those clouds;
-see [Understand Azure role definitions](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions).
+For Azure Government, set `environment = "usgovernment"` (or `ARM_ENVIRONMENT=usgovernment`) so Terragrunt
+talks to the Government endpoints for auth, ARM, and blob storage. Credentials must come from that partition
+(for example `az cloud set --name AzureUSGovernment` then `az login`, or a Government tenant service principal).
+Bootstrap and `assign_blob_data_role` use the same keys as public cloud; built-in role definition IDs
+(including **Storage Blob Data Contributor**) are the same across partitions per
+[Understand Azure role definitions](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions).
+
+```hcl
+# root.hcl
+remote_state {
+  backend = "azurerm"
+  config = {
+    # ...
+
+    environment           = "usgovernment"
+    use_azuread_auth      = true
+    assign_blob_data_role = true
+  }
+}
+```
 
 <Aside type="note" title="Known limitations">
 - SAS token and access key authentication are data-plane only: Terragrunt can create the blob container but not the resource group or storage account, which must already exist.

--- a/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
+++ b/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
@@ -408,6 +408,32 @@ remote_state {
 }
 ```
 
+Creating a storage account grants no access to the blobs inside it, so an identity using
+`use_azuread_auth` can create the account and still read state as unauthorized. Set
+`assign_blob_data_role` to have bootstrap grant **Storage Blob Data Contributor** on the
+account, which closes that gap:
+
+```hcl
+# root.hcl
+remote_state {
+  backend = "azurerm"
+  config = {
+    # ...
+
+    use_azuread_auth      = true
+    assign_blob_data_role = true
+  }
+}
+```
+
+The role is granted to the identity Terragrunt authenticated as. Set `principal_id` to
+the object id of a user, group, or service principal to grant it to someone else instead.
+The assignment is skipped when it already exists, so reruns need no write permission.
+
+This is opt-in because creating a role assignment requires
+`Microsoft.Authorization/roleAssignments/write` (held by Owner and User Access
+Administrator, but not Contributor), which many CI identities deliberately lack.
+
 When bootstrapping (`terragrunt backend bootstrap` or `--backend-bootstrap`), Terragrunt creates the resource group,
 storage account, and blob container when they do not exist (each step can be skipped with the `skip_*` options below),
 then enables blob versioning and, when requested, soft delete on both new and pre-existing accounts.
@@ -444,7 +470,7 @@ The `environment` key selects the Azure cloud: `public` (the default), `usgovern
 <Aside type="note" title="Known limitations">
 - SAS token and access key authentication are data-plane only: Terragrunt can create the blob container but not the resource group or storage account, which must already exist.
 - With SAS token or access key authentication, or when `resource_group_name` is not set, Terragrunt cannot verify blob versioning (it is an ARM management-plane property), so `backend delete` and `backend migrate` treat the account as unversioned and require the `--force` flag even when versioning is enabled.
-- With `use_azuread_auth`, reading and writing state requires the **Storage Blob Data Contributor** role on the storage account; the control-plane Contributor role alone is not sufficient. Terragrunt does not yet assign this role automatically.
+- With `use_azuread_auth`, reading and writing state requires the **Storage Blob Data Contributor** role on the storage account; the control-plane Contributor role alone is not sufficient. Set `assign_blob_data_role = true` to have bootstrap assign it, or grant it out of band.
 - State migration is supported within a single storage account; cross-account migration must be performed manually (init, state pull, state push).
 </Aside>
 </Since>

--- a/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
+++ b/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
@@ -409,8 +409,9 @@ remote_state {
 ```
 
 Creating a storage account grants no access to the blobs inside it, so an identity using
-`use_azuread_auth` can create the account and still read state as unauthorized. Set
-`assign_blob_data_role` to have bootstrap grant **Storage Blob Data Contributor** on the
+`use_azuread_auth` can create the account and still read state as unauthorized.
+<Since version="1.1.5">
+Set `assign_blob_data_role` to have bootstrap grant **Storage Blob Data Contributor** on the
 account, which closes that gap:
 
 ```hcl
@@ -433,6 +434,7 @@ The assignment is skipped when it already exists, so reruns need no write permis
 This is opt-in because creating a role assignment requires
 `Microsoft.Authorization/roleAssignments/write` (held by Owner and User Access
 Administrator, but not Contributor), which many CI identities deliberately lack.
+</Since>
 
 When bootstrapping (`terragrunt backend bootstrap` or `--backend-bootstrap`), Terragrunt creates the resource group,
 storage account, and blob container when they do not exist (each step can be skipped with the `skip_*` options below),
@@ -454,7 +456,10 @@ The following config options are only valid for the `azurerm` backend and are us
 - `soft_delete_retention_days` - Soft delete retention in days, 1 to 365. Defaults to 7 when unset; values outside 1 to 365 are clamped to 7 at bootstrap (a warning is logged).
 - `allow_blob_public_access` - When `true`, allow containers on the account to permit anonymous access. Defaults to `false`.
 - `msi_resource_id` - Resource ID of a user-assigned managed identity to use with `use_msi`.
-
+<Since version="1.1.5">
+- `assign_blob_data_role` - When `true`, bootstrap grants **Storage Blob Data Contributor** on the storage account to `principal_id` (or to the identity Terragrunt authenticated as when unset). Opt-in because it requires `Microsoft.Authorization/roleAssignments/write`.
+- `principal_id` - Microsoft Entra object id that receives the data-plane role when `assign_blob_data_role` is `true`. Defaults to the caller resolved from the access token.
+</Since>
 Authentication is resolved in the following order, with `ARM_*` and `AZURE_*` environment variable fallbacks applied
 to any values not set in the config:
 

--- a/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
+++ b/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
@@ -471,6 +471,8 @@ to any values not set in the config:
 6. Azure AD (`use_azuread_auth`, or the default credential chain, which honors `az login`)
 
 The `environment` key selects the Azure cloud: `public` (the default), `usgovernment`, or `china`.
+Built-in role definition IDs (including **Storage Blob Data Contributor**) are the same across those clouds;
+see [Understand Azure role definitions](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions).
 
 <Aside type="note" title="Known limitations">
 - SAS token and access key authentication are data-plane only: Terragrunt can create the blob container but not the resource group or storage account, which must already exist.

--- a/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
+++ b/docs/src/content/docs/03-features/01-units/03-state-backend.mdx
@@ -474,6 +474,7 @@ The `environment` key selects the Azure cloud: `public` (the default), `usgovern
 
 <Aside type="note" title="Known limitations">
 - SAS token and access key authentication are data-plane only: Terragrunt can create the blob container but not the resource group or storage account, which must already exist.
+- With SAS token or access key authentication, `assign_blob_data_role = true` errors because role assignment needs Microsoft Entra / ARM authentication (`use_azuread_auth`, a service principal, managed identity, or OIDC). Grant **Storage Blob Data Contributor** out of band and unset `assign_blob_data_role`, or switch auth.
 - With SAS token or access key authentication, or when `resource_group_name` is not set, Terragrunt cannot verify blob versioning (it is an ARM management-plane property), so `backend delete` and `backend migrate` treat the account as unversioned and require the `--force` flag even when versioning is enabled.
 - With `use_azuread_auth`, reading and writing state requires the **Storage Blob Data Contributor** role on the storage account; the control-plane Contributor role alone is not sufficient. Set `assign_blob_data_role = true` to have bootstrap assign it, or grant it out of band.
 - State migration is supported within a single storage account; cross-account migration must be performed manually (init, state pull, state push).

--- a/docs/src/data/changelog/v1.1.3/azure-backend-rbac.mdx
+++ b/docs/src/data/changelog/v1.1.3/azure-backend-rbac.mdx
@@ -1,0 +1,39 @@
+---
+version: "v1.1.3"
+category: "experiments-updated"
+---
+
+#### `azure-backend` can assign the blob data role during bootstrap
+
+Creating an Azure storage account grants no access to the blobs inside it, so an identity
+using `use_azuread_auth` could bootstrap the backend and then fail to read state as
+unauthorized until someone granted the data-plane role by hand.
+
+With the `azure-backend` experiment enabled, `assign_blob_data_role = true` now has
+bootstrap grant **Storage Blob Data Contributor** on the storage account:
+
+```hcl
+remote_state {
+  backend = "azurerm"
+  config = {
+    storage_account_name  = "myterragruntstate"
+    container_name        = "tfstate"
+    key                   = "${path_relative_to_include()}/terraform.tfstate"
+    resource_group_name   = "terraform-rg"
+    use_azuread_auth      = true
+    assign_blob_data_role = true
+  }
+}
+```
+
+The role goes to the identity Terragrunt authenticated as, resolved from the access token
+it already holds rather than from a directory lookup, so it works for identities that
+cannot read Microsoft Entra. Set `principal_id` to grant the role to a different user,
+group, or service principal.
+
+Existing assignments are detected and left alone, so reruns need only read permission on
+role assignments.
+
+The setting is opt-in: creating a role assignment requires
+`Microsoft.Authorization/roleAssignments/write`, which Contributor does not include.
+Leaving it unset preserves the previous behavior of assigning nothing.

--- a/docs/src/data/changelog/v1.1.5/azure-backend-rbac.mdx
+++ b/docs/src/data/changelog/v1.1.5/azure-backend-rbac.mdx
@@ -1,5 +1,5 @@
 ---
-version: "v1.1.3"
+version: "v1.1.5"
 category: "experiments-updated"
 ---
 

--- a/docs/src/data/experiments/azure-backend.mdx
+++ b/docs/src/data/experiments/azure-backend.mdx
@@ -50,8 +50,8 @@ Authentication supports six methods, resolved in the following order:
 5. OIDC / workload identity
 6. Azure AD (`use_azuread_auth` or the default credential chain, which honors `az login`)
 
-`ARM_*` and `AZURE_*` environment variable fallbacks are applied, and public, US
-Government, and China clouds are supported via the `environment` key.
+`ARM_*` and `AZURE_*` environment variable fallbacks are applied. Set `environment`
+(or `ARM_ENVIRONMENT`) to `usgovernment` for Azure Government.
 
 Without the experiment enabled, these lifecycle operations return an error naming
 the experiment; normal state reading and writing is handled by the native

--- a/docs/src/data/experiments/azure-backend.mdx
+++ b/docs/src/data/experiments/azure-backend.mdx
@@ -99,5 +99,5 @@ To transition the `azure-backend` feature to a stable release, the following mus
 - [x] Direct state file reads from Azure blobs for `--dependency-fetch-output-from-state`.
 - [x] Documentation covering authentication methods, configuration keys, and troubleshooting.
 - [x] End-to-end live coverage against a real subscription for container bootstrap, blob versioning convergence, backend delete, and direct dependency state reads, behind the `azure` build tag.
-- [ ] End-to-end live coverage for resource group and storage account creation, soft-delete retention convergence, and state migration. The current live tests assume a pre-existing storage account.
+- [x] End-to-end live coverage for resource group and storage account creation, soft-delete retention convergence, and state migration.
 - [ ] Community feedback on real-world usage.

--- a/docs/src/data/experiments/azure-backend.mdx
+++ b/docs/src/data/experiments/azure-backend.mdx
@@ -94,7 +94,7 @@ To transition the `azure-backend` feature to a stable release, the following mus
 
 - [x] `internal/azurehelper` package wrapping the Azure SDK with a builder pattern matching `awshelper`/`gcphelper`.
 - [x] Bootstrap of storage accounts and blob containers, including versioning and soft delete convergence.
-- [ ] Optional RBAC role assignment for `use_azuread_auth` during bootstrap (the data-plane role must currently be granted manually).
+- [x] Optional RBAC role assignment for `use_azuread_auth` during bootstrap, via `assign_blob_data_role`.
 - [x] Delete operations for state blobs and containers, with confirmation prompts, and state migration within a storage account.
 - [x] Direct state file reads from Azure blobs for `--dependency-fetch-output-from-state`.
 - [x] Documentation covering authentication methods, configuration keys, and troubleshooting.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	dario.cat/mergo v1.0.2
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDH
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 h1:Hp+EScFOu9HeCbeW8WU2yQPJd4gGwhMgKxWe+G6jNzw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0/go.mod h1:/pz8dyNQe+Ey3yBp/XuYz7oqX8YDNWVpPB0hH3XWfbc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0 h1:2qsIIvxVT+uE6yrNldntJKlLRgxGbZ85kgtz5SNBhMw=

--- a/internal/azurehelper/errors.go
+++ b/internal/azurehelper/errors.go
@@ -23,7 +23,30 @@ var (
 	ErrLocationRequired             = errors.New("location is required")
 	ErrNoAccessKeysReturned         = errors.New("no access keys returned for storage account")
 	ErrAllAccessKeysEmpty           = errors.New("storage account returned keys but all values were empty")
+	ErrScopePrincipalRoleArgs       = errors.New("scope, principal id, and role definition id are required")
+	ErrPrincipalIDUnresolved        = errors.New("principal id could not be resolved from the access token")
 )
+
+// InvalidPrincipalIDError is returned when a principal id is not a UUID, which
+// Azure requires for the object id of a user, group, or service principal.
+// Match with errors.As.
+type InvalidPrincipalIDError struct {
+	PrincipalID string
+}
+
+func (e *InvalidPrincipalIDError) Error() string {
+	return fmt.Sprintf("principal id %q is not a valid uuid", e.PrincipalID)
+}
+
+// InvalidRoleDefinitionIDError is returned when a role definition id is not a
+// UUID. Match with errors.As.
+type InvalidRoleDefinitionIDError struct {
+	RoleDefinitionID string
+}
+
+func (e *InvalidRoleDefinitionIDError) Error() string {
+	return fmt.Sprintf("role definition id %q is not a valid uuid", e.RoleDefinitionID)
+}
 
 // TooManyBlobPagesError is returned when a ListBlobs walk exceeds the page
 // bound, which indicates a container far larger than a state container

--- a/internal/azurehelper/errors.go
+++ b/internal/azurehelper/errors.go
@@ -24,6 +24,12 @@ var (
 	ErrNoAccessKeysReturned         = errors.New("no access keys returned for storage account")
 	ErrAllAccessKeysEmpty           = errors.New("storage account returned keys but all values were empty")
 	ErrScopePrincipalRoleArgs       = errors.New("scope, principal id, and role definition id are required")
+	// ErrARMAudienceRequired is returned when the cloud config has no Resource
+	// Manager audience, so ResolvePrincipal cannot pick a sovereign-cloud scope.
+	ErrARMAudienceRequired = errors.New(
+		"azure cloud configuration is missing a Resource Manager audience; " +
+			"set remote_state.config.environment to public, usgovernment, or china",
+	)
 	// ErrPrincipalIDUnresolved is returned when the access token has no usable oid claim.
 	// Set remote_state.config.principal_id to the Microsoft Entra object id instead.
 	ErrPrincipalIDUnresolved = errors.New(

--- a/internal/azurehelper/errors.go
+++ b/internal/azurehelper/errors.go
@@ -24,7 +24,12 @@ var (
 	ErrNoAccessKeysReturned         = errors.New("no access keys returned for storage account")
 	ErrAllAccessKeysEmpty           = errors.New("storage account returned keys but all values were empty")
 	ErrScopePrincipalRoleArgs       = errors.New("scope, principal id, and role definition id are required")
-	ErrPrincipalIDUnresolved        = errors.New("principal id could not be resolved from the access token")
+	// ErrPrincipalIDUnresolved is returned when the access token has no usable oid claim.
+	// Set remote_state.config.principal_id to the Microsoft Entra object id instead.
+	ErrPrincipalIDUnresolved = errors.New(
+		"principal id could not be resolved from the access token; " +
+			"set remote_state.config.principal_id to the Microsoft Entra object id to assign",
+	)
 )
 
 // InvalidPrincipalIDError is returned when a principal id is not a UUID, which
@@ -46,6 +51,16 @@ type InvalidRoleDefinitionIDError struct {
 
 func (e *InvalidRoleDefinitionIDError) Error() string {
 	return fmt.Sprintf("role definition id %q is not a valid uuid", e.RoleDefinitionID)
+}
+
+// TooManyRoleAssignmentPagesError is returned when a role-assignment list exceeds the page bound.
+type TooManyRoleAssignmentPagesError struct {
+	Scope    string
+	MaxPages int
+}
+
+func (e *TooManyRoleAssignmentPagesError) Error() string {
+	return fmt.Sprintf("listing role assignments at %s exceeded %d pages", e.Scope, e.MaxPages)
 }
 
 // TooManyBlobPagesError is returned when a ListBlobs walk exceeds the page

--- a/internal/azurehelper/rbac.go
+++ b/internal/azurehelper/rbac.go
@@ -38,6 +38,10 @@ const (
 // jwtParts is the number of dot-separated segments in a JWT.
 const jwtParts = 3
 
+// maxRoleAssignmentPages bounds role-assignment list walks so a misbehaving
+// service cannot hang bootstrap indefinitely.
+const maxRoleAssignmentPages = 100
+
 // roleDefinitionsPath joins a subscription and a role GUID into a full role definition id.
 const roleDefinitionsPath = "/providers/Microsoft.Authorization/roleDefinitions/"
 
@@ -167,7 +171,14 @@ func (c *RBACClient) HasRoleAssignment(ctx context.Context, scope, principalID, 
 		Filter: new("assignedTo('" + principalID + "')"),
 	})
 
+	pages := 0
+
 	for pager.More() {
+		pages++
+		if pages > maxRoleAssignmentPages {
+			return false, &TooManyRoleAssignmentPagesError{Scope: scope, MaxPages: maxRoleAssignmentPages}
+		}
+
 		page, err := pager.NextPage(ctx)
 		if err != nil {
 			return false, fmt.Errorf("listing role assignments: %w", err)
@@ -175,6 +186,10 @@ func (c *RBACClient) HasRoleAssignment(ctx context.Context, scope, principalID, 
 
 		for _, ra := range page.Value {
 			if ra == nil || ra.Properties == nil || ra.Properties.RoleDefinitionID == nil {
+				continue
+			}
+
+			if ra.Properties.PrincipalID == nil || !strings.EqualFold(*ra.Properties.PrincipalID, principalID) {
 				continue
 			}
 
@@ -224,14 +239,20 @@ func (c *RBACClient) RemoveRole(ctx context.Context, l log.Logger, scope, princi
 	var errs []error
 
 	removed := 0
+	pages := 0
 
 	for pager.More() {
+		pages++
+		if pages > maxRoleAssignmentPages {
+			return &TooManyRoleAssignmentPagesError{Scope: scope, MaxPages: maxRoleAssignmentPages}
+		}
+
 		page, err := pager.NextPage(ctx)
 		if err != nil {
 			return fmt.Errorf("listing role assignments for removal: %w", err)
 		}
 
-		n, pageErrs := c.deleteMatchingAssignments(ctx, page.Value, roleDefSuffix)
+		n, pageErrs := c.deleteMatchingAssignments(ctx, page.Value, principalID, roleDefSuffix)
 		errs = append(errs, pageErrs...)
 		removed += n
 	}
@@ -245,14 +266,24 @@ func (c *RBACClient) RemoveRole(ctx context.Context, l log.Logger, scope, princi
 	return nil
 }
 
-// deleteMatchingAssignments deletes assignments matching roleDefSuffix, counting a concurrent removal as success.
-func (c *RBACClient) deleteMatchingAssignments(ctx context.Context, ras []*armauthorization.RoleAssignment, roleDefSuffix string) (int, []error) {
+// deleteMatchingAssignments deletes assignments owned by principalID that match roleDefSuffix.
+// A concurrent removal is treated as success. assignedTo() can also surface group-inherited
+// rows, so the principal id is checked before delete.
+func (c *RBACClient) deleteMatchingAssignments(
+	ctx context.Context,
+	ras []*armauthorization.RoleAssignment,
+	principalID, roleDefSuffix string,
+) (int, []error) {
 	var errs []error
 
 	removed := 0
 
 	for _, ra := range ras {
 		if ra == nil || ra.Properties == nil || ra.Properties.RoleDefinitionID == nil || ra.ID == nil {
+			continue
+		}
+
+		if ra.Properties.PrincipalID == nil || !strings.EqualFold(*ra.Properties.PrincipalID, principalID) {
 			continue
 		}
 

--- a/internal/azurehelper/rbac.go
+++ b/internal/azurehelper/rbac.go
@@ -1,0 +1,342 @@
+// Role-assignment helpers: creating a storage account grants its creator no access to the blobs inside it.
+
+package azurehelper
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	"github.com/google/uuid"
+
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+)
+
+// Built-in Azure role definition ids, stable across every subscription.
+const (
+	RoleStorageBlobDataOwner       = "b7e6dc6d-f1e8-4753-8033-0f276bb0955b"
+	RoleStorageBlobDataContributor = "ba92f5b4-2d11-453d-a403-e96b0029c9fe"
+	RoleStorageBlobDataReader      = "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1"
+)
+
+// armScope is the token audience whose access token carries the caller's object id.
+const armScope = "https://management.azure.com/.default"
+
+// Principal types accepted by the role-assignment API.
+const (
+	PrincipalTypeUser             = "User"
+	PrincipalTypeServicePrincipal = "ServicePrincipal"
+)
+
+// jwtParts is the number of dot-separated segments in a JWT.
+const jwtParts = 3
+
+// roleDefinitionsPath joins a subscription and a role GUID into a full role definition id.
+const roleDefinitionsPath = "/providers/Microsoft.Authorization/roleDefinitions/"
+
+// RBACClient wraps the Azure role-assignment management API.
+type RBACClient struct {
+	client         *armauthorization.RoleAssignmentsClient
+	subscriptionID string
+}
+
+// NewRBACClient creates a role-assignment client; SAS-token and access-key configs cannot manage RBAC.
+func NewRBACClient(cfg *AzureConfig) (*RBACClient, error) {
+	if cfg == nil {
+		return nil, ErrAzureConfigRequired
+	}
+
+	if cfg.SubscriptionID == "" {
+		return nil, ErrSubscriptionIDRequired
+	}
+
+	if cfg.Credential == nil {
+		return nil, &UnsupportedAuthForOpError{Method: cfg.Method, Operation: "RBAC operations"}
+	}
+
+	clientFactory, err := armauthorization.NewClientFactory(cfg.SubscriptionID, cfg.Credential, &arm.ClientOptions{
+		ClientOptions: cfg.ClientOptions,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating armauthorization client factory: %w", err)
+	}
+
+	return &RBACClient{
+		client:         clientFactory.NewRoleAssignmentsClient(),
+		subscriptionID: cfg.SubscriptionID,
+	}, nil
+}
+
+// AssignRoleInput carries the parameters for a role assignment.
+type AssignRoleInput struct {
+	// Scope is the resource id the assignment applies to.
+	Scope string
+	// PrincipalID is the Microsoft Entra object id of a user, group, or service principal.
+	PrincipalID string
+	// PrincipalType is "User", "Group", or "ServicePrincipal"; empty lets Azure infer it.
+	PrincipalType string
+	// RoleDefinitionID is the GUID of a built-in or custom role definition.
+	RoleDefinitionID string
+}
+
+// StorageAccountScope builds the resource id a data-plane role assignment applies to.
+func StorageAccountScope(subscriptionID, resourceGroup, account string) string {
+	return "/subscriptions/" + subscriptionID +
+		"/resourceGroups/" + resourceGroup +
+		"/providers/Microsoft.Storage/storageAccounts/" + account
+}
+
+// Principal identifies the caller for a role assignment.
+type Principal struct {
+	// ID is the Microsoft Entra object id.
+	ID string
+	// Type is "User" or "ServicePrincipal", derived because Azure rejects a mismatch.
+	Type string
+}
+
+// ResolvePrincipal reads the caller from its own access token, avoiding a Graph call that directory policy often denies.
+func ResolvePrincipal(ctx context.Context, cfg *AzureConfig) (Principal, error) {
+	if cfg == nil {
+		return Principal{}, ErrAzureConfigRequired
+	}
+
+	if cfg.Credential == nil {
+		return Principal{}, &UnsupportedAuthForOpError{Method: cfg.Method, Operation: "resolving the caller principal"}
+	}
+
+	tok, err := cfg.Credential.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{armScope}})
+	if err != nil {
+		return Principal{}, fmt.Errorf("acquiring token to resolve principal id: %w", err)
+	}
+
+	return principalFromToken(tok.Token)
+}
+
+// AssignRole creates a role assignment, treating an already-existing one as success.
+func (c *RBACClient) AssignRole(ctx context.Context, l log.Logger, in AssignRoleInput) error {
+	if err := validateAssignRoleInput(in); err != nil {
+		return err
+	}
+
+	props := &armauthorization.RoleAssignmentProperties{
+		PrincipalID:      new(in.PrincipalID),
+		RoleDefinitionID: new("/subscriptions/" + c.subscriptionID + roleDefinitionsPath + in.RoleDefinitionID),
+	}
+
+	// A wrongly declared type is rejected as UnmatchedPrincipalType, so an unknown one is omitted.
+	if in.PrincipalType != "" {
+		props.PrincipalType = new(armauthorization.PrincipalType(in.PrincipalType))
+	}
+
+	params := armauthorization.RoleAssignmentCreateParameters{Properties: props}
+
+	// The assignment name is a caller-chosen GUID Azure uses as the resource name.
+	_, err := c.client.Create(ctx, in.Scope, uuid.NewString(), params, nil)
+	if err == nil {
+		l.Debugf("azurehelper: assigned role %s to %s on %s", in.RoleDefinitionID, in.PrincipalID, in.Scope)
+
+		return nil
+	}
+
+	if isAlreadyAssigned(err) {
+		l.Debugf("azurehelper: role %s already assigned to %s on %s", in.RoleDefinitionID, in.PrincipalID, in.Scope)
+
+		return nil
+	}
+
+	return fmt.Errorf("creating role assignment: %w", err)
+}
+
+// HasRoleAssignment reports whether principalID already holds roleDefinitionID at scope.
+func (c *RBACClient) HasRoleAssignment(ctx context.Context, scope, principalID, roleDefinitionID string) (bool, error) {
+	if err := validateAssignRoleInput(AssignRoleInput{Scope: scope, PrincipalID: principalID, RoleDefinitionID: roleDefinitionID}); err != nil {
+		return false, err
+	}
+
+	roleDefSuffix := roleDefinitionsPath + roleDefinitionID
+
+	// principalId eq is only accepted at subscription scope; assignedTo() works at every scope.
+	pager := c.client.NewListForScopePager(scope, &armauthorization.RoleAssignmentsClientListForScopeOptions{
+		Filter: new("assignedTo('" + principalID + "')"),
+	})
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return false, fmt.Errorf("listing role assignments: %w", err)
+		}
+
+		for _, ra := range page.Value {
+			if ra == nil || ra.Properties == nil || ra.Properties.RoleDefinitionID == nil {
+				continue
+			}
+
+			if strings.HasSuffix(*ra.Properties.RoleDefinitionID, roleDefSuffix) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// AssignRoleIfMissing assigns only when missing, so a rerun needs no write permission.
+func (c *RBACClient) AssignRoleIfMissing(ctx context.Context, l log.Logger, in AssignRoleInput) error {
+	if err := validateAssignRoleInput(in); err != nil {
+		return err
+	}
+
+	has, err := c.HasRoleAssignment(ctx, in.Scope, in.PrincipalID, in.RoleDefinitionID)
+	if err != nil {
+		return err
+	}
+
+	if has {
+		l.Debugf("azurehelper: role %s already assigned to %s on %s; skipping create",
+			in.RoleDefinitionID, in.PrincipalID, in.Scope)
+
+		return nil
+	}
+
+	return c.AssignRole(ctx, l, in)
+}
+
+// RemoveRole removes every matching assignment; removing an absent one is a no-op.
+func (c *RBACClient) RemoveRole(ctx context.Context, l log.Logger, scope, principalID, roleDefinitionID string) error {
+	if err := validateAssignRoleInput(AssignRoleInput{Scope: scope, PrincipalID: principalID, RoleDefinitionID: roleDefinitionID}); err != nil {
+		return err
+	}
+
+	roleDefSuffix := roleDefinitionsPath + roleDefinitionID
+
+	// See HasRoleAssignment for why assignedTo() is used here too.
+	pager := c.client.NewListForScopePager(scope, &armauthorization.RoleAssignmentsClientListForScopeOptions{
+		Filter: new("assignedTo('" + principalID + "')"),
+	})
+
+	var errs []error
+
+	removed := 0
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("listing role assignments for removal: %w", err)
+		}
+
+		n, pageErrs := c.deleteMatchingAssignments(ctx, page.Value, roleDefSuffix)
+		errs = append(errs, pageErrs...)
+		removed += n
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return err
+	}
+
+	l.Debugf("azurehelper: removed %d role assignment(s) for principal %s on %s", removed, principalID, scope)
+
+	return nil
+}
+
+// deleteMatchingAssignments deletes assignments matching roleDefSuffix, counting a concurrent removal as success.
+func (c *RBACClient) deleteMatchingAssignments(ctx context.Context, ras []*armauthorization.RoleAssignment, roleDefSuffix string) (int, []error) {
+	var errs []error
+
+	removed := 0
+
+	for _, ra := range ras {
+		if ra == nil || ra.Properties == nil || ra.Properties.RoleDefinitionID == nil || ra.ID == nil {
+			continue
+		}
+
+		if !strings.HasSuffix(*ra.Properties.RoleDefinitionID, roleDefSuffix) {
+			continue
+		}
+
+		if _, err := c.client.DeleteByID(ctx, *ra.ID, nil); err != nil {
+			if IsNotFound(err) {
+				continue
+			}
+
+			errs = append(errs, fmt.Errorf("deleting role assignment %s: %w", *ra.ID, err))
+
+			continue
+		}
+
+		removed++
+	}
+
+	return removed, errs
+}
+
+// validateAssignRoleInput surfaces bad input as a typed error instead of a service 400.
+func validateAssignRoleInput(in AssignRoleInput) error {
+	if in.Scope == "" || in.PrincipalID == "" || in.RoleDefinitionID == "" {
+		return ErrScopePrincipalRoleArgs
+	}
+
+	if _, err := uuid.Parse(in.PrincipalID); err != nil {
+		return &InvalidPrincipalIDError{PrincipalID: in.PrincipalID}
+	}
+
+	if _, err := uuid.Parse(in.RoleDefinitionID); err != nil {
+		return &InvalidRoleDefinitionIDError{RoleDefinitionID: in.RoleDefinitionID}
+	}
+
+	return nil
+}
+
+// principalFromToken reads the oid and idtyp claims; Entra already verified the signature.
+func principalFromToken(token string) (Principal, error) {
+	segments := strings.Split(token, ".")
+	if len(segments) != jwtParts {
+		return Principal{}, ErrPrincipalIDUnresolved
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(segments[1])
+	if err != nil {
+		return Principal{}, ErrPrincipalIDUnresolved
+	}
+
+	var claims struct {
+		OID   string `json:"oid"`
+		IDTyp string `json:"idtyp"`
+	}
+
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return Principal{}, ErrPrincipalIDUnresolved
+	}
+
+	if claims.OID == "" {
+		return Principal{}, ErrPrincipalIDUnresolved
+	}
+
+	// Entra sets idtyp to "app" on an app-only token.
+	principalType := PrincipalTypeUser
+	if strings.EqualFold(claims.IDTyp, "app") {
+		principalType = PrincipalTypeServicePrincipal
+	}
+
+	return Principal{ID: claims.OID, Type: principalType}, nil
+}
+
+// isAlreadyAssigned matches by error code so wrapping or SDK message changes do not break it.
+func isAlreadyAssigned(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	respErr, ok := errors.AsType[*azcore.ResponseError](err)
+	if !ok {
+		return false
+	}
+
+	return strings.EqualFold(respErr.ErrorCode, "RoleAssignmentExists")
+}

--- a/internal/azurehelper/rbac.go
+++ b/internal/azurehelper/rbac.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/google/uuid"
@@ -19,15 +20,14 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
-// Built-in Azure role definition ids, stable across every subscription.
+// Built-in Azure role definition ids. Microsoft documents that built-in roles keep
+// the same role ID across clouds (Azure public, Azure Government, Azure China):
+// https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions
 const (
 	RoleStorageBlobDataOwner       = "b7e6dc6d-f1e8-4753-8033-0f276bb0955b"
 	RoleStorageBlobDataContributor = "ba92f5b4-2d11-453d-a403-e96b0029c9fe"
 	RoleStorageBlobDataReader      = "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1"
 )
-
-// armScope is the token audience whose access token carries the caller's object id.
-const armScope = "https://management.azure.com/.default"
 
 // Principal types accepted by the role-assignment API.
 const (
@@ -115,12 +115,34 @@ func ResolvePrincipal(ctx context.Context, cfg *AzureConfig) (Principal, error) 
 		return Principal{}, &UnsupportedAuthForOpError{Method: cfg.Method, Operation: "resolving the caller principal"}
 	}
 
-	tok, err := cfg.Credential.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{armScope}})
+	scope, err := armTokenScope(cfg)
+	if err != nil {
+		return Principal{}, err
+	}
+
+	tok, err := cfg.Credential.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{scope}})
 	if err != nil {
 		return Principal{}, fmt.Errorf("acquiring token to resolve principal id: %w", err)
 	}
 
 	return principalFromToken(tok.Token)
+}
+
+// armTokenScope returns the ARM OAuth scope for cfg's cloud. Sovereign clouds
+// reject a public-cloud audience, so the scope must follow CloudConfig (or the
+// ClientOptions cloud) rather than a fixed management.azure.com value.
+func armTokenScope(cfg *AzureConfig) (string, error) {
+	cloudCfg := cfg.CloudConfig
+	if len(cloudCfg.Services) == 0 {
+		cloudCfg = cfg.ClientOptions.Cloud
+	}
+
+	svc, ok := cloudCfg.Services[cloud.ResourceManager]
+	if !ok || svc.Audience == "" {
+		return "", ErrARMAudienceRequired
+	}
+
+	return strings.TrimSuffix(svc.Audience, "/") + "/.default", nil
 }
 
 // AssignRole creates a role assignment, treating an already-existing one as success.

--- a/internal/azurehelper/rbac.go
+++ b/internal/azurehelper/rbac.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Built-in Azure role definition ids. Microsoft documents that built-in roles keep
-// the same role ID across clouds (Azure public, Azure Government, Azure China):
+// the same role ID across clouds (including Azure Government / usgovernment):
 // https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions
 const (
 	RoleStorageBlobDataOwner       = "b7e6dc6d-f1e8-4753-8033-0f276bb0955b"

--- a/internal/azurehelper/rbac_test.go
+++ b/internal/azurehelper/rbac_test.go
@@ -30,16 +30,25 @@ func TestNewRBACClient_Validation(t *testing.T) {
 	t.Parallel()
 
 	tt := []struct {
-		cfg  *azurehelper.AzureConfig
-		name string
+		checkAs func(t *testing.T, err error)
+		cfg     *azurehelper.AzureConfig
+		wantIs  error
+		name    string
 	}{
-		{name: "nil config", cfg: nil},
-		{name: "missing subscription", cfg: &azurehelper.AzureConfig{Credential: fakeCredential{}}},
+		{name: "nil config", cfg: nil, wantIs: azurehelper.ErrAzureConfigRequired},
+		{name: "missing subscription", cfg: &azurehelper.AzureConfig{Credential: fakeCredential{}}, wantIs: azurehelper.ErrSubscriptionIDRequired},
 		{
 			name: "data-plane auth cannot manage rbac",
 			cfg: &azurehelper.AzureConfig{
 				SubscriptionID: testSub,
 				Method:         azurehelper.AuthMethodAccessKey,
+			},
+			checkAs: func(t *testing.T, err error) {
+				t.Helper()
+
+				var unsupported *azurehelper.UnsupportedAuthForOpError
+				require.ErrorAs(t, err, &unsupported)
+				assert.Equal(t, azurehelper.AuthMethodAccessKey, unsupported.Method)
 			},
 		},
 	}
@@ -50,6 +59,14 @@ func TestNewRBACClient_Validation(t *testing.T) {
 
 			_, err := azurehelper.NewRBACClient(tc.cfg)
 			require.Error(t, err)
+
+			if tc.wantIs != nil {
+				require.ErrorIs(t, err, tc.wantIs)
+			}
+
+			if tc.checkAs != nil {
+				tc.checkAs(t, err)
+			}
 		})
 	}
 }
@@ -157,7 +174,10 @@ func TestAssignRole_SurfacesOtherFailures(t *testing.T) {
 		RoleDefinitionID: azurehelper.RoleStorageBlobDataContributor,
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "AuthorizationFailed")
+
+	var respErr *azcore.ResponseError
+	require.ErrorAs(t, err, &respErr)
+	assert.Equal(t, "AuthorizationFailed", respErr.ErrorCode)
 }
 
 // TestHasRoleAssignment_UsesAssignedToFilter pins the filter form: Azure only
@@ -207,8 +227,11 @@ func TestHasRoleAssignment_MatchesBySuffix(t *testing.T) {
 			tr := &stubTransport{status: http.StatusOK, body: jsonBody(map[string]any{
 				"value": []any{
 					map[string]any{
-						"id":         "/ra/1",
-						"properties": map[string]any{"roleDefinitionId": tc.roleDef},
+						"id": "/ra/1",
+						"properties": map[string]any{
+							"principalId":      testPrincipalID,
+							"roleDefinitionId": tc.roleDef,
+						},
 					},
 				},
 			})}
@@ -233,6 +256,7 @@ func TestAssignRoleIfMissing_SkipsCreateWhenPresent(t *testing.T) {
 			map[string]any{
 				"id": "/ra/1",
 				"properties": map[string]any{
+					"principalId":      testPrincipalID,
 					"roleDefinitionId": "/subscriptions/x/providers/Microsoft.Authorization/roleDefinitions/" + azurehelper.RoleStorageBlobDataContributor,
 				},
 			},
@@ -262,6 +286,52 @@ func TestRemoveRole_MissingAssignmentIsNoop(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, c.RemoveRole(t.Context(), log.New(), testScope, testPrincipalID, azurehelper.RoleStorageBlobDataContributor))
+}
+
+// TestRemoveRole_IgnoresInheritedAssignments pins that assignedTo() rows for a
+// different principal (for example a group membership expansion) are not deleted.
+func TestRemoveRole_IgnoresInheritedAssignments(t *testing.T) {
+	t.Parallel()
+
+	otherPrincipal := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	tr := &recordingTransport{status: http.StatusOK, body: jsonBody(map[string]any{
+		"value": []any{
+			map[string]any{
+				"id": "/ra/group",
+				"properties": map[string]any{
+					"principalId":      otherPrincipal,
+					"roleDefinitionId": "/subscriptions/x/providers/Microsoft.Authorization/roleDefinitions/" + azurehelper.RoleStorageBlobDataContributor,
+				},
+			},
+		},
+	})}
+
+	c, err := azurehelper.NewRBACClient(cfgWithTransport(tr))
+	require.NoError(t, err)
+
+	require.NoError(t, c.RemoveRole(t.Context(), log.New(), testScope, testPrincipalID, azurehelper.RoleStorageBlobDataContributor))
+
+	for _, m := range tr.methods {
+		assert.NotEqual(t, http.MethodDelete, m, "inherited assignments must not be deleted")
+	}
+}
+
+func TestHasRoleAssignment_BoundsPages(t *testing.T) {
+	t.Parallel()
+
+	tr := &stubTransport{status: http.StatusOK, body: jsonBody(map[string]any{
+		"value":    []any{},
+		"nextLink": "https://management.azure.com/next",
+	})}
+	c, err := azurehelper.NewRBACClient(cfgWithTransport(tr))
+	require.NoError(t, err)
+
+	_, err = c.HasRoleAssignment(t.Context(), testScope, testPrincipalID, azurehelper.RoleStorageBlobDataContributor)
+
+	var tooMany *azurehelper.TooManyRoleAssignmentPagesError
+	require.ErrorAs(t, err, &tooMany)
+	assert.Equal(t, testScope, tooMany.Scope)
+	assert.Equal(t, 100, tooMany.MaxPages)
 }
 
 func TestStorageAccountScope(t *testing.T) {
@@ -355,6 +425,10 @@ func TestResolvePrincipal_RequiresTokenCredential(t *testing.T) {
 
 	_, err := azurehelper.ResolvePrincipal(t.Context(), &azurehelper.AzureConfig{Method: azurehelper.AuthMethodAccessKey})
 	require.Error(t, err)
+
+	var unsupported *azurehelper.UnsupportedAuthForOpError
+	require.ErrorAs(t, err, &unsupported)
+	assert.Equal(t, azurehelper.AuthMethodAccessKey, unsupported.Method)
 
 	_, err = azurehelper.ResolvePrincipal(t.Context(), nil)
 	require.ErrorIs(t, err, azurehelper.ErrAzureConfigRequired)

--- a/internal/azurehelper/rbac_test.go
+++ b/internal/azurehelper/rbac_test.go
@@ -1,0 +1,411 @@
+//go:build azure
+
+package azurehelper_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/azurehelper"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+)
+
+const (
+	testPrincipalID = "11111111-2222-3333-4444-555555555555"
+	testScope       = "/subscriptions/" + testSub + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/" + testAccount
+)
+
+func TestNewRBACClient_Validation(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		cfg  *azurehelper.AzureConfig
+		name string
+	}{
+		{name: "nil config", cfg: nil},
+		{name: "missing subscription", cfg: &azurehelper.AzureConfig{Credential: fakeCredential{}}},
+		{
+			name: "data-plane auth cannot manage rbac",
+			cfg: &azurehelper.AzureConfig{
+				SubscriptionID: testSub,
+				Method:         azurehelper.AuthMethodAccessKey,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := azurehelper.NewRBACClient(tc.cfg)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestAssignRole_RejectsMalformedInput(t *testing.T) {
+	t.Parallel()
+
+	c, err := azurehelper.NewRBACClient(cfgWithTransport(&stubTransport{status: http.StatusOK, body: []byte(`{}`)}))
+	require.NoError(t, err)
+
+	tt := []struct {
+		wantErr error
+		name    string
+		in      azurehelper.AssignRoleInput
+	}{
+		{
+			name:    "empty scope",
+			in:      azurehelper.AssignRoleInput{PrincipalID: testPrincipalID, RoleDefinitionID: azurehelper.RoleStorageBlobDataContributor},
+			wantErr: azurehelper.ErrScopePrincipalRoleArgs,
+		},
+		{
+			name:    "empty principal",
+			in:      azurehelper.AssignRoleInput{Scope: testScope, RoleDefinitionID: azurehelper.RoleStorageBlobDataContributor},
+			wantErr: azurehelper.ErrScopePrincipalRoleArgs,
+		},
+		{
+			name:    "empty role definition",
+			in:      azurehelper.AssignRoleInput{Scope: testScope, PrincipalID: testPrincipalID},
+			wantErr: azurehelper.ErrScopePrincipalRoleArgs,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.ErrorIs(t, c.AssignRole(t.Context(), log.New(), tc.in), tc.wantErr)
+		})
+	}
+}
+
+func TestAssignRole_RejectsNonUUIDs(t *testing.T) {
+	t.Parallel()
+
+	c, err := azurehelper.NewRBACClient(cfgWithTransport(&stubTransport{status: http.StatusOK, body: []byte(`{}`)}))
+	require.NoError(t, err)
+
+	err = c.AssignRole(t.Context(), log.New(), azurehelper.AssignRoleInput{
+		Scope:            testScope,
+		PrincipalID:      "not-a-uuid",
+		RoleDefinitionID: azurehelper.RoleStorageBlobDataContributor,
+	})
+
+	var principalErr *azurehelper.InvalidPrincipalIDError
+	require.ErrorAs(t, err, &principalErr)
+
+	err = c.AssignRole(t.Context(), log.New(), azurehelper.AssignRoleInput{
+		Scope:            testScope,
+		PrincipalID:      testPrincipalID,
+		RoleDefinitionID: "not-a-uuid",
+	})
+
+	var roleErr *azurehelper.InvalidRoleDefinitionIDError
+	require.ErrorAs(t, err, &roleErr)
+}
+
+// TestAssignRole_ExistingAssignmentIsNotAnError covers bootstrap reruns: Azure
+// answers 409 RoleAssignmentExists, which must not fail the bootstrap.
+func TestAssignRole_ExistingAssignmentIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	tr := &stubTransport{
+		status: http.StatusConflict,
+		body: jsonBody(map[string]any{
+			"error": map[string]any{"code": "RoleAssignmentExists", "message": "already exists"},
+		}),
+	}
+
+	c, err := azurehelper.NewRBACClient(cfgWithTransport(tr))
+	require.NoError(t, err)
+
+	require.NoError(t, c.AssignRole(t.Context(), log.New(), azurehelper.AssignRoleInput{
+		Scope:            testScope,
+		PrincipalID:      testPrincipalID,
+		RoleDefinitionID: azurehelper.RoleStorageBlobDataContributor,
+	}))
+}
+
+func TestAssignRole_SurfacesOtherFailures(t *testing.T) {
+	t.Parallel()
+
+	tr := &stubTransport{
+		status: http.StatusForbidden,
+		body: jsonBody(map[string]any{
+			"error": map[string]any{"code": "AuthorizationFailed", "message": "no permission"},
+		}),
+	}
+
+	c, err := azurehelper.NewRBACClient(cfgWithTransport(tr))
+	require.NoError(t, err)
+
+	err = c.AssignRole(t.Context(), log.New(), azurehelper.AssignRoleInput{
+		Scope:            testScope,
+		PrincipalID:      testPrincipalID,
+		RoleDefinitionID: azurehelper.RoleStorageBlobDataContributor,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AuthorizationFailed")
+}
+
+// TestHasRoleAssignment_UsesAssignedToFilter pins the filter form: Azure only
+// accepts `principalId eq` at subscription scope and answers 400 at resource
+// scope, so a regression here would break every non-subscription lookup.
+func TestHasRoleAssignment_UsesAssignedToFilter(t *testing.T) {
+	t.Parallel()
+
+	tr := &recordingTransport{status: http.StatusOK, body: jsonBody(map[string]any{"value": []any{}})}
+
+	c, err := azurehelper.NewRBACClient(cfgWithTransport(tr))
+	require.NoError(t, err)
+
+	has, err := c.HasRoleAssignment(t.Context(), testScope, testPrincipalID, azurehelper.RoleStorageBlobDataContributor)
+	require.NoError(t, err)
+	assert.False(t, has)
+
+	require.NotEmpty(t, tr.urls)
+	assert.Contains(t, tr.urls[0], "assignedTo('"+testPrincipalID+"')")
+	assert.NotContains(t, tr.urls[0], "principalId")
+}
+
+func TestHasRoleAssignment_MatchesBySuffix(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name     string
+		roleDef  string
+		expected bool
+	}{
+		{
+			name:     "same role",
+			roleDef:  "/subscriptions/x/providers/Microsoft.Authorization/roleDefinitions/" + azurehelper.RoleStorageBlobDataContributor,
+			expected: true,
+		},
+		{
+			name:     "different role",
+			roleDef:  "/subscriptions/x/providers/Microsoft.Authorization/roleDefinitions/" + azurehelper.RoleStorageBlobDataReader,
+			expected: false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tr := &stubTransport{status: http.StatusOK, body: jsonBody(map[string]any{
+				"value": []any{
+					map[string]any{
+						"id":         "/ra/1",
+						"properties": map[string]any{"roleDefinitionId": tc.roleDef},
+					},
+				},
+			})}
+
+			c, err := azurehelper.NewRBACClient(cfgWithTransport(tr))
+			require.NoError(t, err)
+
+			has, err := c.HasRoleAssignment(t.Context(), testScope, testPrincipalID, azurehelper.RoleStorageBlobDataContributor)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, has)
+		})
+	}
+}
+
+// TestAssignRoleIfMissing_SkipsCreateWhenPresent proves the pre-check short
+// circuits, so a rerun needs only read permission on role assignments.
+func TestAssignRoleIfMissing_SkipsCreateWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	tr := &recordingTransport{status: http.StatusOK, body: jsonBody(map[string]any{
+		"value": []any{
+			map[string]any{
+				"id": "/ra/1",
+				"properties": map[string]any{
+					"roleDefinitionId": "/subscriptions/x/providers/Microsoft.Authorization/roleDefinitions/" + azurehelper.RoleStorageBlobDataContributor,
+				},
+			},
+		},
+	})}
+
+	c, err := azurehelper.NewRBACClient(cfgWithTransport(tr))
+	require.NoError(t, err)
+
+	require.NoError(t, c.AssignRoleIfMissing(t.Context(), log.New(), azurehelper.AssignRoleInput{
+		Scope:            testScope,
+		PrincipalID:      testPrincipalID,
+		RoleDefinitionID: azurehelper.RoleStorageBlobDataContributor,
+	}))
+
+	for _, m := range tr.methods {
+		assert.NotEqual(t, http.MethodPut, m, "an existing assignment must not be re-created")
+	}
+}
+
+func TestRemoveRole_MissingAssignmentIsNoop(t *testing.T) {
+	t.Parallel()
+
+	tr := &stubTransport{status: http.StatusOK, body: jsonBody(map[string]any{"value": []any{}})}
+
+	c, err := azurehelper.NewRBACClient(cfgWithTransport(tr))
+	require.NoError(t, err)
+
+	require.NoError(t, c.RemoveRole(t.Context(), log.New(), testScope, testPrincipalID, azurehelper.RoleStorageBlobDataContributor))
+}
+
+func TestStorageAccountScope(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, testScope, azurehelper.StorageAccountScope(testSub, "rg", testAccount))
+}
+
+// TestResolvePrincipal reads the caller from its own token rather than Microsoft Graph, which directory policy often denies.
+func TestResolvePrincipal(t *testing.T) {
+	t.Parallel()
+
+	// Azure rejects an assignment whose declared type does not match the principal.
+	tt := []struct {
+		name     string
+		idtyp    string
+		wantType string
+	}{
+		{name: "app-only token is a service principal", idtyp: "app", wantType: azurehelper.PrincipalTypeServicePrincipal},
+		{name: "signed-in human is a user", idtyp: "user", wantType: azurehelper.PrincipalTypeUser},
+		{name: "absent idtyp defaults to user", idtyp: "", wantType: azurehelper.PrincipalTypeUser},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			claims := map[string]any{"oid": testPrincipalID}
+			if tc.idtyp != "" {
+				claims["idtyp"] = tc.idtyp
+			}
+
+			cfg := cfgWithTransport(&stubTransport{status: http.StatusOK, body: []byte(`{}`)})
+			cfg.Credential = tokenCredential{token: jwtWithClaims(claims)}
+
+			got, err := azurehelper.ResolvePrincipal(t.Context(), cfg)
+			require.NoError(t, err)
+			assert.Equal(t, testPrincipalID, got.ID)
+			assert.Equal(t, tc.wantType, got.Type)
+		})
+	}
+}
+
+// TestAssignRole_OmitsUnknownPrincipalType pins that an unset type is left out so Azure infers it instead of answering UnmatchedPrincipalType.
+func TestAssignRole_OmitsUnknownPrincipalType(t *testing.T) {
+	t.Parallel()
+
+	tr := &recordingTransport{status: http.StatusCreated, body: jsonBody(map[string]any{"id": "/ra/1"})}
+
+	c, err := azurehelper.NewRBACClient(cfgWithTransport(tr))
+	require.NoError(t, err)
+
+	require.NoError(t, c.AssignRole(t.Context(), log.New(), azurehelper.AssignRoleInput{
+		Scope:            testScope,
+		PrincipalID:      testPrincipalID,
+		RoleDefinitionID: azurehelper.RoleStorageBlobDataContributor,
+	}))
+
+	require.NotEmpty(t, tr.bodies)
+	assert.NotContains(t, tr.bodies[0], "principalType")
+}
+
+func TestResolvePrincipal_Failures(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name  string
+		token string
+	}{
+		{name: "not a jwt", token: "opaque-token"},
+		{name: "payload not base64", token: "a.!!!.c"},
+		{name: "payload not json", token: "a." + base64.RawURLEncoding.EncodeToString([]byte("nope")) + ".c"},
+		{name: "no oid claim", token: jwtWithClaims(map[string]any{"appid": "x"})},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := cfgWithTransport(&stubTransport{status: http.StatusOK, body: []byte(`{}`)})
+			cfg.Credential = tokenCredential{token: tc.token}
+
+			_, err := azurehelper.ResolvePrincipal(t.Context(), cfg)
+			require.ErrorIs(t, err, azurehelper.ErrPrincipalIDUnresolved)
+		})
+	}
+}
+
+func TestResolvePrincipal_RequiresTokenCredential(t *testing.T) {
+	t.Parallel()
+
+	_, err := azurehelper.ResolvePrincipal(t.Context(), &azurehelper.AzureConfig{Method: azurehelper.AuthMethodAccessKey})
+	require.Error(t, err)
+
+	_, err = azurehelper.ResolvePrincipal(t.Context(), nil)
+	require.ErrorIs(t, err, azurehelper.ErrAzureConfigRequired)
+}
+
+// tokenCredential returns a caller-supplied token so tests can drive the
+// claim parsing directly.
+type tokenCredential struct {
+	token string
+}
+
+func (c tokenCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: c.token, ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+// recordingTransport captures the request line of every call so tests can
+// assert on the query Azure actually receives.
+type recordingTransport struct {
+	body    []byte
+	urls    []string
+	methods []string
+	bodies  []string
+	status  int
+}
+
+func (r *recordingTransport) Do(req *http.Request) (*http.Response, error) {
+	r.urls = append(r.urls, req.URL.String())
+	r.methods = append(r.methods, req.Method)
+
+	if req.Body != nil {
+		if b, err := io.ReadAll(req.Body); err == nil {
+			r.bodies = append(r.bodies, string(b))
+		}
+	}
+
+	return &http.Response{
+		Request:    req,
+		StatusCode: r.status,
+		Status:     http.StatusText(r.status),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(string(r.body))),
+	}, nil
+}
+
+// jwtWithClaims builds an unsigned JWT whose payload carries claims; only the
+// payload segment is ever read.
+func jwtWithClaims(claims map[string]any) string {
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		panic(err)
+	}
+
+	return "header." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}

--- a/internal/azurehelper/rbac_test.go
+++ b/internal/azurehelper/rbac_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -375,6 +376,51 @@ func TestResolvePrincipal(t *testing.T) {
 	}
 }
 
+// TestResolvePrincipal_UsesCloudARMAudience pins that sovereign clouds request
+// their own ARM token audience instead of the public management.azure.com scope.
+func TestResolvePrincipal_UsesCloudARMAudience(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name      string
+		cloudCfg  cloud.Configuration
+		wantScope string
+	}{
+		{
+			name:      "public",
+			cloudCfg:  cloud.AzurePublic,
+			wantScope: strings.TrimSuffix(cloud.AzurePublic.Services[cloud.ResourceManager].Audience, "/") + "/.default",
+		},
+		{
+			name:      "us government",
+			cloudCfg:  cloud.AzureGovernment,
+			wantScope: strings.TrimSuffix(cloud.AzureGovernment.Services[cloud.ResourceManager].Audience, "/") + "/.default",
+		},
+		{
+			name:      "china",
+			cloudCfg:  cloud.AzureChina,
+			wantScope: strings.TrimSuffix(cloud.AzureChina.Services[cloud.ResourceManager].Audience, "/") + "/.default",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cred := &recordingCredential{token: jwtWithClaims(map[string]any{"oid": testPrincipalID})}
+			cfg := cfgWithTransport(&stubTransport{status: http.StatusOK, body: []byte(`{}`)})
+			cfg.CloudConfig = tc.cloudCfg
+			cfg.ClientOptions.Cloud = tc.cloudCfg
+			cfg.Credential = cred
+
+			got, err := azurehelper.ResolvePrincipal(t.Context(), cfg)
+			require.NoError(t, err)
+			assert.Equal(t, testPrincipalID, got.ID)
+			require.Equal(t, []string{tc.wantScope}, cred.scopes)
+		})
+	}
+}
+
 // TestAssignRole_OmitsUnknownPrincipalType pins that an unset type is left out so Azure infers it instead of answering UnmatchedPrincipalType.
 func TestAssignRole_OmitsUnknownPrincipalType(t *testing.T) {
 	t.Parallel()
@@ -441,6 +487,19 @@ type tokenCredential struct {
 }
 
 func (c tokenCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: c.token, ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+// recordingCredential captures the scopes ResolvePrincipal requested so tests
+// can assert sovereign-cloud audiences.
+type recordingCredential struct {
+	token  string
+	scopes []string
+}
+
+func (c *recordingCredential) GetToken(_ context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	c.scopes = append([]string(nil), opts.Scopes...)
+
 	return azcore.AccessToken{Token: c.token, ExpiresOn: time.Now().Add(time.Hour)}, nil
 }
 

--- a/internal/remotestate/backend/azurerm/backend.go
+++ b/internal/remotestate/backend/azurerm/backend.go
@@ -387,6 +387,14 @@ func (b *Backend) Bootstrap(ctx context.Context, l log.Logger, v *venv.Venv, bac
 		return err
 	}
 
+	// Resolve the auto principal before the inited short-circuit so CacheKey
+	// includes the identity that AssignRoleIfMissing will target. Without this,
+	// two callers sharing assign_blob_data_role=true and an empty principal_id
+	// would share one "already initialized" entry and the second would skip the grant.
+	if err := resolveAssignBlobDataPrincipal(ctx, extCfg, cfg); err != nil {
+		return err
+	}
+
 	rs := &extCfg.RemoteStateConfigAzurerm
 
 	// Only one goroutine bootstraps a given account/container at a time.
@@ -529,7 +537,7 @@ func ensureBlobDataRole(
 		return nil
 	}
 
-	// A configured principal is left untyped so Azure infers it.
+	// A configured or pre-resolved principal is left untyped so Azure infers it.
 	principal := azurehelper.Principal{ID: extCfg.PrincipalID}
 
 	if principal.ID == "" {
@@ -554,6 +562,28 @@ func ensureBlobDataRole(
 		PrincipalType:    principal.Type,
 		RoleDefinitionID: azurehelper.RoleStorageBlobDataContributor,
 	})
+}
+
+// resolveAssignBlobDataPrincipal fills PrincipalID from the caller's token when
+// assign_blob_data_role is set and principal_id was left empty, so CacheKey
+// distinguishes identities before the bootstrap short-circuit.
+func resolveAssignBlobDataPrincipal(
+	ctx context.Context,
+	extCfg *ExtendedRemoteStateConfigAzurerm,
+	cfg *azurehelper.AzureConfig,
+) error {
+	if !extCfg.AssignBlobDataRole || extCfg.PrincipalID != "" || !armCapable(cfg) {
+		return nil
+	}
+
+	resolved, err := azurehelper.ResolvePrincipal(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	extCfg.PrincipalID = resolved.ID
+
+	return nil
 }
 
 // createAccount provisions the resource group (when allowed) and the storage

--- a/internal/remotestate/backend/azurerm/backend.go
+++ b/internal/remotestate/backend/azurerm/backend.go
@@ -98,7 +98,8 @@ func armCapable(cfg *azurehelper.AzureConfig) bool {
 // armWorkRequested reports whether the config asks for any ARM control-plane
 // work; a user-managed account with no policy convergence requires none.
 func armWorkRequested(extCfg *ExtendedRemoteStateConfigAzurerm) bool {
-	return !extCfg.SkipStorageAccountCreation || !extCfg.SkipVersioning || extCfg.EnableSoftDelete
+	return !extCfg.SkipStorageAccountCreation || !extCfg.SkipVersioning || extCfg.EnableSoftDelete ||
+		extCfg.AssignBlobDataRole
 }
 
 // warnArmWorkSkipped logs that account creation or versioning/soft-delete
@@ -514,7 +515,45 @@ func (b *Backend) bootstrapAccount(
 		}
 	}
 
-	return nil
+	return ensureBlobDataRole(ctx, l, extCfg, cfg)
+}
+
+// ensureBlobDataRole grants data-plane access, which creating the account does not convey.
+func ensureBlobDataRole(
+	ctx context.Context,
+	l log.Logger,
+	extCfg *ExtendedRemoteStateConfigAzurerm,
+	cfg *azurehelper.AzureConfig,
+) error {
+	if !extCfg.AssignBlobDataRole {
+		return nil
+	}
+
+	// A configured principal is left untyped so Azure infers it.
+	principal := azurehelper.Principal{ID: extCfg.PrincipalID}
+
+	if principal.ID == "" {
+		resolved, err := azurehelper.ResolvePrincipal(ctx, cfg)
+		if err != nil {
+			return err
+		}
+
+		principal = resolved
+	}
+
+	rbacClient, err := azurehelper.NewRBACClient(cfg)
+	if err != nil {
+		return err
+	}
+
+	rs := &extCfg.RemoteStateConfigAzurerm
+
+	return rbacClient.AssignRoleIfMissing(ctx, l, azurehelper.AssignRoleInput{
+		Scope:            azurehelper.StorageAccountScope(cfg.SubscriptionID, cfg.ResourceGroup, rs.StorageAccountName),
+		PrincipalID:      principal.ID,
+		PrincipalType:    principal.Type,
+		RoleDefinitionID: azurehelper.RoleStorageBlobDataContributor,
+	})
 }
 
 // createAccount provisions the resource group (when allowed) and the storage

--- a/internal/remotestate/backend/azurerm/backend.go
+++ b/internal/remotestate/backend/azurerm/backend.go
@@ -102,11 +102,11 @@ func armWorkRequested(extCfg *ExtendedRemoteStateConfigAzurerm) bool {
 		extCfg.AssignBlobDataRole
 }
 
-// warnArmWorkSkipped logs that account creation or versioning/soft-delete
-// convergence was requested but cannot run under data-plane-only auth.
+// warnArmWorkSkipped logs that account creation, versioning/soft-delete
+// convergence, or role assignment was requested but cannot run under data-plane-only auth.
 func warnArmWorkSkipped(l log.Logger, name string, method azurehelper.AuthMethod) {
 	l.Warnf(
-		"Cannot manage the storage account for %s backend with %s authentication; skipping account creation and versioning/soft-delete convergence.",
+		"Cannot manage the storage account for %s backend with %s authentication; skipping account creation, versioning/soft-delete convergence, and role assignment.",
 		name,
 		method,
 	)
@@ -313,6 +313,10 @@ func (b *Backend) NeedsBootstrap(ctx context.Context, l log.Logger, v *venv.Venv
 	rs := &extCfg.RemoteStateConfigAzurerm
 
 	if armWorkRequested(extCfg) && !armCapable(cfg) {
+		if extCfg.AssignBlobDataRole {
+			return false, &AssignBlobDataRoleRequiresARMError{Method: cfg.Method}
+		}
+
 		warnArmWorkSkipped(l, b.Name(), cfg.Method)
 	}
 
@@ -369,10 +373,10 @@ func accountNeedsBootstrap(
 		return !extCfg.SkipStorageAccountCreation, nil
 	}
 
-	// An existing account is checked for versioning / soft-delete drift even
+	// An existing account is checked for versioning / soft-delete / role drift even
 	// under skip_storage_account_creation, since those policies are converged
 	// on pre-created accounts too.
-	return accountPolicyDrift(ctx, saClient, extCfg)
+	return accountPolicyDrift(ctx, saClient, cfg, extCfg)
 }
 
 // Bootstrap creates (if necessary) the resource group, storage account, and
@@ -407,6 +411,10 @@ func (b *Backend) Bootstrap(ctx context.Context, l log.Logger, v *venv.Venv, bac
 		l.Debugf("%s container %s has already been confirmed to be initialized, skipping initialization checks", b.Name(), rs.CacheKey())
 
 		return nil
+	}
+
+	if extCfg.AssignBlobDataRole && !armCapable(cfg) {
+		return &AssignBlobDataRoleRequiresARMError{Method: cfg.Method}
 	}
 
 	if armWorkRequested(extCfg) && !armCapable(cfg) {
@@ -620,11 +628,12 @@ func createAccount(
 	return saClient.Create(ctx, l, extCfg.StorageAccountConfig())
 }
 
-// accountPolicyDrift reports whether the existing account's blob versioning or
-// soft-delete configuration differs from what the config requests.
+// accountPolicyDrift reports whether the existing account's blob versioning,
+// soft-delete, or blob-data role configuration differs from what the config requests.
 func accountPolicyDrift(
 	ctx context.Context,
 	saClient *azurehelper.StorageAccountClient,
+	cfg *azurehelper.AzureConfig,
 	extCfg *ExtendedRemoteStateConfigAzurerm,
 ) (bool, error) {
 	if !extCfg.SkipVersioning {
@@ -653,7 +662,51 @@ func accountPolicyDrift(
 		}
 	}
 
-	return false, nil
+	missing, err := blobDataRoleMissing(ctx, cfg, extCfg)
+	if err != nil {
+		return false, err
+	}
+
+	return missing, nil
+}
+
+// blobDataRoleMissing reports whether assign_blob_data_role is set and the
+// target principal does not yet hold Storage Blob Data Contributor. Without
+// this check, --backend-bootstrap skips ensureBlobDataRole on an otherwise
+// healthy account and OpenTofu/Terraform then fails data-plane auth.
+func blobDataRoleMissing(
+	ctx context.Context,
+	cfg *azurehelper.AzureConfig,
+	extCfg *ExtendedRemoteStateConfigAzurerm,
+) (bool, error) {
+	if !extCfg.AssignBlobDataRole {
+		return false, nil
+	}
+
+	principalID := extCfg.PrincipalID
+	if principalID == "" {
+		resolved, err := azurehelper.ResolvePrincipal(ctx, cfg)
+		if err != nil {
+			return false, err
+		}
+
+		principalID = resolved.ID
+	}
+
+	rbacClient, err := azurehelper.NewRBACClient(cfg)
+	if err != nil {
+		return false, err
+	}
+
+	rs := &extCfg.RemoteStateConfigAzurerm
+	scope := azurehelper.StorageAccountScope(cfg.SubscriptionID, cfg.ResourceGroup, rs.StorageAccountName)
+
+	has, err := rbacClient.HasRoleAssignment(ctx, scope, principalID, azurehelper.RoleStorageBlobDataContributor)
+	if err != nil {
+		return false, err
+	}
+
+	return !has, nil
 }
 
 // effectiveSoftDeleteDays returns the retention that bootstrap actually applies

--- a/internal/remotestate/backend/azurerm/backend_test.go
+++ b/internal/remotestate/backend/azurerm/backend_test.go
@@ -128,8 +128,11 @@ func TestMigrate_CrossAccountRefused(t *testing.T) {
 
 	err := b.Migrate(ctx, l, venvtest.New(), venvtest.New(), srcCfg, dstCfg, opts)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cross-account")
-	assert.NotContains(t, err.Error(), "server-side", "copy is client-side streaming, not server-side")
+
+	var crossAccount *azurerm.CrossAccountMigrationError
+	require.ErrorAs(t, err, &crossAccount)
+	assert.Equal(t, "tfstate1234", crossAccount.SrcStorageAccount)
+	assert.Equal(t, "differentaccount", crossAccount.DstStorageAccount)
 }
 
 // TestMigrate_CrossCloudRefused verifies the azurerm backend refuses a

--- a/internal/remotestate/backend/azurerm/backend_test.go
+++ b/internal/remotestate/backend/azurerm/backend_test.go
@@ -249,6 +249,10 @@ func rgLessSkipAllConfig() azurerm.Config {
 	delete(cfg, "resource_group_name")
 	delete(cfg, "enable_soft_delete")
 	delete(cfg, "soft_delete_retention_days")
+	// A role assignment is ARM work too, so it has to go for this fixture to
+	// mean "nothing needs the management plane".
+	delete(cfg, "assign_blob_data_role")
+	delete(cfg, "principal_id")
 
 	cfg["skip_storage_account_creation"] = true
 	cfg["skip_versioning"] = true

--- a/internal/remotestate/backend/azurerm/backend_test.go
+++ b/internal/remotestate/backend/azurerm/backend_test.go
@@ -3,6 +3,7 @@ package azurerm_test
 import (
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/azurehelper"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend/azurerm"
@@ -216,6 +217,45 @@ func TestBootstrap_SkipsArmPlaneWhenNoArmWork(t *testing.T) {
 		t.Context(),
 		logger.CreateLogger(), venvtest.New(), backend.Config(rgLessSkipAllConfig()), optsWithExperiment(t, true))
 	require.NoError(t, err)
+}
+
+// TestBootstrap_AssignBlobDataRoleRequiresARM refuses silent success when the
+// flag is set under data-plane-only auth that cannot call roleAssignments.
+func TestBootstrap_AssignBlobDataRoleRequiresARM(t *testing.T) {
+	t.Parallel()
+
+	cfg := fullConfig()
+	cfg["access_key"] = "dGVzdGtleQ=="
+	cfg["assign_blob_data_role"] = true
+	delete(cfg, "use_azuread_auth")
+
+	err := azurerm.NewBackend().Bootstrap(
+		t.Context(),
+		logger.CreateLogger(), venvtest.New(), backend.Config(cfg), optsWithExperiment(t, true))
+
+	var requiresARM *azurerm.AssignBlobDataRoleRequiresARMError
+	require.ErrorAs(t, err, &requiresARM)
+	assert.Equal(t, azurehelper.AuthMethodAccessKey, requiresARM.Method)
+}
+
+// TestNeedsBootstrap_AssignBlobDataRoleRequiresARM mirrors Bootstrap: the flag
+// must not be soft-skipped under SAS/access-key auth.
+func TestNeedsBootstrap_AssignBlobDataRoleRequiresARM(t *testing.T) {
+	t.Parallel()
+
+	cfg := fullConfig()
+	cfg["sas_token"] = "sv=test"
+	cfg["assign_blob_data_role"] = true
+	delete(cfg, "access_key")
+	delete(cfg, "use_azuread_auth")
+
+	_, err := azurerm.NewBackend().NeedsBootstrap(
+		t.Context(),
+		logger.CreateLogger(), venvtest.New(), backend.Config(cfg), optsWithExperiment(t, true))
+
+	var requiresARM *azurerm.AssignBlobDataRoleRequiresARMError
+	require.ErrorAs(t, err, &requiresARM)
+	assert.Equal(t, azurehelper.AuthMethodSasToken, requiresARM.Method)
 }
 
 // TestIsVersionControlEnabled_NoResourceGroupDegrades verifies the versioning

--- a/internal/remotestate/backend/azurerm/backend_test.go
+++ b/internal/remotestate/backend/azurerm/backend_test.go
@@ -1,12 +1,17 @@
 package azurerm_test
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/azurehelper"
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend/azurerm"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
@@ -258,6 +263,42 @@ func TestNeedsBootstrap_AssignBlobDataRoleRequiresARM(t *testing.T) {
 	assert.Equal(t, azurehelper.AuthMethodSasToken, requiresARM.Method)
 }
 
+// TestNeedsBootstrap_RoleOnlyDriftRequiresBootstrap locks the regression where
+// an otherwise healthy account with assign_blob_data_role set and the blob-data
+// role absent returned NeedsBootstrap false, so --backend-bootstrap skipped the
+// grant and OpenTofu/Terraform then failed data-plane auth.
+func TestNeedsBootstrap_RoleOnlyDriftRequiresBootstrap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("role absent", func(t *testing.T) {
+		t.Parallel()
+
+		needs, err := azurerm.NewBackend().NeedsBootstrap(
+			t.Context(),
+			logger.CreateLogger(),
+			venvtest.New().WithHTTP(roleDriftHTTP(false)),
+			backend.Config(roleOnlyDriftConfig()),
+			optsWithExperiment(t, true),
+		)
+		require.NoError(t, err)
+		assert.True(t, needs, "missing blob-data role must require bootstrap")
+	})
+
+	t.Run("role present", func(t *testing.T) {
+		t.Parallel()
+
+		needs, err := azurerm.NewBackend().NeedsBootstrap(
+			t.Context(),
+			logger.CreateLogger(),
+			venvtest.New().WithHTTP(roleDriftHTTP(true)),
+			backend.Config(roleOnlyDriftConfig()),
+			optsWithExperiment(t, true),
+		)
+		require.NoError(t, err)
+		assert.False(t, needs, "assigned blob-data role must not require bootstrap")
+	})
+}
+
 // TestIsVersionControlEnabled_NoResourceGroupDegrades verifies the versioning
 // check degrades to false instead of erroring when no resource group is known.
 func TestIsVersionControlEnabled_NoResourceGroupDegrades(t *testing.T) {
@@ -302,6 +343,84 @@ func rgLessSkipAllConfig() azurerm.Config {
 	cfg["skip_container_creation"] = true
 
 	return cfg
+}
+
+// roleOnlyDriftConfig is a pre-created account with every policy converged
+// except optional blob-data role assignment: the only ARM work left is RBAC.
+func roleOnlyDriftConfig() azurerm.Config {
+	cfg := fullConfig()
+	delete(cfg, "enable_soft_delete")
+	delete(cfg, "soft_delete_retention_days")
+	delete(cfg, "use_azuread_auth")
+
+	cfg["skip_storage_account_creation"] = true
+	cfg["skip_versioning"] = true
+	cfg["skip_container_creation"] = true
+	cfg["assign_blob_data_role"] = true
+	cfg["principal_id"] = "11111111-2222-3333-4444-555555555555"
+	// Service principal auth reaches ARM through the stubbed HTTP transport.
+	cfg["client_id"] = "00000000-0000-0000-0000-000000000001"
+	cfg["client_secret"] = "test-secret"
+	cfg["tenant_id"] = "00000000-0000-0000-0000-000000000002"
+
+	return cfg
+}
+
+// roleDriftHTTP answers Entra token issuance, storage-account Exists, and
+// role-assignment list so NeedsBootstrap can exercise blobDataRoleMissing
+// without a live subscription.
+func roleDriftHTTP(rolePresent bool) vhttp.Client {
+	jsonHeaders := http.Header{"Content-Type": []string{"application/json"}}
+
+	return vhttp.NewMemClient(func(_ context.Context, req *http.Request) (*http.Response, error) {
+		path := req.URL.Path
+
+		switch {
+		case strings.HasSuffix(path, "/discovery/instance"):
+			return vhttp.Respond(http.StatusOK, []byte(
+				`{"tenant_discovery_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000002/v2.0/.well-known/openid-configuration","metadata":[{"preferred_network":"login.microsoftonline.com","preferred_cache":"login.microsoftonline.com","aliases":["login.microsoftonline.com"]}]}`,
+			), jsonHeaders), nil
+		case strings.HasSuffix(path, "/openid-configuration"):
+			return vhttp.Respond(http.StatusOK, []byte(
+				`{"token_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000002/oauth2/v2.0/token","issuer":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000002/v2.0","authorization_endpoint":"https://login.microsoftonline.com/00000000-0000-0000-0000-000000000002/oauth2/v2.0/authorize"}`,
+			), jsonHeaders), nil
+		case strings.HasSuffix(path, "/token"):
+			return vhttp.Respond(http.StatusOK, []byte(
+				`{"token_type":"Bearer","expires_in":3600,"access_token":"test-token"}`,
+			), jsonHeaders), nil
+		case strings.Contains(path, "/roleAssignments"):
+			body := map[string]any{"value": []any{}}
+			if rolePresent {
+				body["value"] = []any{
+					map[string]any{
+						"id": "/ra/1",
+						"properties": map[string]any{
+							"principalId": "11111111-2222-3333-4444-555555555555",
+							"roleDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000" +
+								"/providers/Microsoft.Authorization/roleDefinitions/" +
+								azurehelper.RoleStorageBlobDataContributor,
+						},
+					},
+				}
+			}
+
+			raw, err := json.Marshal(body)
+			if err != nil {
+				return nil, err
+			}
+
+			return vhttp.Respond(http.StatusOK, raw, jsonHeaders), nil
+		case strings.Contains(path, "/Microsoft.Storage/storageAccounts/"):
+			return vhttp.Respond(http.StatusOK, []byte(
+				`{"name":"tfstate1234","location":"eastus"}`,
+			), jsonHeaders), nil
+		default:
+			// 400 is terminal for the Azure SDK retry policy.
+			return vhttp.Respond(http.StatusBadRequest, []byte(
+				`{"error":{"code":"UnmatchedTestRequest","message":"`+path+`"}}`,
+			), jsonHeaders), nil
+		}
+	})
 }
 
 // TestMigrate_CrossCloudFromDestinationEnvRefused pins the case a config-only

--- a/internal/remotestate/backend/azurerm/config_test.go
+++ b/internal/remotestate/backend/azurerm/config_test.go
@@ -93,6 +93,7 @@ func TestGetTFInitArgs_StripsTerragruntOnlyKeys(t *testing.T) {
 		"access_tier", "tags", "skip_resource_group_creation", "skip_storage_account_creation",
 		"skip_container_creation", "skip_versioning", "enable_soft_delete",
 		"soft_delete_retention_days", "allow_blob_public_access",
+		"assign_blob_data_role", "principal_id",
 	} {
 		_, ok := args[k]
 		assert.Falsef(t, ok, "terragrunt-only key %q must not be forwarded to tofu init", k)
@@ -178,6 +179,8 @@ func fullConfig() azurerm.Config {
 		"enable_soft_delete":         true,
 		"soft_delete_retention_days": 14,
 		"tags":                       map[string]string{"team": "platform"},
+		"assign_blob_data_role":      true,
+		"principal_id":               "11111111-2222-3333-4444-555555555555",
 	}
 }
 
@@ -255,4 +258,33 @@ func TestExtendedCacheKey_IsPolicyAware(t *testing.T) {
 	// The container identity is still part of it.
 	assert.NotEqual(t, base, keyFor(func(c azurerm.Config) { c["container_name"] = "other" }))
 	assert.NotEqual(t, base, keyFor(func(c azurerm.Config) { c["environment"] = "usgovernment" }))
+}
+
+// TestCacheKey_DistinguishesRoleAssignment pins that a unit asking for the
+// blob data role does not inherit the "already initialized" entry of a unit
+// that did not, which would silently skip the assignment.
+func TestCacheKey_DistinguishesRoleAssignment(t *testing.T) {
+	t.Parallel()
+
+	base := fullConfig()
+	base["assign_blob_data_role"] = false
+	delete(base, "principal_id")
+
+	withRole := fullConfig()
+	withRole["assign_blob_data_role"] = true
+	delete(withRole, "principal_id")
+
+	otherPrincipal := fullConfig()
+	otherPrincipal["assign_blob_data_role"] = true
+	otherPrincipal["principal_id"] = "99999999-8888-7777-6666-555555555555"
+
+	keyOf := func(c azurerm.Config) string {
+		ext, err := c.ExtendedAzurermConfig()
+		require.NoError(t, err)
+
+		return ext.CacheKey()
+	}
+
+	assert.NotEqual(t, keyOf(base), keyOf(withRole))
+	assert.NotEqual(t, keyOf(withRole), keyOf(otherPrincipal))
 }

--- a/internal/remotestate/backend/azurerm/errors.go
+++ b/internal/remotestate/backend/azurerm/errors.go
@@ -3,6 +3,8 @@ package azurerm
 import (
 	"errors"
 	"fmt"
+
+	"github.com/gruntwork-io/terragrunt/internal/azurehelper"
 )
 
 // MissingRequiredAzurermRemoteStateConfigError is returned when a required
@@ -105,3 +107,19 @@ var ErrAzureBackendExperimentRequired = errors.New(
 	"the azurerm backend is experimental and requires the 'azure-backend' experiment to be enabled " +
 		"(e.g. --experiment azure-backend or experiments = [\"azure-backend\"])",
 )
+
+// AssignBlobDataRoleRequiresARMError is returned when assign_blob_data_role is
+// set but the resolved auth method cannot call the ARM role-assignment API
+// (SAS token and access key are data-plane only). Match with errors.As.
+type AssignBlobDataRoleRequiresARMError struct {
+	Method azurehelper.AuthMethod
+}
+
+func (e *AssignBlobDataRoleRequiresARMError) Error() string {
+	return fmt.Sprintf(
+		"assign_blob_data_role requires Microsoft Entra / ARM authentication, not %s; "+
+			"use use_azuread_auth, a service principal, managed identity, or OIDC, "+
+			"or grant Storage Blob Data Contributor out of band and unset assign_blob_data_role",
+		e.Method,
+	)
+}

--- a/internal/remotestate/backend/azurerm/remote_state_config.go
+++ b/internal/remotestate/backend/azurerm/remote_state_config.go
@@ -180,7 +180,7 @@ func (cfg *ExtendedRemoteStateConfigAzurerm) normalize() {
 		&rs.SasToken, &rs.AccessKey, &rs.Environment, &rs.MSIResourceID,
 		&rs.OIDCTokenFilePath,
 		&cfg.Location, &cfg.AccountTier, &cfg.AccountReplicationType,
-		&cfg.AccountKind, &cfg.AccessTier,
+		&cfg.AccountKind, &cfg.AccessTier, &cfg.PrincipalID,
 	} {
 		*field = strings.TrimSpace(*field)
 	}

--- a/internal/remotestate/backend/azurerm/remote_state_config.go
+++ b/internal/remotestate/backend/azurerm/remote_state_config.go
@@ -25,6 +25,8 @@ var terragruntOnlyConfigs = []string{
 	"enable_soft_delete",
 	"soft_delete_retention_days",
 	"allow_blob_public_access",
+	"assign_blob_data_role",
+	"principal_id",
 	// msi_resource_id is used by Terragrunt to select a user-assigned managed
 	// identity during bootstrap, but it is NOT a valid azurerm backend argument
 	// (the backend uses msi_endpoint), so it must not reach `tofu init`.
@@ -35,12 +37,14 @@ var terragruntOnlyConfigs = []string{
 // the Terragrunt-only bootstrap options (location, SKU, skip_* toggles) that
 // are stripped before the config is handed to `tofu init -backend-config`.
 type ExtendedRemoteStateConfigAzurerm struct {
-	Tags                     map[string]string        `mapstructure:"tags"`
-	Location                 string                   `mapstructure:"location"`
-	AccountTier              string                   `mapstructure:"account_tier"`
-	AccountReplicationType   string                   `mapstructure:"account_replication_type"`
-	AccountKind              string                   `mapstructure:"account_kind"`
-	AccessTier               string                   `mapstructure:"access_tier"`
+	Tags                   map[string]string `mapstructure:"tags"`
+	Location               string            `mapstructure:"location"`
+	AccountTier            string            `mapstructure:"account_tier"`
+	AccountReplicationType string            `mapstructure:"account_replication_type"`
+	AccountKind            string            `mapstructure:"account_kind"`
+	AccessTier             string            `mapstructure:"access_tier"`
+	// PrincipalID defaults to the identity Terragrunt authenticated as.
+	PrincipalID              string                   `mapstructure:"principal_id"`
 	RemoteStateConfigAzurerm RemoteStateConfigAzurerm `mapstructure:",squash"`
 	SoftDeleteRetentionDays  int                      `mapstructure:"soft_delete_retention_days"`
 
@@ -50,6 +54,8 @@ type ExtendedRemoteStateConfigAzurerm struct {
 	SkipVersioning             bool `mapstructure:"skip_versioning"`
 	EnableSoftDelete           bool `mapstructure:"enable_soft_delete"`
 	AllowBlobPublicAccess      bool `mapstructure:"allow_blob_public_access"`
+	// AssignBlobDataRole grants Storage Blob Data Contributor during bootstrap; opt-in because it needs roleAssignments/write.
+	AssignBlobDataRole bool `mapstructure:"assign_blob_data_role"`
 }
 
 // RemoteStateConfigAzurerm mirrors the configuration keys accepted by the
@@ -155,6 +161,8 @@ func (cfg *ExtendedRemoteStateConfigAzurerm) CacheKey() string {
 		strconv.FormatBool(cfg.SkipStorageAccountCreation),
 		strconv.FormatBool(cfg.SkipResourceGroupCreation),
 		strconv.FormatBool(cfg.SkipContainerCreation),
+		strconv.FormatBool(cfg.AssignBlobDataRole),
+		cfg.PrincipalID,
 	}, "|")
 }
 

--- a/test/fixtures/azure-backend/common.hcl
+++ b/test/fixtures/azure-backend/common.hcl
@@ -26,5 +26,7 @@ remote_state {
     access_tier              = "Hot"
 
     skip_versioning = feature.disable_versioning.value
+
+    assign_blob_data_role = __FILL_IN_ASSIGN_ROLE__
   }
 }

--- a/test/fixtures/azure-backend/common.hcl
+++ b/test/fixtures/azure-backend/common.hcl
@@ -2,6 +2,10 @@ feature "disable_versioning" {
   default = false
 }
 
+feature "enable_soft_delete" {
+  default = false
+}
+
 feature "key_prefix" {
   default = ""
 }
@@ -25,7 +29,9 @@ remote_state {
     account_kind             = "StorageV2"
     access_tier              = "Hot"
 
-    skip_versioning = feature.disable_versioning.value
+    skip_versioning            = feature.disable_versioning.value
+    enable_soft_delete         = feature.enable_soft_delete.value
+    soft_delete_retention_days = 14
 
     assign_blob_data_role = __FILL_IN_ASSIGN_ROLE__
   }

--- a/test/integration_azure_test.go
+++ b/test/integration_azure_test.go
@@ -464,7 +464,7 @@ func createAzureTestAccount(t *testing.T) (string, string) {
 		ReplicationType:   "LRS",
 	}), "creating the throwaway storage account")
 
-	t.Cleanup(func() { deleteAzureTestAccount(saClient) })
+	t.Cleanup(func() { deleteAzureTestAccount(t, saClient) })
 
 	return account, resourceGroup
 }
@@ -534,11 +534,15 @@ func deleteAzureResourceGroup(t *testing.T, account, resourceGroup string) {
 
 // deleteAzureTestAccount tears down a throwaway account on its own context,
 // because the test context is cancelled by the time cleanup runs.
-func deleteAzureTestAccount(saClient *azurehelper.StorageAccountClient) {
+func deleteAzureTestAccount(t *testing.T, saClient *azurehelper.StorageAccountClient) {
+	t.Helper()
+
 	ctx, cancel := context.WithTimeout(context.Background(), azureCleanupTimeout)
 	defer cancel()
 
-	_ = saClient.EnsureDeleted(ctx, log.New())
+	if err := saClient.EnsureDeleted(ctx, log.New()); err != nil {
+		t.Logf("cleanup: deleting throwaway storage account: %v", err)
+	}
 }
 
 // azureFixtureForAccount renders the shared fixture against an explicit account.

--- a/test/integration_azure_test.go
+++ b/test/integration_azure_test.go
@@ -248,6 +248,126 @@ func TestAzureBackendRequiresExperiment(t *testing.T) {
 		"the failure must name the experiment the user needs to enable")
 }
 
+// TestAzureCreatesResourceGroupAndStorageAccount proves bootstrap provisions both
+// when they do not already exist, rather than assuming a pre-created account.
+func TestAzureCreatesResourceGroupAndStorageAccount(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	account, resourceGroup, container, rootPath := setupAzureProvisionFixture(t, true)
+
+	cfg := azureTestConfigForAccount(ctx, t, account, resourceGroup)
+
+	saClient, err := azurehelper.NewStorageAccountClient(cfg)
+	require.NoError(t, err)
+
+	rgClient, err := azurehelper.NewResourceGroupClient(cfg)
+	require.NoError(t, err)
+
+	exists, err := saClient.Exists(ctx)
+	require.NoError(t, err)
+	require.False(t, exists, "test must start from a missing storage account")
+
+	exists, err = rgClient.Exists(ctx, resourceGroup)
+	require.NoError(t, err)
+	require.False(t, exists, "test must start from a missing resource group")
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt backend bootstrap --all --non-interactive --experiment azure-backend --working-dir "+rootPath,
+	)
+	require.NoError(t, err)
+
+	exists, err = rgClient.Exists(ctx, resourceGroup)
+	require.NoError(t, err)
+	assert.True(t, exists, "bootstrap must create the resource group")
+
+	exists, err = saClient.Exists(ctx)
+	require.NoError(t, err)
+	assert.True(t, exists, "bootstrap must create the storage account")
+
+	assertAzureContainerExists(t, ctx, account, container)
+}
+
+// TestAzureSoftDeleteRetentionConverges verifies bootstrap enables soft delete and
+// reconciles retention on an existing account that was created without it.
+func TestAzureSoftDeleteRetentionConverges(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	account, resourceGroup, _, rootPath := setupAzureProvisionFixture(t, true)
+
+	bootstrap := "terragrunt backend bootstrap --all --non-interactive --experiment azure-backend --working-dir " + rootPath
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(t, bootstrap)
+	require.NoError(t, err)
+
+	cfg := azureTestConfigForAccount(ctx, t, account, resourceGroup)
+	saClient, err := azurehelper.NewStorageAccountClient(cfg)
+	require.NoError(t, err)
+
+	blobDays, containerDays, err := saClient.SoftDeleteRetention(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, blobDays, "soft delete stays off until requested")
+	assert.Zero(t, containerDays, "container soft delete stays off until requested")
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(
+		t,
+		bootstrap+" --feature enable_soft_delete=true",
+	)
+	require.NoError(t, err)
+
+	blobDays, containerDays, err = saClient.SoftDeleteRetention(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int32(14), blobDays, "bootstrap must converge blob soft-delete retention")
+	assert.Equal(t, int32(14), containerDays, "bootstrap must converge container soft-delete retention")
+}
+
+// TestAzureMigrateBackend moves state from unit1 to unit2 inside one storage account.
+func TestAzureMigrateBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	account, container, rootPath := setupAzureBackendFixture(t)
+
+	unit1Path := filepath.Join(rootPath, "unit1")
+	unit1Key := "unit1/tofu.tfstate"
+	unit2Key := "unit2/tofu.tfstate"
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt run apply --backend-bootstrap --experiment azure-backend --non-interactive --log-level debug --working-dir "+
+			unit1Path+" -- -auto-approve",
+	)
+	require.NoError(t, err)
+
+	blobClient, err := azurehelper.NewBlobClient(azureTestConfig(ctx, t, account))
+	require.NoError(t, err)
+
+	exists, err := blobClient.Container(container).BlobExists(ctx, unit1Key)
+	require.NoError(t, err)
+	require.True(t, exists, "unit1 apply must write %s", unit1Key)
+
+	exists, err = blobClient.Container(container).BlobExists(ctx, unit2Key)
+	require.NoError(t, err)
+	require.False(t, exists, "unit2 state must not exist before migrate")
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt backend migrate --experiment azure-backend --non-interactive --log-level debug --working-dir "+
+			rootPath+" unit1 unit2",
+	)
+	require.NoError(t, err)
+
+	exists, err = blobClient.Container(container).BlobExists(ctx, unit1Key)
+	require.NoError(t, err)
+	assert.False(t, exists, "migrate must remove the source state blob")
+
+	exists, err = blobClient.Container(container).BlobExists(ctx, unit2Key)
+	require.NoError(t, err)
+	assert.True(t, exists, "migrate must write the destination state blob")
+}
+
 // TestAzureAssignsBlobDataRole verifies that bootstrap grants the caller
 // Storage Blob Data Contributor, which creating a storage account does not
 // convey, and that a rerun detects the assignment instead of duplicating it.
@@ -328,11 +448,7 @@ func createAzureTestAccount(t *testing.T) (string, string) {
 	shared := requireAzureEnv(t, envAzureStorageAccount)
 	resourceGroup := azureResourceGroup(ctx, t, shared)
 
-	// Storage account names are 3-24 lowercase alphanumerics.
-	account := "tgrbac" + strings.ToLower(helpers.UniqueID())
-	if len(account) > 24 {
-		account = account[:24]
-	}
+	account := uniqueAzureStorageAccountName("tgrbac")
 
 	cfg := azureTestConfigForAccount(ctx, t, account, resourceGroup)
 
@@ -351,6 +467,69 @@ func createAzureTestAccount(t *testing.T) (string, string) {
 	t.Cleanup(func() { deleteAzureTestAccount(saClient) })
 
 	return account, resourceGroup
+}
+
+// setupAzureProvisionFixture prepares a fixture pointed at a resource group and
+// storage account that do not exist yet, so bootstrap must create both. Cleanup
+// deletes the whole resource group (and therefore the account and containers).
+func setupAzureProvisionFixture(t *testing.T, assignRole bool) (account, resourceGroup, container, rootPath string) {
+	t.Helper()
+
+	subscriptionID := requireAzureEnv(t, envAzureSubscriptionID)
+	account = uniqueAzureStorageAccountName("tgprov")
+	resourceGroup = "tg-test-rg-" + strings.ToLower(helpers.UniqueID())
+	container = "tg-test-" + strings.ToLower(helpers.UniqueID())
+
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAzureBackend)
+	rootPath = filepath.Join(tmpEnvPath, testFixtureAzureBackend)
+	helpers.CleanupTerraformFolder(t, rootPath)
+
+	commonConfigPath := filepath.Join(rootPath, "common.hcl")
+	helpers.CopyAndFillMapPlaceholders(t, commonConfigPath, commonConfigPath, map[string]string{
+		"__FILL_IN_STORAGE_ACCOUNT__": account,
+		"__FILL_IN_CONTAINER__":       container,
+		"__FILL_IN_RESOURCE_GROUP__":  resourceGroup,
+		"__FILL_IN_SUBSCRIPTION_ID__": subscriptionID,
+		"__FILL_IN_LOCATION__":        azureTestLocation,
+		"__FILL_IN_ASSIGN_ROLE__":     strconv.FormatBool(assignRole),
+	})
+
+	t.Cleanup(func() { deleteAzureResourceGroup(t, account, resourceGroup) })
+
+	return account, resourceGroup, container, rootPath
+}
+
+// uniqueAzureStorageAccountName returns a valid Azure storage account name
+// (3-24 lowercase alphanumerics) with the given prefix.
+func uniqueAzureStorageAccountName(prefix string) string {
+	name := prefix + strings.ToLower(helpers.UniqueID())
+	if len(name) > 24 {
+		name = name[:24]
+	}
+
+	return name
+}
+
+// deleteAzureResourceGroup removes a throwaway resource group created by a
+// provision test. Failures are logged: assertions have already run.
+func deleteAzureResourceGroup(t *testing.T, account, resourceGroup string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), azureCleanupTimeout)
+	defer cancel()
+
+	cfg := azureTestConfigForAccount(ctx, t, account, resourceGroup)
+
+	rgClient, err := azurehelper.NewResourceGroupClient(cfg)
+	if err != nil {
+		t.Logf("cleanup: building resource group client for %s: %v", resourceGroup, err)
+
+		return
+	}
+
+	if err := rgClient.EnsureDeleted(ctx, log.New(), resourceGroup); err != nil {
+		t.Logf("cleanup: deleting resource group %s: %v", resourceGroup, err)
+	}
 }
 
 // deleteAzureTestAccount tears down a throwaway account on its own context,

--- a/test/integration_azure_test.go
+++ b/test/integration_azure_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -32,6 +33,10 @@ const (
 	// azureTestLocation is the region the test resource group and storage
 	// account are created in.
 	azureTestLocation = "eastus"
+
+	// Azure applies role assignment changes asynchronously.
+	azureRBACPropagationTimeout = 3 * time.Minute
+	azureRBACPollInterval       = 5 * time.Second
 
 	// azureCleanupTimeout bounds the post-test teardown, which runs with a
 	// fresh context because the test context is already cancelled by then.
@@ -243,6 +248,180 @@ func TestAzureBackendRequiresExperiment(t *testing.T) {
 		"the failure must name the experiment the user needs to enable")
 }
 
+// TestAzureAssignsBlobDataRole verifies that bootstrap grants the caller
+// Storage Blob Data Contributor, which creating a storage account does not
+// convey, and that a rerun detects the assignment instead of duplicating it.
+func TestAzureAssignsBlobDataRole(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// A dedicated account: the assertions add and remove role assignments, and
+	// the shared test account is read concurrently by the azure unit-test job.
+	account, resourceGroup := createAzureTestAccount(t)
+
+	rootPath := azureFixtureForAccount(t, account, resourceGroup, true)
+	cfg := azureTestConfigForAccount(ctx, t, account, resourceGroup)
+
+	principal, err := azurehelper.ResolvePrincipal(ctx, cfg)
+	require.NoError(t, err, "resolving the caller principal from its own token")
+	require.NotEmpty(t, principal.ID)
+
+	rbacClient, err := azurehelper.NewRBACClient(cfg)
+	require.NoError(t, err)
+
+	scope := azurehelper.StorageAccountScope(cfg.SubscriptionID, resourceGroup, account)
+
+	// A fresh account carries no data-plane assignment, which is the gap this
+	// feature closes.
+	waitForRoleAssignment(ctx, t, rbacClient, scope, principal.ID, false)
+
+	bootstrap := "terragrunt backend bootstrap --all --non-interactive --experiment azure-backend --working-dir " + rootPath
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, bootstrap)
+	require.NoError(t, err)
+
+	waitForRoleAssignment(ctx, t, rbacClient, scope, principal.ID, true)
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t, bootstrap)
+	require.NoError(t, err, "bootstrap must be idempotent when the role already exists")
+}
+
+// TestAzureSkipsRoleAssignmentByDefault pins that the assignment is opt-in, so
+// an identity without Microsoft.Authorization/roleAssignments/write is not
+// broken by merely bootstrapping.
+func TestAzureSkipsRoleAssignmentByDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	account, resourceGroup := createAzureTestAccount(t)
+
+	rootPath := azureFixtureForAccount(t, account, resourceGroup, false)
+	cfg := azureTestConfigForAccount(ctx, t, account, resourceGroup)
+
+	rbacClient, err := azurehelper.NewRBACClient(cfg)
+	require.NoError(t, err)
+
+	principal, err := azurehelper.ResolvePrincipal(ctx, cfg)
+	require.NoError(t, err)
+
+	scope := azurehelper.StorageAccountScope(cfg.SubscriptionID, resourceGroup, account)
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt backend bootstrap --all --non-interactive --experiment azure-backend --working-dir "+rootPath)
+	require.NoError(t, err)
+
+	has, err := rbacClient.HasRoleAssignment(ctx, scope, principal.ID, azurehelper.RoleStorageBlobDataContributor)
+	require.NoError(t, err)
+	assert.False(t, has, "no role may be assigned unless assign_blob_data_role is set")
+}
+
+// createAzureTestAccount provisions a throwaway storage account and returns it
+// with its resource group, so role-assignment tests never mutate access on the
+// shared account the azure unit-test job reads concurrently.
+func createAzureTestAccount(t *testing.T) (string, string) {
+	t.Helper()
+
+	ctx := t.Context()
+
+	shared := requireAzureEnv(t, envAzureStorageAccount)
+	resourceGroup := azureResourceGroup(ctx, t, shared)
+
+	// Storage account names are 3-24 lowercase alphanumerics.
+	account := "tgrbac" + strings.ToLower(helpers.UniqueID())
+	if len(account) > 24 {
+		account = account[:24]
+	}
+
+	cfg := azureTestConfigForAccount(ctx, t, account, resourceGroup)
+
+	saClient, err := azurehelper.NewStorageAccountClient(cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, saClient.Create(ctx, log.New(), &azurehelper.StorageAccountConfig{
+		Name:              account,
+		ResourceGroupName: resourceGroup,
+		Location:          azureTestLocation,
+		AccountKind:       "StorageV2",
+		AccountTier:       "Standard",
+		ReplicationType:   "LRS",
+	}), "creating the throwaway storage account")
+
+	t.Cleanup(func() { deleteAzureTestAccount(saClient) })
+
+	return account, resourceGroup
+}
+
+// deleteAzureTestAccount tears down a throwaway account on its own context,
+// because the test context is cancelled by the time cleanup runs.
+func deleteAzureTestAccount(saClient *azurehelper.StorageAccountClient) {
+	ctx, cancel := context.WithTimeout(context.Background(), azureCleanupTimeout)
+	defer cancel()
+
+	_ = saClient.EnsureDeleted(ctx, log.New())
+}
+
+// azureFixtureForAccount renders the shared fixture against an explicit account.
+func azureFixtureForAccount(t *testing.T, account, resourceGroup string, assignRole bool) string {
+	t.Helper()
+
+	helpers.CleanupTerraformFolder(t, testFixtureAzureBackend)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAzureBackend)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureAzureBackend)
+
+	commonConfigPath := filepath.Join(rootPath, "common.hcl")
+	helpers.CopyAndFillMapPlaceholders(t, commonConfigPath, commonConfigPath, map[string]string{
+		"__FILL_IN_STORAGE_ACCOUNT__": account,
+		"__FILL_IN_CONTAINER__":       "tg-test-" + strings.ToLower(helpers.UniqueID()),
+		"__FILL_IN_RESOURCE_GROUP__":  resourceGroup,
+		"__FILL_IN_SUBSCRIPTION_ID__": requireAzureEnv(t, envAzureSubscriptionID),
+		"__FILL_IN_LOCATION__":        azureTestLocation,
+		"__FILL_IN_ASSIGN_ROLE__":     strconv.FormatBool(assignRole),
+	})
+
+	return rootPath
+}
+
+// azureTestConfigForAccount resolves credentials bound to an explicit account.
+func azureTestConfigForAccount(ctx context.Context, t *testing.T, account, resourceGroup string) *azurehelper.AzureConfig {
+	t.Helper()
+
+	cfg, err := azurehelper.NewAzureConfigBuilder().
+		WithSessionConfig(&azurehelper.AzureSessionConfig{
+			SubscriptionID:     requireAzureEnv(t, envAzureSubscriptionID),
+			ResourceGroupName:  resourceGroup,
+			StorageAccountName: account,
+			UseAzureADAuth:     new(true),
+		}).
+		Build(log.New(), venv.OSVenv())
+	require.NoError(t, err, "resolving Azure credentials")
+
+	return cfg
+}
+
+// waitForRoleAssignment blocks until the assignment reaches want, because Azure
+// applies role assignment changes asynchronously and a read straight after a
+// create or delete still reports the previous state.
+func waitForRoleAssignment(ctx context.Context, t *testing.T, c *azurehelper.RBACClient, scope, principalID string, want bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(azureRBACPropagationTimeout)
+
+	for time.Now().Before(deadline) {
+		has, err := c.HasRoleAssignment(ctx, scope, principalID, azurehelper.RoleStorageBlobDataContributor)
+		require.NoError(t, err)
+
+		if has == want {
+			return
+		}
+
+		time.Sleep(azureRBACPollInterval)
+	}
+
+	t.Fatalf("role assignment did not converge to present=%v within %s", want, azureRBACPropagationTimeout)
+}
+
 // setupAzureBackendFixture copies the fixture, fills in the live account
 // details, and registers cleanup of the container it will create. It returns
 // the storage account, the container name, and the working directory.
@@ -275,6 +454,7 @@ func setupAzureFixture(t *testing.T, fixture string) (string, string, string) {
 		"__FILL_IN_RESOURCE_GROUP__":  resourceGroup,
 		"__FILL_IN_SUBSCRIPTION_ID__": subscriptionID,
 		"__FILL_IN_LOCATION__":        azureTestLocation,
+		"__FILL_IN_ASSIGN_ROLE__":     "false",
 	})
 
 	t.Cleanup(func() { deleteAzureContainer(t, account, container) })


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

* add assign_blob_data_role bootstrap config key
* resolve caller principal from ARM token
* cover provision soft-delete and migrate live
* document RBAC and update experiment checklist

RFC: https://github.com/gruntwork-io/terragrunt/issues/4307

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added opt-in Azure backend support for granting the **Storage Blob Data Contributor** role during bootstrap.
- Added `assign_blob_data_role` and `principal_id` configuration options.
- Bootstrap now detects missing role assignments and safely reapplies them.
- Expanded Azure support for resource creation, state migration, soft-delete settings, and role assignment.

## Bug Fixes
- Improved Azure Entra ID authentication for identities that create storage accounts but cannot access state.
- Added clear errors when role assignment is requested with SAS-token or access-key authentication.
- Expanded Azure Government configuration guidance and cloud environment support documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->