### PR TITLE
perf: Using a `sync.Pool` for hot buffers

### DIFF
--- a/internal/runner/json_output.go
+++ b/internal/runner/json_output.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"path/filepath"
+	"sync"
 
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 )
@@ -23,6 +24,14 @@ const (
 
 	jsonOutputTempPattern = ".*.tmp"
 )
+
+// jsonOutputWriters bounds buffer memory by how many units write at once. A fresh
+// buffer per call costs jsonOutputBufferSize for every unit in a `run --all`.
+var jsonOutputWriters = sync.Pool{
+	New: func() any {
+		return bufio.NewWriterSize(io.Discard, jsonOutputBufferSize)
+	},
+}
 
 // WriteJSONOutput streams whatever fn writes into the file at path, creating the
 // parent directory first. Plan JSON runs to tens of megabytes on large units and
@@ -74,7 +83,11 @@ func WriteJSONOutput(fsys vfs.FS, path string, fn func(w io.Writer) error) (err 
 		return err
 	}
 
-	buffered := bufio.NewWriterSize(file, jsonOutputBufferSize)
+	// Nothing but New and releaseJSONOutputWriter fills this pool, so the assertion holds.
+	buffered := jsonOutputWriters.Get().(*bufio.Writer)
+	buffered.Reset(file)
+
+	defer releaseJSONOutputWriter(buffered)
 
 	if err := fn(buffered); err != nil {
 		return err
@@ -85,4 +98,12 @@ func WriteJSONOutput(fsys vfs.FS, path string, fn func(w io.Writer) error) (err 
 	}
 
 	return fsys.Rename(tmpPath, path)
+}
+
+// releaseJSONOutputWriter returns w to the pool. Resetting it away from the file
+// stops a parked buffer from holding the last unit's closed file for as long as the
+// pool keeps it.
+func releaseJSONOutputWriter(w *bufio.Writer) {
+	w.Reset(io.Discard)
+	jsonOutputWriters.Put(w)
 }

--- a/internal/runner/json_output_racing_test.go
+++ b/internal/runner/json_output_racing_test.go
@@ -61,6 +61,52 @@ func TestWriteJSONOutputSamePathConcurrentWithRacing(t *testing.T) {
 	)
 }
 
+// TestWriteJSONOutputDistinctPathsConcurrentWithRacing writes distinguishable plans
+// from several goroutines, the way a `run --all` does. The write buffers are shared
+// between units, so a buffer reaching two of them at once shows up as one unit's
+// plan carrying another unit's content.
+func TestWriteJSONOutputDistinctPathsConcurrentWithRacing(t *testing.T) {
+	t.Parallel()
+
+	const (
+		units = 8
+		// Enough lines to run well past the 256 KB write buffer.
+		lines    = 10000
+		fillLine = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	fsys := vfs.NewOSFS()
+	dir := t.TempDir()
+
+	group, _ := errgroup.WithContext(t.Context())
+
+	for i := range units {
+		group.Go(func() error {
+			body := strings.Repeat(strconv.Itoa(i)+fillLine+"\n", lines)
+
+			return runner.WriteJSONOutput(
+				fsys,
+				filepath.Join(dir, strconv.Itoa(i)+".json"),
+				func(w io.Writer) error {
+					_, err := io.WriteString(w, body)
+
+					return err
+				},
+			)
+		})
+	}
+
+	require.NoError(t, group.Wait())
+
+	for i := range units {
+		contents, err := vfs.ReadFile(fsys, filepath.Join(dir, strconv.Itoa(i)+".json"))
+		require.NoError(t, err)
+
+		want := strings.Repeat(strconv.Itoa(i)+fillLine+"\n", lines)
+		assert.Equal(t, want, string(contents), "unit %d received another unit's content", i)
+	}
+}
+
 // TestWriteJSONOutputLeavesNoScratchFiles pins that scratch files are removed on
 // both the success and failure paths. Their names are random, so a leaked one
 // accumulates rather than being overwritten by the next run.

--- a/internal/runner/json_output_test.go
+++ b/internal/runner/json_output_test.go
@@ -177,6 +177,26 @@ func writeJSONOutputBuffered(fsys vfs.FS, path string, fn func(w io.Writer) erro
 	return vfs.WriteFile(fsys, path, buf.Bytes(), filePerms)
 }
 
+// BenchmarkWriteJSONOutputPerUnit writes a plan the size a small unit produces.
+// Moving content to disk dominates the larger sizes below and hides the setup each
+// call does first. At this size that setup is most of the cost, and a `run --all`
+// pays it once per unit.
+func BenchmarkWriteJSONOutputPerUnit(b *testing.B) {
+	const smallPlan = 64 << 10
+
+	fsys := vfs.NewOSFS()
+	path := filepath.Join(b.TempDir(), "plan.json")
+
+	b.ReportAllocs()
+	b.SetBytes(smallPlan)
+
+	for b.Loop() {
+		require.NoError(b, runner.WriteJSONOutput(fsys, path, func(w io.Writer) error {
+			return showJSON(w, smallPlan)
+		}))
+	}
+}
+
 // BenchmarkWriteJSONOutput contrasts streaming a plan document to disk against
 // buffering it first. Read the bytes-per-operation column. Under `run --all` every
 // unit running concurrently pays that figure at the same time.
@@ -208,12 +228,9 @@ func BenchmarkWriteJSONOutput(b *testing.B) {
 				b.SetBytes(int64(size.size))
 
 				for b.Loop() {
-					err := strategy.write(fsys, path, func(w io.Writer) error {
+					require.NoError(b, strategy.write(fsys, path, func(w io.Writer) error {
 						return showJSON(w, size.size)
-					})
-					if err != nil {
-						b.Fatal(err)
-					}
+					}))
 				}
 			})
 		}

--- a/internal/util/copy_bench_test.go
+++ b/internal/util/copy_bench_test.go
@@ -1,0 +1,81 @@
+package util_test
+
+import (
+	"bytes"
+	"io"
+	"strconv"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blackholeWriter keeps the destination out of the timings, leaving the copy
+// machinery as the only thing they measure.
+type blackholeWriter struct{}
+
+func (blackholeWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// BenchmarkCopy moves a payload through the context-cancellable copy. The sizes are
+// the three things the provider cache puts through it: a detached signature, a
+// SHA256SUMS document, and a provider archive. The scratch space is claimed once per
+// call, so it is most of the cost of the first two and invisible against the third.
+func BenchmarkCopy(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{name: "signature", size: 566},
+		{name: "checksums", size: 1600},
+		{name: "archive", size: 64 << 20},
+	}
+
+	for _, size := range sizes {
+		b.Run(size.name, func(b *testing.B) {
+			payload := bytes.Repeat([]byte("terragrunt"), size.size/10+1)[:size.size]
+			ctx := b.Context()
+			dst := blackholeWriter{}
+
+			b.ReportAllocs()
+			b.SetBytes(int64(size.size))
+
+			for b.Loop() {
+				_, err := util.Copy(ctx, dst, bytes.NewReader(payload))
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
+// BenchmarkCopyConcurrent runs the copies in parallel, the way the provider cache
+// reaches this code when it warms several providers at once. A pool holding a single
+// buffer shows up here as contention.
+func BenchmarkCopyConcurrent(b *testing.B) {
+	for _, workers := range []int{2, 8} {
+		b.Run(strconv.Itoa(workers)+"workers", func(b *testing.B) {
+			const payloadSize = 64 << 10
+
+			payload := bytes.Repeat([]byte("terragrunt"), payloadSize/10+1)[:payloadSize]
+			ctx := b.Context()
+
+			b.SetParallelism(workers)
+			b.ReportAllocs()
+			b.SetBytes(payloadSize)
+
+			b.RunParallel(func(pb *testing.PB) {
+				var dst io.Writer = blackholeWriter{}
+
+				for pb.Next() {
+					_, err := util.Copy(ctx, dst, bytes.NewReader(payload))
+
+					// require.NoError here would call Goexit off the benchmark
+					// goroutine, so the failure is recorded instead.
+					if !assert.NoError(b, err) {
+						return
+					}
+				}
+			})
+		})
+	}
+}

--- a/internal/util/copy_racing_test.go
+++ b/internal/util/copy_racing_test.go
@@ -1,0 +1,54 @@
+package util_test
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestCopyConcurrentWithRacing runs copies of different payloads at the same time.
+// They share the scratch space the copy reads through, so a buffer handed to two
+// callers at once shows up as one copy's content landing in another's output.
+func TestCopyConcurrentWithRacing(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workers     = 8
+		payloadSize = 128 << 10
+	)
+
+	payloads := make([][]byte, workers)
+	for i := range payloads {
+		payloads[i] = bytes.Repeat([]byte(strconv.Itoa(i)), payloadSize)
+	}
+
+	results := make([]*bytes.Buffer, workers)
+
+	group, ctx := errgroup.WithContext(t.Context())
+
+	for i := range workers {
+		results[i] = &bytes.Buffer{}
+
+		group.Go(func() error {
+			_, err := util.Copy(ctx, results[i], bytes.NewReader(payloads[i]))
+
+			return err
+		})
+	}
+
+	require.NoError(t, group.Wait())
+
+	for i := range workers {
+		assert.True(
+			t,
+			bytes.Equal(payloads[i], results[i].Bytes()),
+			"copy %d received bytes from another copy",
+			i,
+		)
+	}
+}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -1855,9 +1855,28 @@ type writerFunc func(data []byte) (int, error)
 
 func (wf writerFunc) Write(data []byte) (int, error) { return wf(data) }
 
+// copyBufferSize matches what io.Copy allocates for itself, so pooling changes how
+// often the memory is claimed rather than how much moves per read.
+const copyBufferSize = 32 * 1024
+
+// copyBuffers holds the scratch space [Copy] reads through. The wrappers below hide
+// whatever WriteTo or ReadFrom dst and src implement, leaving io.Copy no fast path
+// and a fresh buffer on every call.
+var copyBuffers = sync.Pool{
+	New: func() any {
+		buf := make([]byte, copyBufferSize)
+
+		return &buf
+	},
+}
+
 // Copy is a io.Copy cancellable by context.
 func Copy(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
-	num, err := io.Copy(
+	// Only New fills this pool, so the assertion holds.
+	buf := copyBuffers.Get().(*[]byte)
+	defer copyBuffers.Put(buf)
+
+	return io.CopyBuffer(
 		writerFunc(func(data []byte) (int, error) {
 			select {
 			case <-ctx.Done():
@@ -1878,9 +1897,8 @@ func Copy(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
 				return src.Read(data)
 			}
 		}),
+		*buf,
 	)
-
-	return num, err
 }
 
 // ErrPathEscapesBaseDir reports that a path handed to [SanitizePath] would


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

I thought maybe we could get more out of adding some `sync.Pool` usage in the codebase, but ultimately, we get pretty marginal benefits here.

Open to closing this out if you don't think the added complexity is worth it.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved performance and reduced memory overhead when producing JSON output.
  - Improved file-copy efficiency, particularly for larger payloads and concurrent operations.

- **Reliability**
  - Strengthened concurrent processing to help ensure outputs remain isolated and accurate when multiple operations run simultaneously.

- **Tests**
  - Added coverage and benchmarks for concurrent output generation and file-copy workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->