### PR TITLE
chore: Validating device auth duration better

### DIFF
--- a/internal/portal/deviceauth.go
+++ b/internal/portal/deviceauth.go
@@ -132,7 +132,8 @@ func parseDeviceAuthorization(r io.Reader) (*DeviceAuthorization, error) {
 		}
 	}
 
-	if parsed.ExpiresIn <= 0 {
+	expiresIn, ok := secondsToDuration(parsed.ExpiresIn)
+	if !ok {
 		return nil, fmt.Errorf("%w: unusable expires_in of %d", ErrMalformedResponse, parsed.ExpiresIn)
 	}
 
@@ -148,8 +149,8 @@ func parseDeviceAuthorization(r io.Reader) (*DeviceAuthorization, error) {
 		}
 	}
 
-	interval := time.Duration(parsed.Interval) * time.Second
-	if interval <= 0 {
+	interval, ok := secondsToDuration(parsed.Interval)
+	if !ok {
 		interval = defaultPollInterval
 	}
 
@@ -158,7 +159,7 @@ func parseDeviceAuthorization(r io.Reader) (*DeviceAuthorization, error) {
 		UserCode:                parsed.UserCode,
 		VerificationURI:         parsed.VerificationURI,
 		VerificationURIComplete: parsed.VerificationURIComplete,
-		ExpiresIn:               time.Duration(parsed.ExpiresIn) * time.Second,
+		ExpiresIn:               expiresIn,
 		Interval:                interval,
 	}, nil
 }
@@ -201,6 +202,10 @@ func checkBrowsable(rawURL string) error {
 
 	if parsed.Scheme != "https" && parsed.Scheme != "http" {
 		return fmt.Errorf("%w: verification URL %q is not an HTTP URL", ErrMalformedResponse, rawURL)
+	}
+
+	if parsed.Host == "" {
+		return fmt.Errorf("%w: verification URL %q names no host", ErrMalformedResponse, rawURL)
 	}
 
 	return nil

--- a/internal/portal/deviceauth_test.go
+++ b/internal/portal/deviceauth_test.go
@@ -113,6 +113,29 @@ func TestAuthorizeDeviceDefaultsInterval(t *testing.T) {
 	assert.Empty(t, auth.VerificationURIComplete)
 }
 
+// TestAuthorizeDeviceDefaultsOverflowingInterval pins that a polling interval
+// that overflows a [time.Duration] falls back to the default. The interval here
+// wraps to roughly forty-nine years, which is positive, so a check for a
+// negative wait would let it through.
+func TestAuthorizeDeviceDefaultsOverflowingInterval(t *testing.T) {
+	t.Parallel()
+
+	body := `{
+		"device_code": "fake-device-code",
+		"user_code": "FAKE-CODE",
+		"verification_uri": "https://portal.example.com/auth/device",
+		"expires_in": 600,
+		"interval": 20000000000
+	}`
+
+	c := respondJSON(nil, http.StatusOK, body, nil)
+
+	auth, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "https://portal.example.com")
+	require.NoError(t, err)
+
+	assert.Equal(t, 5*time.Second, auth.Interval)
+}
+
 func TestAuthorizeDeviceRejectsUnusableResponse(t *testing.T) {
 	t.Parallel()
 
@@ -135,6 +158,16 @@ func TestAuthorizeDeviceRejectsUnusableResponse(t *testing.T) {
 			name: "unbrowsable complete verification uri",
 			body: `{"device_code":"fake-device-code","user_code":"FAKE-CODE","verification_uri":"https://p.example.com/d",` +
 				`"verification_uri_complete":"file:///fake/path","expires_in":600}`,
+		},
+		{
+			name: "hostless verification uri",
+			body: `{"device_code":"fake-device-code","user_code":"FAKE-CODE","verification_uri":"https:///auth/device",` +
+				`"expires_in":600}`,
+		},
+		{
+			name: "overflowing expires_in",
+			body: `{"device_code":"fake-device-code","user_code":"FAKE-CODE","verification_uri":"https://p.example.com/d",` +
+				`"expires_in":20000000000}`,
 		},
 	}
 
@@ -278,25 +311,32 @@ func TestAuthorizeDeviceReportsRefusal(t *testing.T) {
 	}
 }
 
-// TestAuthorizeDeviceIgnoresUnreadableRetryAfter pins that the HTTP-date form of
-// Retry-After, which the portal does not send, reads as no advice rather than as
-// an immediate retry.
-func TestAuthorizeDeviceIgnoresUnreadableRetryAfter(t *testing.T) {
+// TestAuthorizeDeviceIgnoresUnusableRetryAfter pins that a Retry-After the CLI
+// cannot act on reads as no advice rather than as an immediate retry: the
+// HTTP-date form, which the portal does not send, and a delta-seconds count
+// that overflows a [time.Duration].
+func TestAuthorizeDeviceIgnoresUnusableRetryAfter(t *testing.T) {
 	t.Parallel()
 
-	c := respondJSON(
-		nil,
-		http.StatusTooManyRequests,
-		`{"error":"slow_down"}`,
-		http.Header{"Retry-After": {"Wed, 21 Oct 2026 07:28:00 GMT"}},
-	)
+	for _, header := range []string{"Wed, 21 Oct 2026 07:28:00 GMT", "20000000000"} {
+		t.Run(header, func(t *testing.T) {
+			t.Parallel()
 
-	_, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "https://portal.example.com")
+			c := respondJSON(
+				nil,
+				http.StatusTooManyRequests,
+				`{"error":"slow_down"}`,
+				http.Header{"Retry-After": {header}},
+			)
 
-	var portalErr *portal.Error
-	require.ErrorAs(t, err, &portalErr)
+			_, err := portal.AuthorizeDevice(t.Context(), logger.CreateLogger(), c, "https://portal.example.com")
 
-	assert.Zero(t, portalErr.RetryAfter)
+			var portalErr *portal.Error
+			require.ErrorAs(t, err, &portalErr)
+
+			assert.Zero(t, portalErr.RetryAfter)
+		})
+	}
 }
 
 // truncatedReader serves prefix and then fails, standing in for a connection

--- a/internal/portal/errors.go
+++ b/internal/portal/errors.go
@@ -104,13 +104,18 @@ func newError(resp *http.Response, body io.Reader) *Error {
 }
 
 // retryAfter reads the delta-seconds form of Retry-After (RFC 9110 §10.2.3),
-// which is what the portal sends. An HTTP-date, or a header the portal omitted,
-// reads as no advice.
+// which is what the portal sends. An HTTP-date, a count that overflows a
+// [time.Duration], or a header the portal omitted, reads as no advice.
 func retryAfter(header http.Header) time.Duration {
 	seconds, err := strconv.Atoi(header.Get("Retry-After"))
-	if err != nil || seconds < 0 {
+	if err != nil {
 		return 0
 	}
 
-	return time.Duration(seconds) * time.Second
+	delay, ok := secondsToDuration(int64(seconds))
+	if !ok {
+		return 0
+	}
+
+	return delay
 }

--- a/internal/portal/portal.go
+++ b/internal/portal/portal.go
@@ -14,6 +14,11 @@
 // [RFC 8628]: https://datatracker.ietf.org/doc/html/rfc8628
 package portal
 
+import (
+	"math"
+	"time"
+)
+
 const (
 	// DefaultBaseURL addresses the production Gruntwork Developer Portal. A
 	// preview or local deployment answers on its own host, so every URL in a
@@ -54,4 +59,19 @@ func (s Secret) GoString() string {
 // Reveal returns the credential, for the request that has to carry it.
 func (s Secret) Reveal() string {
 	return string(s)
+}
+
+// maxDurationSeconds is the largest whole-second count that fits in a
+// [time.Duration].
+const maxDurationSeconds = math.MaxInt64 / int64(time.Second)
+
+// secondsToDuration reads a wait the portal reported in whole seconds. A count
+// that overflows a [time.Duration] wraps to an unrelated wait, so it is
+// rejected along with the counts that are zero or negative.
+func secondsToDuration(n int64) (time.Duration, bool) {
+	if n <= 0 || n > maxDurationSeconds {
+		return 0, false
+	}
+
+	return time.Duration(n) * time.Second, true
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Addresses review feedback in #6759.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device authorization handling for unusually large or invalid expiration and polling intervals.
  - Verification URLs are now rejected when they use an unsupported scheme or lack a valid host.
  - Invalid or unrepresentable `Retry-After` values no longer cause excessive or unusable delays.
  - Device authorization continues using safe defaults when polling guidance cannot be interpreted reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->