### PR TITLE
chore: Typed stack validation errors and consistent generated-path comparison

### DIFF
--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -608,3 +608,63 @@ func (err EnabledRequiresExperimentError) Error() string {
 // valid: every block may be disabled, or expanded over an empty collection, leaving nothing
 // to generate.
 var ErrStackHasNoComponents = errors.New("stack config must contain at least one unit or stack")
+
+// ComponentKind is the kind of block a stack component was declared as. The values reach
+// users verbatim in validation messages.
+type ComponentKind string
+
+const (
+	ComponentKindUnit  ComponentKind = "unit"
+	ComponentKindStack ComponentKind = "stack"
+)
+
+// ComponentFieldEmptyError is returned when a unit or stack leaves a required attribute
+// empty.
+type ComponentFieldEmptyError struct {
+	Kind  ComponentKind
+	Field string
+	Name  string
+	Index int
+}
+
+func (err ComponentFieldEmptyError) Error() string {
+	// The label names a component in every other message, so one missing its label has to be
+	// identified by position.
+	if err.Name == "" {
+		return fmt.Sprintf("%s at index %d has empty %s", err.Kind, err.Index, err.Field)
+	}
+
+	return fmt.Sprintf("%s '%s' has empty %s", err.Kind, err.Name, err.Field)
+}
+
+// DuplicateComponentNameError is returned when two units or two stacks in one file claim the
+// same address, leaving no way to reference one of them.
+type DuplicateComponentNameError struct {
+	Kind ComponentKind
+	Name string
+}
+
+func (err DuplicateComponentNameError) Error() string {
+	return fmt.Sprintf("duplicate %s name found: '%s'", err.Kind, err.Name)
+}
+
+// DuplicateComponentPathError is returned when two units or two stacks generate into the
+// same directory.
+type DuplicateComponentPathError struct {
+	Kind ComponentKind
+	Path string
+}
+
+func (err DuplicateComponentPathError) Error() string {
+	return fmt.Sprintf("duplicate %s path found: '%s'", err.Kind, err.Path)
+}
+
+// ComponentPathCollisionError is returned when a unit and a stack generate into the same
+// directory.
+type ComponentPathCollisionError struct {
+	Path string
+}
+
+func (err ComponentPathCollisionError) Error() string {
+	return fmt.Sprintf("duplicate path found across unit and stack: '%s'", err.Path)
+}

--- a/pkg/config/stack_validation.go
+++ b/pkg/config/stack_validation.go
@@ -1,24 +1,22 @@
 package config
 
 import (
-	"fmt"
-	"strings"
-
 	"errors"
+	"strings"
 )
 
 // ValidateStackConfig validates the components a StackConfigFile resolved to, according to
 // the rules:
 // - Unit name, source, and path shouldn't be empty
 // - Unit names should be unique
-// - Units shouldn't have duplicate paths
+// - Units shouldn't generate to duplicate paths
 // - Stack name, source, and path shouldn't be empty
 // - Stack names should be unique
-// - Stack shouldn't have duplicate paths
+// - Stacks shouldn't generate to duplicate paths
 // - A unit and a stack shouldn't generate to the same path
 //
-// stackDir is the directory containing the stack file; it is used to compute the
-// generated on-disk path of each unit and stack for the cross-kind collision check.
+// Components are validated after expansion. The names compared are keyed addresses, and the
+// paths compared are the directories each component generates into under stackDir.
 //
 // Resolving to no components at all is valid here: a file that declares blocks which all
 // expand to zero elements or set enabled to false has nothing to generate, and
@@ -28,198 +26,167 @@ func ValidateStackConfig(config *StackConfigFile, stackDir string) error {
 		return errors.New("stack config cannot be nil")
 	}
 
+	units := unitViews(config.Units, stackDir)
+	stacks := stackViews(config.Stacks, stackDir)
+
+	return errors.Join(
+		validateComponents(units, ComponentKindUnit),
+		validateComponents(stacks, ComponentKindStack),
+		validateCrossKindPaths(units, stacks),
+	)
+}
+
+// componentView is how stack validation reads a unit or stack. The two kinds carry the same
+// fields and obey the same uniqueness rules, so one implementation checks both.
+//
+// [decodeUnitBlocks] and [decodeStackBlocks] construct every element they return, and the
+// autoinclude merge only passes those values along, so the slices read here hold no nil
+// components.
+type componentView struct {
+	label         string
+	address       string
+	source        string
+	generatedPath string
+}
+
+func unitViews(units []*Unit, stackDir string) []componentView {
+	views := make([]componentView, len(units))
+
+	for i, u := range units {
+		label := strings.TrimSpace(u.Name)
+
+		views[i] = componentView{
+			label:         label,
+			address:       componentAddress(label, u.Expansion),
+			source:        strings.TrimSpace(u.Source),
+			generatedPath: generatedPathOrEmpty(u.Path, u.GeneratedPath(stackDir)),
+		}
+	}
+
+	return views
+}
+
+func stackViews(stacks []*Stack, stackDir string) []componentView {
+	views := make([]componentView, len(stacks))
+
+	for i, s := range stacks {
+		label := strings.TrimSpace(s.Name)
+
+		views[i] = componentView{
+			label:         label,
+			address:       componentAddress(label, s.Expansion),
+			source:        strings.TrimSpace(s.Source),
+			generatedPath: generatedPathOrEmpty(s.Path, s.GeneratedPath(stackDir)),
+		}
+	}
+
+	return views
+}
+
+// generatedPathOrEmpty returns the empty string for a component that declared no path.
+// Joining an empty path lands on the stack directory itself, so two components that both
+// omit path would otherwise compare equal and be reported as colliding.
+func generatedPathOrEmpty(rawPath, generatedPath string) string {
+	if strings.TrimSpace(rawPath) == "" {
+		return ""
+	}
+
+	return generatedPath
+}
+
+// validateComponents reports the components of one kind that are missing a required field
+// or that collide with each other on address or generated path.
+func validateComponents(views []componentView, kind ComponentKind) error {
 	var validationErrors []error
 
-	if err := validateUnits(config.Units); err != nil {
-		validationErrors = append(validationErrors, err)
-	}
+	addresses := make(map[string]struct{}, len(views))
+	paths := make(map[string]struct{}, len(views))
 
-	if err := validateStacks(config.Stacks); err != nil {
-		validationErrors = append(validationErrors, err)
-	}
+	for i, view := range views {
+		// Ordered rather than ranged over a map so a component missing more than one field
+		// reports them in the same order every run.
+		for _, required := range []struct {
+			field string
+			value string
+		}{
+			{field: "name", value: view.label},
+			{field: "source", value: view.source},
+			{field: "path", value: view.generatedPath},
+		} {
+			if required.value != "" {
+				continue
+			}
 
-	if err := validateCrossKindPaths(config.Units, config.Stacks, stackDir); err != nil {
-		validationErrors = append(validationErrors, err)
+			validationErrors = append(validationErrors, ComponentFieldEmptyError{
+				Kind:  kind,
+				Field: required.field,
+				Name:  view.address,
+				Index: i,
+			})
+		}
+
+		if view.label != "" {
+			if _, duplicate := addresses[view.address]; duplicate {
+				validationErrors = append(
+					validationErrors,
+					DuplicateComponentNameError{Kind: kind, Name: view.address},
+				)
+			}
+
+			addresses[view.address] = struct{}{}
+		}
+
+		if view.generatedPath != "" {
+			if _, duplicate := paths[view.generatedPath]; duplicate {
+				validationErrors = append(
+					validationErrors,
+					DuplicateComponentPathError{Kind: kind, Path: view.generatedPath},
+				)
+			}
+
+			paths[view.generatedPath] = struct{}{}
+		}
 	}
 
 	return errors.Join(validationErrors...)
 }
 
 // validateCrossKindPaths reports a generated path used by both a unit and a stack, since both
-// components generate into the same on-disk directory and would collide. The comparison uses
-// the normalized GeneratedPath (honoring no_dot_terragrunt_stack and path cleaning), not the raw
-// path string, so it neither misses real collisions nor flags non-colliding raw strings.
-// Within-kind duplicates are already reported by validateUnits and validateStacks.
-func validateCrossKindPaths(units []*Unit, stacks []*Stack, stackDir string) error {
-	unitGenPaths := make(map[string]struct{}, len(units))
+// components generate into the same on-disk directory and would collide. Within-kind
+// duplicates are already reported by [validateComponents].
+func validateCrossKindPaths(units, stacks []componentView) error {
+	unitPaths := make(map[string]struct{}, len(units))
 
 	for _, u := range units {
-		if u == nil {
+		if u.generatedPath == "" {
 			continue
 		}
 
-		if strings.TrimSpace(u.Path) == "" {
-			continue
-		}
-
-		unitGenPaths[u.GeneratedPath(stackDir)] = struct{}{}
+		unitPaths[u.generatedPath] = struct{}{}
 	}
 
-	validationErrors := make([]error, 0, len(stacks))
+	var validationErrors []error
 
 	reported := make(map[string]struct{})
 
 	for _, s := range stacks {
-		if s == nil {
+		if s.generatedPath == "" {
 			continue
 		}
 
-		if strings.TrimSpace(s.Path) == "" {
+		if _, collides := unitPaths[s.generatedPath]; !collides {
 			continue
 		}
 
-		genPath := s.GeneratedPath(stackDir)
-
-		if _, collides := unitGenPaths[genPath]; !collides {
+		if _, seen := reported[s.generatedPath]; seen {
 			continue
 		}
 
-		if _, seen := reported[genPath]; seen {
-			continue
-		}
-
-		reported[genPath] = struct{}{}
+		reported[s.generatedPath] = struct{}{}
 		validationErrors = append(
 			validationErrors,
-			fmt.Errorf("duplicate path found across unit and stack: '%s'", genPath),
+			ComponentPathCollisionError{Path: s.generatedPath},
 		)
-	}
-
-	return errors.Join(validationErrors...)
-}
-
-// validateUnits validates all units in the configuration
-func validateUnits(units []*Unit) error {
-	return validateConfigElementsGeneric(
-		units,
-		"unit",
-		func(element any, i int) (string, string, string) {
-			unit := element.(*Unit)
-			return componentAddress(unit.Name, unit.Expansion), unit.Path, unit.Source
-		},
-	)
-}
-
-// validateStacks validates all stacks in the configuration
-func validateStacks(stacks []*Stack) error {
-	return validateConfigElementsGeneric(
-		stacks,
-		"stack",
-		func(element any, i int) (string, string, string) {
-			stack := element.(*Stack)
-			return componentAddress(stack.Name, stack.Expansion), stack.Path, stack.Source
-		},
-	)
-}
-
-// validateConfigElementsGeneric is a generic function to validate configuration elements
-// It takes a slice of elements, the element type name, and a function to extract name, path, and source from an element
-func validateConfigElementsGeneric(
-	elements any,
-	elementType string,
-	getValues func(element any, index int) (name, path, source string),
-) error {
-	var validationErrors []error
-
-	var slice []any
-
-	// Convert to []any storing nil pointers as untyped nil so the element==nil guard below catches them.
-	switch v := elements.(type) {
-	case []*Unit:
-		slice = make([]any, len(v))
-		for i, unit := range v {
-			if unit == nil {
-				continue
-			}
-
-			slice[i] = unit
-		}
-	case []*Stack:
-		slice = make([]any, len(v))
-		for i, stack := range v {
-			if stack == nil {
-				continue
-			}
-
-			slice[i] = stack
-		}
-	default:
-		return errors.New("unknown element type")
-	}
-
-	names := make(map[string]bool, len(slice))
-	paths := make(map[string]bool, len(slice))
-
-	for i, element := range slice {
-		if element == nil {
-			validationErrors = append(
-				validationErrors,
-				fmt.Errorf("%s at index %d is nil", elementType, i),
-			)
-
-			continue
-		}
-
-		name, path, source := getValues(element, i)
-		name = strings.TrimSpace(name)
-		path = strings.TrimSpace(path)
-		source = strings.TrimSpace(source)
-
-		// Validate name, source, and path
-		if name == "" {
-			validationErrors = append(
-				validationErrors,
-				fmt.Errorf("%s at index %d has empty name", elementType, i),
-			)
-		}
-
-		if source == "" {
-			validationErrors = append(
-				validationErrors,
-				fmt.Errorf("%s '%s' has empty source", elementType, name),
-			)
-		}
-
-		if path == "" {
-			validationErrors = append(
-				validationErrors,
-				fmt.Errorf("%s '%s' has empty path", elementType, name),
-			)
-		}
-
-		// Check for duplicates
-		if names[name] {
-			validationErrors = append(
-				validationErrors,
-				fmt.Errorf("duplicate %s name found: '%s'", elementType, name),
-			)
-		}
-
-		if paths[path] {
-			validationErrors = append(
-				validationErrors,
-				fmt.Errorf("duplicate %s path found: '%s'", elementType, path),
-			)
-		}
-
-		// Save non-empty values for uniqueness check
-		if name != "" {
-			names[name] = true
-		}
-
-		if path != "" {
-			paths[path] = true
-		}
 	}
 
 	return errors.Join(validationErrors...)

--- a/pkg/config/stack_validation_test.go
+++ b/pkg/config/stack_validation_test.go
@@ -20,282 +20,237 @@ import (
 func TestValidateStackConfig(t *testing.T) {
 	t.Parallel()
 
+	genPath := func(path string) string {
+		return inthclparse.GeneratedComponentPath("/stack", path, false)
+	}
+
 	tests := []struct {
-		name    string
+		wantErr error
 		config  *config.StackConfigFile
-		wantErr string
+		name    string
 	}{
 		{
 			name: "valid config",
 			config: &config.StackConfigFile{
 				Units: []*config.Unit{
-					{
-						Name:   "unit1",
-						Source: "source1",
-						Path:   "path1",
-					},
-					{
-						Name:   "unit2",
-						Source: "source2",
-						Path:   "path2",
-					},
+					{Name: "unit1", Source: "source1", Path: "path1"},
+					{Name: "unit2", Source: "source2", Path: "path2"},
 				},
 			},
-			wantErr: "",
 		},
 		{
 			name: "config that resolved to no components",
 			config: &config.StackConfigFile{
 				Units: []*config.Unit{},
 			},
-			wantErr: "",
 		},
 		{
 			name: "empty unit name",
 			config: &config.StackConfigFile{
 				Units: []*config.Unit{
-					{
-						Name:   "",
-						Source: "source1",
-						Path:   "path1",
-					},
+					{Name: "", Source: "source1", Path: "path1"},
 				},
 			},
-			wantErr: "unit at index 0 has empty name",
+			wantErr: config.ComponentFieldEmptyError{Kind: config.ComponentKindUnit, Field: "name"},
 		},
 		{
 			name: "whitespace unit name",
 			config: &config.StackConfigFile{
 				Units: []*config.Unit{
-					{
-						Name:   "  ",
-						Source: "source1",
-						Path:   "path1",
-					},
+					{Name: "  ", Source: "source1", Path: "path1"},
 				},
 			},
-			wantErr: "unit at index 0 has empty name",
+			wantErr: config.ComponentFieldEmptyError{Kind: config.ComponentKindUnit, Field: "name"},
 		},
 		{
 			name: "empty unit source",
 			config: &config.StackConfigFile{
 				Units: []*config.Unit{
-					{
-						Name:   "unit1",
-						Source: "",
-						Path:   "path1",
-					},
+					{Name: "unit1", Source: "", Path: "path1"},
 				},
 			},
-			wantErr: "unit 'unit1' has empty source",
+			wantErr: config.ComponentFieldEmptyError{
+				Kind:  config.ComponentKindUnit,
+				Field: "source",
+				Name:  "unit1",
+			},
 		},
 		{
 			name: "whitespace unit source",
 			config: &config.StackConfigFile{
 				Units: []*config.Unit{
-					{
-						Name:   "unit1",
-						Source: "   ",
-						Path:   "path1",
-					},
+					{Name: "unit1", Source: "   ", Path: "path1"},
 				},
 			},
-			wantErr: "unit 'unit1' has empty source",
+			wantErr: config.ComponentFieldEmptyError{
+				Kind:  config.ComponentKindUnit,
+				Field: "source",
+				Name:  "unit1",
+			},
 		},
 		{
 			name: "empty unit path",
 			config: &config.StackConfigFile{
 				Units: []*config.Unit{
-					{
-						Name:   "unit1",
-						Source: "source1",
-						Path:   "",
-					},
+					{Name: "unit1", Source: "source1", Path: ""},
 				},
 			},
-			wantErr: "unit 'unit1' has empty path",
+			wantErr: config.ComponentFieldEmptyError{
+				Kind:  config.ComponentKindUnit,
+				Field: "path",
+				Name:  "unit1",
+			},
 		},
 		{
 			name: "whitespace unit path",
 			config: &config.StackConfigFile{
 				Units: []*config.Unit{
-					{
-						Name:   "unit1",
-						Source: "source1",
-						Path:   "  ",
-					},
+					{Name: "unit1", Source: "source1", Path: "  "},
 				},
 			},
-			wantErr: "unit 'unit1' has empty path",
+			wantErr: config.ComponentFieldEmptyError{
+				Kind:  config.ComponentKindUnit,
+				Field: "path",
+				Name:  "unit1",
+			},
 		},
 		{
 			name: "duplicate unit names",
 			config: &config.StackConfigFile{
 				Units: []*config.Unit{
-					{
-						Name:   "unit1",
-						Source: "source1",
-						Path:   "path1",
-					},
-					{
-						Name:   "unit1",
-						Source: "source2",
-						Path:   "path2",
-					},
+					{Name: "unit1", Source: "source1", Path: "path1"},
+					{Name: "unit1", Source: "source2", Path: "path2"},
 				},
 			},
-			wantErr: "duplicate unit name found: 'unit1'",
+			wantErr: config.DuplicateComponentNameError{Kind: config.ComponentKindUnit, Name: "unit1"},
 		},
 		{
 			name: "duplicate unit paths",
 			config: &config.StackConfigFile{
 				Units: []*config.Unit{
-					{
-						Name:   "unit1",
-						Source: "source1",
-						Path:   "path1",
-					},
-					{
-						Name:   "unit2",
-						Source: "source2",
-						Path:   "path1",
-					},
+					{Name: "unit1", Source: "source1", Path: "path1"},
+					{Name: "unit2", Source: "source2", Path: "path1"},
 				},
 			},
-			wantErr: "duplicate unit path found: 'path1'",
+			wantErr: config.DuplicateComponentPathError{
+				Kind: config.ComponentKindUnit,
+				Path: genPath("path1"),
+			},
 		},
-
+		{
+			name: "unit paths that differ only before cleaning",
+			config: &config.StackConfigFile{
+				Units: []*config.Unit{
+					{Name: "unit1", Source: "source1", Path: "./path1"},
+					{Name: "unit2", Source: "source2", Path: "path1"},
+				},
+			},
+			wantErr: config.DuplicateComponentPathError{
+				Kind: config.ComponentKindUnit,
+				Path: genPath("path1"),
+			},
+		},
 		{
 			name: "valid config with stacks",
 			config: &config.StackConfigFile{
 				Stacks: []*config.Stack{
-					{
-						Name:   "stack1",
-						Source: "source1",
-						Path:   "path1",
-					},
-					{
-						Name:   "stack2",
-						Source: "source2",
-						Path:   "path2",
-					},
+					{Name: "stack1", Source: "source1", Path: "path1"},
+					{Name: "stack2", Source: "source2", Path: "path2"},
 				},
 			},
-			wantErr: "",
 		},
 		{
 			name: "empty stack name",
 			config: &config.StackConfigFile{
 				Stacks: []*config.Stack{
-					{
-						Name:   "",
-						Source: "source1",
-						Path:   "path1",
-					},
+					{Name: "", Source: "source1", Path: "path1"},
 				},
 			},
-			wantErr: "stack at index 0 has empty name",
+			wantErr: config.ComponentFieldEmptyError{Kind: config.ComponentKindStack, Field: "name"},
 		},
 		{
 			name: "whitespace stack name",
 			config: &config.StackConfigFile{
 				Stacks: []*config.Stack{
-					{
-						Name:   "  ",
-						Source: "source1",
-						Path:   "path1",
-					},
+					{Name: "  ", Source: "source1", Path: "path1"},
 				},
 			},
-			wantErr: "stack at index 0 has empty name",
+			wantErr: config.ComponentFieldEmptyError{Kind: config.ComponentKindStack, Field: "name"},
 		},
 		{
 			name: "empty stack source",
 			config: &config.StackConfigFile{
 				Stacks: []*config.Stack{
-					{
-						Name:   "stack1",
-						Source: "",
-						Path:   "path1",
-					},
+					{Name: "stack1", Source: "", Path: "path1"},
 				},
 			},
-			wantErr: "stack 'stack1' has empty source",
+			wantErr: config.ComponentFieldEmptyError{
+				Kind:  config.ComponentKindStack,
+				Field: "source",
+				Name:  "stack1",
+			},
 		},
 		{
 			name: "whitespace stack source",
 			config: &config.StackConfigFile{
 				Stacks: []*config.Stack{
-					{
-						Name:   "stack1",
-						Source: "   ",
-						Path:   "path1",
-					},
+					{Name: "stack1", Source: "   ", Path: "path1"},
 				},
 			},
-			wantErr: "stack 'stack1' has empty source",
+			wantErr: config.ComponentFieldEmptyError{
+				Kind:  config.ComponentKindStack,
+				Field: "source",
+				Name:  "stack1",
+			},
 		},
 		{
 			name: "empty stack path",
 			config: &config.StackConfigFile{
 				Stacks: []*config.Stack{
-					{
-						Name:   "stack1",
-						Source: "source1",
-						Path:   "",
-					},
+					{Name: "stack1", Source: "source1", Path: ""},
 				},
 			},
-			wantErr: "stack 'stack1' has empty path",
+			wantErr: config.ComponentFieldEmptyError{
+				Kind:  config.ComponentKindStack,
+				Field: "path",
+				Name:  "stack1",
+			},
 		},
 		{
 			name: "whitespace stack path",
 			config: &config.StackConfigFile{
 				Stacks: []*config.Stack{
-					{
-						Name:   "stack1",
-						Source: "source1",
-						Path:   "  ",
-					},
+					{Name: "stack1", Source: "source1", Path: "  "},
 				},
 			},
-			wantErr: "stack 'stack1' has empty path",
+			wantErr: config.ComponentFieldEmptyError{
+				Kind:  config.ComponentKindStack,
+				Field: "path",
+				Name:  "stack1",
+			},
 		},
 		{
 			name: "duplicate stack names",
 			config: &config.StackConfigFile{
 				Stacks: []*config.Stack{
-					{
-						Name:   "stack1",
-						Source: "source1",
-						Path:   "path1",
-					},
-					{
-						Name:   "stack1",
-						Source: "source2",
-						Path:   "path2",
-					},
+					{Name: "stack1", Source: "source1", Path: "path1"},
+					{Name: "stack1", Source: "source2", Path: "path2"},
 				},
 			},
-			wantErr: "duplicate stack name found: 'stack1'",
+			wantErr: config.DuplicateComponentNameError{Kind: config.ComponentKindStack, Name: "stack1"},
 		},
 		{
 			name: "duplicate stack paths",
 			config: &config.StackConfigFile{
 				Stacks: []*config.Stack{
-					{
-						Name:   "stack1",
-						Source: "source1",
-						Path:   "path1",
-					},
-					{
-						Name:   "stack2",
-						Source: "source2",
-						Path:   "path1",
-					},
+					{Name: "stack1", Source: "source1", Path: "path1"},
+					{Name: "stack2", Source: "source2", Path: "path1"},
 				},
 			},
-			wantErr: "duplicate stack path found: 'path1'",
+			wantErr: config.DuplicateComponentPathError{
+				Kind: config.ComponentKindStack,
+				Path: genPath("path1"),
+			},
 		},
 	}
 
@@ -304,11 +259,13 @@ func TestValidateStackConfig(t *testing.T) {
 			t.Parallel()
 
 			err := config.ValidateStackConfig(tt.config, "/stack")
-			if tt.wantErr != "" {
-				assert.Contains(t, err.Error(), tt.wantErr)
-			} else {
-				assert.NoError(t, err)
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+
+				return
 			}
+
+			require.ErrorIs(t, err, tt.wantErr)
 		})
 	}
 }
@@ -387,8 +344,9 @@ func TestValidateStackConfigCrossKindPathCollision(t *testing.T) {
 	}
 
 	err := config.ValidateStackConfig(cfg, "/stack")
-	require.Error(t, err, "a unit and a stack sharing a generated path must be rejected")
-	require.Contains(t, err.Error(), "collide")
+	require.ErrorIs(t, err, config.ComponentPathCollisionError{
+		Path: inthclparse.GeneratedComponentPath("/stack", "collide", false),
+	})
 }
 
 // TestValidateStackConfigCrossKindEqualRawPathNoStackNoCollision proves the cross-kind check
@@ -424,28 +382,14 @@ func TestValidateStackConfigCrossKindDifferentRawSameGeneratedCollision(t *testi
 	}
 
 	err := config.ValidateStackConfig(cfg, "/stack")
-	require.Error(
+	require.ErrorIs(
 		t,
 		err,
+		config.ComponentPathCollisionError{
+			Path: inthclparse.GeneratedComponentPath("/stack", "shared", true),
+		},
 		"different raw paths cleaning to the same generated dir must be flagged as a collision",
 	)
-}
-
-// TestValidateStackConfigNilElementDoesNotPanic proves a nil unit or stack element is skipped by the
-// cross-kind check (reported as nil by the generic validator) instead of panicking before that error surfaces.
-func TestValidateStackConfigNilElementDoesNotPanic(t *testing.T) {
-	t.Parallel()
-
-	cfg := &config.StackConfigFile{
-		Units:  []*config.Unit{nil, {Name: "a", Source: "src-a", Path: "x"}},
-		Stacks: []*config.Stack{nil, {Name: "b", Source: "src-b", Path: "y"}},
-	}
-
-	require.NotPanics(t, func() {
-		err := config.ValidateStackConfig(cfg, "/stack")
-		require.Error(t, err, "nil elements must surface as a validation error, not a panic")
-		require.Contains(t, err.Error(), "is nil")
-	})
 }
 
 // TestStackAutoIncludeBackstopPopulatesTypedErrorFields covers the pkg/config backstop in
@@ -1008,4 +952,115 @@ unit "vpc" {
 		"anchor",
 		"the injected path must resolve unit.anchor.path against the base component",
 	)
+}
+
+// TestValidateStackConfigExpandedUnitsCollidingOnPath pins that two elements of one expanded
+// block collide when their paths interpolate to the same string. The elements carry distinct
+// addresses, so the name check passes and only the path check catches them.
+func TestValidateStackConfigExpandedUnitsCollidingOnPath(t *testing.T) {
+	t.Parallel()
+
+	err := parseStackErr(t, `
+unit "app" {
+  expansion {
+    for_each = {
+      a = "shared"
+      b = "shared"
+    }
+  }
+
+  source = "./units/app"
+  path   = "app/${each.value}"
+}
+`)
+
+	require.ErrorIs(t, err, config.DuplicateComponentPathError{
+		Kind: config.ComponentKindUnit,
+		Path: inthclparse.GeneratedComponentPath(".", "app/shared", false),
+	})
+}
+
+// TestValidateStackConfigExpandedStacksCollidingOnPath is the stack-block counterpart, where
+// the path omits count.index so every element targets one directory.
+func TestValidateStackConfigExpandedStacksCollidingOnPath(t *testing.T) {
+	t.Parallel()
+
+	err := parseStackErr(t, `
+stack "team" {
+  expansion {
+    count = 2
+  }
+
+  source = "./stacks/team"
+  path   = "team"
+}
+`)
+
+	require.ErrorIs(t, err, config.DuplicateComponentPathError{
+		Kind: config.ComponentKindStack,
+		Path: inthclparse.GeneratedComponentPath(".", "team", false),
+	})
+}
+
+// TestValidateStackConfigExpandedComponentsKeepDistinctAddresses guards the other
+// direction. Every element of an expanded block carries the label the block was written
+// with, so comparing labels alone would reject a valid block.
+func TestValidateStackConfigExpandedComponentsKeepDistinctAddresses(t *testing.T) {
+	t.Parallel()
+
+	stackCfg, err := parseStackString(t, `
+unit "app" {
+  expansion {
+    for_each = toset(["web", "api"])
+  }
+
+  source = "./units/app"
+  path   = "app/${each.value}"
+}
+`)
+
+	require.NoError(t, err)
+	assert.Len(t, stackCfg.Units, 2)
+}
+
+// TestValidateStackConfigExpandedUnitCollidesWithStack pins that the cross-kind check reads
+// expanded components too, so an element can collide with a statically declared stack.
+func TestValidateStackConfigExpandedUnitCollidesWithStack(t *testing.T) {
+	t.Parallel()
+
+	err := parseStackErr(t, `
+unit "app" {
+  expansion {
+    for_each = toset(["web"])
+  }
+
+  source = "./units/app"
+  path   = each.value
+}
+
+stack "web" {
+  source = "./stacks/web"
+  path   = "web"
+}
+`)
+
+	require.ErrorIs(t, err, config.ComponentPathCollisionError{
+		Path: inthclparse.GeneratedComponentPath(".", "web", false),
+	})
+}
+
+// TestValidateStackConfigSameRawPathDifferentGeneratedDirs pins the within-kind side of the
+// no_dot_terragrunt_stack case. Two units whose raw paths match generate to different
+// directories when one is hoisted out, so they do not collide.
+func TestValidateStackConfigSameRawPathDifferentGeneratedDirs(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.StackConfigFile{
+		Units: []*config.Unit{
+			{Name: "a", Source: "src-a", Path: "x"},
+			{Name: "b", Source: "src-b", Path: "x", NoStack: new(true)},
+		},
+	}
+
+	require.NoError(t, config.ValidateStackConfig(cfg, "/stack"))
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds improved error handling for stack generation collisions, and better handles collisions for collisions that can happen because of expansion.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer validation errors for missing fields, duplicate component names or paths, and unit/stack path conflicts.
  * Validation now distinguishes between labeled and unlabeled components for more actionable messages.

* **Bug Fixes**
  * Improved path normalization and collision detection across units and stacks.
  * Preserved distinct component addresses when paths differ after normalization.

* **Tests**
  * Expanded coverage for duplicate paths, cross-component collisions, and generated path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->