### PR TITLE
chore: Running `go fix ./...` on all tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
       contents: read
     secrets: inherit
 
+  go_fix_check:
+    uses: ./.github/workflows/go-fix-check.yml
+    permissions:
+      contents: read
+    secrets: inherit
+
   markdownlint:
     uses: ./.github/workflows/markdownlint.yml
     permissions:
@@ -57,8 +63,8 @@ jobs:
     secrets: inherit
 
   # Fast feedback: only gate on lint/precommit/go_mod_tidy. Other checks (codespell,
-  # markdownlint, license_check, install_script_test) run in parallel and are enforced
-  # by branch protection rules, not by job dependencies.
+  # markdownlint, license_check, install_script_test, go_fix_check) run in parallel and
+  # are enforced by branch protection rules, not by job dependencies.
   base_tests:
     needs: [lint, precommit, go_mod_tidy_check]
     uses: ./.github/workflows/base-test.yml

--- a/.github/workflows/go-fix-check.yml
+++ b/.github/workflows/go-fix-check.yml
@@ -1,0 +1,29 @@
+name: Go Fix Check
+
+on:
+  workflow_call:
+
+jobs:
+  go-fix-check:
+    name: Check go fix has nothing to apply
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Use mise to install dependencies
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.5.12
+        env:
+          # Adding token here to reduce the likelihood of hitting rate limit issues.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run go fix
+        run: |
+          if ! make run-go-fix-check; then
+            echo "::error::go fix has pending fixes. Please run 'make run-go-fix' locally and commit the changes."
+            exit 1
+          fi
+          echo "go fix has nothing to apply"

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,18 @@ run-lint-fix:
 	@echo "Linting with feature flags: [$(LINT_TAGS)]"
 	GOFLAGS="-tags=$(LINT_TAGS)" mise x golangci-lint -- golangci-lint run -v --timeout=30m --fix ./...
 
+# go fix only analyzes files whose build tags are satisfied, so a bare `go fix ./...`
+# skips every tagged package without reporting it.
+run-go-fix:
+	@echo "Running go fix with feature flags: [$(LINT_TAGS)]"
+	mise x go -- go fix -tags=$(LINT_TAGS) ./...
+	@echo "Reformatting, since go fix does not gofmt the code it rewrites..."
+	mise x go -- gofmt -w $(GOFMT_FILES)
+
+run-go-fix-check:
+	@echo "Checking go fix with feature flags: [$(LINT_TAGS)]"
+	mise x go -- go fix -diff -tags=$(LINT_TAGS) ./...
+
 generate-mocks:
 	go generate ./...
 
@@ -67,4 +79,4 @@ fuzz:
 		done; \
 	done
 
-.PHONY: help fmt fmtcheck install-pre-commit-hook clean run-lint run-lint-fix fuzz print-lint-tags
+.PHONY: help fmt fmtcheck install-pre-commit-hook clean run-lint run-lint-fix run-go-fix run-go-fix-check fuzz print-lint-tags

--- a/internal/remotestate/backend/s3/client_test.go
+++ b/internal/remotestate/backend/s3/client_test.go
@@ -75,15 +75,11 @@ func TestAwsCreateLockTableConcurrency(t *testing.T) {
 	// Launch a bunch of goroutines who will all try to create the same table at more or less the same time.
 	// DynamoDB will, of course, only allow a single table to be created, but we still need to make sure none of
 	// the goroutines report an error.
-	for i := 0; i < 20; i++ {
-		waitGroup.Add(1)
-
-		go func() {
-			defer waitGroup.Done()
-
+	for range 20 {
+		waitGroup.Go(func() {
 			err := client.CreateLockTableIfNecessary(t.Context(), l, tableName, nil)
 			assert.NoError(t, err, "Unexpected error: %v", err)
-		}()
+		})
 	}
 
 	waitGroup.Wait()

--- a/internal/tf/getproviders/lock_test.go
+++ b/internal/tf/getproviders/lock_test.go
@@ -41,7 +41,7 @@ func mockProviderWithConstraints(
 
 	var documentSB strings.Builder
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		packageName := fmt.Sprintf("%s-%s-%d", address, ver, i)
 		hasher := sha256.New()
 		_, err := hasher.Write([]byte(packageName))
@@ -84,7 +84,7 @@ func mockProviderUpdateLock(
 
 	var documentSB strings.Builder
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		packageName := fmt.Sprintf("%s-%s-%d", address, version, i)
 		hasher := sha256.New()
 		_, err := hasher.Write([]byte(packageName))

--- a/internal/util/shell.go
+++ b/internal/util/shell.go
@@ -25,15 +25,19 @@ type CmdOutput struct {
 	Stderr bytes.Buffer
 }
 
-// GetExitCode returns the exit code of a command. If the error does not
-// implement errorCode or is not an exec.ExitError, the error is returned.
-// Joined errors are traversed by errors.As via their Unwrap() []error method.
-func GetExitCode(err error) (int, error) {
-	var exitStatus interface {
-		ExitStatus() (int, error)
-	}
+// exitStatuser is an error that carries the exit status of a failed command.
+// [errors.AsType] constrains its type parameter to error, so the embedded error is
+// required even though every value it can return already implements it.
+type exitStatuser interface {
+	error
+	ExitStatus() (int, error)
+}
 
-	if errors.As(err, &exitStatus) {
+// GetExitCode returns the exit code of a command. An error that implements neither
+// [exitStatuser] nor [clihelper.ExitCoder] and is not an [exec.ExitError] comes back
+// unchanged. The search walks joined errors through their Unwrap() []error method.
+func GetExitCode(err error) (int, error) {
+	if exitStatus, ok := errors.AsType[exitStatuser](err); ok {
 		return exitStatus.ExitStatus()
 	}
 

--- a/pkg/config/dependency_state_azurerm.go
+++ b/pkg/config/dependency_state_azurerm.go
@@ -258,10 +258,8 @@ func azureBackendConfigSupported(config backend.Config) bool {
 func azureEnvSupported(pctx *ParsingContext) bool {
 	env := pctx.Venv.Env
 
-	for _, key := range azureSDKAmbientEnvKeys {
-		if pctx.dependencyOutputEnvOverridden(key) {
-			return false
-		}
+	if slices.ContainsFunc(azureSDKAmbientEnvKeys, pctx.dependencyOutputEnvOverridden) {
+		return false
 	}
 
 	for _, key := range azureTrimmedEnvKeys {

--- a/pkg/config/dependency_state_gcs.go
+++ b/pkg/config/dependency_state_gcs.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	gcsbackend "github.com/gruntwork-io/terragrunt/internal/remotestate/backend/gcs"
@@ -418,13 +419,7 @@ func gcsUnsupportedEnvUnset(env map[string]string) bool {
 
 // gcsSDKAmbientEnvOverridden reports whether output-specific configuration changed a value the in-process client reads from the real process.
 func gcsSDKAmbientEnvOverridden(pctx *ParsingContext) bool {
-	for _, key := range gcsSDKAmbientEnvKeys {
-		if pctx.dependencyOutputEnvOverridden(key) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(gcsSDKAmbientEnvKeys, pctx.dependencyOutputEnvOverridden)
 }
 
 // gcsEnvFallbackSuppressionSupported rejects empty configured values whose suppression of an environment fallback gcphelper misses.

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -3331,9 +3331,9 @@ func assertS3Tags(
 
 	ctx := t.Context()
 
-	var in = s3.GetBucketTaggingInput{}
-
-	in.Bucket = aws.String(bucketName)
+	var in = s3.GetBucketTaggingInput{
+		Bucket: aws.String(bucketName),
+	}
 
 	var tags, err2 = client.GetBucketTagging(ctx, &in)
 	if err2 != nil {
@@ -3501,8 +3501,7 @@ func doesS3BucketKeyExist(t *testing.T, awsRegion string, bucketName, key string
 		Key:    aws.String(key),
 	})
 	if err != nil {
-		var apiErr smithy.APIError
-		if errors.As(err, &apiErr) {
+		if apiErr, ok := errors.AsType[smithy.APIError](err); ok {
 			if apiErr.ErrorCode() == "NotFound" {
 				return false
 			}

--- a/test/integration_tf_test.go
+++ b/test/integration_tf_test.go
@@ -5073,7 +5073,7 @@ func TestTFLogStreaming(t *testing.T) {
 					continue
 				}
 
-				dateTimestampStr := strings.Split(line, " ")[0]
+				dateTimestampStr, _, _ := strings.Cut(line, " ")
 				// The dateTimestampStr looks like this:
 				// time=2025-01-09EST15:47:04-05:00
 				//

--- a/test/integration_tflint_test.go
+++ b/test/integration_tflint_test.go
@@ -143,7 +143,7 @@ func TestTflintInitSameModule(t *testing.T) {
 	runPath := filepath.Join(rootPath, testFixtureParallelRun, "dev")
 	appTemplate := filepath.Join(rootPath, testFixtureParallelRun, "dev", "app")
 	// generate multiple "app" modules that will be initialized in parallel
-	for i := 0; i < tflintInitSamples; i++ {
+	for i := range tflintInitSamples {
 		appPath := filepath.Join(modulePath, "dev", fmt.Sprintf("app-%d", i))
 		err := util.CopyFolderContents(createLogger(), vfs.NewOSFS(), appTemplate, appPath, ".terragrunt-test")
 		require.NoError(t, err)


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Accidentally only ran this on the untagged stuff.

Also adds a workflow so that we avoid regressions on this going forward.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to detect when Go source files require standard formatting or modernization fixes.
  * Added commands to apply or validate Go fixes locally.

* **Bug Fixes**
  * Improved exit-status handling for shell commands, including combined errors.
  * Preserved environment detection and integration-test behavior while improving compatibility with current Go and cloud SDK APIs.

* **Tests**
  * Simplified concurrency and iteration logic across unit and integration tests without changing coverage or expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->