### PR TITLE
fix: Writing more generated files atomically

### DIFF
--- a/docs/src/data/changelog/v1.1.5/atomic-file-generation.mdx
+++ b/docs/src/data/changelog/v1.1.5/atomic-file-generation.mdx
@@ -1,0 +1,17 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### More generated files are written atomically
+
+Terragrunt used to generate most files by opening the destination and writing into it, so the file spent time on disk half-written, and a run that failed partway through left a truncated one behind.
+
+These now go to a temporary file that replaces the destination once it is complete:
+
+- Files from [`generate`](/reference/hcl/blocks#generate) blocks
+- The config from [`render --write`](/reference/cli/commands/render#write)
+- Run reports from [`--report-file`](/reference/cli/commands/run#report-file)
+- The debug file from [`--debug`](/reference/cli/commands/run#debug)
+- `.terraform.lock.hcl`
+- The CLI config Terragrunt generates for OpenTofu/Terraform when the [Provider Cache Server](/features/caching/provider-cache-server) is enabled

--- a/docs/src/data/changelog/v1.1.5/generate-block-file-permissions.mdx
+++ b/docs/src/data/changelog/v1.1.5/generate-block-file-permissions.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### Files from `generate` blocks are created as `0600`
+
+A [`generate`](/reference/hcl/blocks#generate) block writes files for Terragrunt and the processes it spawns, all of which run as the user who ran Terragrunt. Creating them as `0644` granted read access that nothing uses.
+
+They are now created as `0600`. Under the [`mutable-generate`](/reference/experiments/active#mutable-generate) experiment, where the file is a read-only link to a copy shared between working directories, it is `0400` rather than `0444`.

--- a/docs/src/data/changelog/v1.1.5/generate-block-file-permissions.mdx
+++ b/docs/src/data/changelog/v1.1.5/generate-block-file-permissions.mdx
@@ -7,4 +7,6 @@ category: "bug-fixes"
 
 A [`generate`](/reference/hcl/blocks#generate) block writes files for Terragrunt and the processes it spawns, all of which run as the user who ran Terragrunt. Creating them as `0644` granted read access that nothing uses.
 
-They are now created as `0600`. Under the [`mutable-generate`](/reference/experiments/active#mutable-generate) experiment, where the file is a read-only link to a copy shared between working directories, it is `0400` rather than `0444`.
+They are now created as `0600`. Under the [`mutable-generate`](/reference/experiments/active#mutable-generate) experiment, where the file is a read-only link to a copy shared between working directories, new content is stored as `0400` rather than `0444`.
+
+Content the [CAS](/features/caching/cas) is already holding keeps the permissions it was stored with, since changing them would change every file linked to that copy. Those files stay `0444` until the cache is cleared. Run with `--log-level debug` to see which ones.

--- a/docs/src/data/changelog/v1.1.5/generate-block-file-permissions.mdx
+++ b/docs/src/data/changelog/v1.1.5/generate-block-file-permissions.mdx
@@ -7,6 +7,6 @@ category: "bug-fixes"
 
 A [`generate`](/reference/hcl/blocks#generate) block writes files for Terragrunt and the processes it spawns, all of which run as the user who ran Terragrunt. Creating them as `0644` granted read access that nothing uses.
 
-They are now created as `0600`. Under the [`mutable-generate`](/reference/experiments/active#mutable-generate) experiment, where the file is a read-only link to a copy shared between working directories, new content is stored as `0400` rather than `0444`.
+They are now created as `0600`. Under the [`mutable-generate`](/reference/experiments/active#mutable-generate) experiment, a block without `mutable = true` gets a read-only link to a copy shared between working directories, and Terragrunt stores new content as `0400` rather than `0444`. With `mutable = true`, the block keeps a writable `0600` file of its own.
 
 Content the [CAS](/features/caching/cas) is already holding keeps the permissions it was stored with, since changing them would change every file linked to that copy. Those files stay `0444` until the cache is cleared. Run with `--log-level debug` to see which ones.

--- a/internal/cas/benchmark_test.go
+++ b/internal/cas/benchmark_test.go
@@ -98,7 +98,7 @@ func BenchmarkContent(b *testing.B) {
 
 			b.StartTimer()
 
-			require.NoError(b, content.Store(l, v, hash, testData))
+			require.NoError(b, content.Store(l, v, hash, testData, cas.StoredFilePerms))
 		}
 	})
 
@@ -124,7 +124,7 @@ func BenchmarkContent(b *testing.B) {
 
 				mu.Unlock()
 
-				if err := content.Store(l, v, hash, testData); err != nil {
+				if err := content.Store(l, v, hash, testData, cas.StoredFilePerms); err != nil {
 					b.Fatal(err)
 				}
 

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -649,7 +649,7 @@ func (c *CAS) storeRootTreeFrom(
 			fmt.Appendf(nil, "%06o blob %s\t%s\n", stat.Mode().Perm(), includedHash, path)...)
 	}
 
-	return treeContent.Store(l, v, hash, data)
+	return treeContent.Store(l, v, hash, data, StoredFilePerms)
 }
 
 // storeTreeRecursive stores a tree fetched from git ls-tree -r. The tree
@@ -676,7 +676,7 @@ func (c *CAS) storeTreeRecursive(
 	}
 
 	treeContent := NewContent(c.treeStore)
-	if err := treeContent.EnsureWithWait(l, v, hash, tree.Data()); err != nil {
+	if err := treeContent.EnsureWithWait(l, v, hash, tree.Data(), StoredFilePerms); err != nil {
 		return err
 	}
 

--- a/internal/cas/content.go
+++ b/internal/cas/content.go
@@ -84,6 +84,15 @@ func (c *Content) Link(
 	}, func(childCtx context.Context, _ log.Logger) error {
 		sourcePath := c.getPath(hash)
 
+		targetDir := filepath.Dir(targetPath)
+		if err := v.FS.MkdirAll(targetDir, DefaultDirPerms); err != nil {
+			return &WrappedError{
+				Op:   "write_target",
+				Path: targetDir,
+				Err:  err,
+			}
+		}
+
 		// Hardlink when the stored blob's perms already match what the caller
 		// wants. Otherwise we must produce a fresh inode so a chmod cannot
 		// leak back into the shared store and so the destination carries the
@@ -108,15 +117,6 @@ func (c *Content) Link(
 				Op:   "read_source",
 				Path: sourcePath,
 				Err:  ErrReadFile,
-			}
-		}
-
-		targetDir := filepath.Dir(targetPath)
-		if err := v.FS.MkdirAll(targetDir, DefaultDirPerms); err != nil {
-			return &WrappedError{
-				Op:   "write_target",
-				Path: targetDir,
-				Err:  err,
 			}
 		}
 

--- a/internal/cas/content.go
+++ b/internal/cas/content.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -102,12 +103,22 @@ func (c *Content) Link(
 				sourcePath,
 			); statErr == nil &&
 				info.Mode().Perm() == desired {
-				if err := vfs.Link(v.FS, sourcePath, targetPath); err == nil {
+				linkErr := vfs.Link(v.FS, sourcePath, targetPath)
+				if linkErr == nil {
 					return nil
 				}
-				// Fall through to copy on link failure. An existing
-				// targetPath is handled by the temp-file+rename below,
-				// which overwrites stale bytes atomically.
+
+				// A link refused only because the name is taken is worth a
+				// second attempt beside the target, which keeps the sharing
+				// that a copy would give up.
+				if errors.Is(linkErr, fs.ErrExist) {
+					if err := linkOver(v, sourcePath, targetPath); err == nil {
+						return nil
+					}
+				}
+				// Fall through to copy when neither link lands, on a
+				// filesystem that has no hard links or across a device
+				// boundary.
 			}
 		}
 
@@ -124,7 +135,7 @@ func (c *Content) Link(
 		// reopening that name fails with EACCES once a prior write (an
 		// interrupted run, or a concurrent Link to the same target) left it at
 		// the read-only `desired` mode.
-		tmp, err := vfs.CreateTemp(v.FS, targetDir, filepath.Base(targetPath)+".tmp")
+		tmp, err := vfs.CreateTemp(v.FS, targetDir, vfs.TempPattern(filepath.Base(targetPath)))
 		if err != nil {
 			return &WrappedError{
 				Op:   "write_target",
@@ -170,6 +181,38 @@ func (c *Content) Link(
 
 		return nil
 	})
+}
+
+// linkOver hardlinks sourcePath beside targetPath and renames the result onto
+// it. A hard link cannot be made over a name that already exists, and unlinking
+// the target first would drop it for as long as the link takes and lose it for
+// good if the link then fails.
+func linkOver(v *venv.Venv, sourcePath, targetPath string) error {
+	tmp, err := vfs.CreateTemp(
+		v.FS,
+		filepath.Dir(targetPath),
+		vfs.TempPattern(filepath.Base(targetPath)),
+	)
+	if err != nil {
+		return err
+	}
+
+	tempPath := tmp.Name()
+
+	// The scratch file exists only to reserve a name the link can have.
+	if err := errors.Join(tmp.Close(), v.FS.Remove(tempPath)); err != nil {
+		return err
+	}
+
+	if err := vfs.Link(v.FS, sourcePath, tempPath); err != nil {
+		return err
+	}
+
+	if err := v.FS.Rename(tempPath, targetPath); err != nil {
+		return errors.Join(err, v.FS.Remove(tempPath))
+	}
+
+	return nil
 }
 
 // Store stores a single content item. This is typically used for trees,

--- a/internal/cas/content.go
+++ b/internal/cas/content.go
@@ -379,6 +379,10 @@ func (c *Content) EnsureCopy(l log.Logger, v *venv.Venv, hash, src string) (err 
 	// is the publish step.
 	tempPath := path + ".tmp"
 
+	if rmErr := v.FS.Remove(tempPath); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
+		return fmt.Errorf("remove stale temp file %s: %w", tempPath, rmErr)
+	}
+
 	f, err := v.FS.Create(tempPath)
 	if err != nil {
 		return fmt.Errorf("create file %s: %w", tempPath, err)
@@ -469,6 +473,10 @@ func (c *Content) writeContentToFile(
 
 	path := c.getPath(hash)
 	tempPath := path + ".tmp"
+
+	if err := v.FS.Remove(tempPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove stale temp file %s: %w", tempPath, err)
+	}
 
 	f, err := v.FS.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, RegularFilePerms)
 	if err != nil {

--- a/internal/cas/content.go
+++ b/internal/cas/content.go
@@ -43,7 +43,8 @@ func NewContent(store *Store) *Content {
 type LinkOption func(*linkOpts)
 
 type linkOpts struct {
-	forceCopy bool
+	forceCopy  bool
+	storedPerm bool
 }
 
 // WithLinkForceCopy makes Link copy the file from the store into the target
@@ -53,15 +54,23 @@ func WithLinkForceCopy() LinkOption {
 	return func(o *linkOpts) { o.forceCopy = true }
 }
 
+// WithLinkStoredPerm leaves the destination at the blob's stored permissions
+// when they differ from the ones requested, rather than taking a private copy.
+// Permissions are fixed when content is first stored.
+func WithLinkStoredPerm() LinkOption {
+	return func(o *linkOpts) { o.storedPerm = true }
+}
+
 // Link materializes a stored blob at targetPath under gitPerm.
 //
 // The default path hardlinks the stored blob with its write bits stripped, so
 // the destination cannot be edited back into the shared store. The fallback
-// copy path applies when stored perms don't match the request (rare cross-mode
-// collision) or when [WithLinkForceCopy] is in effect, so callers can edit
-// the working tree freely.
+// copy path applies when stored perms don't match the request (a cross-mode
+// collision, unless [WithLinkStoredPerm] says to share anyway) or when
+// [WithLinkForceCopy] is in effect, so callers can edit the working tree freely.
 func (c *Content) Link(
 	ctx context.Context,
+	l log.Logger,
 	v *venv.Venv,
 	hash, targetPath string,
 	gitPerm os.FileMode,
@@ -77,12 +86,12 @@ func (c *Content) Link(
 		desired &^= WriteBitMask
 	}
 
-	return telemetry.TelemeterFromContext(ctx).Collect(ctx, nil, "cas_link", map[string]any{
+	return telemetry.TelemeterFromContext(ctx).Collect(ctx, l, "cas_link", map[string]any{
 		"hash":       hash,
 		"path":       targetPath,
 		"force_copy": o.forceCopy,
 		"perm":       uint32(desired),
-	}, func(childCtx context.Context, _ log.Logger) error {
+	}, func(childCtx context.Context, l log.Logger) error {
 		sourcePath := c.getPath(hash)
 
 		targetDir := filepath.Dir(targetPath)
@@ -99,10 +108,8 @@ func (c *Content) Link(
 		// leak back into the shared store and so the destination carries the
 		// requested mode.
 		if !o.forceCopy {
-			if info, statErr := v.FS.Stat(
-				sourcePath,
-			); statErr == nil &&
-				info.Mode().Perm() == desired {
+			if info, statErr := v.FS.Stat(sourcePath); statErr == nil &&
+				linkable(l, hash, targetPath, info.Mode().Perm(), desired, o.storedPerm) {
 				linkErr := vfs.Link(v.FS, sourcePath, targetPath)
 				if linkErr == nil {
 					return nil
@@ -181,6 +188,33 @@ func (c *Content) Link(
 
 		return nil
 	})
+}
+
+// linkable reports whether a blob stored under stored can be shared by hard
+// link with a caller wanting desired. The modes have to agree, since a link and
+// the blob are one inode, unless the caller has said it would rather share on
+// the store's terms than take a private copy.
+func linkable(
+	l log.Logger,
+	hash, targetPath string,
+	stored, desired os.FileMode,
+	acceptStored bool,
+) bool {
+	if stored == desired {
+		return true
+	}
+
+	if !acceptStored {
+		return false
+	}
+
+	l.Debugf(
+		"CAS already holds %s with permissions %#o, so %s keeps those rather than %#o."+
+			" Permissions are fixed when content is first stored.",
+		hash, uint32(stored), targetPath, uint32(desired),
+	)
+
+	return true
 }
 
 // linkOver hardlinks sourcePath beside targetPath and renames the result onto

--- a/internal/cas/content.go
+++ b/internal/cas/content.go
@@ -215,9 +215,17 @@ func linkOver(v *venv.Venv, sourcePath, targetPath string) error {
 	return nil
 }
 
-// Store stores a single content item. This is typically used for trees,
-// as blobs are written directly from git cat-file stdout.
-func (c *Content) Store(l log.Logger, v *venv.Venv, hash string, data []byte) error {
+// Store stores a single content item under perm with its write bits cleared, so
+// nothing holding a link to the blob can edit the copy every other holder sees.
+// This is typically used for trees, as blobs are written directly from git
+// cat-file stdout.
+func (c *Content) Store(
+	l log.Logger,
+	v *venv.Venv,
+	hash string,
+	data []byte,
+	perm os.FileMode,
+) error {
 	lock, err := c.store.AcquireLock(v, hash)
 	if err != nil {
 		return fmt.Errorf("acquire lock for %s: %w", hash, err)
@@ -238,22 +246,36 @@ func (c *Content) Store(l log.Logger, v *venv.Venv, hash string, data []byte) er
 		return fmt.Errorf("create partition dir %s: %w", partitionDir, ErrCreateDir)
 	}
 
-	return c.writeContentToFile(l, v, hash, data)
+	return c.writeContentToFile(l, v, hash, data, perm)
 }
 
-// Ensure ensures that a content item exists in the store.
-func (c *Content) Ensure(l log.Logger, v *venv.Venv, hash string, data []byte) error {
+// Ensure ensures that a content item exists in the store under perm. A blob
+// already there keeps the mode it was first stored with, so content two callers
+// want at different modes is stored once and the second caller links a copy.
+func (c *Content) Ensure(
+	l log.Logger,
+	v *venv.Venv,
+	hash string,
+	data []byte,
+	perm os.FileMode,
+) error {
 	path := c.getPath(hash)
 	if c.store.hasContent(v, path) {
 		return nil
 	}
 
-	return c.Store(l, v, hash, data)
+	return c.Store(l, v, hash, data, perm)
 }
 
 // EnsureWithWait ensures that a content item exists in the store, with optimization
 // to wait for concurrent writes instead of doing redundant work.
-func (c *Content) EnsureWithWait(l log.Logger, v *venv.Venv, hash string, data []byte) error {
+func (c *Content) EnsureWithWait(
+	l log.Logger,
+	v *venv.Venv,
+	hash string,
+	data []byte,
+	perm os.FileMode,
+) error {
 	needsWrite, lock, err := c.store.EnsureWithWait(v, hash)
 	if err != nil {
 		return fmt.Errorf("ensure content for %s: %w", hash, err)
@@ -278,7 +300,7 @@ func (c *Content) EnsureWithWait(l log.Logger, v *venv.Venv, hash string, data [
 		return fmt.Errorf("create partition dir %s: %w", partitionDir, ErrCreateDir)
 	}
 
-	return c.writeContentToFile(l, v, hash, data)
+	return c.writeContentToFile(l, v, hash, data, perm)
 }
 
 // EnsureCopy ensures that a content item exists in the store by copying from a file.
@@ -402,7 +424,13 @@ func (c *Content) Read(v *venv.Venv, hash string) ([]byte, error) {
 
 // writeContentToFile writes data to a temporary file, sets appropriate
 // permissions, and performs an atomic rename.
-func (c *Content) writeContentToFile(l log.Logger, v *venv.Venv, hash string, data []byte) error {
+func (c *Content) writeContentToFile(
+	l log.Logger,
+	v *venv.Venv,
+	hash string,
+	data []byte,
+	perm os.FileMode,
+) error {
 	v.RequireGOOS()
 
 	path := c.getPath(hash)
@@ -447,7 +475,9 @@ func (c *Content) writeContentToFile(l log.Logger, v *venv.Venv, hash string, da
 		return fmt.Errorf("close %s: %w", tempPath, err)
 	}
 
-	if err := v.FS.Chmod(tempPath, StoredFilePerms); err != nil {
+	stored := perm.Perm() &^ WriteBitMask
+
+	if err := v.FS.Chmod(tempPath, stored); err != nil {
 		if removeErr := v.FS.Remove(tempPath); removeErr != nil {
 			l.Warnf("failed to remove temp file %s: %v", tempPath, removeErr)
 		}
@@ -472,7 +502,7 @@ func (c *Content) writeContentToFile(l log.Logger, v *venv.Venv, hash string, da
 	}
 
 	if v.Platform.GOOS == WindowsOS {
-		if err := v.FS.Chmod(path, StoredFilePerms); err != nil {
+		if err := v.FS.Chmod(path, stored); err != nil {
 			return fmt.Errorf("chmod %s: %w", path, err)
 		}
 	}

--- a/internal/cas/content_test.go
+++ b/internal/cas/content_test.go
@@ -63,6 +63,33 @@ func TestContent_Store(t *testing.T) {
 			"a caller asking for an owner-only blob must not get a world-readable one")
 	})
 
+	t.Run("recovers from a stale read-only temp file", func(t *testing.T) {
+		t.Parallel()
+
+		v := venvtest.NewOSWithEmptyEnv()
+
+		storeDir := t.TempDir()
+		store := cas.NewStore(storeDir)
+
+		content := cas.NewContent(store)
+		testHash := testHashValue
+		testData := []byte("test content")
+
+		partitionDir := filepath.Join(storeDir, testHash[:2])
+		require.NoError(t, os.MkdirAll(partitionDir, 0o755))
+
+		// An interrupted run can leave a read-only temp file behind. Opening
+		// it for writing fails with EACCES, so Store must not reuse it.
+		storedPath := filepath.Join(partitionDir, testHash)
+		require.NoError(t, os.WriteFile(storedPath+".tmp", []byte("partial"), 0o400))
+
+		require.NoError(t, content.Store(l, v, testHash, testData, cas.StoredFilePerms))
+
+		got, err := os.ReadFile(storedPath)
+		require.NoError(t, err)
+		assert.Equal(t, testData, got)
+	})
+
 	t.Run("ensure existing content", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/cas/content_test.go
+++ b/internal/cas/content_test.go
@@ -162,6 +162,36 @@ func TestContent_Link(t *testing.T) {
 		assert.True(t, os.SameFile(sourceInfo, targetInfo), "expected hard link (same inode)")
 	})
 
+	// A generated file whose destination directory was deleted between runs still
+	// hardlinks, rather than quietly falling back to a copy.
+	t.Run("create hard link under missing directory on real filesystem", func(t *testing.T) {
+		t.Parallel()
+
+		v := venvtest.NewOSWithEmptyEnv()
+
+		storeDir := t.TempDir()
+		targetDir := t.TempDir()
+		store := cas.NewStore(storeDir)
+
+		content := cas.NewContent(store)
+		testHash := testHashValue
+		testData := []byte("test content")
+
+		err := content.Store(l, v, testHash, testData)
+		require.NoError(t, err)
+
+		targetPath := filepath.Join(targetDir, "generated", "nested", "test.txt")
+		err = content.Link(t.Context(), v, testHash, targetPath, 0o644)
+		require.NoError(t, err)
+
+		sourcePath := filepath.Join(storeDir, testHash[:2], testHash)
+		sourceInfo, err := os.Stat(sourcePath)
+		require.NoError(t, err)
+		targetInfo, err := os.Stat(targetPath)
+		require.NoError(t, err)
+		assert.True(t, os.SameFile(sourceInfo, targetInfo), "expected hard link (same inode)")
+	})
+
 	t.Run("force copy creates independent inode on real filesystem", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/cas/content_test.go
+++ b/internal/cas/content_test.go
@@ -33,7 +33,7 @@ func TestContent_Store(t *testing.T) {
 		testHash := testHashValue
 		testData := []byte("test content")
 
-		err := content.Store(l, v, testHash, testData)
+		err := content.Store(l, v, testHash, testData, cas.StoredFilePerms)
 		require.NoError(t, err)
 
 		// Verify content was stored
@@ -42,6 +42,25 @@ func TestContent_Store(t *testing.T) {
 		storedData, err := vfs.ReadFile(v.FS, storedPath)
 		require.NoError(t, err)
 		assert.Equal(t, testData, storedData)
+	})
+
+	t.Run("stores under the requested perm with write bits cleared", func(t *testing.T) {
+		t.Parallel()
+
+		v := venvtest.NewOSWithEmptyEnv()
+
+		storeDir := t.TempDir()
+		store := cas.NewStore(storeDir)
+
+		content := cas.NewContent(store)
+		testHash := testHashValue
+
+		require.NoError(t, content.Store(l, v, testHash, []byte("test content"), 0o600))
+
+		info, err := os.Stat(filepath.Join(storeDir, testHash[:2], testHash))
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o400), info.Mode().Perm(),
+			"a caller asking for an owner-only blob must not get a world-readable one")
 	})
 
 	t.Run("ensure existing content", func(t *testing.T) {
@@ -58,9 +77,9 @@ func TestContent_Store(t *testing.T) {
 		differentData := []byte("different content")
 
 		// Store content twice
-		err := content.Ensure(l, v, testHash, testData)
+		err := content.Ensure(l, v, testHash, testData, cas.StoredFilePerms)
 		require.NoError(t, err)
-		err = content.Ensure(l, v, testHash, differentData)
+		err = content.Ensure(l, v, testHash, differentData, cas.StoredFilePerms)
 		require.NoError(t, err)
 
 		// Verify original content remains
@@ -85,9 +104,9 @@ func TestContent_Store(t *testing.T) {
 		differentData := []byte("different content")
 
 		// Store content twice
-		err := content.Store(l, v, testHash, testData)
+		err := content.Store(l, v, testHash, testData, cas.StoredFilePerms)
 		require.NoError(t, err)
-		err = content.Store(l, v, testHash, differentData)
+		err = content.Store(l, v, testHash, differentData, cas.StoredFilePerms)
 		require.NoError(t, err)
 
 		// Verify content was overwritten
@@ -118,7 +137,7 @@ func TestContent_Link(t *testing.T) {
 		testData := []byte("test content")
 
 		// First store some content
-		err := content.Store(l, v, testHash, testData)
+		err := content.Store(l, v, testHash, testData, cas.StoredFilePerms)
 		require.NoError(t, err)
 
 		// Then create a link to it
@@ -146,7 +165,7 @@ func TestContent_Link(t *testing.T) {
 		testHash := testHashValue
 		testData := []byte("test content")
 
-		err := content.Store(l, v, testHash, testData)
+		err := content.Store(l, v, testHash, testData, cas.StoredFilePerms)
 		require.NoError(t, err)
 
 		targetPath := filepath.Join(targetDir, "test.txt")
@@ -177,7 +196,7 @@ func TestContent_Link(t *testing.T) {
 		testHash := testHashValue
 		testData := []byte("test content")
 
-		err := content.Store(l, v, testHash, testData)
+		err := content.Store(l, v, testHash, testData, cas.StoredFilePerms)
 		require.NoError(t, err)
 
 		targetPath := filepath.Join(targetDir, "generated", "nested", "test.txt")
@@ -205,7 +224,7 @@ func TestContent_Link(t *testing.T) {
 		testHash := testHashValue
 		testData := []byte("test content")
 
-		err := content.Store(l, v, testHash, testData)
+		err := content.Store(l, v, testHash, testData, cas.StoredFilePerms)
 		require.NoError(t, err)
 
 		targetPath := filepath.Join(targetDir, "test.txt")
@@ -251,7 +270,7 @@ func TestContent_Link(t *testing.T) {
 		testHash := testHashValue
 		testData := []byte("test content")
 
-		require.NoError(t, content.Store(l, v, testHash, testData))
+		require.NoError(t, content.Store(l, v, testHash, testData, cas.StoredFilePerms))
 
 		targetPath := filepath.Join(targetDir, "test.txt")
 		require.NoError(t, content.Link(t.Context(), v, testHash, targetPath, 0o644))
@@ -277,7 +296,7 @@ func TestContent_Link(t *testing.T) {
 			testHash := testHashValue
 			testData := []byte("#!/bin/sh\necho hi\n")
 
-			require.NoError(t, content.Store(l, v, testHash, testData))
+			require.NoError(t, content.Store(l, v, testHash, testData, cas.StoredFilePerms))
 
 			// Mirror the store-side chmod that the git-clone path applies: stored
 			// blobs carry their original git mode with write bits cleared, so
@@ -313,7 +332,7 @@ func TestContent_Link(t *testing.T) {
 		testHash := testHashValue
 		testData := []byte("test content")
 
-		require.NoError(t, content.Store(l, v, testHash, testData))
+		require.NoError(t, content.Store(l, v, testHash, testData, cas.StoredFilePerms))
 
 		// The blob landed in the store at 0o444 (treated as non-exec). A second
 		// tree referencing the same content under mode 100755 wants 0o555.
@@ -346,7 +365,7 @@ func TestContent_Link(t *testing.T) {
 		testHash := testHashValue
 		testData := []byte("#!/bin/sh\necho hi\n")
 
-		require.NoError(t, content.Store(l, v, testHash, testData))
+		require.NoError(t, content.Store(l, v, testHash, testData, cas.StoredFilePerms))
 
 		targetPath := filepath.Join(targetDir, "run.sh")
 		require.NoError(
@@ -374,7 +393,7 @@ func TestContent_Link(t *testing.T) {
 		testData := []byte("test content")
 
 		// Store content
-		err := content.Store(l, v, testHash, testData)
+		err := content.Store(l, v, testHash, testData, cas.StoredFilePerms)
 		require.NoError(t, err)
 
 		// Pre-populate the target with stale bytes. A previous failed
@@ -406,7 +425,7 @@ func TestContent_Link(t *testing.T) {
 		testHash := testHashValue
 		testData := []byte("test content")
 
-		require.NoError(t, content.Store(l, v, testHash, testData))
+		require.NoError(t, content.Store(l, v, testHash, testData, cas.StoredFilePerms))
 
 		// The state a rerun finds: the previous materialization is still
 		// there, read-only, on a name no hard link can be made over.
@@ -441,7 +460,7 @@ func TestContent_Link(t *testing.T) {
 		testHash := testHashValue
 		testData := []byte("ref: refs/heads/master\n")
 
-		require.NoError(t, content.Store(l, v, testHash, testData))
+		require.NoError(t, content.Store(l, v, testHash, testData, cas.StoredFilePerms))
 
 		// Mismatched store perms route Link through the copy path.
 		require.NoError(t, os.Chmod(filepath.Join(storeDir, testHash[:2], testHash), 0o644))
@@ -478,11 +497,11 @@ func TestContent_EnsureWithWait(t *testing.T) {
 		testData := []byte("test content")
 
 		// Store content first
-		err := content.Store(l, v, testHash, testData)
+		err := content.Store(l, v, testHash, testData, cas.StoredFilePerms)
 		require.NoError(t, err)
 
 		// EnsureWithWait should not need to write again
-		err = content.EnsureWithWait(l, v, testHash, []byte("different content"))
+		err = content.EnsureWithWait(l, v, testHash, []byte("different content"), cas.StoredFilePerms)
 		require.NoError(t, err)
 
 		// Verify original content remains
@@ -506,7 +525,7 @@ func TestContent_EnsureWithWait(t *testing.T) {
 		testData := []byte("new test content")
 
 		// EnsureWithWait should store the content
-		err := content.EnsureWithWait(l, v, testHash, testData)
+		err := content.EnsureWithWait(l, v, testHash, testData, cas.StoredFilePerms)
 		require.NoError(t, err)
 
 		// Verify content was stored
@@ -537,7 +556,7 @@ func TestContent_EnsureWithWait(t *testing.T) {
 		go func() {
 			defer close(process1Done)
 
-			err := content.EnsureWithWait(l, v, testHash, []byte("process 1 data"))
+			err := content.EnsureWithWait(l, v, testHash, []byte("process 1 data"), cas.StoredFilePerms)
 			assert.NoError(t, err)
 
 			close(process1Started)
@@ -550,7 +569,7 @@ func TestContent_EnsureWithWait(t *testing.T) {
 			// Wait for process 1 to start
 			<-process1Started
 
-			err := content.EnsureWithWait(l, v, testHash, []byte("process 2 data"))
+			err := content.EnsureWithWait(l, v, testHash, []byte("process 2 data"), cas.StoredFilePerms)
 			assert.NoError(t, err)
 		}()
 

--- a/internal/cas/content_test.go
+++ b/internal/cas/content_test.go
@@ -393,6 +393,41 @@ func TestContent_Link(t *testing.T) {
 		assert.Equal(t, testData, got)
 	})
 
+	t.Run("default path replaces an occupied target with a hardlink", func(t *testing.T) {
+		t.Parallel()
+
+		v := venvtest.NewOSWithEmptyEnv()
+
+		storeDir := t.TempDir()
+		targetDir := t.TempDir()
+		store := cas.NewStore(storeDir)
+
+		content := cas.NewContent(store)
+		testHash := testHashValue
+		testData := []byte("test content")
+
+		require.NoError(t, content.Store(l, v, testHash, testData))
+
+		// The state a rerun finds: the previous materialization is still
+		// there, read-only, on a name no hard link can be made over.
+		targetPath := filepath.Join(targetDir, "test.txt")
+		require.NoError(t, os.WriteFile(targetPath, []byte("stale"), 0o444))
+
+		require.NoError(t, content.Link(t.Context(), v, testHash, targetPath, 0o644))
+
+		got, err := os.ReadFile(targetPath)
+		require.NoError(t, err)
+		assert.Equal(t, testData, got)
+
+		sourceInfo, err := os.Stat(filepath.Join(storeDir, testHash[:2], testHash))
+		require.NoError(t, err)
+
+		info, err := os.Stat(targetPath)
+		require.NoError(t, err)
+		assert.True(t, os.SameFile(sourceInfo, info),
+			"an occupied target must still end up sharing the stored blob")
+	})
+
 	t.Run("copy path recovers from a stale read-only temp file", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/cas/content_test.go
+++ b/internal/cas/content_test.go
@@ -143,7 +143,7 @@ func TestContent_Link(t *testing.T) {
 		// Then create a link to it
 		targetPath := filepath.Join("/target", "test.txt")
 
-		err = content.Link(t.Context(), v, testHash, targetPath, 0o644)
+		err = content.Link(t.Context(), l, v, testHash, targetPath, 0o644)
 		require.NoError(t, err)
 
 		// Verify link was created and contains correct content
@@ -169,7 +169,7 @@ func TestContent_Link(t *testing.T) {
 		require.NoError(t, err)
 
 		targetPath := filepath.Join(targetDir, "test.txt")
-		err = content.Link(t.Context(), v, testHash, targetPath, 0o644)
+		err = content.Link(t.Context(), l, v, testHash, targetPath, 0o644)
 		require.NoError(t, err)
 
 		// Verify hard link by comparing inodes
@@ -200,7 +200,7 @@ func TestContent_Link(t *testing.T) {
 		require.NoError(t, err)
 
 		targetPath := filepath.Join(targetDir, "generated", "nested", "test.txt")
-		err = content.Link(t.Context(), v, testHash, targetPath, 0o644)
+		err = content.Link(t.Context(), l, v, testHash, targetPath, 0o644)
 		require.NoError(t, err)
 
 		sourcePath := filepath.Join(storeDir, testHash[:2], testHash)
@@ -228,7 +228,7 @@ func TestContent_Link(t *testing.T) {
 		require.NoError(t, err)
 
 		targetPath := filepath.Join(targetDir, "test.txt")
-		err = content.Link(t.Context(), v, testHash, targetPath, 0o644, cas.WithLinkForceCopy())
+		err = content.Link(t.Context(), l, v, testHash, targetPath, 0o644, cas.WithLinkForceCopy())
 		require.NoError(t, err)
 
 		sourcePath := filepath.Join(storeDir, testHash[:2], testHash)
@@ -273,7 +273,7 @@ func TestContent_Link(t *testing.T) {
 		require.NoError(t, content.Store(l, v, testHash, testData, cas.StoredFilePerms))
 
 		targetPath := filepath.Join(targetDir, "test.txt")
-		require.NoError(t, content.Link(t.Context(), v, testHash, targetPath, 0o644))
+		require.NoError(t, content.Link(t.Context(), l, v, testHash, targetPath, 0o644))
 
 		info, err := os.Stat(targetPath)
 		require.NoError(t, err)
@@ -305,7 +305,7 @@ func TestContent_Link(t *testing.T) {
 			require.NoError(t, os.Chmod(sourcePath, 0o555))
 
 			targetPath := filepath.Join(targetDir, "run.sh")
-			require.NoError(t, content.Link(t.Context(), v, testHash, targetPath, 0o755))
+			require.NoError(t, content.Link(t.Context(), l, v, testHash, targetPath, 0o755))
 
 			info, err := os.Stat(targetPath)
 			require.NoError(t, err)
@@ -339,7 +339,7 @@ func TestContent_Link(t *testing.T) {
 		// Link must produce a fresh inode at 0o555 rather than hardlinking
 		// the 0o444 blob.
 		targetPath := filepath.Join(targetDir, "run.sh")
-		require.NoError(t, content.Link(t.Context(), v, testHash, targetPath, 0o755))
+		require.NoError(t, content.Link(t.Context(), l, v, testHash, targetPath, 0o755))
 
 		info, err := os.Stat(targetPath)
 		require.NoError(t, err)
@@ -370,7 +370,7 @@ func TestContent_Link(t *testing.T) {
 		targetPath := filepath.Join(targetDir, "run.sh")
 		require.NoError(
 			t,
-			content.Link(t.Context(), v, testHash, targetPath, 0o755, cas.WithLinkForceCopy()),
+			content.Link(t.Context(), l, v, testHash, targetPath, 0o755, cas.WithLinkForceCopy()),
 		)
 
 		info, err := os.Stat(targetPath)
@@ -404,7 +404,7 @@ func TestContent_Link(t *testing.T) {
 		err = vfs.WriteFile(v.FS, targetPath, []byte("existing content"), 0644)
 		require.NoError(t, err)
 
-		err = content.Link(t.Context(), v, testHash, targetPath, 0o644)
+		err = content.Link(t.Context(), l, v, testHash, targetPath, 0o644)
 		require.NoError(t, err)
 
 		got, err := vfs.ReadFile(v.FS, targetPath)
@@ -432,7 +432,7 @@ func TestContent_Link(t *testing.T) {
 		targetPath := filepath.Join(targetDir, "test.txt")
 		require.NoError(t, os.WriteFile(targetPath, []byte("stale"), 0o444))
 
-		require.NoError(t, content.Link(t.Context(), v, testHash, targetPath, 0o644))
+		require.NoError(t, content.Link(t.Context(), l, v, testHash, targetPath, 0o644))
 
 		got, err := os.ReadFile(targetPath)
 		require.NoError(t, err)
@@ -445,6 +445,68 @@ func TestContent_Link(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, os.SameFile(sourceInfo, info),
 			"an occupied target must still end up sharing the stored blob")
+	})
+
+	t.Run("stored perms win over a narrower request when accepted", func(t *testing.T) {
+		t.Parallel()
+
+		v := venvtest.NewOSWithEmptyEnv()
+
+		storeDir := t.TempDir()
+		targetDir := t.TempDir()
+		store := cas.NewStore(storeDir)
+
+		content := cas.NewContent(store)
+		testHash := testHashValue
+
+		require.NoError(
+			t,
+			content.Store(l, v, testHash, []byte("test content"), cas.StoredFilePerms),
+		)
+
+		sourceInfo, err := os.Stat(filepath.Join(storeDir, testHash[:2], testHash))
+		require.NoError(t, err)
+
+		targetPath := filepath.Join(targetDir, "test.txt")
+		require.NoError(t, content.Link(
+			t.Context(), l, v, testHash, targetPath, 0o600, cas.WithLinkStoredPerm(),
+		))
+
+		info, err := os.Stat(targetPath)
+		require.NoError(t, err)
+		assert.True(t, os.SameFile(sourceInfo, info),
+			"sharing the stored blob matters more than the exact mode")
+		assert.Equal(t, os.FileMode(0o444), info.Mode().Perm())
+	})
+
+	t.Run("a narrower request copies when stored perms are not accepted", func(t *testing.T) {
+		t.Parallel()
+
+		v := venvtest.NewOSWithEmptyEnv()
+
+		storeDir := t.TempDir()
+		targetDir := t.TempDir()
+		store := cas.NewStore(storeDir)
+
+		content := cas.NewContent(store)
+		testHash := testHashValue
+
+		require.NoError(
+			t,
+			content.Store(l, v, testHash, []byte("test content"), cas.StoredFilePerms),
+		)
+
+		sourceInfo, err := os.Stat(filepath.Join(storeDir, testHash[:2], testHash))
+		require.NoError(t, err)
+
+		targetPath := filepath.Join(targetDir, "test.txt")
+		require.NoError(t, content.Link(t.Context(), l, v, testHash, targetPath, 0o600))
+
+		info, err := os.Stat(targetPath)
+		require.NoError(t, err)
+		assert.False(t, os.SameFile(sourceInfo, info))
+		assert.Equal(t, os.FileMode(0o400), info.Mode().Perm(),
+			"a caller holding out for the narrow mode gets an inode of its own")
 	})
 
 	t.Run("copy path recovers from a stale read-only temp file", func(t *testing.T) {
@@ -471,7 +533,7 @@ func TestContent_Link(t *testing.T) {
 		// it for writing fails with EACCES, so Link must not reuse it.
 		require.NoError(t, os.WriteFile(targetPath+".tmp", []byte("partial"), 0o444))
 
-		require.NoError(t, content.Link(t.Context(), v, testHash, targetPath, 0o644))
+		require.NoError(t, content.Link(t.Context(), l, v, testHash, targetPath, 0o644))
 
 		got, err := os.ReadFile(targetPath)
 		require.NoError(t, err)

--- a/internal/cas/local.go
+++ b/internal/cas/local.go
@@ -89,7 +89,7 @@ func (c *CAS) StoreLocalDirectory(
 		return fmt.Errorf("failed to parse local tree: %w", err)
 	}
 
-	return LinkTree(ctx, v, c.blobStore, c.treeStore, tree, targetDir, opts...)
+	return LinkTree(ctx, l, v, c.blobStore, c.treeStore, tree, targetDir, opts...)
 }
 
 // ComputeLocalRootHash walks dir in deterministic (lexical) order and produces a

--- a/internal/cas/materialize_test.go
+++ b/internal/cas/materialize_test.go
@@ -37,14 +37,14 @@ func TestMaterializeTree_FromSynthStore(t *testing.T) {
 	blobHash := "abc123"
 
 	blobContent := cas.NewContent(blobStore)
-	require.NoError(t, blobContent.Store(l, v, blobHash, blobData))
+	require.NoError(t, blobContent.Store(l, v, blobHash, blobData, cas.StoredFilePerms))
 
 	// Store a synthetic tree that references the blob
 	treeData := []byte("100644 blob abc123\tREADME.md\n")
 	treeHash := "synth999"
 
 	synthContent := cas.NewContent(synthStore)
-	require.NoError(t, synthContent.Store(l, v, treeHash, treeData))
+	require.NoError(t, synthContent.Store(l, v, treeHash, treeData, cas.StoredFilePerms))
 
 	// Build a CAS instance using the same store paths
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
@@ -81,14 +81,14 @@ func TestMaterializeTree_FromGitTreeStore(t *testing.T) {
 	blobHash := "blob111"
 
 	blobContent := cas.NewContent(blobStore)
-	require.NoError(t, blobContent.Store(l, v, blobHash, blobData))
+	require.NoError(t, blobContent.Store(l, v, blobHash, blobData, cas.StoredFilePerms))
 
 	// Store a tree in the git tree store (not synth)
 	treeData := []byte("100644 blob blob111\tmain.tf\n")
 	treeHash := "tree222"
 
 	treeContent := cas.NewContent(treeStore)
-	require.NoError(t, treeContent.Store(l, v, treeHash, treeData))
+	require.NoError(t, treeContent.Store(l, v, treeHash, treeData, cas.StoredFilePerms))
 
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
 	require.NoError(t, err)
@@ -142,18 +142,18 @@ func TestMaterializeTree_SynthTakesPrecedence(t *testing.T) {
 	blobB := []byte("git version\n")
 
 	blobContent := cas.NewContent(blobStore)
-	require.NoError(t, blobContent.Store(l, v, "blobA", blobA))
-	require.NoError(t, blobContent.Store(l, v, "blobB", blobB))
+	require.NoError(t, blobContent.Store(l, v, "blobA", blobA, cas.StoredFilePerms))
+	require.NoError(t, blobContent.Store(l, v, "blobB", blobB, cas.StoredFilePerms))
 
 	hash := "samehash"
 
 	// Store in synth store (references blobA)
 	synthContent := cas.NewContent(synthStore)
-	require.NoError(t, synthContent.Store(l, v, hash, []byte("100644 blob blobA\tfile.txt\n")))
+	require.NoError(t, synthContent.Store(l, v, hash, []byte("100644 blob blobA\tfile.txt\n"), cas.StoredFilePerms))
 
 	// Store in git tree store (references blobB)
 	gitContent := cas.NewContent(treeStore)
-	require.NoError(t, gitContent.Store(l, v, hash, []byte("100644 blob blobB\tfile.txt\n")))
+	require.NoError(t, gitContent.Store(l, v, hash, []byte("100644 blob blobB\tfile.txt\n"), cas.StoredFilePerms))
 
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
 	require.NoError(t, err)
@@ -210,13 +210,13 @@ func TestCASProtocolGetterGet(t *testing.T) {
 	fileHash := cas.HashSHA1.Sum(fileContent)
 
 	blobContent := cas.NewContent(blobStore)
-	require.NoError(t, blobContent.Store(l, v, fileHash, fileContent))
+	require.NoError(t, blobContent.Store(l, v, fileHash, fileContent, cas.StoredFilePerms))
 
 	treeData := []byte("100644 blob " + fileHash + "\tmain.tf\n")
 	treeHash := cas.HashSHA1.Sum(treeData)
 
 	synthContent := cas.NewContent(synthStore)
-	require.NoError(t, synthContent.Store(l, v, treeHash, treeData))
+	require.NoError(t, synthContent.Store(l, v, treeHash, treeData, cas.StoredFilePerms))
 
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
 	require.NoError(t, err)
@@ -265,13 +265,13 @@ func TestCASProtocolGetterGet_Mutable(t *testing.T) {
 	fileHash := cas.HashSHA1.Sum(fileContent)
 
 	blobContent := cas.NewContent(blobStore)
-	require.NoError(t, blobContent.Store(l, v, fileHash, fileContent))
+	require.NoError(t, blobContent.Store(l, v, fileHash, fileContent, cas.StoredFilePerms))
 
 	treeData := []byte("100644 blob " + fileHash + "\tmain.tf\n")
 	treeHash := cas.HashSHA1.Sum(treeData)
 
 	synthContent := cas.NewContent(synthStore)
-	require.NoError(t, synthContent.Store(l, v, treeHash, treeData))
+	require.NoError(t, synthContent.Store(l, v, treeHash, treeData, cas.StoredFilePerms))
 
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storeDir))
 	require.NoError(t, err)

--- a/internal/cas/protocol.go
+++ b/internal/cas/protocol.go
@@ -165,7 +165,7 @@ func (c *CAS) MaterializeTree(
 		return fmt.Errorf("failed to parse CAS tree %s: %w", hash, err)
 	}
 
-	return LinkTree(ctx, v, c.blobStore, treeStoreUsed, tree, dest, opts...)
+	return LinkTree(ctx, l, v, c.blobStore, treeStoreUsed, tree, dest, opts...)
 }
 
 // isValidHexDigest reports whether s is a lowercase hex digest of the length

--- a/internal/cas/race_test.go
+++ b/internal/cas/race_test.go
@@ -152,7 +152,7 @@ func TestContentLinkConcurrentSameTargetWithRacing(t *testing.T) {
 	content := cas.NewContent(store)
 
 	const hash = "3333333333333333333333333333333333333333"
-	require.NoError(t, content.Store(l, v, hash, []byte("ref: refs/heads/master\n")))
+	require.NoError(t, content.Store(l, v, hash, []byte("ref: refs/heads/master\n"), cas.StoredFilePerms))
 
 	// Leave the stored blob writable so its perms differ from the requested
 	// read-only result, forcing Link onto the copy path even on a

--- a/internal/cas/race_test.go
+++ b/internal/cas/race_test.go
@@ -176,7 +176,7 @@ func TestContentLinkConcurrentSameTargetWithRacing(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 
-			errs[idx] = content.Link(t.Context(), v, hash, targetPath, 0o644)
+			errs[idx] = content.Link(t.Context(), l, v, hash, targetPath, 0o644)
 		}(i)
 	}
 

--- a/internal/cas/source.go
+++ b/internal/cas/source.go
@@ -344,7 +344,7 @@ func (c *CAS) storeFetchedContent(
 				return fmt.Errorf("read symlink %s: %w", path, err)
 			}
 
-			if err := blobContent.Ensure(l, v, blobHash, []byte(target)); err != nil {
+			if err := blobContent.Ensure(l, v, blobHash, []byte(target), StoredFilePerms); err != nil {
 				return fmt.Errorf("store symlink blob %s: %w", path, err)
 			}
 		default:
@@ -360,7 +360,7 @@ func (c *CAS) storeFetchedContent(
 	}
 
 	treeContent := NewContent(c.treeStore)
-	if err := treeContent.EnsureWithWait(l, v, treeKey, treeData); err != nil {
+	if err := treeContent.EnsureWithWait(l, v, treeKey, treeData, StoredFilePerms); err != nil {
 		return fmt.Errorf("store tree %s: %w", treeKey, err)
 	}
 

--- a/internal/cas/source.go
+++ b/internal/cas/source.go
@@ -117,7 +117,7 @@ func (c *CAS) FetchSource(
 			if suggestedKey != "" && !c.treeStore.NeedsWrite(v, suggestedKey) {
 				recordFetchOutcome(childCtx, true)
 
-				return c.linkStoredTree(childCtx, v, opts, suggestedKey)
+				return c.linkStoredTree(childCtx, l, v, opts, suggestedKey)
 			}
 
 			recordFetchOutcome(childCtx, false)
@@ -127,7 +127,7 @@ func (c *CAS) FetchSource(
 				return fmt.Errorf("fetch %s: %w", src.URL, err)
 			}
 
-			return c.linkStoredTree(childCtx, v, opts, treeKey)
+			return c.linkStoredTree(childCtx, l, v, opts, treeKey)
 		},
 	)
 }
@@ -267,6 +267,7 @@ func recordFetchOutcome(ctx context.Context, cacheHit bool) {
 // linkStoredTree materializes the tree at key into opts.Dir.
 func (c *CAS) linkStoredTree(
 	ctx context.Context,
+	l log.Logger,
 	v *venv.Venv,
 	opts *CloneOptions,
 	key string,
@@ -288,7 +289,7 @@ func (c *CAS) linkStoredTree(
 		linkOpts = append(linkOpts, WithForceCopy())
 	}
 
-	return LinkTree(ctx, v, c.blobStore, c.treeStore, tree, opts.Dir, linkOpts...)
+	return LinkTree(ctx, l, v, c.blobStore, c.treeStore, tree, opts.Dir, linkOpts...)
 }
 
 // storeFetchedContent stores every blob referenced by the tree, then

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -488,7 +488,7 @@ func (c *CAS) buildSyntheticTree(
 			}
 
 			blobHash := hashAlg.Sum([]byte(target))
-			if err := blobContent.Ensure(l, v, blobHash, []byte(target)); err != nil {
+			if err := blobContent.Ensure(l, v, blobHash, []byte(target), StoredFilePerms); err != nil {
 				return fmt.Errorf("failed to store symlink blob %s: %w", path, err)
 			}
 
@@ -528,7 +528,7 @@ func (c *CAS) buildSyntheticTree(
 	treeHash := hashAlg.Sum([]byte(refHash + relPathInRepo))
 
 	synthContent := NewContent(c.synthStore)
-	if err := synthContent.Ensure(l, v, treeHash, treeData); err != nil {
+	if err := synthContent.Ensure(l, v, treeHash, treeData, StoredFilePerms); err != nil {
 		return "", fmt.Errorf("failed to store synthetic tree: %w", err)
 	}
 

--- a/internal/cas/tree.go
+++ b/internal/cas/tree.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
 // unixPermMask isolates the user/group/other rwx bits from a git tree mode.
@@ -44,6 +45,7 @@ func WithForceCopy() LinkTreeOption {
 // blobStore is used to resolve blob entries, treeStore is used to resolve subtree entries.
 func LinkTree(
 	ctx context.Context,
+	l log.Logger,
 	v *venv.Venv,
 	blobStore *Store,
 	treeStore *Store,
@@ -56,7 +58,7 @@ func LinkTree(
 		opt(&o)
 	}
 
-	return linkTree(ctx, v, blobStore, treeStore, t, targetDir, targetDir, &o)
+	return linkTree(ctx, l, v, blobStore, treeStore, t, targetDir, targetDir, &o)
 }
 
 // linkTree is the recursive implementation behind LinkTree. rootDir is the
@@ -66,6 +68,7 @@ func LinkTree(
 // resolve outside the original tree even when the link sits in a subdirectory.
 func linkTree(
 	ctx context.Context,
+	l log.Logger,
 	v *venv.Venv,
 	blobStore *Store,
 	treeStore *Store,
@@ -157,6 +160,7 @@ func linkTree(
 			case "link":
 				err := blobContent.Link(
 					ctx,
+					l,
 					v,
 					work.entry.Hash,
 					work.path,
@@ -197,7 +201,7 @@ func linkTree(
 					return fmt.Errorf("parse tree %s: %w", work.entry.Hash, err)
 				}
 
-				err = linkTree(ctx, v, blobStore, treeStore, subTree, rootDir, work.path, o)
+				err = linkTree(ctx, l, v, blobStore, treeStore, subTree, rootDir, work.path, o)
 				if err != nil {
 					return fmt.Errorf("link subtree %s: %w", work.path, err)
 				}
@@ -225,7 +229,7 @@ func linkTree(
 					return fmt.Errorf("parse submodule tree %s: %w", work.entry.Hash, err)
 				}
 
-				err = linkTree(ctx, v, blobStore, treeStore, subTree, rootDir, work.path, o)
+				err = linkTree(ctx, l, v, blobStore, treeStore, subTree, rootDir, work.path, o)
 				if err != nil {
 					return fmt.Errorf("link submodule %s: %w", work.path, err)
 				}

--- a/internal/cas/tree_test.go
+++ b/internal/cas/tree_test.go
@@ -215,10 +215,10 @@ func TestLinkTreeSymlinks(t *testing.T) {
 						target = tt.wantLinks[entry.Path]
 					}
 
-					require.NoError(t, content.Store(l, v, entry.Hash, []byte(target)))
+					require.NoError(t, content.Store(l, v, entry.Hash, []byte(target), cas.StoredFilePerms))
 				default:
 					if data, ok := tt.wantBlobs[entry.Path]; ok {
-						require.NoError(t, content.Store(l, v, entry.Hash, data))
+						require.NoError(t, content.Store(l, v, entry.Hash, data, cas.StoredFilePerms))
 					}
 				}
 			}
@@ -292,13 +292,13 @@ func TestLinkTree(t *testing.T) {
 				// Create test content
 				testData := []byte("test content")
 				testHash := "a1b2c3d4"
-				err := content.Store(l, v, testHash, testData)
+				err := content.Store(l, v, testHash, testData, cas.StoredFilePerms)
 				require.NoError(t, err)
 
 				// Create and store the src directory tree data
 				srcTreeData := `100644 blob a1b2c3d4 README.md`
 				srcTreeHash := "i9j0k1l2"
-				err = content.Store(l, v, srcTreeHash, []byte(srcTreeData))
+				err = content.Store(l, v, srcTreeHash, []byte(srcTreeData), cas.StoredFilePerms)
 				require.NoError(t, err)
 
 				return store, testHash

--- a/internal/cas/tree_test.go
+++ b/internal/cas/tree_test.go
@@ -226,7 +226,7 @@ func TestLinkTreeSymlinks(t *testing.T) {
 			targetDir := "/target"
 			require.NoError(t, v.FS.MkdirAll(targetDir, 0o755))
 
-			err = cas.LinkTree(t.Context(), v, store, store, tree, targetDir)
+			err = cas.LinkTree(t.Context(), l, v, store, store, tree, targetDir)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -389,7 +389,7 @@ func TestLinkTree(t *testing.T) {
 			require.NoError(t, v.FS.MkdirAll(targetDir, 0755))
 
 			// Link the tree
-			err = cas.LinkTree(t.Context(), v, store, store, tree, targetDir)
+			err = cas.LinkTree(t.Context(), l, v, store, store, tree, targetDir)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/internal/cli/commands/render/render.go
+++ b/internal/cli/commands/render/render.go
@@ -2,11 +2,10 @@
 package render
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/fs"
+	"io"
 	"path/filepath"
 
 	"errors"
@@ -115,14 +114,11 @@ func runRender(l log.Logger, v *venv.Venv, opts *Options, cfg *config.Terragrunt
 
 func renderHCL(l log.Logger, v *venv.Venv, opts *Options, cfg *config.TerragruntConfig) error {
 	if opts.Write {
-		buf := new(bytes.Buffer)
+		return writeRendered(l, v.FS, opts, func(w io.Writer) error {
+			_, err := cfg.WriteTo(w)
 
-		_, err := cfg.WriteTo(buf)
-		if err != nil {
 			return err
-		}
-
-		return writeRendered(l, v.FS, opts, buf.Bytes())
+		})
 	}
 
 	l.Debugf("Rendering config %s", opts.TerragruntConfigPath)
@@ -160,7 +156,11 @@ func renderJSON(l log.Logger, v *venv.Venv, opts *Options, cfg *config.Terragrun
 	}
 
 	if opts.Write {
-		return writeRendered(l, v.FS, opts, jsonBytes)
+		return writeRendered(l, v.FS, opts, func(w io.Writer) error {
+			_, err := w.Write(jsonBytes)
+
+			return err
+		})
 	}
 
 	l.Debugf("Rendering config %s", opts.TerragruntConfigPath)
@@ -173,7 +173,12 @@ func renderJSON(l log.Logger, v *venv.Venv, opts *Options, cfg *config.Terragrun
 	return nil
 }
 
-func writeRendered(l log.Logger, fsys vfs.FS, opts *Options, data []byte) error {
+func writeRendered(
+	l log.Logger,
+	fsys vfs.FS,
+	opts *Options,
+	render func(w io.Writer) error,
+) error {
 	outPath := opts.OutputPath
 	if !filepath.IsAbs(outPath) {
 		terragruntConfigDir := filepath.Dir(opts.TerragruntConfigPath)
@@ -186,17 +191,9 @@ func writeRendered(l log.Logger, fsys vfs.FS, opts *Options, data []byte) error 
 
 	l.Debugf("Rendering config %s to %s", opts.TerragruntConfigPath, outPath)
 
-	if err := fsys.Remove(outPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return err
-	}
-
 	const ownerReadWritePerms = 0o600
 
-	if err := vfs.WriteFile(fsys, outPath, data, ownerReadWritePerms); err != nil {
-		return err
-	}
-
-	return nil
+	return vfs.StreamFileAtomic(fsys, outPath, ownerReadWritePerms, render)
 }
 
 // marshalCtyValueJSONWithoutType marshals the given cty.Value object into a JSON object that does not have the type.

--- a/internal/codegen/generate.go
+++ b/internal/codegen/generate.go
@@ -233,7 +233,7 @@ func materialize(
 	store *cas.Content,
 ) error {
 	if store == nil || (mutable != nil && *mutable) {
-		return vfs.WriteFile(v.FS, targetPath, contents, generatedFilePerms)
+		return vfs.WriteFileAtomic(v.FS, targetPath, contents, generatedFilePerms)
 	}
 
 	// Matches how the blob store keys files ingested from local sources, so a

--- a/internal/codegen/generate.go
+++ b/internal/codegen/generate.go
@@ -139,7 +139,7 @@ func WriteToFile(
 		targetPath = filepath.Join(basePath, config.Path)
 	}
 
-	targetInfo, statErr := vfs.Lstat(v.FS, targetPath)
+	_, statErr := vfs.Lstat(v.FS, targetPath)
 	if statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
 		return statErr
 	}
@@ -203,15 +203,6 @@ func WriteToFile(
 		contentsToWrite = hclwrite.Format(contentsToWrite)
 	}
 
-	// A surviving target may be a read-only hard link into the store, and even a
-	// writable one would block a fresh link and silently degrade it into a copy.
-	// A symlink must go too, or the write follows it to its destination.
-	if targetFileExists && !targetInfo.IsDir() {
-		if err := v.FS.Remove(targetPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return err
-		}
-	}
-
 	if err := materialize(ctx, l, v, targetPath, contentsToWrite, config.Mutable, o.store); err != nil {
 		return err
 	}
@@ -222,7 +213,9 @@ func WriteToFile(
 }
 
 // materialize puts contents at targetPath, sharing one stored copy across
-// working directories unless the block opts into mutability.
+// working directories unless the block opts into mutability. Either route
+// publishes by rename, so a target already there is replaced whole and survives
+// untouched if the generation fails, whatever mode or link count it carries.
 func materialize(
 	ctx context.Context,
 	l log.Logger,

--- a/internal/codegen/generate.go
+++ b/internal/codegen/generate.go
@@ -32,7 +32,10 @@ const (
 	// The default prefix to use for comments in the generated file
 	DefaultCommentPrefix = "# "
 
-	generatedFilePerms = 0644
+	// generatedFilePerms is the mode a generated file is written under. The
+	// store clears the write bits from it for the copy it shares between
+	// working directories.
+	generatedFilePerms = 0o600
 )
 
 // GenerateConfigExists is an enum to represent valid values for if_exists.
@@ -229,10 +232,10 @@ func materialize(
 		return vfs.WriteFileAtomic(v.FS, targetPath, contents, generatedFilePerms)
 	}
 
-	// Matches how the blob store keys files ingested from local sources, so a
-	// generated file also dedupes against an identical file from a module.
+	// Keyed the way the blob store keys files ingested from local sources, so
+	// every working directory generating these contents lands on one blob.
 	hash := cas.HashSHA256.Sum(contents)
-	if err := store.Ensure(l, v, hash, contents); err != nil {
+	if err := store.Ensure(l, v, hash, contents, generatedFilePerms); err != nil {
 		return err
 	}
 

--- a/internal/codegen/generate.go
+++ b/internal/codegen/generate.go
@@ -239,7 +239,15 @@ func materialize(
 		return err
 	}
 
-	return store.Link(ctx, v, hash, targetPath, generatedFilePerms)
+	return store.Link(
+		ctx,
+		l,
+		v,
+		hash,
+		targetPath,
+		generatedFilePerms,
+		cas.WithLinkStoredPerm(),
+	)
 }
 
 // Whether or not file generation should continue if the file path already exists. The answer depends on the

--- a/internal/codegen/generate_test.go
+++ b/internal/codegen/generate_test.go
@@ -681,6 +681,50 @@ func TestWriteToFileOverwriteDoesNotMutateHardlinkedStore(t *testing.T) {
 	assert.Contains(t, string(targetContent), ">= 1.3.0")
 }
 
+// TestWriteToFileCreatesParentDirs covers a generate block whose path names a
+// subdirectory the module does not have, such as a "generated" directory that a
+// prior run created and the user then deleted.
+func TestWriteToFileCreatesParentDirs(t *testing.T) {
+	t.Parallel()
+
+	contents := "terraform {\n  required_version = \">= 1.0\"\n}\n"
+
+	for _, tc := range []struct {
+		name      string
+		withStore bool
+	}{
+		{name: "without a content store"},
+		{name: "with a content store", withStore: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			testDir := helpers.TmpDirWOSymlinks(t)
+
+			config := codegen.GenerateConfig{
+				Path:             filepath.Join("generated", "provider.tf"),
+				IfExists:         codegen.ExistsOverwrite,
+				DisableSignature: true,
+				Contents:         contents,
+			}
+
+			var opts []codegen.WriteOption
+			if tc.withStore {
+				opts = append(opts, codegen.WithContentStore(newTestContentStore(t, testDir)))
+			}
+
+			l := logger.CreateLogger()
+			require.NoError(t, codegen.WriteToFile(
+				t.Context(), l, venvtest.NewOSWithEmptyEnv(), testDir, &config, opts...,
+			))
+
+			written, err := os.ReadFile(filepath.Join(testDir, "generated", "provider.tf"))
+			require.NoError(t, err)
+			assert.Equal(t, contents, string(written))
+		})
+	}
+}
+
 // TestWriteToFileTargetIsDirectory verifies that a directory at the target
 // path still produces an error instead of being removed.
 func TestWriteToFileTargetIsDirectory(t *testing.T) {

--- a/internal/codegen/generate_test.go
+++ b/internal/codegen/generate_test.go
@@ -697,6 +697,37 @@ func (f *createErrorFS) OpenFile(name string, flag int, perm os.FileMode) (vfs.F
 	return f.FS.OpenFile(name, flag, perm)
 }
 
+// TestWriteToFileKeepsGeneratedFilePrivate covers the mode a generate block's
+// output lands with. A generate block is where backend and provider credentials
+// get written, so no other user on the machine may read it, whatever umask the
+// run happened to inherit.
+func TestWriteToFileKeepsGeneratedFilePrivate(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("read-only permission bits are not meaningfully observable on Windows")
+	}
+
+	path := filepath.Join(helpers.TmpDirWOSymlinks(t), "backend.tf")
+
+	config := codegen.GenerateConfig{
+		Path:             path,
+		IfExists:         codegen.ExistsOverwrite,
+		DisableSignature: true,
+		Contents:         "terraform {\n  required_version = \">= 1.0.0\"\n}\n",
+	}
+
+	l := logger.CreateLogger()
+	require.NoError(
+		t,
+		codegen.WriteToFile(t.Context(), l, venvtest.NewOSWithEmptyEnv(), "", &config),
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
 // TestWriteToFileFailedWriteLeavesExistingFile covers a generation that cannot
 // get its contents onto disk. The file it was going to overwrite is the one the
 // module is still configured with, so a run that gets nowhere has to leave it.
@@ -996,7 +1027,7 @@ func TestWriteToFileWithContentStoreDeduplicates(t *testing.T) {
 
 	assert.True(t, os.SameFile(firstInfo, secondInfo),
 		"identical generated contents must share one inode")
-	assert.Equal(t, os.FileMode(0444), firstInfo.Mode().Perm(),
+	assert.Equal(t, os.FileMode(0400), firstInfo.Mode().Perm(),
 		"deduplicated files must be read-only so an edit cannot reach the store")
 
 	firstContents, err := os.ReadFile(first)

--- a/internal/codegen/generate_test.go
+++ b/internal/codegen/generate_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/codegen"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -679,6 +680,62 @@ func TestWriteToFileOverwriteDoesNotMutateHardlinkedStore(t *testing.T) {
 	targetContent, err := os.ReadFile(targetPath)
 	require.NoError(t, err)
 	assert.Contains(t, string(targetContent), ">= 1.3.0")
+}
+
+// createErrorFS refuses to create a file, standing in for a destination the
+// process may read but cannot write into.
+type createErrorFS struct {
+	vfs.FS
+	err error
+}
+
+func (f *createErrorFS) OpenFile(name string, flag int, perm os.FileMode) (vfs.File, error) {
+	if flag&os.O_CREATE != 0 {
+		return nil, f.err
+	}
+
+	return f.FS.OpenFile(name, flag, perm)
+}
+
+// TestWriteToFileFailedWriteLeavesExistingFile covers a generation that cannot
+// get its contents onto disk. The file it was going to overwrite is the one the
+// module is still configured with, so a run that gets nowhere has to leave it.
+func TestWriteToFileFailedWriteLeavesExistingFile(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("read-only permission bits are not meaningfully observable on Windows")
+	}
+
+	existing := "terraform {\n  required_version = \">= 1.0.0\"\n}\n"
+
+	path := filepath.Join(helpers.TmpDirWOSymlinks(t), "versions.tf")
+
+	// Read-only is how a previous run leaves a file it materialized from the
+	// content store, so the surviving file is one this run could not have
+	// written over in place.
+	writeFileWithPerms(t, path, existing, 0444)
+
+	v := venvtest.NewOSWithEmptyEnv().
+		WithFS(&createErrorFS{FS: vfs.NewOSFS(), err: os.ErrPermission})
+
+	config := codegen.GenerateConfig{
+		Path:             path,
+		IfExists:         codegen.ExistsOverwrite,
+		DisableSignature: true,
+		Contents:         "terraform {\n  required_version = \">= 1.3.0\"\n}\n",
+	}
+
+	l := logger.CreateLogger()
+	require.ErrorIs(
+		t,
+		codegen.WriteToFile(t.Context(), l, v, "", &config),
+		os.ErrPermission,
+	)
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, existing, string(contents))
 }
 
 // TestWriteToFileCreatesParentDirs covers a generate block whose path names a

--- a/internal/report/writer.go
+++ b/internal/report/writer.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/csv"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -23,6 +22,9 @@ const (
 	csvFieldCount = 9
 	// csvRowOffset accounts for: 0-indexed loop (i starts at 0) + skipped header row.
 	csvRowOffset = 2
+	// reportFilePerms keeps a report readable only by the user who ran the command,
+	// since it names every unit and why each one failed.
+	reportFilePerms = 0o600
 )
 
 // JSONRun represents a run in JSON format.
@@ -250,7 +252,11 @@ func (r *Report) WriteToFile(fsys vfs.FS, path string) error {
 		path = filepath.Join(r.workingDir, path)
 	}
 
-	return writeFileAtomic(fsys, path, writeBody)
+	if err := vfs.StreamFileAtomic(fsys, path, reportFilePerms, writeBody); err != nil {
+		return fmt.Errorf("failed to write report: %w", err)
+	}
+
+	return nil
 }
 
 // WriteCSV writes the report to a writer in CSV format.
@@ -387,35 +393,8 @@ func (r *Report) WriteSchemaToFile(fsys vfs.FS, path string) error {
 		path = filepath.Join(r.workingDir, path)
 	}
 
-	return writeFileAtomic(fsys, path, WriteSchema)
-}
-
-// writeFileAtomic writes content produced by write into a temporary file in
-// path's directory and then renames it onto path, so a concurrent reader never
-// observes a partially written file and a failed write leaves no truncated one.
-// The temp file shares path's directory so the rename stays on one filesystem.
-func writeFileAtomic(fsys vfs.FS, path string, write func(w io.Writer) error) error {
-	tmpFile, err := vfs.CreateTemp(fsys, filepath.Dir(path), "terragrunt-report-")
-	if err != nil {
-		return err
-	}
-
-	tmpName := tmpFile.Name()
-
-	if err := write(tmpFile); err != nil {
-		return errors.Join(
-			fmt.Errorf("failed to write report: %w", err),
-			tmpFile.Close(),
-			fsys.Remove(tmpName),
-		)
-	}
-
-	if err := tmpFile.Close(); err != nil {
-		return errors.Join(fmt.Errorf("failed to close report file: %w", err), fsys.Remove(tmpName))
-	}
-
-	if err := fsys.Rename(tmpName, path); err != nil {
-		return errors.Join(err, fsys.Remove(tmpName))
+	if err := vfs.StreamFileAtomic(fsys, path, reportFilePerms, WriteSchema); err != nil {
+		return fmt.Errorf("failed to write report schema: %w", err)
 	}
 
 	return nil

--- a/internal/runner/run/debug.go
+++ b/internal/runner/run/debug.go
@@ -3,6 +3,7 @@ package run
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -49,15 +50,17 @@ func WriteTerragruntDebugFile(
 	l.Debugf("The following variables were detected in the %s module:", tofuImpl)
 	l.Debugf("%v", variables)
 
-	fileContents, err := terragruntDebugFileContents(l, v.Env, cfg, variables)
-	if err != nil {
-		return err
-	}
-
 	configFolder := filepath.Dir(opts.TerragruntConfigPath)
 
 	fileName := filepath.Join(configFolder, TerragruntTFVarsFile)
-	if err := vfs.WriteFile(v.FS, fileName, fileContents, os.FileMode(defaultPermissions)); err != nil {
+	if err := vfs.StreamFileAtomic(
+		v.FS,
+		fileName,
+		os.FileMode(defaultPermissions),
+		func(w io.Writer) error {
+			return writeDebugVars(w, l, v.Env, cfg, variables)
+		},
+	); err != nil {
 		return err
 	}
 
@@ -77,12 +80,13 @@ func WriteTerragruntDebugFile(
 // terragruntDebugFileContents will return a tfvars file in json format of all the terragrunt rendered variables values
 // that should be set to invoke the tofu/terraform module in the same way as terragrunt. Note that this will only include the
 // values of variables that are actually defined in the module.
-func terragruntDebugFileContents(
+func writeDebugVars(
+	w io.Writer,
 	l log.Logger,
 	env map[string]string,
 	cfg *runcfg.RunConfig,
 	moduleVariables []string,
-) ([]byte, error) {
+) error {
 	envVars := map[string]string{}
 	if env != nil {
 		envVars = env
@@ -115,10 +119,8 @@ func terragruntDebugFileContents(
 		}
 	}
 
-	jsonContent, err := json.MarshalIndent(jsonValuesByKey, "", "  ")
-	if err != nil {
-		return nil, err
-	}
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
 
-	return jsonContent, nil
+	return encoder.Encode(jsonValuesByKey)
 }

--- a/internal/tf/cliconfig/config.go
+++ b/internal/tf/cliconfig/config.go
@@ -2,6 +2,7 @@
 package cliconfig
 
 import (
+	"io"
 	"maps"
 	"slices"
 
@@ -203,16 +204,17 @@ func (cfg *Config) Save(configPath string) error {
 	gohcl.EncodeIntoBody(cfg, file.Body())
 
 	const ownerReadWritePerms = 0o600
-	if err := vfs.WriteFile(
+
+	return vfs.StreamFileAtomic(
 		cfg.FS(),
 		configPath,
-		file.Bytes(),
 		ownerReadWritePerms,
-	); err != nil {
-		return err
-	}
+		func(w io.Writer) error {
+			_, err := file.WriteTo(w)
 
-	return nil
+			return err
+		},
+	)
 }
 
 // CredentialsSource creates and returns a service credentials source whose behavior depends on which "credentials" if are present in the receiving config.

--- a/internal/tf/cliconfig/save_test.go
+++ b/internal/tf/cliconfig/save_test.go
@@ -1,0 +1,47 @@
+package cliconfig_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSaveReplacesSymlink confirms a symlink at the config path is replaced
+// rather than followed, so Save writes to the path it was given.
+func TestSaveReplacesSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.hcl")
+	require.NoError(t, os.WriteFile(target, []byte("original"), 0o600))
+
+	configPath := filepath.Join(dir, "config.hcl")
+	require.NoError(t, os.Symlink(target, configPath))
+
+	cfg := cliconfig.NewConfig(vfs.NewOSFS()).WithCredentials([]cliconfig.ConfigCredentials{
+		{Name: "registry.opentofu.org", Token: "example-token"},
+	})
+
+	require.NoError(t, cfg.Save(configPath))
+
+	contents, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(contents), "the symlink target was written to")
+
+	info, err := os.Lstat(configPath)
+	require.NoError(t, err)
+	assert.Zero(t, info.Mode()&os.ModeSymlink, "the symlink is still in place")
+
+	written, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(written), "example-token")
+
+	info, err = os.Stat(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}

--- a/internal/tf/getproviders/lock.go
+++ b/internal/tf/getproviders/lock.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
+	"io"
 	"io/fs"
 	"path/filepath"
 	"slices"
@@ -51,17 +51,15 @@ func UpdateLockfile(ctx context.Context, fsys vfs.FS, workingDir string, provide
 		return err
 	}
 
-	// CAS may materialize the lock file as a read-only hard link, so remove it before writing
-	if err := fsys.Remove(filename); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("failed to remove lock file %s before writing: %w", filename, err)
-	}
-
 	const ownerWriteGlobalReadPerms = 0644
-	if err := vfs.WriteFile(fsys, filename, file.Bytes(), ownerWriteGlobalReadPerms); err != nil {
-		return err
-	}
 
-	return nil
+	// The rename replaces the entry rather than the file, so a read-only hard link
+	// the CAS materialized here is left intact for whatever else points at it.
+	return vfs.StreamFileAtomic(fsys, filename, ownerWriteGlobalReadPerms, func(w io.Writer) error {
+		_, err := file.WriteTo(w)
+
+		return err
+	})
 }
 
 func updateLockfile(ctx context.Context, fsys vfs.FS, file *hclwrite.File, providers []Provider) error {
@@ -386,9 +384,12 @@ func UpdateLockfileConstraints(
 
 	if updated {
 		const ownerWriteGlobalReadPerms = 0644
-		if err := vfs.WriteFile(fsys, filename, file.Bytes(), ownerWriteGlobalReadPerms); err != nil {
+
+		return vfs.StreamFileAtomic(fsys, filename, ownerWriteGlobalReadPerms, func(w io.Writer) error {
+			_, err := file.WriteTo(w)
+
 			return err
-		}
+		})
 	}
 
 	return nil

--- a/internal/vfs/atomic.go
+++ b/internal/vfs/atomic.go
@@ -13,7 +13,7 @@ const atomicTempPattern = ".*.tmp"
 
 // WriteFileAtomic writes data to path through a scratch file that replaces path
 // only once the content is on disk. See [StreamFileAtomic] for what that buys and
-// how perm is applied. The parent directory must already exist.
+// how perm is applied.
 func WriteFileAtomic(fsys FS, path string, data []byte, perm os.FileMode) error {
 	return StreamFileAtomic(fsys, path, perm, func(w io.Writer) error {
 		_, err := w.Write(data)
@@ -23,8 +23,8 @@ func WriteFileAtomic(fsys FS, path string, data []byte, perm os.FileMode) error 
 }
 
 // StreamFileAtomic passes a writer to write and renames what it produces onto
-// path. The scratch file shares path's directory so the rename stays on one
-// filesystem, and the parent directory must already exist.
+// path, creating path's parent directories if they are missing. The scratch file
+// shares path's directory so the rename stays on one filesystem.
 //
 // Three properties come out of this that a plain [WriteFile] does not have. A
 // reader never sees a half-written file, and a failed write leaves the previous
@@ -35,7 +35,12 @@ func WriteFileAtomic(fsys FS, path string, data []byte, perm os.FileMode) error 
 // perm is applied exactly, not masked by the process umask, so a caller asking
 // for a mode wider than 0600 gets it whatever the umask would have allowed.
 func StreamFileAtomic(fsys FS, path string, perm os.FileMode, write func(w io.Writer) error) error {
-	file, err := CreateTemp(fsys, filepath.Dir(path), filepath.Base(path)+atomicTempPattern)
+	dir := filepath.Dir(path)
+	if err := fsys.MkdirAll(dir, os.ModePerm); err != nil {
+		return err
+	}
+
+	file, err := CreateTemp(fsys, dir, filepath.Base(path)+atomicTempPattern)
 	if err != nil {
 		return err
 	}

--- a/internal/vfs/atomic.go
+++ b/internal/vfs/atomic.go
@@ -5,11 +5,28 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"unicode/utf8"
 )
 
-// atomicTempPattern names the scratch file after its destination so one left
-// behind is traceable, with the random component [CreateTemp] substitutes for "*".
-const atomicTempPattern = ".*.tmp"
+const (
+	// atomicTempPattern names the scratch file after its destination so one left
+	// behind is traceable, with the random component [CreateTemp] substitutes for "*".
+	atomicTempPattern = ".*.tmp"
+
+	// maxTempNameLen is the shortest per-component name limit Terragrunt can
+	// land on, NAME_MAX on Linux and macOS. A filesystem allowing more costs
+	// only a shorter scratch name than it had to have.
+	maxTempNameLen = 255
+
+	// maxTempRandomLen bounds the decimal random component [CreateTemp]
+	// substitutes for "*".
+	maxTempRandomLen = 10
+
+	// maxTempBaseLen is what a scratch name has left over for the part naming
+	// its destination, once the pattern's literal bytes and the random
+	// component are accounted for.
+	maxTempBaseLen = maxTempNameLen - (len(atomicTempPattern) - 1) - maxTempRandomLen
+)
 
 // WriteFileAtomic writes data to path through a scratch file that replaces path
 // only once the content is on disk. See [StreamFileAtomic] for what that buys and
@@ -40,7 +57,7 @@ func StreamFileAtomic(fsys FS, path string, perm os.FileMode, write func(w io.Wr
 		return err
 	}
 
-	file, err := CreateTemp(fsys, dir, filepath.Base(path)+atomicTempPattern)
+	file, err := CreateTemp(fsys, dir, TempPattern(filepath.Base(path)))
 	if err != nil {
 		return err
 	}
@@ -64,4 +81,29 @@ func StreamFileAtomic(fsys FS, path string, perm os.FileMode, write func(w io.Wr
 	}
 
 	return nil
+}
+
+// TempPattern builds a [CreateTemp] pattern for a scratch file that sits beside
+// a file named base, so one left behind still names what it was written for.
+//
+// base is trimmed as far as it must be for the name CreateTemp expands the
+// pattern into to stay within maxTempNameLen. base can sit at that limit
+// itself, and its scratch file would then be unnameable in the very directory
+// that accepted it.
+func TempPattern(base string) string {
+	if len(base) > maxTempBaseLen {
+		base = base[:maxTempBaseLen]
+
+		// macOS rejects a name holding a partial encoding outright (EILSEQ),
+		// so give back the bytes a cut through the middle of a rune split.
+		for len(base) > 0 {
+			if r, size := utf8.DecodeLastRuneInString(base); r != utf8.RuneError || size > 1 {
+				break
+			}
+
+			base = base[:len(base)-1]
+		}
+	}
+
+	return base + atomicTempPattern
 }

--- a/internal/vfs/atomic.go
+++ b/internal/vfs/atomic.go
@@ -1,0 +1,62 @@
+package vfs
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// atomicTempPattern names the scratch file after its destination so one left
+// behind is traceable, with the random component [CreateTemp] substitutes for "*".
+const atomicTempPattern = ".*.tmp"
+
+// WriteFileAtomic writes data to path through a scratch file that replaces path
+// only once the content is on disk. See [StreamFileAtomic] for what that buys and
+// how perm is applied. The parent directory must already exist.
+func WriteFileAtomic(fsys FS, path string, data []byte, perm os.FileMode) error {
+	return StreamFileAtomic(fsys, path, perm, func(w io.Writer) error {
+		_, err := w.Write(data)
+
+		return err
+	})
+}
+
+// StreamFileAtomic passes a writer to write and renames what it produces onto
+// path. The scratch file shares path's directory so the rename stays on one
+// filesystem, and the parent directory must already exist.
+//
+// Three properties come out of this that a plain [WriteFile] does not have. A
+// reader never sees a half-written file, and a failed write leaves the previous
+// one untouched rather than truncated. A symlink at path is replaced rather than
+// followed, so the content lands where the caller named. An existing file takes
+// perm rather than keeping the mode it already had, which a create cannot do.
+//
+// perm is applied exactly, not masked by the process umask, so a caller asking
+// for a mode wider than 0600 gets it whatever the umask would have allowed.
+func StreamFileAtomic(fsys FS, path string, perm os.FileMode, write func(w io.Writer) error) error {
+	file, err := CreateTemp(fsys, filepath.Dir(path), filepath.Base(path)+atomicTempPattern)
+	if err != nil {
+		return err
+	}
+
+	tmpPath := file.Name()
+
+	if err := fsys.Chmod(tmpPath, perm); err != nil {
+		return errors.Join(err, file.Close(), fsys.Remove(tmpPath))
+	}
+
+	if err := write(file); err != nil {
+		return errors.Join(err, file.Close(), fsys.Remove(tmpPath))
+	}
+
+	if err := file.Close(); err != nil {
+		return errors.Join(err, fsys.Remove(tmpPath))
+	}
+
+	if err := fsys.Rename(tmpPath, path); err != nil {
+		return errors.Join(err, fsys.Remove(tmpPath))
+	}
+
+	return nil
+}

--- a/internal/vfs/atomic_test.go
+++ b/internal/vfs/atomic_test.go
@@ -5,7 +5,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
@@ -151,4 +153,54 @@ func TestStreamFileAtomicConcurrentWithRacing(t *testing.T) {
 	contents, err := vfs.ReadFile(fsys, path)
 	require.NoError(t, err)
 	assert.Contains(t, bodies, string(contents), "the file is a mixture of writers")
+}
+
+// TestWriteFileAtomicNameAtComponentLimit covers a destination whose own name
+// fills the per-component limit, where a scratch name built from it untrimmed
+// would be too long for the directory that just accepted the destination.
+func TestWriteFileAtomicNameAtComponentLimit(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows caps the whole path, not the component, so a maximal name proves nothing here")
+	}
+
+	const nameMax = 255
+
+	testCases := []struct {
+		name string
+		base string
+	}{
+		{
+			name: "single-byte runes",
+			base: strings.Repeat("a", nameMax),
+		},
+		{
+			// The leading byte offsets the runes so the trim falls inside one
+			// of them, which is the cut macOS rejects the name for.
+			name: "multi-byte runes",
+			base: "a" + strings.Repeat("\u00e9", (nameMax-1)/2),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fsys := vfs.NewOSFS()
+			dir := t.TempDir()
+			path := filepath.Join(dir, tc.base)
+
+			require.Len(t, tc.base, nameMax)
+			require.NoError(t, vfs.WriteFileAtomic(fsys, path, []byte("hello"), 0o600))
+
+			contents, err := vfs.ReadFile(fsys, path)
+			require.NoError(t, err)
+			assert.Equal(t, "hello", string(contents))
+
+			entries, err := os.ReadDir(dir)
+			require.NoError(t, err)
+			assert.Len(t, entries, 1, "the scratch file must not outlive the write")
+		})
+	}
 }

--- a/internal/vfs/atomic_test.go
+++ b/internal/vfs/atomic_test.go
@@ -31,6 +31,21 @@ func TestWriteFileAtomic(t *testing.T) {
 	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 }
 
+// TestWriteFileAtomicCreatesParentDirs confirms a destination under a directory
+// that does not exist yet is written rather than failing on the scratch file.
+func TestWriteFileAtomicCreatesParentDirs(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewOSFS()
+	path := filepath.Join(t.TempDir(), "generated", "nested", "out.txt")
+
+	require.NoError(t, vfs.WriteFileAtomic(fsys, path, []byte("hello"), 0o600))
+
+	contents, err := vfs.ReadFile(fsys, path)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(contents))
+}
+
 // TestWriteFileAtomicReplacesSymlink confirms a symlink at the destination is
 // replaced rather than followed, so the content goes to the path that was named.
 func TestWriteFileAtomicReplacesSymlink(t *testing.T) {

--- a/internal/vfs/atomic_test.go
+++ b/internal/vfs/atomic_test.go
@@ -1,0 +1,139 @@
+package vfs_test
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestWriteFileAtomic(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewOSFS()
+	path := filepath.Join(t.TempDir(), "out.txt")
+
+	require.NoError(t, vfs.WriteFileAtomic(fsys, path, []byte("hello"), 0o600))
+
+	contents, err := vfs.ReadFile(fsys, path)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(contents))
+
+	info, err := fsys.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+// TestWriteFileAtomicReplacesSymlink confirms a symlink at the destination is
+// replaced rather than followed, so the content goes to the path that was named.
+func TestWriteFileAtomicReplacesSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	require.NoError(t, os.WriteFile(target, []byte("original"), 0o600))
+
+	path := filepath.Join(dir, "out.txt")
+	require.NoError(t, os.Symlink(target, path))
+
+	require.NoError(t, vfs.WriteFileAtomic(vfs.NewOSFS(), path, []byte("updated"), 0o600))
+
+	contents, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(contents), "the symlink target was written to")
+
+	info, err := os.Lstat(path)
+	require.NoError(t, err)
+	assert.Zero(t, info.Mode()&os.ModeSymlink, "the symlink is still in place")
+}
+
+// TestWriteFileAtomicTightensExistingMode confirms the destination takes perm
+// rather than keeping the mode it already had, which a plain create cannot do for
+// a file that exists.
+func TestWriteFileAtomicTightensExistingMode(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewOSFS()
+	path := filepath.Join(t.TempDir(), "out.txt")
+
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0o644))
+	require.NoError(t, os.Chmod(path, 0o644))
+
+	require.NoError(t, vfs.WriteFileAtomic(fsys, path, []byte("new"), 0o600))
+
+	info, err := fsys.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestStreamFileAtomicLeavesPreviousFileOnFailure(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewOSFS()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.txt")
+
+	require.NoError(t, vfs.WriteFileAtomic(fsys, path, []byte("first"), 0o600))
+
+	sentinel := errors.New("write failed")
+	err := vfs.StreamFileAtomic(fsys, path, 0o600, func(w io.Writer) error {
+		if _, err := io.WriteString(w, "partial"); err != nil {
+			return err
+		}
+
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+
+	contents, err := vfs.ReadFile(fsys, path)
+	require.NoError(t, err)
+	assert.Equal(t, "first", string(contents))
+
+	entries, err := vfs.ReadDir(fsys, dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "a scratch file was left behind")
+}
+
+// TestStreamFileAtomicConcurrentWithRacing pins that the destination holds one
+// writer's content rather than a mixture when several target it at once.
+func TestStreamFileAtomicConcurrentWithRacing(t *testing.T) {
+	t.Parallel()
+
+	const (
+		writers = 8
+		size    = 256 << 10
+	)
+
+	fsys := vfs.NewOSFS()
+	path := filepath.Join(t.TempDir(), "out.txt")
+
+	bodies := make([]string, writers)
+	for i := range bodies {
+		bodies[i] = strconv.Itoa(i) + string(make([]byte, size))
+	}
+
+	group, _ := errgroup.WithContext(t.Context())
+
+	for i := range writers {
+		group.Go(func() error {
+			return vfs.StreamFileAtomic(fsys, path, 0o600, func(w io.Writer) error {
+				_, err := io.WriteString(w, bodies[i])
+
+				return err
+			})
+		})
+	}
+
+	require.NoError(t, group.Wait())
+
+	contents, err := vfs.ReadFile(fsys, path)
+	require.NoError(t, err)
+	assert.Contains(t, bodies, string(contents), "the file is a mixture of writers")
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -769,8 +769,9 @@ func TestNoDefaultForwardingUnknownCommand(t *testing.T) {
 }
 
 // TestTerragruntMutableGenerateBlock verifies that units generating identical
-// contents share one read-only file, and that a block asking to stay mutable
-// gets its own writable copy.
+// contents share one read-only file, that a block asking to stay mutable gets
+// its own writable copy, and that content the store is already holding is
+// shared on the permissions it was stored under.
 func TestTerragruntMutableGenerateBlock(t *testing.T) {
 	t.Parallel()
 
@@ -778,34 +779,110 @@ func TestTerragruntMutableGenerateBlock(t *testing.T) {
 		t.Skip("read-only permission bits are not meaningfully observable on Windows")
 	}
 
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
-	fixtureRoot := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "mutable-generate")
-
-	generated := map[string]os.FileInfo{}
-
-	for _, unit := range []string{"unit-a", "unit-b", "unit-mutable"} {
-		unitPath := filepath.Join(fixtureRoot, unit)
-		helpers.CleanupTerraformFolder(t, unitPath)
-		helpers.CleanupTerragruntFolder(t, unitPath)
-
-		_, _, err := helpers.RunTerragruntCommandWithOutput(
-			t,
-			"terragrunt exec --experiment mutable-generate --working-dir "+unitPath+" -- true",
-		)
-		require.NoError(t, err)
-
-		generated[unit] = statGeneratedFile(t, unitPath, "provider.tf")
+	testCases := []struct {
+		name       string
+		storedPerm os.FileMode
+		wantPerm   os.FileMode
+	}{
+		{
+			name:     "content the store has not seen",
+			wantPerm: 0400,
+		},
+		{
+			name:       "content an earlier version stored world-readable",
+			storedPerm: 0444,
+			wantPerm:   0444,
+		},
 	}
 
-	assert.True(t, os.SameFile(generated["unit-a"], generated["unit-b"]),
-		"units generating identical contents must share one file")
-	assert.Equal(t, os.FileMode(0400), generated["unit-a"].Mode().Perm(),
-		"deduplicated files must be read-only so an edit cannot reach the shared store")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	assert.False(t, os.SameFile(generated["unit-a"], generated["unit-mutable"]),
-		"a mutable generate block must get its own file")
-	assert.NotZero(t, generated["unit-mutable"].Mode().Perm()&0200,
-		"a mutable generate block must stay writable")
+			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureCodegenPath)
+			fixtureRoot := filepath.Join(tmpEnvPath, testFixtureCodegenPath, "mutable-generate")
+
+			units := []string{"unit-a", "unit-b", "unit-mutable"}
+
+			// The store is the one on the machine running the suite, so the
+			// generated contents have to be unique to this run for the case
+			// starting without them to mean anything.
+			for _, unit := range units {
+				markGeneratedContents(t, filepath.Join(fixtureRoot, unit), tmpEnvPath)
+			}
+
+			if tc.storedPerm != 0 {
+				seedStoredContent(t, filepath.Join(fixtureRoot, "unit-a"), tc.storedPerm)
+			}
+
+			generated := map[string]os.FileInfo{}
+
+			for _, unit := range units {
+				unitPath := filepath.Join(fixtureRoot, unit)
+				runMutableGenerateUnit(t, unitPath)
+				generated[unit] = statGeneratedFile(t, unitPath, "provider.tf")
+			}
+
+			assert.True(t, os.SameFile(generated["unit-a"], generated["unit-b"]),
+				"units generating identical contents must share one file")
+			assert.Equal(t, tc.wantPerm, generated["unit-a"].Mode().Perm(),
+				"the shared file takes the mode the store holds the content under")
+
+			assert.False(t, os.SameFile(generated["unit-a"], generated["unit-mutable"]),
+				"a mutable generate block must get its own file")
+			assert.NotZero(t, generated["unit-mutable"].Mode().Perm()&0200,
+				"a mutable generate block must stay writable")
+		})
+	}
+}
+
+// markGeneratedContents rewrites a unit's generate block so what it produces is
+// unique to marker, keeping whatever the machine's store already holds from
+// deciding which path the test takes.
+func markGeneratedContents(t *testing.T, unitPath, marker string) {
+	t.Helper()
+
+	path := filepath.Join(unitPath, "terragrunt.hcl")
+
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	const placeholder = "provider \"null\" {\n}"
+
+	marked := strings.Replace(
+		string(body),
+		placeholder,
+		"provider \"null\" {\n  # "+marker+"\n}",
+		1,
+	)
+	require.NotEqual(t, string(body), marked, "fixture no longer holds %q", placeholder)
+
+	require.NoError(t, os.WriteFile(path, []byte(marked), 0644))
+}
+
+// seedStoredContent leaves the store holding a unit's generated contents at
+// perm, standing in for a store filled before Terragrunt asked for a narrower
+// mode. The generated file shares the stored blob's inode, so widening it
+// through the link widens what every later unit links to.
+func seedStoredContent(t *testing.T, unitPath string, perm os.FileMode) {
+	t.Helper()
+
+	runMutableGenerateUnit(t, unitPath)
+
+	require.NoError(t, os.Chmod(generatedFilePath(t, unitPath, "provider.tf"), perm))
+}
+
+func runMutableGenerateUnit(t *testing.T, unitPath string) {
+	t.Helper()
+
+	helpers.CleanupTerraformFolder(t, unitPath)
+	helpers.CleanupTerragruntFolder(t, unitPath)
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt exec --experiment mutable-generate --working-dir "+unitPath+" -- true",
+	)
+	require.NoError(t, err)
 }
 
 // TestTerragruntMutableGenerateBlockRequiresExperiment verifies that the mutable
@@ -841,7 +918,19 @@ func TestTerragruntMutableGenerateBlockRequiresExperiment(t *testing.T) {
 func statGeneratedFile(t *testing.T, unitPath, name string) os.FileInfo {
 	t.Helper()
 
-	var found os.FileInfo
+	info, err := os.Stat(generatedFilePath(t, unitPath, name))
+	require.NoError(t, err)
+
+	return info
+}
+
+// generatedFilePath finds the file a generate block wrote under a unit's cache
+// directory, whose intermediate directory names are hashes the test cannot
+// predict.
+func generatedFilePath(t *testing.T, unitPath, name string) string {
+	t.Helper()
+
+	var found string
 
 	require.NoError(t, filepath.WalkDir(
 		filepath.Join(unitPath, util.TerragruntCacheDir),
@@ -854,17 +943,12 @@ func statGeneratedFile(t *testing.T, unitPath, name string) os.FileInfo {
 				return nil
 			}
 
-			info, err := d.Info()
-			if err != nil {
-				return err
-			}
-
-			found = info
+			found = path
 
 			return nil
 		},
 	))
-	require.NotNil(t, found, "expected %s to be generated under %s", name, unitPath)
+	require.NotEmpty(t, found, "expected %s to be generated under %s", name, unitPath)
 
 	return found
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -799,7 +799,7 @@ func TestTerragruntMutableGenerateBlock(t *testing.T) {
 
 	assert.True(t, os.SameFile(generated["unit-a"], generated["unit-b"]),
 		"units generating identical contents must share one file")
-	assert.Equal(t, os.FileMode(0444), generated["unit-a"].Mode().Perm(),
+	assert.Equal(t, os.FileMode(0400), generated["unit-a"].Mode().Perm(),
 		"deduplicated files must be read-only so an edit cannot reach the shared store")
 
 	assert.False(t, os.SameFile(generated["unit-a"], generated["unit-mutable"]),


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Writes more generated files atomically to avoid issues from incomplete writes.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when generating configuration, reports, debug files, lockfiles, and other outputs by writing them atomically.
  * Existing files are preserved if generation fails or is interrupted.
  * Replacing files through symlink paths now updates the requested path without modifying the target.
  * Generated files now use secure user-only permissions; shared read-only copies use restricted permissions.
  * Improved handling of long and multibyte filenames and missing parent directories.

* **Documentation**
  * Added v1.1.5 changelog entries describing atomic file generation and updated file permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->