### PR TITLE
chore: Adding injectable cap to speed up `TestUnitPathsFromStackDir_DepthCapReturnsError` test

### DIFF
--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -401,7 +401,7 @@ func stackDependencyPaths(
 			continue
 		}
 
-		unitPaths, err := inthclparse.UnitPathsFromStackDir(v.FS, depPath, funcsFor)
+		unitPaths, err := inthclparse.UnitPathsFromStackDir(v.FS, depPath, &inthclparse.StackDirArgs{FuncsFor: funcsFor})
 		if err != nil {
 			return nil, NewStackDependencyExpansionError(depPath, err)
 		}

--- a/internal/hclparse/fuzz_test.go
+++ b/internal/hclparse/fuzz_test.go
@@ -306,7 +306,7 @@ func FuzzUnitPathsFromStackDir_ArgPanics(f *testing.F) {
 			}
 		}()
 
-		_, _ = hclparse.UnitPathsFromStackDir(fs, stackDir, noFuncs)
+		_, _ = hclparse.UnitPathsFromStackDir(fs, stackDir, &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	})
 }
 
@@ -460,6 +460,6 @@ func FuzzUnitPathsFromStackDir_AutoIncludeContent(f *testing.F) {
 			0644,
 		)
 
-		_, _ = hclparse.UnitPathsFromStackDir(fs, "/fuzz", noFuncs)
+		_, _ = hclparse.UnitPathsFromStackDir(fs, "/fuzz", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	})
 }

--- a/internal/hclparse/panic_test.go
+++ b/internal/hclparse/panic_test.go
@@ -64,20 +64,31 @@ func TestParseStackFileFromPath_EmptyStackDir_Panics(t *testing.T) {
 func TestUnitPathsFromStackDir_NilFS_Panics(t *testing.T) {
 	t.Parallel()
 	assertPanicsContaining(t, "hclparse.UnitPathsFromStackDir: fsys is nil", func() {
-		_, _ = hclparse.UnitPathsFromStackDir(nil, "/x", noFuncs)
+		_, _ = hclparse.UnitPathsFromStackDir(nil, "/x", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	})
 }
 
 func TestUnitPathsFromStackDir_EmptyStackDir_Panics(t *testing.T) {
 	t.Parallel()
 	assertPanicsContaining(t, "hclparse.UnitPathsFromStackDir: stackDir is empty", func() {
-		_, _ = hclparse.UnitPathsFromStackDir(vfs.NewMemMapFS(), "", noFuncs)
+		_, _ = hclparse.UnitPathsFromStackDir(
+			vfs.NewMemMapFS(),
+			"",
+			&hclparse.StackDirArgs{FuncsFor: noFuncs},
+		)
 	})
 }
 
 func TestUnitPathsFromStackDir_NilFuncsFactory_Panics(t *testing.T) {
 	t.Parallel()
 	assertPanicsContaining(t, "hclparse.UnitPathsFromStackDir: funcsFor is nil", func() {
+		_, _ = hclparse.UnitPathsFromStackDir(vfs.NewMemMapFS(), "/x", &hclparse.StackDirArgs{})
+	})
+}
+
+func TestUnitPathsFromStackDir_NilArgs_Panics(t *testing.T) {
+	t.Parallel()
+	assertPanicsContaining(t, "hclparse.UnitPathsFromStackDir: args is nil", func() {
 		_, _ = hclparse.UnitPathsFromStackDir(vfs.NewMemMapFS(), "/x", nil)
 	})
 }

--- a/internal/hclparse/stack.go
+++ b/internal/hclparse/stack.go
@@ -192,10 +192,10 @@ func ParseStackFileFromPath(fsys vfs.FS, stackDir string) (*ParseResult, error) 
 	})
 }
 
-// maxStackRecursionDepth bounds nested-stack expansion so a pathological tree (a path
+// defaultMaxStackRecursionDepth bounds nested-stack expansion so a pathological tree (a path
 // escaping via "..", or a symlink loop EvalSymlinks cannot canonicalize) cannot recurse
 // without end. Real generated nesting is only a handful of levels deep.
-const maxStackRecursionDepth = 1000
+const defaultMaxStackRecursionDepth = 1000
 
 // StackFuncFactory builds the HCL function map used while decoding the stack file
 // in a given stack directory. Each nesting level rebuilds the map for its own dir
@@ -205,14 +205,30 @@ const maxStackRecursionDepth = 1000
 // exercise only literal attributes return an empty map.
 type StackFuncFactory func(stackDir string) (map[string]function.Function, error)
 
+// StackDirArgs bundles the shared arguments for nested-stack expansion.
+type StackDirArgs struct {
+	FuncsFor StackFuncFactory
+	MaxDepth int
+}
+
+// maxDepth returns the recursion bound to enforce, falling back to
+// defaultMaxStackRecursionDepth when the caller leaves MaxDepth unset.
+func (args *StackDirArgs) maxDepth() int {
+	if args.MaxDepth > 0 {
+		return args.MaxDepth
+	}
+
+	return defaultMaxStackRecursionDepth
+}
+
 // UnitPathsFromStackDir returns generated unit paths from discovery parsing. Nested stacks
 // are expanded recursively so a stack composed of sub-stacks yields the sub-stacks' units.
-// funcsFor builds the dir-scoped HCL function map for each stack directory visited; it
+// args.FuncsFor builds the dir-scoped HCL function map for each stack directory visited; it
 // must be non-nil and must return a non-nil map.
 func UnitPathsFromStackDir(
 	fsys vfs.FS,
 	stackDir string,
-	funcsFor StackFuncFactory,
+	args *StackDirArgs,
 ) ([]string, error) {
 	if fsys == nil {
 		panic(fmt.Sprintf("hclparse.UnitPathsFromStackDir: fsys is nil (stackDir=%q)", stackDir))
@@ -222,13 +238,17 @@ func UnitPathsFromStackDir(
 		panic("hclparse.UnitPathsFromStackDir: stackDir is empty")
 	}
 
-	if funcsFor == nil {
+	if args == nil {
+		panic(fmt.Sprintf("hclparse.UnitPathsFromStackDir: args is nil (stackDir=%q)", stackDir))
+	}
+
+	if args.FuncsFor == nil {
 		panic(
 			fmt.Sprintf("hclparse.UnitPathsFromStackDir: funcsFor is nil (stackDir=%q)", stackDir),
 		)
 	}
 
-	return unitPathsFromStackDir(fsys, stackDir, funcsFor, make(map[string]struct{}), 0)
+	return unitPathsFromStackDir(fsys, stackDir, args, make(map[string]struct{}), 0)
 }
 
 // DirectComponentPaths returns the generated on-disk paths of the direct unit and
@@ -293,13 +313,14 @@ func DirectComponentPaths(
 func unitPathsFromStackDir(
 	fsys vfs.FS,
 	stackDir string,
-	funcsFor StackFuncFactory,
+	args *StackDirArgs,
 	visited map[string]struct{},
 	depth int,
 ) ([]string, error) {
-	if depth > maxStackRecursionDepth {
+	maxDepth := args.maxDepth()
+	if depth > maxDepth {
 		return nil, StackRecursionDepthExceededError{
-			MaxDepth: maxStackRecursionDepth,
+			MaxDepth: maxDepth,
 			StackDir: stackDir,
 		}
 	}
@@ -315,7 +336,7 @@ func unitPathsFromStackDir(
 	stackFile := filepath.Join(stackDir, stackFileName)
 
 	// Rebuild the function map for this dir so dir-sensitive functions resolve against it.
-	funcs, err := funcsFor(stackDir)
+	funcs, err := args.FuncsFor(stackDir)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +373,7 @@ func unitPathsFromStackDir(
 			stack.NoStack != nil && *stack.NoStack,
 		)
 
-		nestedPaths, nestedErr := unitPathsFromStackDir(fsys, nestedDir, funcsFor, visited, depth+1)
+		nestedPaths, nestedErr := unitPathsFromStackDir(fsys, nestedDir, args, visited, depth+1)
 		if nestedErr != nil {
 			return nil, nestedErr
 		}

--- a/internal/hclparse/stack_test.go
+++ b/internal/hclparse/stack_test.go
@@ -50,7 +50,7 @@ unit "db" {
 }
 `), 0644))
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.NoError(t, err)
 	require.Len(t, paths, 2)
 	assert.Contains(t, paths[0], ".terragrunt-stack")
@@ -78,7 +78,7 @@ func TestUnitPathsFromStackDir_RecursesNestedStacks(t *testing.T) {
 `), 0644),
 	)
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -108,7 +108,7 @@ unit "vpc" {
 	require.NoError(t, vfs.WriteFile(fs, "/test/terragrunt.values.hcl", []byte(`env = "dev"
 `), 0644))
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.NoError(
 		t,
 		err,
@@ -135,7 +135,7 @@ unit "vpc" {
 }
 `), 0644))
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.NoError(t, err)
 	assert.Equal(t, []string{filepath.Join("/test", ".terragrunt-stack", "prod-vpc")}, paths)
 }
@@ -158,7 +158,7 @@ unit "vpc" {
 }
 `), 0644))
 
-	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.Error(
 		t,
 		err,
@@ -213,7 +213,7 @@ unit "deep" {
 		),
 	)
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -245,7 +245,7 @@ func TestUnitPathsFromStackDir_MalformedValuesFileReturnsError(t *testing.T) {
 `), 0644))
 	require.NoError(t, vfs.WriteFile(fs, "/test/terragrunt.values.hcl", []byte(`env = `), 0644))
 
-	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.Error(t, err)
 
 	var typed hclparse.FileParseError
@@ -275,7 +275,7 @@ func TestUnitPathsFromStackDir_MergesStackAutoInclude(t *testing.T) {
 `), 0644),
 	)
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.NoError(t, err)
 	require.Len(
 		t,
@@ -310,7 +310,7 @@ func TestUnitPathsFromStackDir_StackAutoIncludePathReferencesSiblingRef(t *testi
 `), 0644),
 	)
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.NoError(
 		t,
 		err,
@@ -348,7 +348,7 @@ func TestUnitPathsFromStackDir_RecursesStackAutoIncludeInjectedStack(t *testing.
 `), 0644),
 	)
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.NoError(t, err)
 	assert.Contains(t, paths, filepath.Join("/test", ".terragrunt-stack", "vpc"))
 	assert.Contains(
@@ -384,7 +384,7 @@ func TestUnitPathsFromStackDir_StackAutoIncludeDepValuesRejected(t *testing.T) {
 `), 0644),
 	)
 
-	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.Error(
 		t,
 		err,
@@ -422,7 +422,7 @@ func TestUnitPathsFromStackDir_StackAutoIncludeSameNameOverrides(t *testing.T) {
 `), 0644),
 	)
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.NoError(
 		t,
 		err,
@@ -451,7 +451,7 @@ unit "vpc" {
 }
 `), 0644))
 
-	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.Error(
 		t,
 		err,
@@ -490,7 +490,7 @@ unit "vpc" {
 `), 0644),
 	)
 
-	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.Error(
 		t,
 		err,
@@ -529,7 +529,7 @@ unit "extra" {
 `), 0644),
 	)
 
-	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.Error(
 		t,
 		err,
@@ -563,7 +563,7 @@ unit "extra" {
 }
 `), 0644))
 
-	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.Error(
 		t,
 		err,
@@ -605,7 +605,7 @@ unit "extra" {
 `), 0644),
 	)
 
-	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.Error(
 		t,
 		err,
@@ -642,7 +642,7 @@ func TestUnitPathsFromStackDir_FuncFactoryRebuiltPerNestedDir(t *testing.T) {
 		return map[string]function.Function{}, nil
 	}
 
-	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", funcsFor)
+	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: funcsFor})
 	require.NoError(t, err)
 
 	nested := filepath.Join("/test", ".terragrunt-stack", "more")
@@ -672,7 +672,9 @@ func TestUnitPathsFromStackDir_NilFuncsFactoryMapPanics(t *testing.T) {
 
 	assert.PanicsWithValue(t,
 		`hclparse.UnitPathsFromStackDir: funcsFor returned a nil map (stackDir="/test")`,
-		func() { _, _ = hclparse.UnitPathsFromStackDir(fs, "/test", nilMapFactory) },
+		func() {
+			_, _ = hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: nilMapFactory})
+		},
 	)
 }
 
@@ -689,7 +691,7 @@ func TestUnitPathsFromStackDir_CycleTerminates(t *testing.T) {
 }
 `), 0644))
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.NoError(t, err)
 	assert.Empty(t, paths)
 }
@@ -697,12 +699,17 @@ func TestUnitPathsFromStackDir_CycleTerminates(t *testing.T) {
 func TestUnitPathsFromStackDir_DepthCapReturnsError(t *testing.T) {
 	t.Parallel()
 
+	// Resolving each nested dir walks its whole prefix, so building the chain at the
+	// production cap of 1000 costs a million filesystem calls. The cap under test is
+	// the one MaxDepth sets, so a shallow chain exercises the same branch.
+	const maxDepth = 8
+
 	fs := vfs.NewMemMapFS()
 
-	// Build a chain deeper than the recursion cap, every level a distinct path so the
-	// visited set never collapses it; only the depth cap can stop the recursion.
+	// Build a chain deeper than the cap, every level a distinct path so the visited
+	// set never collapses it; only the depth cap can stop the recursion.
 	dir := "/test"
-	for range 1002 {
+	for range maxDepth + 2 {
 		require.NoError(t, fs.MkdirAll(dir, 0755))
 		require.NoError(
 			t,
@@ -715,11 +722,15 @@ func TestUnitPathsFromStackDir_DepthCapReturnsError(t *testing.T) {
 		dir = filepath.Join(dir, ".terragrunt-stack", "next")
 	}
 
-	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{
+		FuncsFor: noFuncs,
+		MaxDepth: maxDepth,
+	})
 	require.Error(t, err)
 
 	var depthErr hclparse.StackRecursionDepthExceededError
 	require.ErrorAs(t, err, &depthErr)
+	assert.Equal(t, maxDepth, depthErr.MaxDepth, "the configured cap is the one enforced")
 }
 
 func TestUnitPathsFromStackDir_WithIncludedUnits(t *testing.T) {
@@ -739,7 +750,7 @@ include "units" {
 }
 `), 0644))
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.NoError(t, err)
 	require.Len(t, paths, 1)
 	assert.Contains(t, paths[0], filepath.Join(hclparse.StackDir, "vpc"))
@@ -757,7 +768,7 @@ unit "vpc" {
 }
 `), 0644))
 
-	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	_, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get_repo_root")
 }
@@ -768,7 +779,7 @@ func TestUnitPathsFromStackDir_NotAStack(t *testing.T) {
 	fs := vfs.NewMemMapFS()
 	require.NoError(t, fs.MkdirAll("/test", 0755))
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.NoError(t, err)
 	assert.Nil(t, paths)
 }
@@ -778,7 +789,7 @@ func TestUnitPathsFromStackDir_Nonexistent(t *testing.T) {
 
 	fs := vfs.NewMemMapFS()
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/nonexistent", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/nonexistent", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.NoError(t, err)
 	assert.Nil(t, paths)
 }
@@ -793,7 +804,7 @@ func TestUnitPathsFromStackDir_MalformedReturnsError(t *testing.T) {
 		vfs.WriteFile(fs, "/test/terragrunt.stack.hcl", []byte(`unit "x" { source = "." `), 0644),
 	)
 
-	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(fs, "/test", &hclparse.StackDirArgs{FuncsFor: noFuncs})
 	require.Error(t, err)
 	assert.Nil(t, paths)
 
@@ -896,7 +907,11 @@ unit "vpc" {
 	symlinkDir := filepath.Join(tmpDir, "symlinked-stack")
 	require.NoError(t, os.Symlink(realDir, symlinkDir))
 
-	paths, err := hclparse.UnitPathsFromStackDir(vfs.NewOSFS(), symlinkDir, noFuncs)
+	paths, err := hclparse.UnitPathsFromStackDir(
+		vfs.NewOSFS(),
+		symlinkDir,
+		&hclparse.StackDirArgs{FuncsFor: noFuncs},
+	)
 	require.NoError(t, err)
 	require.Len(t, paths, 1)
 	// Path should resolve to the real directory, not the symlink path.

--- a/pkg/config/early_stack_eval_test.go
+++ b/pkg/config/early_stack_eval_test.go
@@ -291,7 +291,11 @@ unit "vpc" {
 		return config.EarlyStackParseFunctions(t.Context(), logger.CreateLogger(), dir, pctx)
 	}
 
-	paths, err := inthclparse.UnitPathsFromStackDir(vfs.NewOSFS(), stackDir, funcsFor)
+	paths, err := inthclparse.UnitPathsFromStackDir(
+		vfs.NewOSFS(),
+		stackDir,
+		&inthclparse.StackDirArgs{FuncsFor: funcsFor},
+	)
 	require.NoError(t, err)
 	require.Len(t, paths, 1)
 	// basename(dirname(.../root.hcl)) == basename(tmpRoot); resolve symlinks
@@ -330,7 +334,11 @@ unit "vpc" {
 		return config.EarlyStackParseFunctions(t.Context(), logger.CreateLogger(), dir, pctx)
 	}
 
-	paths, err := inthclparse.UnitPathsFromStackDir(vfs.NewOSFS(), stackDir, funcsFor)
+	paths, err := inthclparse.UnitPathsFromStackDir(
+		vfs.NewOSFS(),
+		stackDir,
+		&inthclparse.StackDirArgs{FuncsFor: funcsFor},
+	)
 	require.NoError(t, err)
 	require.Len(t, paths, 1)
 	assert.True(

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -367,7 +367,7 @@ func TestStackDepsDAGExpandsStackToUnits(t *testing.T) {
 	unitPaths, err := inthclparse.UnitPathsFromStackDir(
 		vfs.NewOSFS(),
 		stackDir,
-		stackDepsFuncsFor(ctx, l, pctx),
+		&inthclparse.StackDirArgs{FuncsFor: stackDepsFuncsFor(ctx, l, pctx)},
 	)
 	require.NoError(t, err)
 	require.Len(t, unitPaths, 2, "networking stack should expand to 2 unit paths")
@@ -410,7 +410,7 @@ func TestStackDepsUnitPathsFromNestedOnlyStack(t *testing.T) {
 	unitPaths, err := inthclparse.UnitPathsFromStackDir(
 		vfs.NewOSFS(),
 		root,
-		stackDepsFuncsFor(ctx, l, pctx),
+		&inthclparse.StackDirArgs{FuncsFor: stackDepsFuncsFor(ctx, l, pctx)},
 	)
 	require.NoError(t, err)
 
@@ -436,7 +436,7 @@ func TestStackDepsUnitPathsFromMissingStackFile(t *testing.T) {
 	unitPaths, err := inthclparse.UnitPathsFromStackDir(
 		vfs.NewOSFS(),
 		root,
-		stackDepsFuncsFor(ctx, l, pctx),
+		&inthclparse.StackDirArgs{FuncsFor: stackDepsFuncsFor(ctx, l, pctx)},
 	)
 	require.NoError(t, err)
 	assert.Empty(t, unitPaths, "a directory without a stack file expands to no unit paths")


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Leverages an injectable cap for max symlink depth so that we can test `TestUnitPathsFromStackDir_DepthCapReturnsError` without actually creating a 1000+ deep symlink.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for nested stack discovery, helping control recursion depth during stack dependency resolution.
  * Improved validation and error reporting for invalid stack traversal configuration.

* **Tests**
  * Expanded coverage for recursion limits, invalid arguments, and nested stack dependency discovery.
  * Updated existing tests to support the enhanced stack traversal configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->