### PR TITLE
docs: Updating docs for supported flags on `dag graph`

### DIFF
--- a/docs/src/content/docs/03-features/08-filter/index.mdx
+++ b/docs/src/content/docs/03-features/08-filter/index.mdx
@@ -81,6 +81,7 @@ The following commands all support the `--filter` flag using the same filtering 
 - [hcl validate](/reference/cli/commands/hcl/validate)
 - [stack run](/reference/cli/commands/stack/run)
 - [stack generate](/reference/cli/commands/stack/generate)
+- [dag graph](/reference/cli/commands/dag/graph)
 
 This flag is intended to be a flexible way to target specific infrastructure that allows you to dry-run infrastructure targeting using discovery commands (like `find` and `list`) before running a command that actually affects infrastructure (like `run`).
 

--- a/docs/src/data/commands/dag/graph.mdx
+++ b/docs/src/data/commands/dag/graph.mdx
@@ -22,6 +22,10 @@ examples:
   - description: Graph all dependencies in visual diagram.
     code: |
       $ terragrunt dag graph  | dot -Tpng > graph.png
+flags:
+  - filter
+  - filter-affected
+  - discovery-boundary
 
 ---
 

--- a/docs/src/data/flags/filter.mdx
+++ b/docs/src/data/flags/filter.mdx
@@ -195,14 +195,13 @@ type=unit
 
 ## Supported Commands
 
-Currently supported in:
 - [find](/reference/cli/commands/find)
 - [list](/reference/cli/commands/list)
 - [run](/reference/cli/commands/run)
 - [hcl fmt](/reference/cli/commands/hcl/fmt)
 - [hcl validate](/reference/cli/commands/hcl/validate)
-
-Planned for future releases:
+- [stack run](/reference/cli/commands/stack/run)
+- [stack generate](/reference/cli/commands/stack/generate)
 - [dag graph](/reference/cli/commands/dag/graph)
 
 ## Learn More


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Updates docs for `dag graph`. It's currently listed as "planned" for `--filter` support, but it already supports it.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented filtering support for the `dag graph` command.
  - Added documentation for `filter`, `filter-affected`, and `discovery-boundary` options.
  - Updated the filter flag documentation to include `stack run` and `stack generate` as supported commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->