### PR TITLE
fix(cliconfig): isolate cloned helpers and hosts

### DIFF
--- a/internal/tf/cliconfig/config.go
+++ b/internal/tf/cliconfig/config.go
@@ -126,12 +126,24 @@ func (cfg *Config) Clone() *Config {
 	var providerInstallation *ProviderInstallation
 
 	hosts := make([]ConfigHost, 0, len(cfg.Hosts))
-
-	hosts = append(hosts, cfg.Hosts...)
+	for _, host := range cfg.Hosts {
+		hosts = append(hosts, ConfigHost{
+			Name:     host.Name,
+			Services: maps.Clone(host.Services),
+		})
+	}
 
 	if cfg.ProviderInstallation != nil {
 		providerInstallation = &ProviderInstallation{
 			Methods: cfg.ProviderInstallation.Methods.Clone(),
+		}
+	}
+
+	var credentialsHelpers *ConfigCredentialsHelper
+	if cfg.CredentialsHelpers != nil {
+		credentialsHelpers = &ConfigCredentialsHelper{
+			Name: cfg.CredentialsHelpers.Name,
+			Args: slices.Clone(cfg.CredentialsHelpers.Args),
 		}
 	}
 
@@ -140,7 +152,7 @@ func (cfg *Config) Clone() *Config {
 		DisableCheckpoint:          cfg.DisableCheckpoint,
 		DisableCheckpointSignature: cfg.DisableCheckpointSignature,
 		Credentials:                slices.Clone(cfg.Credentials),
-		CredentialsHelpers:         cfg.CredentialsHelpers,
+		CredentialsHelpers:         credentialsHelpers,
 		Hosts:                      hosts,
 		ProviderInstallation:       providerInstallation,
 		fsys:                       cfg.fsys,

--- a/internal/tf/cliconfig/config_test.go
+++ b/internal/tf/cliconfig/config_test.go
@@ -228,3 +228,38 @@ func TestCloneCredentialsAreIndependent(t *testing.T) {
 	assert.Equal(t, "real-token", original.Credentials[0].Token)
 	assert.Equal(t, "substituted-token", clone.Credentials[0].Token)
 }
+
+// TestCloneCredentialsHelpersAreIndependent pins that rewriting a clone's helper
+// args leaves the source config untouched.
+func TestCloneCredentialsHelpersAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	original := cliconfig.NewConfig(vfs.NewMemMapFS())
+	original.CredentialsHelpers = &cliconfig.ConfigCredentialsHelper{
+		Name: "my-helper",
+		Args: []string{"arg1", "arg2"},
+	}
+
+	clone := original.Clone()
+	clone.CredentialsHelpers.Args[0] = "modified"
+
+	assert.Equal(t, "arg1", original.CredentialsHelpers.Args[0])
+	assert.Equal(t, "modified", clone.CredentialsHelpers.Args[0])
+}
+
+// TestCloneHostsServicesAreIndependent pins that rewriting a clone's host
+// services map leaves the source config untouched.
+func TestCloneHostsServicesAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	original := cliconfig.NewConfig(vfs.NewMemMapFS())
+	original.AddHost("registry.example.com", map[string]string{
+		"providers.v1": "https://old.example.com/",
+	})
+
+	clone := original.Clone()
+	clone.Hosts[0].Services["providers.v1"] = "https://new.example.com/"
+
+	assert.Equal(t, "https://old.example.com/", original.Hosts[0].Services["providers.v1"])
+	assert.Equal(t, "https://new.example.com/", clone.Hosts[0].Services["providers.v1"])
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Included changes:
  - Deep-copy CredentialsHelpers Args in Clone
  - Clone each host Services map independently
  - Add regression tests for clone independence

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration cloning so copied configurations remain fully independent.
  * Prevented changes to cloned host services or credential helper arguments from affecting the original configuration.

* **Tests**
  * Added coverage verifying independent copies of host services and credential helper arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->