### PR TITLE
chore: Modernizing with new Go 1.27 constructs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/gofrs/flock v0.13.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
-	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/boilerplate v0.16.0
 	github.com/gruntwork-io/terragrunt-engine-go v0.1.0
 	github.com/hashicorp/go-getter/gcs/v2 v2.2.3
@@ -202,6 +201,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-jsonnet v0.21.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.20 // indirect
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect

--- a/internal/cas/giturl.go
+++ b/internal/cas/giturl.go
@@ -12,11 +12,11 @@ import "net/url"
 // honored. Clone depth comes solely from --cas-clone-depth, whose default of 1
 // applies whether or not the flag was passed.
 func StripGitURLParams(u *url.URL) (*url.URL, string) {
-	stripped := *u
+	stripped := u.Clone()
 
 	q := stripped.Query()
 	if len(q) == 0 {
-		return &stripped, ""
+		return stripped, ""
 	}
 
 	ref := q.Get("ref")
@@ -26,5 +26,5 @@ func StripGitURLParams(u *url.URL) (*url.URL, string) {
 
 	stripped.RawQuery = q.Encode()
 
-	return &stripped, ref
+	return stripped, ref
 }

--- a/internal/cli/commands/catalog/tui/synctest_helpers_test.go
+++ b/internal/cli/commands/catalog/tui/synctest_helpers_test.go
@@ -147,7 +147,7 @@ func driveModel(t *testing.T, m tea.Model, width, height int, interact []tea.Msg
 			break
 		}
 
-		time.Sleep(50 * time.Millisecond)
+		synctest.Sleep(50 * time.Millisecond)
 	}
 
 	if iter == settleMaxIterations-1 {

--- a/internal/cli/commands/catalog/tui/view_test.go
+++ b/internal/cli/commands/catalog/tui/view_test.go
@@ -517,7 +517,7 @@ func runUntilQuiet(t *testing.T, m tea.Model, initialCmd tea.Cmd, budget time.Du
 			}
 		}
 
-		time.Sleep(50 * time.Millisecond)
+		synctest.Sleep(50 * time.Millisecond)
 	}
 
 	return m
@@ -607,7 +607,7 @@ func TestWelcomeStreamingFlow_LoadingIndicatorClearsAfterDiscoveryWithRacing(t *
 		// Repeatedly nudge time forward and drain. Each cycle gives any
 		// goroutines we've spawned a chance to finish and push onto msgCh.
 		for range 20 {
-			time.Sleep(100 * time.Millisecond)
+			synctest.Sleep(100 * time.Millisecond)
 			drainOnce()
 		}
 

--- a/internal/cli/commands/scaffold/interactive.go
+++ b/internal/cli/commands/scaffold/interactive.go
@@ -90,8 +90,8 @@ func sourceTitle(moduleURL string) string {
 	title, _, _ := strings.Cut(moduleURL, "?")
 	title = strings.TrimSuffix(title, "/")
 
-	if idx := strings.LastIndexAny(title, "/"); idx >= 0 {
-		title = title[idx+1:]
+	if _, last, ok := strings.CutLast(title, "/"); ok {
+		title = last
 	}
 
 	if title == "" {

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -569,11 +569,9 @@ func ExtractQueryParam(rawURL, param string) string {
 // string. Go-getter URLs may contain "::" prefixes that prevent full URL
 // parsing, but the query string is always after the final "?".
 func splitURLQuery(rawURL string) (string, string) {
-	if idx := strings.LastIndex(rawURL, "?"); idx >= 0 {
-		return rawURL[:idx], rawURL[idx+1:]
-	}
+	base, query, _ := strings.CutLast(rawURL, "?")
 
-	return rawURL, ""
+	return base, query
 }
 
 // applyCatalogConfigToScaffold applies catalog configuration settings to scaffold options.

--- a/internal/git/submodule.go
+++ b/internal/git/submodule.go
@@ -110,13 +110,13 @@ func ResolveSubmoduleURL(parentURL, url string) string {
 
 		url = rest
 
-		if i := strings.LastIndexByte(base, '/'); i >= 0 {
-			base = base[:i]
+		if parent, _, ok := strings.CutLast(base, "/"); ok {
+			base = parent
 			continue
 		}
 
-		if i := strings.LastIndexByte(base, ':'); i >= 0 {
-			base = base[:i]
+		if parent, _, ok := strings.CutLast(base, ":"); ok {
+			base = parent
 			colonsep = true
 
 			continue

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -274,11 +274,8 @@ func splitRoot(pattern string) (string, bool) {
 		return filepath.FromSlash(pattern), false
 	}
 
-	prefix := pattern[:metaIdx]
-
-	if i := strings.LastIndex(prefix, "/"); i >= 0 {
-		prefix = prefix[:i]
-	} else {
+	prefix, _, ok := strings.CutLast(pattern[:metaIdx], "/")
+	if !ok {
 		prefix = "."
 	}
 

--- a/internal/providercache/archive_staging_test.go
+++ b/internal/providercache/archive_staging_test.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/gruntwork-io/terragrunt/internal/providercache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"

--- a/internal/providercache/concurrent_warmup_test.go
+++ b/internal/providercache/concurrent_warmup_test.go
@@ -16,8 +16,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/gruntwork-io/terragrunt/internal/providercache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"

--- a/internal/providercache/nested_modules_credentials_test.go
+++ b/internal/providercache/nested_modules_credentials_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/gruntwork-io/terragrunt/internal/providercache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"

--- a/internal/providercache/providercache.go
+++ b/internal/providercache/providercache.go
@@ -12,12 +12,12 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
 	"maps"
 
 	"errors"
 
-	"github.com/google/uuid"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
 	pcoptions "github.com/gruntwork-io/terragrunt/internal/providercache/options"

--- a/internal/providercache/providercache_test.go
+++ b/internal/providercache/providercache_test.go
@@ -14,8 +14,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/gruntwork-io/terragrunt/internal/providercache"
 	pcoptions "github.com/gruntwork-io/terragrunt/internal/providercache/options"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache"

--- a/internal/view/diagnostic/function.go
+++ b/internal/view/diagnostic/function.go
@@ -107,8 +107,8 @@ func DescribeFunctionCall(hclDiag *hcl.Diagnostic) *FunctionCall {
 	calledAs := callInfo.CalledFunctionName()
 
 	baseName := calledAs
-	if idx := strings.LastIndex(baseName, "::"); idx >= 0 {
-		baseName = baseName[idx+2:]
+	if _, bare, ok := strings.CutLast(calledAs, "::"); ok {
+		baseName = bare
 	}
 
 	var signature *Function

--- a/pkg/config/dependency_state.go
+++ b/pkg/config/dependency_state.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"context"
-	"encoding/json"
+	"encoding/json/jsontext"
 	"errors"
 	"io"
 
@@ -58,61 +58,53 @@ func readDependencyStateOutputs(
 // state normally costs one buffered read instead of a full download.
 func stateOutputsJSON(r io.Reader, location string) ([]byte, error) {
 	body := &stateBodyReader{r: r}
-	d := json.NewDecoder(body)
+	// jsontext rejects duplicate names and invalid UTF-8 by default, and the v1 decoder
+	// this replaced accepted both. A state that reads today would start failing with an
+	// error whose guidance points at client-side encryption.
+	d := jsontext.NewDecoder(
+		body,
+		jsontext.AllowDuplicateNames(true),
+		jsontext.AllowInvalidUTF8(true),
+	)
 
-	tok, err := d.Token()
+	tok, err := d.ReadToken()
 	if err != nil {
 		return nil, stateReadError(body, location, err)
 	}
 
-	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+	if tok.Kind() != '{' {
 		return nil, DependencyStateParseError{
 			Err:      errors.New("state is not a JSON object"),
 			Location: location,
 		}
 	}
 
-	for d.More() {
-		key, err := d.Token()
+	// PeekKind reports an invalid kind after a read failure, which keeps this condition
+	// true so ReadToken returns the cached error instead of spinning here forever.
+	for d.PeekKind() != '}' {
+		name, err := d.ReadToken()
 		if err != nil {
 			return nil, stateReadError(body, location, err)
 		}
 
-		if name, _ := key.(string); name != "outputs" {
-			if err := skipValue(d); err != nil {
+		if name.String() != "outputs" {
+			if err := d.SkipValue(); err != nil {
 				return nil, stateReadError(body, location, err)
 			}
 
 			continue
 		}
 
-		var outputs json.RawMessage
-		if err := d.Decode(&outputs); err != nil {
+		outputs, err := d.ReadValue()
+		if err != nil {
 			return nil, stateReadError(body, location, err)
 		}
 
-		if len(outputs) == 0 {
-			return []byte("null"), nil
-		}
-
-		return outputs, nil
-	}
-
-	if _, err := d.Token(); err != nil {
-		return nil, stateReadError(body, location, err)
+		// ReadValue borrows the decoder's buffer, which the next decoder call invalidates.
+		return outputs.Clone(), nil
 	}
 
 	return []byte("null"), nil
-}
-
-// skipValue advances past the next value. Decoding into a RawMessage materializes
-// what it skips, which a token walk would avoid, but the token walk costs four times
-// as much when it has to step over a large resources array. State files put outputs
-// ahead of resources, so this normally skips only scalars.
-func skipValue(d *json.Decoder) error {
-	var skip json.RawMessage
-
-	return d.Decode(&skip)
 }
 
 // stateBodyReader records the last transport failure so a dropped connection is not

--- a/test/helpers/ociregistry/ociregistry.go
+++ b/test/helpers/ociregistry/ociregistry.go
@@ -303,22 +303,21 @@ func splitAPIPath(path string) (string, string, string, bool) {
 	}
 
 	// Neither a tag nor a digest holds a slash, so the last two segments are always the kind and the reference.
-	refAt := strings.LastIndex(rest, "/")
-	if refAt < 0 {
+	head, ref, ok := strings.CutLast(rest, "/")
+	if !ok {
 		return "", "", "", false
 	}
 
-	kindAt := strings.LastIndex(rest[:refAt], "/")
-	if kindAt < 0 {
+	name, kind, ok := strings.CutLast(head, "/")
+	if !ok {
 		return "", "", "", false
 	}
 
-	kind := rest[kindAt+1 : refAt]
 	if kind != pathManifests && kind != pathBlobs {
 		return "", "", "", false
 	}
 
-	return rest[:kindAt], kind, rest[refAt+1:], true
+	return name, kind, ref, true
 }
 
 // moduleZip builds the module package zip the registry serves as its single layer.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Modernizes some usage of pre-1.27 with the new stuff available in the standard library.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved original Git URLs when processing references and depth parameters.
  * Improved handling of repository paths, URL queries, submodule locations, glob patterns, and function names containing separators.
  * Improved dependency-state parsing, including duplicate fields, invalid text encoding, and missing outputs.
  * Maintained correct handling of container registry paths with multi-segment repository names.

* **Tests**
  * Improved timing reliability for streaming and background-processing tests by using deterministic simulated time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->