### PR TITLE
fix: Use partial parse when possible for backend commands

### DIFF
--- a/docs/src/data/changelog/v1.1.5/backend-unapplied-dependency.mdx
+++ b/docs/src/data/changelog/v1.1.5/backend-unapplied-dependency.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### `backend` commands no longer fail on unapplied dependencies
+
+[`backend bootstrap`](/reference/cli/commands/backend/bootstrap), [`backend migrate`](/reference/cli/commands/backend/migrate) and [`backend delete`](/reference/cli/commands/backend/delete) used to read the whole configuration of every unit they touched, which meant fetching the outputs of every `dependency` block. Declaring a dependency on a unit you had not applied yet was enough to stop them with the "detected no outputs" error, even when nothing in `remote_state` read that dependency.
+
+These commands now read only the `remote_state` block and the `terraform` block's `source`. They never fetch dependency outputs. A `remote_state` that does read a dependency output still resolves it, and still reports missing outputs when the dependency has not been applied.

--- a/pkg/config/catalog.go
+++ b/pkg/config/catalog.go
@@ -54,8 +54,8 @@ func (cfg *CatalogConfig) String() string {
 	)
 }
 
-func (cfg *CatalogConfig) normalize(fsys vfs.FS, configPath string) {
-	configDir := filepath.Dir(configPath)
+func (cfg *CatalogConfig) normalize(fsys vfs.FS, cfgPath string) {
+	configDir := filepath.Dir(cfgPath)
 
 	// transform relative paths to absolute ones
 	for i, url := range cfg.URLs {
@@ -90,20 +90,20 @@ func ReadCatalogConfig(
 	l log.Logger,
 	pctx *ParsingContext,
 ) (*CatalogConfig, error) {
-	configPath, configString, err := findCatalogConfig(parentCtx, l, pctx)
-	if err != nil || configPath == "" {
+	cfgPath, configString, err := findCatalogConfig(parentCtx, l, pctx)
+	if err != nil || cfgPath == "" {
 		return nil, err
 	}
 
 	pctx = pctx.Clone()
-	pctx.TerragruntConfigPath = configPath
+	pctx.TerragruntConfigPath = cfgPath
 	pctx.ParserOptions = append(
 		pctx.ParserOptions,
 		hclparse.WithHaltOnErrorOnlyForBlocks([]string{MetadataCatalog}),
 	)
 	pctx.ConvertToTerragruntConfigFunc = convertToTerragruntCatalogConfig
 
-	config, err := ParseConfigString(parentCtx, pctx, l, configPath, configString, nil)
+	config, err := ParseConfigString(parentCtx, pctx, l, cfgPath, configString, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func findCatalogConfig(
 	outerPctx *ParsingContext,
 ) (string, string, error) {
 	var (
-		configPath = filepath.Join(
+		cfgPath = filepath.Join(
 			filepath.Dir(outerPctx.TerragruntConfigPath),
 			outerPctx.ScaffoldRootFileName,
 		)
@@ -136,7 +136,7 @@ func findCatalogConfig(
 
 		parseCtx, pctx := NewParsingContext(ctx, l, outerPctx.Venv, WithStrictControls(outerPctx.StrictControls))
 		pctx.TerragruntConfigPath = filepath.Join(
-			filepath.Dir(configPath),
+			filepath.Dir(cfgPath),
 			util.UniqueID(),
 			configName,
 		)
@@ -167,16 +167,16 @@ func findCatalogConfig(
 			catalogConfigPath = newConfigPath
 		}
 
-		configPath = filepath.Dir(newConfigPath)
+		cfgPath = filepath.Dir(newConfigPath)
 	}
 
 	// if the config with the `catalog` block is found, create the root config with `include{ find_in_parent_folders() }`
 	// and the path one directory deeper in order for `find_in_parent_folders` can find the catalog configuration.
 	if catalogConfigPath != "" {
 		configString := fmt.Sprintf(rootConfigFmt, configName)
-		configPath = filepath.Join(filepath.Dir(catalogConfigPath), util.UniqueID(), configName)
+		cfgPath = filepath.Join(filepath.Dir(catalogConfigPath), util.UniqueID(), configName)
 
-		return configPath, configString, nil
+		return cfgPath, configString, nil
 	}
 
 	return "", "", nil
@@ -185,33 +185,31 @@ func findCatalogConfig(
 func convertToTerragruntCatalogConfig(
 	ctx context.Context,
 	pctx *ParsingContext,
-	configPath string,
-	terragruntConfigFromFile *terragruntConfigFile,
+	cfgPath string,
+	cfgFromFile *terragruntConfigFile,
 ) (cfg *TerragruntConfig, err error) {
-	var (
-		terragruntConfig = &TerragruntConfig{}
-		defaultMetadata  = map[string]any{FoundInFile: configPath}
-	)
+	cfg = &TerragruntConfig{}
+	defaultMetadata := map[string]any{FoundInFile: cfgPath}
 
-	if terragruntConfigFromFile.Catalog != nil {
-		terragruntConfig.Catalog = terragruntConfigFromFile.Catalog
-		terragruntConfig.Catalog.normalize(pctx.Venv.FS, configPath)
-		terragruntConfig.SetFieldMetadata(MetadataCatalog, defaultMetadata)
+	if cfgFromFile.Catalog != nil {
+		cfg.Catalog = cfgFromFile.Catalog
+		cfg.Catalog.normalize(pctx.Venv.FS, cfgPath)
+		cfg.SetFieldMetadata(MetadataCatalog, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.Engine != nil {
-		terragruntConfig.Engine = terragruntConfigFromFile.Engine
-		terragruntConfig.SetFieldMetadata(MetadataEngine, defaultMetadata)
+	if cfgFromFile.Engine != nil {
+		cfg.Engine = cfgFromFile.Engine
+		cfg.SetFieldMetadata(MetadataEngine, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.Exclude != nil {
-		terragruntConfig.Exclude = terragruntConfigFromFile.Exclude
-		terragruntConfig.SetFieldMetadata(MetadataExclude, defaultMetadata)
+	if cfgFromFile.Exclude != nil {
+		cfg.Exclude = cfgFromFile.Exclude
+		cfg.SetFieldMetadata(MetadataExclude, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.Errors != nil {
-		terragruntConfig.Errors = terragruntConfigFromFile.Errors
-		terragruntConfig.SetFieldMetadata(MetadataErrors, defaultMetadata)
+	if cfgFromFile.Errors != nil {
+		cfg.Errors = cfgFromFile.Errors
+		cfg.SetFieldMetadata(MetadataErrors, defaultMetadata)
 	}
 
 	if pctx.Locals != nil && *pctx.Locals != cty.NilVal {
@@ -221,10 +219,10 @@ func convertToTerragruntCatalogConfig(
 		localsParsed, _ := ctyhelper.ParseCtyValueToMap(*pctx.Locals)
 		// Only set Locals if there are actual values to avoid setting an empty map
 		if len(localsParsed) > 0 {
-			terragruntConfig.Locals = localsParsed
-			terragruntConfig.SetFieldMetadataMap(MetadataLocals, localsParsed, defaultMetadata)
+			cfg.Locals = localsParsed
+			cfg.SetFieldMetadataMap(MetadataLocals, localsParsed, defaultMetadata)
 		}
 	}
 
-	return terragruntConfig, nil
+	return cfg, nil
 }

--- a/pkg/config/catalog.go
+++ b/pkg/config/catalog.go
@@ -134,7 +134,12 @@ func findCatalogConfig(
 		default: // continue
 		}
 
-		parseCtx, pctx := NewParsingContext(ctx, l, outerPctx.Venv, WithStrictControls(outerPctx.StrictControls))
+		parseCtx, pctx := NewParsingContext(
+			ctx,
+			l,
+			outerPctx.Venv,
+			WithStrictControls(outerPctx.StrictControls),
+		)
 		pctx.TerragruntConfigPath = filepath.Join(
 			filepath.Dir(cfgPath),
 			util.UniqueID(),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2073,6 +2073,23 @@ func getIndexOfExtraArgsWithName(extraArgs []TerraformExtraArguments, name strin
 	return -1
 }
 
+// remoteStateFromAttr decodes a `remote_state` written as an attribute rather than a block.
+// JSON configs produce the attribute form.
+func remoteStateFromAttr(attr cty.Value) (*remotestate.RemoteState, error) {
+	remoteStateMap, err := ctyhelper.ParseCtyValueToMap(attr)
+	if err != nil {
+		return nil, err
+	}
+
+	var config *remotestate.Config
+
+	if err := mapstructure.WeakDecode(remoteStateMap, &config); err != nil {
+		return nil, err
+	}
+
+	return remotestate.New(config), nil
+}
+
 // Convert the contents of a fully resolved Terragrunt configuration to a TerragruntConfig object
 func convertToTerragruntConfig(
 	ctx context.Context,
@@ -2105,19 +2122,12 @@ func convertToTerragruntConfig(
 	}
 
 	if terragruntConfigFromFile.RemoteStateAttr != nil {
-		remoteStateMap, err := ctyhelper.ParseCtyValueToMap(
-			*terragruntConfigFromFile.RemoteStateAttr,
-		)
+		remoteState, err := remoteStateFromAttr(*terragruntConfigFromFile.RemoteStateAttr)
 		if err != nil {
 			return nil, err
 		}
 
-		var config *remotestate.Config
-		if err := mapstructure.WeakDecode(remoteStateMap, &config); err != nil {
-			return nil, err
-		}
-
-		terragruntConfig.RemoteState = remotestate.New(config)
+		terragruntConfig.RemoteState = remoteState
 		terragruntConfig.SetFieldMetadata(MetadataRemoteState, defaultMetadata)
 	}
 
@@ -2752,12 +2762,65 @@ func ParseRemoteState(
 	l log.Logger,
 	pctx *ParsingContext,
 ) (*remotestate.RemoteState, error) {
-	cfg, err := ReadTerragruntConfig(ctx, l, pctx, pctx.ParserOptions)
+	cfg, err := readBackendConfig(ctx, l, pctx)
 	if err != nil {
-		return nil, err
+		l.Debugf(
+			"Decoding only the backend blocks of %s failed (%v), reading the whole config instead",
+			util.RelPathForLog(pctx.RootWorkingDir, pctx.TerragruntConfigPath, pctx.LogShowAbsPaths),
+			err,
+		)
+
+		cfg, err = ReadTerragruntConfig(ctx, l, pctx, pctx.ParserOptions)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return cfg.GetRemoteState(ctx, l, pctx)
+}
+
+// readBackendConfig reads the config and decodes the two things a backend needs: the
+// `remote_state` block, and the `terraform` block's `source`, which decides the directory the
+// backend operates in. Keeping the decode this narrow lets a backend command run against a unit
+// whose dependencies have never been applied.
+//
+// It fails when `remote_state` itself reads dependency outputs, since nothing here defines the
+// `dependency` variable. [ParseRemoteState] handles that by reading the whole config.
+func readBackendConfig(
+	ctx context.Context,
+	l log.Logger,
+	pctx *ParsingContext,
+) (*TerragruntConfig, error) {
+	// The whole-config read decides whether this config is valid, so a failure here must not
+	// print diagnostics for a command that goes on to succeed.
+	quietCtx := pctx.WithDiagnosticsSuppressed(l)
+
+	iamRoleOptions := pctx.OriginalIAMRoleOptions
+
+	// A whole-config read resolves `iam_role` before decoding anything, so that functions such as
+	// get_aws_account_id() called from `remote_state` run under the assumed role.
+	if iamRoleOptions.RoleARN == "" {
+		flags, err := PartialParseConfigFile(
+			ctx,
+			quietCtx.WithDecodeList(TerragruntFlags),
+			l,
+			pctx.TerragruntConfigPath,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		iamRoleOptions = iam.MergeRoleOptions(
+			flags.GetIAMRoleOptions(),
+			pctx.OriginalIAMRoleOptions,
+		)
+	}
+
+	backendCtx := quietCtx.WithDecodeList(RemoteStateBlock, TerraformSource)
+	backendCtx.IAMRoleOptions = iamRoleOptions
+
+	return PartialParseConfigFile(ctx, backendCtx, l, pctx.TerragruntConfigPath, nil)
 }
 
 // siblingAutoIncludePath returns the path of the sibling terragrunt.autoinclude.hcl beside configPath

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -821,7 +821,9 @@ func expansionPreviewLines(deps []*Dependency) ([]string, error) {
 		rendered := hclwrite.NewEmptyFile()
 		rendered.Body().AppendBlock(block)
 
-		lines = append(lines, strings.Split(strings.TrimRight(string(rendered.Bytes()), "\n"), "\n")...)
+		lines = append(
+			lines,
+			strings.Split(strings.TrimRight(string(rendered.Bytes()), "\n"), "\n")...)
 	}
 
 	return lines, nil
@@ -2005,7 +2007,13 @@ func decodeAsTerragruntConfigFile(
 		l.Debugf("Deferred attribute access error to autoinclude merge: %v", diagErr)
 	}
 
-	dependencies, err := decodeDependencyBlocksWithAutoIncludeOverrides(ctx, pctx, l, file, evalContext)
+	dependencies, err := decodeDependencyBlocksWithAutoIncludeOverrides(
+		ctx,
+		pctx,
+		l,
+		file,
+		evalContext,
+	)
 	if err != nil {
 		return &cfgFile, err
 	}
@@ -2766,7 +2774,11 @@ func ParseRemoteState(
 	if err != nil {
 		l.Debugf(
 			"Decoding only the backend blocks of %s failed (%v), reading the whole config instead",
-			util.RelPathForLog(pctx.RootWorkingDir, pctx.TerragruntConfigPath, pctx.LogShowAbsPaths),
+			util.RelPathForLog(
+				pctx.RootWorkingDir,
+				pctx.TerragruntConfigPath,
+				pctx.LogShowAbsPaths,
+			),
 			err,
 		)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1209,14 +1209,14 @@ func (cfg *TerraformConfig) ValidateHooks() error {
 // than per file.
 func (cfg *TerraformConfig) ValidateVersion(
 	experiments experiment.Experiments,
-	configPath string,
+	cfgPath string,
 ) error {
 	if cfg == nil || cfg.Version == nil {
 		return nil
 	}
 
 	if !experiments.Evaluate(experiment.VersionAttribute) {
-		return VersionAttributeRequiresExperimentError{ConfigPath: configPath}
+		return VersionAttributeRequiresExperimentError{ConfigPath: cfgPath}
 	}
 
 	var source string
@@ -1226,11 +1226,11 @@ func (cfg *TerraformConfig) ValidateVersion(
 
 	sourceURL, err := url.Parse(source)
 	if err != nil || sourceURL.Scheme != "tfr" {
-		return VersionAttributeNonRegistrySourceError{ConfigPath: configPath}
+		return VersionAttributeNonRegistrySourceError{ConfigPath: cfgPath}
 	}
 
 	if sourceURL.Query().Has("version") {
-		return VersionAttributeSourceConstraintConflictError{ConfigPath: configPath}
+		return VersionAttributeSourceConstraintConflictError{ConfigPath: cfgPath}
 	}
 
 	return nil
@@ -1289,15 +1289,15 @@ func GetTerraformSourceURL(
 	source string,
 	sourceMap map[string]string,
 	originalConfigPath string,
-	terragruntConfig *TerragruntConfig,
+	cfg *TerragruntConfig,
 ) (string, error) {
 	switch {
 	case source != "":
 		return source, nil
-	case terragruntConfig.Terraform != nil && terragruntConfig.Terraform.Source != nil:
+	case cfg.Terraform != nil && cfg.Terraform.Source != nil:
 		return adjustSourceWithMap(
 			sourceMap,
-			*terragruntConfig.Terraform.Source,
+			*cfg.Terraform.Source,
 			originalConfigPath,
 		)
 	default:
@@ -1383,19 +1383,19 @@ func GetDefaultConfigPath(fsys vfs.FS, workingDir string) string {
 		return workingDir
 	}
 
-	var configPath string
+	var cfgPath string
 
-	for _, configPath = range DefaultTerragruntConfigPaths {
-		if !filepath.IsAbs(configPath) {
-			configPath = filepath.Join(workingDir, configPath)
+	for _, cfgPath = range DefaultTerragruntConfigPaths {
+		if !filepath.IsAbs(cfgPath) {
+			cfgPath = filepath.Join(workingDir, cfgPath)
 		}
 
-		if vfs.Exists(fsys, configPath) {
+		if vfs.Exists(fsys, cfgPath) {
 			break
 		}
 	}
 
-	return configPath
+	return cfgPath
 }
 
 // FindConfigFilesInPath returns a list of all Terragrunt config files in the given path or any subfolder of the path.
@@ -1404,14 +1404,14 @@ func GetDefaultConfigPath(fsys vfs.FS, workingDir string) string {
 //   - fsys: the filesystem to walk
 //   - rootPath: the root directory to search
 //   - experiments: experiment flags (for symlink support)
-//   - configPath: the terragrunt config path (to detect non-default config filenames)
+//   - cfgPath: the terragrunt config path (to detect non-default config filenames)
 //   - env: environment variables (to resolve TF_DATA_DIR)
 //   - downloadDir: the terragrunt download directory to skip
 func FindConfigFilesInPath(
 	fsys vfs.FS,
 	rootPath string,
 	experiments experiment.Experiments,
-	configPath string,
+	cfgPath string,
 	env map[string]string,
 	downloadDir string,
 ) ([]string, error) {
@@ -1441,7 +1441,7 @@ func FindConfigFilesInPath(
 			return filepath.SkipDir
 		}
 
-		for _, configFile := range append(DefaultTerragruntConfigPaths, filepath.Base(configPath)) {
+		for _, configFile := range append(DefaultTerragruntConfigPaths, filepath.Base(cfgPath)) {
 			if !filepath.IsAbs(configFile) {
 				configFile = filepath.Join(path, configFile)
 			}
@@ -1508,7 +1508,7 @@ func ParseConfigFile(
 	ctx context.Context,
 	pctx *ParsingContext,
 	l log.Logger,
-	configPath string,
+	cfgPath string,
 	includeFromChild *IncludeConfig,
 ) (*TerragruntConfig, error) {
 	var err error
@@ -1533,17 +1533,17 @@ func ParseConfigFile(
 		decodeListKey = fmt.Sprintf("%v", pctx.PartialParseDecodeList)
 	}
 
-	fileInfo, err := pctx.Venv.FS.Stat(configPath)
+	fileInfo, err := pctx.Venv.FS.Stat(cfgPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return nil, TerragruntConfigNotFoundError{Path: configPath}
+			return nil, TerragruntConfigNotFoundError{Path: cfgPath}
 		}
 
 		return nil, fmt.Errorf("failed to get file info: %w", err)
 	}
 
 	cacheKey := fmt.Sprintf("%v-%v-%v-%v-%v",
-		configPath,
+		cfgPath,
 		pctx.WorkingDir,
 		childKey,
 		decodeListKey,
@@ -1558,7 +1558,7 @@ func ParseConfigFile(
 	err = TraceParseConfigFile(
 		ctx,
 		l,
-		configPath,
+		cfgPath,
 		pctx.WorkingDir,
 		isPartial,
 		pctx.PartialParseDecodeList,
@@ -1574,7 +1574,7 @@ func ParseConfigFile(
 				var parseErr error
 
 				file, parseErr = hclparse.NewParser(pctx.ParserOptions...).
-					ParseFromFile(pctx.Venv.FS, configPath)
+					ParseFromFile(pctx.Venv.FS, cfgPath)
 				if parseErr != nil {
 					return parseErr
 				}
@@ -1602,12 +1602,12 @@ func ParseConfigString(
 	ctx context.Context,
 	pctx *ParsingContext,
 	l log.Logger,
-	configPath string,
+	cfgPath string,
 	configString string,
 	includeFromChild *IncludeConfig,
 ) (*TerragruntConfig, error) {
 	// Parse the HCL file into an AST body that can be decoded multiple times later without having to re-parse
-	file, err := hclparse.NewParser(pctx.ParserOptions...).ParseFromString(configString, configPath)
+	file, err := hclparse.NewParser(pctx.ParserOptions...).ParseFromString(configString, cfgPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1987,9 +1987,9 @@ func decodeAsTerragruntConfigFile(
 	file *hclparse.File,
 	evalContext *hcl.EvalContext,
 ) (*terragruntConfigFile, error) {
-	terragruntConfig := terragruntConfigFile{}
+	cfgFile := terragruntConfigFile{}
 
-	if err := file.Decode(&terragruntConfig, evalContext); err != nil {
+	if err := file.Decode(&cfgFile, evalContext); err != nil {
 		var diagErr hcl.Diagnostics
 
 		ok := errors.As(err, &diagErr)
@@ -1999,7 +1999,7 @@ func decodeAsTerragruntConfigFile(
 			(isRenderJSONCommand(pctx) || isRenderCommand(pctx) || hasSiblingAutoInclude(pctx))
 
 		if !canSuppress {
-			return &terragruntConfig, err
+			return &cfgFile, err
 		}
 
 		l.Debugf("Deferred attribute access error to autoinclude merge: %v", diagErr)
@@ -2007,21 +2007,21 @@ func decodeAsTerragruntConfigFile(
 
 	dependencies, err := decodeDependencyBlocksWithAutoIncludeOverrides(ctx, pctx, l, file, evalContext)
 	if err != nil {
-		return &terragruntConfig, err
+		return &cfgFile, err
 	}
 
-	terragruntConfig.TerragruntDependencies = dependencies
+	cfgFile.TerragruntDependencies = dependencies
 
-	if terragruntConfig.Inputs != nil {
-		inputs, err := ctyhelper.UpdateUnknownCtyValValues(*terragruntConfig.Inputs)
+	if cfgFile.Inputs != nil {
+		inputs, err := ctyhelper.UpdateUnknownCtyValValues(*cfgFile.Inputs)
 		if err != nil {
 			return nil, err
 		}
 
-		terragruntConfig.Inputs = &inputs
+		cfgFile.Inputs = &inputs
 	}
 
-	return &terragruntConfig, nil
+	return &cfgFile, nil
 }
 
 // Returns the index of the Hook with the given name,
@@ -2094,131 +2094,131 @@ func remoteStateFromAttr(attr cty.Value) (*remotestate.RemoteState, error) {
 func convertToTerragruntConfig(
 	ctx context.Context,
 	pctx *ParsingContext,
-	configPath string,
-	terragruntConfigFromFile *terragruntConfigFile,
+	cfgPath string,
+	cfgFromFile *terragruntConfigFile,
 ) (cfg *TerragruntConfig, err error) {
 	var errs []error
 
 	if pctx.ConvertToTerragruntConfigFunc != nil {
-		return pctx.ConvertToTerragruntConfigFunc(ctx, pctx, configPath, terragruntConfigFromFile)
+		return pctx.ConvertToTerragruntConfigFunc(ctx, pctx, cfgPath, cfgFromFile)
 	}
 
-	terragruntConfig := &TerragruntConfig{
+	cfg = &TerragruntConfig{
 		IsPartial: false,
 		// Initialize GenerateConfigs so we can append to it
 		GenerateConfigs: map[string]codegen.GenerateConfig{},
 	}
 
-	defaultMetadata := map[string]any{FoundInFile: configPath}
+	defaultMetadata := map[string]any{FoundInFile: cfgPath}
 
-	if terragruntConfigFromFile.RemoteState != nil {
-		config, err := terragruntConfigFromFile.RemoteState.Config()
+	if cfgFromFile.RemoteState != nil {
+		config, err := cfgFromFile.RemoteState.Config()
 		if err != nil {
 			errs = append(errs, err)
 		}
 
-		terragruntConfig.RemoteState = remotestate.New(config)
-		terragruntConfig.SetFieldMetadata(MetadataRemoteState, defaultMetadata)
+		cfg.RemoteState = remotestate.New(config)
+		cfg.SetFieldMetadata(MetadataRemoteState, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.RemoteStateAttr != nil {
-		remoteState, err := remoteStateFromAttr(*terragruntConfigFromFile.RemoteStateAttr)
+	if cfgFromFile.RemoteStateAttr != nil {
+		remoteState, err := remoteStateFromAttr(*cfgFromFile.RemoteStateAttr)
 		if err != nil {
 			return nil, err
 		}
 
-		terragruntConfig.RemoteState = remoteState
-		terragruntConfig.SetFieldMetadata(MetadataRemoteState, defaultMetadata)
+		cfg.RemoteState = remoteState
+		cfg.SetFieldMetadata(MetadataRemoteState, defaultMetadata)
 	}
 
-	if err := terragruntConfigFromFile.Terraform.ValidateHooks(); err != nil {
+	if err := cfgFromFile.Terraform.ValidateHooks(); err != nil {
 		errs = append(errs, err)
 	}
 
-	terragruntConfig.Terraform = terragruntConfigFromFile.Terraform
-	if terragruntConfig.Terraform != nil { // since Terraform is nil each time avoid saving metadata when it is nil
-		terragruntConfig.SetFieldMetadata(MetadataTerraform, defaultMetadata)
+	cfg.Terraform = cfgFromFile.Terraform
+	if cfg.Terraform != nil { // since Terraform is nil each time avoid saving metadata when it is nil
+		cfg.SetFieldMetadata(MetadataTerraform, defaultMetadata)
 
 		// This full-parse hook is not redundant with the partial-parse hook in
 		// PartialParseConfig. read_terragrunt_config() runs a full ParseConfigFile
 		// even during discovery's partial parse, and ParsingContext.Clone() shares
 		// FilesRead, so this hook is how files read via read_terragrunt_config of
 		// a config with a local module source reach reading= filters.
-		if terragruntConfig.Terraform.Source != nil {
-			markLocalModuleSourceAsRead(pctx, configPath, *terragruntConfig.Terraform.Source)
+		if cfg.Terraform.Source != nil {
+			markLocalModuleSourceAsRead(pctx, cfgPath, *cfg.Terraform.Source)
 		}
 	}
 
-	if err := validateDependencies(pctx, terragruntConfigFromFile.Dependencies); err != nil {
+	if err := validateDependencies(pctx, cfgFromFile.Dependencies); err != nil {
 		errs = append(errs, err)
 	}
 
-	terragruntConfig.Dependencies = terragruntConfigFromFile.Dependencies
-	if terragruntConfig.Dependencies != nil {
-		for _, item := range terragruntConfig.Dependencies.Paths {
-			terragruntConfig.SetFieldMetadataWithType(MetadataDependencies, item, defaultMetadata)
+	cfg.Dependencies = cfgFromFile.Dependencies
+	if cfg.Dependencies != nil {
+		for _, item := range cfg.Dependencies.Paths {
+			cfg.SetFieldMetadataWithType(MetadataDependencies, item, defaultMetadata)
 		}
 	}
 
-	terragruntConfig.TerragruntDependencies = terragruntConfigFromFile.TerragruntDependencies
-	for _, dep := range terragruntConfig.TerragruntDependencies {
-		terragruntConfig.SetFieldMetadataWithType(MetadataDependency, dep.Name, defaultMetadata)
+	cfg.TerragruntDependencies = cfgFromFile.TerragruntDependencies
+	for _, dep := range cfg.TerragruntDependencies {
+		cfg.SetFieldMetadataWithType(MetadataDependency, dep.Name, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.TerraformBinary != nil {
-		terragruntConfig.TerraformBinary = *terragruntConfigFromFile.TerraformBinary
-		terragruntConfig.SetFieldMetadata(MetadataTerraformBinary, defaultMetadata)
+	if cfgFromFile.TerraformBinary != nil {
+		cfg.TerraformBinary = *cfgFromFile.TerraformBinary
+		cfg.SetFieldMetadata(MetadataTerraformBinary, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.DownloadDir != nil {
-		terragruntConfig.DownloadDir = *terragruntConfigFromFile.DownloadDir
-		terragruntConfig.SetFieldMetadata(MetadataDownloadDir, defaultMetadata)
+	if cfgFromFile.DownloadDir != nil {
+		cfg.DownloadDir = *cfgFromFile.DownloadDir
+		cfg.SetFieldMetadata(MetadataDownloadDir, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.TerraformVersionConstraint != nil {
-		terragruntConfig.TerraformVersionConstraint = *terragruntConfigFromFile.TerraformVersionConstraint
-		terragruntConfig.SetFieldMetadata(MetadataTerraformVersionConstraint, defaultMetadata)
+	if cfgFromFile.TerraformVersionConstraint != nil {
+		cfg.TerraformVersionConstraint = *cfgFromFile.TerraformVersionConstraint
+		cfg.SetFieldMetadata(MetadataTerraformVersionConstraint, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.TerragruntVersionConstraint != nil {
-		terragruntConfig.TerragruntVersionConstraint = *terragruntConfigFromFile.TerragruntVersionConstraint
-		terragruntConfig.SetFieldMetadata(MetadataTerragruntVersionConstraint, defaultMetadata)
+	if cfgFromFile.TerragruntVersionConstraint != nil {
+		cfg.TerragruntVersionConstraint = *cfgFromFile.TerragruntVersionConstraint
+		cfg.SetFieldMetadata(MetadataTerragruntVersionConstraint, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.PreventDestroy != nil {
-		terragruntConfig.PreventDestroy = terragruntConfigFromFile.PreventDestroy
-		terragruntConfig.SetFieldMetadata(MetadataPreventDestroy, defaultMetadata)
+	if cfgFromFile.PreventDestroy != nil {
+		cfg.PreventDestroy = cfgFromFile.PreventDestroy
+		cfg.SetFieldMetadata(MetadataPreventDestroy, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.IamRole != nil {
-		terragruntConfig.IamRole = *terragruntConfigFromFile.IamRole
-		terragruntConfig.SetFieldMetadata(MetadataIamRole, defaultMetadata)
+	if cfgFromFile.IamRole != nil {
+		cfg.IamRole = *cfgFromFile.IamRole
+		cfg.SetFieldMetadata(MetadataIamRole, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.IamAssumeRoleDuration != nil {
-		terragruntConfig.IamAssumeRoleDuration = terragruntConfigFromFile.IamAssumeRoleDuration
-		terragruntConfig.SetFieldMetadata(MetadataIamAssumeRoleDuration, defaultMetadata)
+	if cfgFromFile.IamAssumeRoleDuration != nil {
+		cfg.IamAssumeRoleDuration = cfgFromFile.IamAssumeRoleDuration
+		cfg.SetFieldMetadata(MetadataIamAssumeRoleDuration, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.IamAssumeRoleSessionName != nil {
-		terragruntConfig.IamAssumeRoleSessionName = *terragruntConfigFromFile.IamAssumeRoleSessionName
-		terragruntConfig.SetFieldMetadata(MetadataIamAssumeRoleSessionName, defaultMetadata)
+	if cfgFromFile.IamAssumeRoleSessionName != nil {
+		cfg.IamAssumeRoleSessionName = *cfgFromFile.IamAssumeRoleSessionName
+		cfg.SetFieldMetadata(MetadataIamAssumeRoleSessionName, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.IamWebIdentityToken != nil {
-		terragruntConfig.IamWebIdentityToken = *terragruntConfigFromFile.IamWebIdentityToken
-		terragruntConfig.SetFieldMetadata(MetadataIamWebIdentityToken, defaultMetadata)
+	if cfgFromFile.IamWebIdentityToken != nil {
+		cfg.IamWebIdentityToken = *cfgFromFile.IamWebIdentityToken
+		cfg.SetFieldMetadata(MetadataIamWebIdentityToken, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.Engine != nil {
-		terragruntConfig.Engine = terragruntConfigFromFile.Engine
-		terragruntConfig.SetFieldMetadata(MetadataEngine, defaultMetadata)
+	if cfgFromFile.Engine != nil {
+		cfg.Engine = cfgFromFile.Engine
+		cfg.SetFieldMetadata(MetadataEngine, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.FeatureFlags != nil {
-		terragruntConfig.FeatureFlags = terragruntConfigFromFile.FeatureFlags
-		for _, flag := range terragruntConfig.FeatureFlags {
-			terragruntConfig.SetFieldMetadataWithType(
+	if cfgFromFile.FeatureFlags != nil {
+		cfg.FeatureFlags = cfgFromFile.FeatureFlags
+		for _, flag := range cfg.FeatureFlags {
+			cfg.SetFieldMetadataWithType(
 				MetadataFeatureFlag,
 				flag.Name,
 				defaultMetadata,
@@ -2226,21 +2226,21 @@ func convertToTerragruntConfig(
 		}
 	}
 
-	if terragruntConfigFromFile.Exclude != nil {
-		terragruntConfig.Exclude = terragruntConfigFromFile.Exclude
-		terragruntConfig.SetFieldMetadata(MetadataExclude, defaultMetadata)
+	if cfgFromFile.Exclude != nil {
+		cfg.Exclude = cfgFromFile.Exclude
+		cfg.SetFieldMetadata(MetadataExclude, defaultMetadata)
 	}
 
-	if terragruntConfigFromFile.Errors != nil {
-		terragruntConfig.Errors = terragruntConfigFromFile.Errors
-		terragruntConfig.SetFieldMetadata(MetadataErrors, defaultMetadata)
+	if cfgFromFile.Errors != nil {
+		cfg.Errors = cfgFromFile.Errors
+		cfg.SetFieldMetadata(MetadataErrors, defaultMetadata)
 	}
 
 	generateBlocks := []terragruntGenerateBlock{}
-	generateBlocks = append(generateBlocks, terragruntConfigFromFile.GenerateBlocks...)
+	generateBlocks = append(generateBlocks, cfgFromFile.GenerateBlocks...)
 
-	if terragruntConfigFromFile.GenerateAttrs != nil {
-		generateMap, err := ctyhelper.ParseCtyValueToMap(*terragruntConfigFromFile.GenerateAttrs)
+	if cfgFromFile.GenerateAttrs != nil {
+		generateMap, err := ctyhelper.ParseCtyValueToMap(*cfgFromFile.GenerateAttrs)
 		if err != nil {
 			return nil, err
 		}
@@ -2292,7 +2292,7 @@ func convertToTerragruntConfig(
 
 		if block.Mutable != nil && !pctx.Experiments.Evaluate(experiment.MutableGenerate) {
 			errs = append(errs, MutableGenerateRequiresExperimentError{
-				ConfigPath: configPath,
+				ConfigPath: cfgPath,
 				BlockName:  block.Name,
 			})
 
@@ -2327,24 +2327,24 @@ func convertToTerragruntConfig(
 			genConfig.Disable = *block.Disable
 		}
 
-		terragruntConfig.GenerateConfigs[block.Name] = genConfig
-		terragruntConfig.SetFieldMetadataWithType(
+		cfg.GenerateConfigs[block.Name] = genConfig
+		cfg.SetFieldMetadataWithType(
 			MetadataGenerateConfigs,
 			block.Name,
 			defaultMetadata,
 		)
 	}
 
-	if terragruntConfigFromFile.Inputs != nil {
-		inputs, err := ctyhelper.ParseCtyValueToMap(*terragruntConfigFromFile.Inputs)
+	if cfgFromFile.Inputs != nil {
+		inputs, err := ctyhelper.ParseCtyValueToMap(*cfgFromFile.Inputs)
 		if err != nil {
 			errs = append(errs, err)
 		}
 
-		terragruntConfig.Inputs = inputs
-		terragruntConfig.SetFieldMetadataMap(
+		cfg.Inputs = inputs
+		cfg.SetFieldMetadataMap(
 			MetadataInputs,
-			terragruntConfig.Inputs,
+			cfg.Inputs,
 			defaultMetadata,
 		)
 	}
@@ -2357,12 +2357,12 @@ func convertToTerragruntConfig(
 
 		// Only set Locals if there are actual values to avoid setting an empty map
 		if len(localsParsed) > 0 {
-			terragruntConfig.Locals = localsParsed
-			terragruntConfig.SetFieldMetadataMap(MetadataLocals, localsParsed, defaultMetadata)
+			cfg.Locals = localsParsed
+			cfg.SetFieldMetadataMap(MetadataLocals, localsParsed, defaultMetadata)
 		}
 	}
 
-	return terragruntConfig, errors.Join(errs...)
+	return cfg, errors.Join(errs...)
 }
 
 // moduleSourceReadExtensions lists file extensions within a local terraform module
@@ -2379,18 +2379,18 @@ var moduleSourceReadExtensions = map[string]struct{}{
 // rawSource and marks its configuration files as read in pctx.FilesRead. It is a
 // best-effort annotation: non-local sources are skipped and walk errors are
 // swallowed, since a genuinely broken source will surface during download.
-func markLocalModuleSourceAsRead(pctx *ParsingContext, configPath, rawSource string) {
+func markLocalModuleSourceAsRead(pctx *ParsingContext, cfgPath, rawSource string) {
 	sourceWithoutSubdir, subdir := getter.SourceDirSubdir(rawSource)
 
 	// Anchor a relative config path to the working directory before deriving
 	// the detector pwd. The file detector roots relative output at "/", so a
 	// relative pwd would resolve a relative source to the filesystem root and
 	// walk all of it.
-	if !filepath.IsAbs(configPath) {
-		configPath = filepath.Join(pctx.WorkingDir, configPath)
+	if !filepath.IsAbs(cfgPath) {
+		cfgPath = filepath.Join(pctx.WorkingDir, cfgPath)
 	}
 
-	sourceURL, err := tf.ToSourceURL(sourceWithoutSubdir, filepath.Dir(configPath))
+	sourceURL, err := tf.ToSourceURL(sourceWithoutSubdir, filepath.Dir(cfgPath))
 	if err != nil || !tf.IsLocalSource(sourceURL) {
 		return
 	}
@@ -2506,11 +2506,11 @@ func validateGenerateBlocks(blocks *[]terragruntGenerateBlock) error {
 // configFileHasDependencyBlock statically checks the terrragrunt config file at the given path and checks if it has any
 // dependency or dependencies blocks defined. Note that this does not do any decoding of the blocks, as it is only meant
 // to check for block presence.
-func configFileHasDependencyBlock(fsys vfs.FS, configPath string) (bool, error) {
-	configBytes, err := vfs.ReadFile(fsys, configPath)
+func configFileHasDependencyBlock(fsys vfs.FS, cfgPath string) (bool, error) {
+	configBytes, err := vfs.ReadFile(fsys, cfgPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return false, DependencyFileNotFoundError{Path: configPath}
+			return false, DependencyFileNotFoundError{Path: cfgPath}
 		}
 
 		return false, err
@@ -2519,7 +2519,7 @@ func configFileHasDependencyBlock(fsys vfs.FS, configPath string) (bool, error) 
 	// We use hclwrite to parse the config instead of the normal parser because the normal parser doesn't give us an AST
 	// that we can walk and scan, and requires structured data to map against. This makes the parsing strict, so to
 	// avoid weird parsing errors due to missing dependency data, we do a structural scan here.
-	hclFile, diags := hclwrite.ParseConfig(configBytes, configPath, hcl.InitialPos)
+	hclFile, diags := hclwrite.ParseConfig(configBytes, cfgPath, hcl.InitialPos)
 	if diags.HasErrors() {
 		return false, diags
 	}
@@ -2823,23 +2823,23 @@ func readBackendConfig(
 	return PartialParseConfigFile(ctx, backendCtx, l, pctx.TerragruntConfigPath, nil)
 }
 
-// siblingAutoIncludePath returns the path of the sibling terragrunt.autoinclude.hcl beside configPath
+// siblingAutoIncludePath returns the path of the sibling terragrunt.autoinclude.hcl beside cfgPath
 // and whether it is in scope: the context is not already parsing a file pulled in by an autoinclude
 // merge (skipAutoIncludeMerge, which would recurse and let a pulled-in file fold its own sibling
-// autoinclude), and configPath is not itself an autoinclude file. The registration that records the
+// autoinclude), and cfgPath is not itself an autoinclude file. The registration that records the
 // override on TrackInclude and the partial-parse cache key both route through here. Existence is left
 // to the caller so the cache-key path can distinguish absent from present.
-func siblingAutoIncludePath(pctx *ParsingContext, configPath string) (string, bool) {
+func siblingAutoIncludePath(pctx *ParsingContext, cfgPath string) (string, bool) {
 	if pctx.skipAutoIncludeMerge {
 		return "", false
 	}
 
-	configBase := filepath.Base(configPath)
+	configBase := filepath.Base(cfgPath)
 	if configBase == DefaultAutoIncludeFile || configBase == DefaultAutoIncludeStackFile {
 		return "", false
 	}
 
-	return filepath.Join(filepath.Dir(configPath), DefaultAutoIncludeFile), true
+	return filepath.Join(filepath.Dir(cfgPath), DefaultAutoIncludeFile), true
 }
 
 // hasSiblingAutoInclude reports whether a sibling autoinclude is registered for this parse.

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -185,10 +185,10 @@ func createTerragruntEvalContext(
 	ctx context.Context,
 	pctx *ParsingContext,
 	l log.Logger,
-	configPath string,
+	cfgPath string,
 ) (*hcl.EvalContext, error) {
 	tfscope := tflang.Scope{
-		BaseDir: filepath.Dir(configPath),
+		BaseDir: filepath.Dir(cfgPath),
 	}
 
 	terragruntFunctions := map[string]function.Function{
@@ -428,7 +428,7 @@ func createTerragruntEvalContext(
 		if err != nil && len(pctx.PartialParseDecodeList) == 0 {
 			return nil, fmt.Errorf(
 				"could not resolve exposed includes for eval context in %s: %w",
-				configPath,
+				cfgPath,
 				err,
 			)
 		}
@@ -440,7 +440,7 @@ func createTerragruntEvalContext(
 			// and the system will fall back to full parsing when needed.
 			l.Debugf(
 				"Could not resolve exposed includes for eval context in %s (partial parse): %v",
-				configPath,
+				cfgPath,
 				err,
 			)
 		}
@@ -966,7 +966,7 @@ func getWorkingDir(ctx context.Context, pctx *ParsingContext, l log.Logger) (str
 		FuncNameGetWorkingDir: wrapVoidToEmptyStringAsFuncImpl(),
 	}
 
-	terragruntConfig, err := ParseConfigFile(ctx, pctx, l, pctx.TerragruntConfigPath, nil)
+	cfg, err := ParseConfigFile(ctx, pctx, l, pctx.TerragruntConfigPath, nil)
 	if err != nil {
 		return "", err
 	}
@@ -975,7 +975,7 @@ func getWorkingDir(ctx context.Context, pctx *ParsingContext, l log.Logger) (str
 		pctx.Source,
 		pctx.SourceMap,
 		pctx.OriginalTerragruntConfigPath,
-		terragruntConfig,
+		cfg,
 	)
 	if err != nil {
 		return "", err
@@ -1088,13 +1088,13 @@ func ParseTerragruntConfig(
 	ctx context.Context,
 	pctx *ParsingContext,
 	l log.Logger,
-	configPath string,
+	cfgPath string,
 	defaultVal *cty.Value,
 ) (cty.Value, error) {
 	// target config check: make sure the target config exists. If the file does not exist, and there is no default val,
 	// return an error. If the file does not exist but there is a default val, return the default val. Otherwise,
 	// proceed to parse the file as a terragrunt config file.
-	targetConfig := getCleanedTargetConfigPath(pctx.Venv.FS, configPath, pctx.TerragruntConfigPath)
+	targetConfig := getCleanedTargetConfigPath(pctx.Venv.FS, cfgPath, pctx.TerragruntConfigPath)
 
 	targetConfigFileExists := vfs.Exists(pctx.Venv.FS, targetConfig)
 
@@ -1233,10 +1233,10 @@ func readTerragruntConfigAsFuncImpl(
 // Returns a cleaned path to the target config (the `terragrunt.hcl` or `terragrunt.hcl.json` file), handling relative
 // paths correctly. This will automatically append `terragrunt.hcl` or `terragrunt.hcl.json` to the path if the target
 // path is a directory.
-func getCleanedTargetConfigPath(fsys vfs.FS, configPath string, workingPath string) string {
+func getCleanedTargetConfigPath(fsys vfs.FS, cfgPath string, workingPath string) string {
 	cwd := filepath.Dir(workingPath)
 
-	targetConfig := configPath
+	targetConfig := cfgPath
 	if !filepath.IsAbs(targetConfig) {
 		targetConfig = filepath.Join(cwd, targetConfig)
 	}

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -451,21 +451,21 @@ func PartialParseConfigFile(
 	ctx context.Context,
 	pctx *ParsingContext,
 	l log.Logger,
-	configPath string,
+	cfgPath string,
 	include *IncludeConfig,
 ) (*TerragruntConfig, error) {
 	hclCache := cache.ContextCache[*hclparse.File](ctx, HclCacheContextKey)
 
-	fileInfo, err := pctx.Venv.FS.Stat(configPath)
+	fileInfo, err := pctx.Venv.FS.Stat(cfgPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return nil, TerragruntConfigNotFoundError{Path: configPath}
+			return nil, TerragruntConfigNotFoundError{Path: cfgPath}
 		}
 
 		return nil, err
 	}
 
-	cacheKey := fmt.Sprintf("configPath-%v-modTime-%v", configPath, fileInfo.ModTime().UnixMicro())
+	cacheKey := fmt.Sprintf("configPath-%v-modTime-%v", cfgPath, fileInfo.ModTime().UnixMicro())
 
 	// Check cache hit status before tracing
 	_, cacheHit := hclCache.Get(ctx, cacheKey)
@@ -475,7 +475,7 @@ func PartialParseConfigFile(
 	err = TraceParseConfigFile(
 		ctx,
 		l,
-		configPath,
+		cfgPath,
 		pctx.WorkingDir,
 		true, // isPartial
 		pctx.PartialParseDecodeList,
@@ -490,7 +490,7 @@ func PartialParseConfigFile(
 				var parseErr error
 
 				file, parseErr = hclparse.NewParser(pctx.ParserOptions...).
-					ParseFromFile(pctx.Venv.FS, configPath)
+					ParseFromFile(pctx.Venv.FS, cfgPath)
 				if parseErr != nil {
 					return parseErr
 				}
@@ -590,10 +590,10 @@ func PartialParseConfigString(
 	ctx context.Context,
 	pctx *ParsingContext,
 	l log.Logger,
-	configPath, configString string,
+	cfgPath, configString string,
 	include *IncludeConfig,
 ) (*TerragruntConfig, error) {
-	file, err := hclparse.NewParser(pctx.ParserOptions...).ParseFromString(configString, configPath)
+	file, err := hclparse.NewParser(pctx.ParserOptions...).ParseFromString(configString, cfgPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1015,14 +1015,14 @@ func decodeAsTerragruntInclude(
 // registerSiblingAutoInclude records the sibling terragrunt.autoinclude.hcl on trackInclude as a high-priority override when it is in scope and exists, so the merge consumers read one registered entry instead of recomputing the gate.
 func registerSiblingAutoInclude(
 	pctx *ParsingContext,
-	configPath string,
+	cfgPath string,
 	trackInclude *TrackInclude,
 ) {
 	if trackInclude == nil {
 		return
 	}
 
-	autoIncludePath, ok := siblingAutoIncludePath(pctx, configPath)
+	autoIncludePath, ok := siblingAutoIncludePath(pctx, cfgPath)
 	if !ok {
 		return
 	}
@@ -1147,9 +1147,9 @@ func reconcileAutoIncludeModulePaths(
 func autoIncludeCacheKeySuffix(
 	ctx context.Context,
 	pctx *ParsingContext,
-	configPath string,
+	cfgPath string,
 ) string {
-	autoIncludePath, ok := siblingAutoIncludePath(pctx, configPath)
+	autoIncludePath, ok := siblingAutoIncludePath(pctx, cfgPath)
 	if !ok {
 		return ""
 	}

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -160,10 +160,12 @@ type TerragruntDependency struct {
 	Dependencies Dependencies `hcl:"dependency,block"`
 }
 
-// terragruntRemoteState is a struct that can be used to only decode the remote_state blocks in the terragrunt config
+// terragruntRemoteState is a struct that can be used to only decode the remote_state blocks in the terragrunt config.
+// It decodes remote_state written as either a block or an attribute, as [terragruntConfigFile] does.
 type terragruntRemoteState struct {
-	RemoteState *remotestate.ConfigFile `hcl:"remote_state,block"`
-	Remain      hcl.Body                `hcl:",remain"`
+	RemoteState     *remotestate.ConfigFile `hcl:"remote_state,block"`
+	RemoteStateAttr *cty.Value              `hcl:"remote_state,optional"`
+	Remain          hcl.Body                `hcl:",remain"`
 }
 
 // terragruntEngine is a struct that can only be used to decode the engine block.
@@ -824,6 +826,15 @@ func PartialParseConfig(
 				}
 
 				output.RemoteState = remotestate.New(config)
+			}
+
+			if decoded.RemoteStateAttr != nil {
+				remoteState, err := remoteStateFromAttr(*decoded.RemoteStateAttr)
+				if err != nil {
+					return nil, err
+				}
+
+				output.RemoteState = remoteState
 			}
 		case FeatureFlagsBlock:
 			decoded := terragruntFeatureFlags{}

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -337,19 +337,19 @@ func validateUniqueDependencies(
 	ctx context.Context,
 	pctx *ParsingContext,
 	l log.Logger,
-	configPath string,
+	cfgPath string,
 	deps Dependencies,
 ) error {
 	if address, found := duplicateDependencyAddress(deps); found {
 		return evaluateDuplicateDependency(ctx, pctx, l, DuplicateDependencyError{
-			ConfigPath: configPath,
+			ConfigPath: cfgPath,
 			Address:    address,
 		})
 	}
 
-	if dup, found := duplicateDependencyConfigPath(configPath, deps); found {
+	if dup, found := duplicateDependencyConfigPath(cfgPath, deps); found {
 		return evaluateDuplicateDependency(ctx, pctx, l, DuplicateDependencyConfigPathError{
-			ConfigPath:     configPath,
+			ConfigPath:     cfgPath,
 			DependencyPath: dup.path,
 			FirstAddress:   dup.first,
 			SecondAddress:  dup.second,
@@ -410,7 +410,7 @@ type sharedDependencyPath struct {
 // so two spellings of one directory count as the same path. A disabled dependency reads
 // nothing and so collides with nothing, and a config_path that is not yet a known string
 // is skipped.
-func duplicateDependencyConfigPath(configPath string, deps Dependencies) (sharedDependencyPath, bool) {
+func duplicateDependencyConfigPath(cfgPath string, deps Dependencies) (sharedDependencyPath, bool) {
 	seen := make(map[string]string, len(deps))
 
 	for i := range deps {
@@ -423,7 +423,7 @@ func duplicateDependencyConfigPath(configPath string, deps Dependencies) (shared
 
 		path := dep.ConfigPath.AsString()
 		if !filepath.IsAbs(path) {
-			path = filepath.Join(filepath.Dir(configPath), path)
+			path = filepath.Join(filepath.Dir(cfgPath), path)
 		}
 
 		path = filepath.Clean(path)
@@ -700,11 +700,11 @@ func checkForDependencyBlockCycles(
 	ctx context.Context,
 	pctx *ParsingContext,
 	l log.Logger,
-	configPath string,
+	cfgPath string,
 	decodedDependency TerragruntDependency,
 ) error {
 	visitedPaths := []string{}
-	currentTraversalPaths := []string{configPath}
+	currentTraversalPaths := []string{cfgPath}
 
 	for _, dependency := range decodedDependency.Dependencies {
 		if dependency.isDisabled() {
@@ -722,7 +722,7 @@ func checkForDependencyBlockCycles(
 		dependencyPath := getCleanedTargetConfigPath(
 			pctx.Venv.FS,
 			dependency.ConfigPath.AsString(),
-			configPath,
+			cfgPath,
 		)
 
 		// Skip cycle checking for nonexistent dependency targets — there is nothing to traverse.
@@ -816,7 +816,7 @@ func getDependencyBlockConfigPathsByFilepath(
 	ctx context.Context,
 	pctx *ParsingContext,
 	l log.Logger,
-	configPath string,
+	cfgPath string,
 ) ([]string, error) {
 	// This will automatically parse everything needed to parse the dependency block configs, and load them as
 	// TerragruntConfig.Dependencies. Note that since we aren't passing in `DependenciesBlock` to the
@@ -826,7 +826,7 @@ func getDependencyBlockConfigPathsByFilepath(
 		ctx,
 		pctx.WithDecodeList(DependencyBlock).WithDiagnosticsSuppressed(l),
 		l,
-		configPath,
+		cfgPath,
 		nil,
 	)
 	if err != nil {
@@ -2033,7 +2033,7 @@ func terragruntAlreadyInit(
 	ctx context.Context,
 	l log.Logger,
 	pctx *ParsingContext,
-	configPath string,
+	cfgPath string,
 ) (bool, string, error) {
 	// We need to first determine the working directory where the terraform source should be located. This is dependent
 	// on the source field of the terraform block in the config.
@@ -2041,7 +2041,7 @@ func terragruntAlreadyInit(
 		ctx,
 		pctx.WithDecodeList(TerraformSource),
 		l,
-		configPath,
+		cfgPath,
 		nil,
 	)
 	if err != nil {

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -459,7 +459,13 @@ func decodeAndRetrieveOutputs(
 		return nil, err
 	}
 
-	dependencies, err := decodeDependencyBlocksWithAutoIncludeOverrides(ctx, pctx, l, file, evalParsingContext)
+	dependencies, err := decodeDependencyBlocksWithAutoIncludeOverrides(
+		ctx,
+		pctx,
+		l,
+		file,
+		evalParsingContext,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1595,7 +1601,8 @@ func resolveOutputJSON(
 	// reference the dependency namespace.
 	partialTerragruntConfig, err := PartialParseConfigFile(
 		ctx,
-		pctx.WithDecodeList(DependencyBlock, TerraformExtraArgs, TerragruntVersionConstraints).WithDiagnosticsSuppressed(l),
+		pctx.WithDecodeList(DependencyBlock, TerraformExtraArgs, TerragruntVersionConstraints).
+			WithDiagnosticsSuppressed(l),
 		l,
 		targetConfig,
 		nil,
@@ -1791,7 +1798,10 @@ var directStateBackends = map[string]directStateBackend{
 }
 
 // shouldFetchDependencyOutputFromState reports whether a registered backend supports a direct state read.
-func shouldFetchDependencyOutputFromState(pctx *ParsingContext, remoteState *remotestate.RemoteState) bool {
+func shouldFetchDependencyOutputFromState(
+	pctx *ParsingContext,
+	remoteState *remotestate.RemoteState,
+) bool {
 	if remoteState == nil ||
 		!pctx.Experiments.Evaluate(experiment.DependencyFetchOutputFromState) ||
 		pctx.NoDependencyFetchOutputFromState {
@@ -2194,7 +2204,8 @@ func getTerragruntOutputJSONFromRemoteState(
 	// To speed up dependencies processing it is possible to retrieve its output directly from the backend without init dependencies
 	// A non-empty workspace means the caller already found a supported backend, so
 	// the reader lookup below cannot miss.
-	if stateBackend, supported := directStateBackends[remoteState.BackendName]; supported && workspace != "" {
+	if stateBackend, supported := directStateBackends[remoteState.BackendName]; supported &&
+		workspace != "" {
 		jsonBytes, readErr := stateBackend.read(ctx, l, pctx, remoteState, workspace)
 		if readErr != nil {
 			return nil, readErr
@@ -2627,7 +2638,11 @@ func siblingAutoIncludeDepOverrides(
 		return nil, nil
 	}
 
-	autoFile, err := parseAutoIncludeFileCached(ctx, pctx, pctx.TrackInclude.AutoIncludeOverride.Path)
+	autoFile, err := parseAutoIncludeFileCached(
+		ctx,
+		pctx,
+		pctx.TrackInclude.AutoIncludeOverride.Path,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/parsing_context.go
+++ b/pkg/config/parsing_context.go
@@ -70,7 +70,7 @@ type ParsingContext struct {
 	dependencyOutputEnvKeys map[string]struct{}
 	PredefinedFunctions     map[string]function.Function
 
-	ConvertToTerragruntConfigFunc func(ctx context.Context, pctx *ParsingContext, configPath string, terragruntConfigFromFile *terragruntConfigFile) (cfg *TerragruntConfig, err error)
+	ConvertToTerragruntConfigFunc func(ctx context.Context, pctx *ParsingContext, cfgPath string, cfgFromFile *terragruntConfigFile) (cfg *TerragruntConfig, err error)
 
 	TerragruntConfigPath         string
 	OriginalTerragruntConfigPath string
@@ -277,7 +277,7 @@ func (ctx *ParsingContext) WithIncrementedDepth() (*ParsingContext, error) {
 
 // WithConfigPath returns a new ParsingContext targeting a different config file.
 //
-// It normalizes configPath to an absolute path, sets TerragruntConfigPath and
+// It normalizes cfgPath to an absolute path, sets TerragruntConfigPath and
 // WorkingDir accordingly, and updates the logger when the working directory changes.
 //
 // OriginalTerragruntConfigPath is preserved so that get_original_terragrunt_dir()
@@ -287,14 +287,14 @@ func (ctx *ParsingContext) WithIncrementedDepth() (*ParsingContext, error) {
 // To parse a dependency as an independent unit, use [ParsingContext.WithDependencyConfigPath].
 func (ctx *ParsingContext) WithConfigPath(
 	l log.Logger,
-	configPath string,
+	cfgPath string,
 ) (log.Logger, *ParsingContext, error) {
-	configPath = filepath.Clean(configPath)
-	if !filepath.IsAbs(configPath) {
-		configPath = filepath.Clean(filepath.Join(ctx.WorkingDir, configPath))
+	cfgPath = filepath.Clean(cfgPath)
+	if !filepath.IsAbs(cfgPath) {
+		cfgPath = filepath.Clean(filepath.Join(ctx.WorkingDir, cfgPath))
 	}
 
-	workingDir := filepath.Dir(configPath)
+	workingDir := filepath.Dir(cfgPath)
 
 	if workingDir != ctx.WorkingDir {
 		l = l.WithField(placeholders.WorkDirKeyName, workingDir)
@@ -310,10 +310,10 @@ func (ctx *ParsingContext) WithConfigPath(
 	// dirs (which won't match any module's default) are preserved unchanged.
 	_, defaultDir := util.DefaultWorkingAndDownloadDirs(ctx.TerragruntConfigPath)
 	if filepath.Clean(c.DownloadDir) == filepath.Clean(defaultDir) {
-		_, c.DownloadDir = util.DefaultWorkingAndDownloadDirs(configPath)
+		_, c.DownloadDir = util.DefaultWorkingAndDownloadDirs(cfgPath)
 	}
 
-	c.TerragruntConfigPath = configPath
+	c.TerragruntConfigPath = cfgPath
 	c.WorkingDir = workingDir
 
 	return l, c, nil
@@ -328,9 +328,9 @@ func (ctx *ParsingContext) WithConfigPath(
 // own directory rather than the caller's.
 func (ctx *ParsingContext) WithDependencyConfigPath(
 	l log.Logger,
-	configPath string,
+	cfgPath string,
 ) (log.Logger, *ParsingContext, error) {
-	l, c, err := ctx.WithConfigPath(l, configPath)
+	l, c, err := ctx.WithConfigPath(l, cfgPath)
 	if err != nil {
 		return l, nil, err
 	}

--- a/pkg/config/remote_state_test.go
+++ b/pkg/config/remote_state_test.go
@@ -1,39 +1,45 @@
 package config_test
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// writeUnitPair writes a `bar` unit and a `foo` unit beside it, and returns the path to foo's config.
-func writeUnitPair(t *testing.T, barHCL, fooHCL string) string {
+// unitsVenv builds a venv over an in-memory tree of the given files, rooted at a directory named
+// for the test, and returns it with the root. The exec handle refuses to spawn, so a parse that
+// reaches for `tofu output` fails at the spawn rather than on whatever the machine running the
+// suite happens to have installed.
+func unitsVenv(t *testing.T, files map[string]string) (*venv.Venv, string) {
 	t.Helper()
 
-	tmpDir := t.TempDir()
+	root := filepath.Join("/units", t.Name())
 
-	for name, contents := range map[string]string{"bar": barHCL, "foo": fooHCL} {
-		unitDir := filepath.Join(tmpDir, name)
-		require.NoError(t, os.MkdirAll(unitDir, 0755))
-		require.NoError(t, os.WriteFile(
-			filepath.Join(unitDir, config.DefaultTerragruntConfigPath),
-			[]byte(contents),
-			0644,
-		))
-	}
+	return venvtest.New().WithFS(venvtest.NewFS(t, root, files)), root
+}
 
-	return filepath.Join(tmpDir, "foo", config.DefaultTerragruntConfigPath)
+// unitPairVenv builds a venv over a `bar` unit and a `foo` unit beside it, and returns it with the
+// path to foo's config.
+func unitPairVenv(t *testing.T, barHCL, fooHCL string) (*venv.Venv, string) {
+	t.Helper()
+
+	v, root := unitsVenv(t, map[string]string{
+		filepath.Join("bar", config.DefaultTerragruntConfigPath): barHCL,
+		filepath.Join("foo", config.DefaultTerragruntConfigPath): fooHCL,
+	})
+
+	return v, filepath.Join(root, "foo", config.DefaultTerragruntConfigPath)
 }
 
 func TestParseRemoteStateIgnoresUnappliedDependency(t *testing.T) {
 	t.Parallel()
 
-	fooPath := writeUnitPair(t, `inputs = {}`, `
+	v, fooPath := unitPairVenv(t, `inputs = {}`, `
 dependency "bar" {
   config_path = "../bar"
 }
@@ -54,7 +60,7 @@ inputs = {
 `)
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+	ctx, pctx := newTestParsingContext(t, v, fooPath)
 
 	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
 	require.NoError(t, err)
@@ -67,7 +73,7 @@ inputs = {
 func TestParseRemoteStateResolvesDependencyOutputs(t *testing.T) {
 	t.Parallel()
 
-	fooPath := writeUnitPair(t, `inputs = {}`, `
+	v, fooPath := unitPairVenv(t, `inputs = {}`, `
 dependency "bar" {
   config_path  = "../bar"
   skip_outputs = true
@@ -89,7 +95,7 @@ remote_state {
 `)
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+	ctx, pctx := newTestParsingContext(t, v, fooPath)
 
 	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
 	require.NoError(t, err)
@@ -101,7 +107,7 @@ remote_state {
 func TestParseRemoteStateAsAttribute(t *testing.T) {
 	t.Parallel()
 
-	fooPath := writeUnitPair(t, `inputs = {}`, `
+	v, fooPath := unitPairVenv(t, `inputs = {}`, `
 dependency "bar" {
   config_path = "../bar"
 }
@@ -122,7 +128,7 @@ inputs = {
 `)
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+	ctx, pctx := newTestParsingContext(t, v, fooPath)
 
 	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
 	require.NoError(t, err)
@@ -135,10 +141,8 @@ inputs = {
 func TestParseRemoteStateFromJSONConfig(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
-
-	fooPath := filepath.Join(tmpDir, config.DefaultTerragruntJSONConfigPath)
-	require.NoError(t, os.WriteFile(fooPath, []byte(`{
+	v, root := unitsVenv(t, map[string]string{
+		config.DefaultTerragruntJSONConfigPath: `{
   "remote_state": {
     "backend": "s3",
     "config": {
@@ -148,10 +152,15 @@ func TestParseRemoteStateFromJSONConfig(t *testing.T) {
     }
   }
 }
-`), 0644))
+`,
+	})
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+	ctx, pctx := newTestParsingContext(
+		t,
+		v,
+		filepath.Join(root, config.DefaultTerragruntJSONConfigPath),
+	)
 
 	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
 	require.NoError(t, err)
@@ -164,19 +173,13 @@ func TestParseRemoteStateFromJSONConfig(t *testing.T) {
 func TestParseRemoteStateFromExposedInclude(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
-
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "root.hcl"), []byte(`
+	v, root := unitsVenv(t, map[string]string{
+		"root.hcl": `
 locals {
   bucket = "root-state"
 }
-`), 0644))
-
-	unitDir := filepath.Join(tmpDir, "foo")
-	require.NoError(t, os.MkdirAll(unitDir, 0755))
-
-	fooPath := filepath.Join(unitDir, config.DefaultTerragruntConfigPath)
-	require.NoError(t, os.WriteFile(fooPath, []byte(`
+`,
+		filepath.Join("foo", config.DefaultTerragruntConfigPath): `
 include "root" {
   path   = find_in_parent_folders("root.hcl")
   expose = true
@@ -191,10 +194,15 @@ remote_state {
     region = "us-east-1"
   }
 }
-`), 0644))
+`,
+	})
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+	ctx, pctx := newTestParsingContext(
+		t,
+		v,
+		filepath.Join(root, "foo", config.DefaultTerragruntConfigPath),
+	)
 
 	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
 	require.NoError(t, err)
@@ -206,9 +214,8 @@ remote_state {
 func TestParseRemoteStateFromIncludeReadingDependencyOutputs(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
-
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "root.hcl"), []byte(`
+	v, root := unitsVenv(t, map[string]string{
+		"root.hcl": `
 remote_state {
   backend = "s3"
 
@@ -218,20 +225,9 @@ remote_state {
     region = "us-east-1"
   }
 }
-`), 0644))
-
-	for _, name := range []string{"foo", "bar"} {
-		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, name), 0755))
-	}
-
-	require.NoError(t, os.WriteFile(
-		filepath.Join(tmpDir, "bar", config.DefaultTerragruntConfigPath),
-		[]byte(`inputs = {}`),
-		0644,
-	))
-
-	fooPath := filepath.Join(tmpDir, "foo", config.DefaultTerragruntConfigPath)
-	require.NoError(t, os.WriteFile(fooPath, []byte(`
+`,
+		filepath.Join("bar", config.DefaultTerragruntConfigPath): `inputs = {}`,
+		filepath.Join("foo", config.DefaultTerragruntConfigPath): `
 include "root" {
   path = find_in_parent_folders("root.hcl")
 }
@@ -244,10 +240,15 @@ dependency "bar" {
     bucket = "bar-state"
   }
 }
-`), 0644))
+`,
+	})
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+	ctx, pctx := newTestParsingContext(
+		t,
+		v,
+		filepath.Join(root, "foo", config.DefaultTerragruntConfigPath),
+	)
 
 	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
 	require.NoError(t, err)
@@ -259,9 +260,8 @@ dependency "bar" {
 func TestParseRemoteStateFromIncludedConfig(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
-
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "root.hcl"), []byte(`
+	v, root := unitsVenv(t, map[string]string{
+		"root.hcl": `
 locals {
   bucket = "root-state"
 }
@@ -275,13 +275,9 @@ remote_state {
     region = "us-east-1"
   }
 }
-`), 0644))
-
-	unitDir := filepath.Join(tmpDir, "foo")
-	require.NoError(t, os.MkdirAll(unitDir, 0755))
-
-	fooPath := filepath.Join(unitDir, config.DefaultTerragruntConfigPath)
-	require.NoError(t, os.WriteFile(fooPath, []byte(`
+`,
+		filepath.Join("bar", config.DefaultTerragruntConfigPath): `inputs = {}`,
+		filepath.Join("foo", config.DefaultTerragruntConfigPath): `
 include "root" {
   path = find_in_parent_folders("root.hcl")
 }
@@ -293,18 +289,15 @@ dependency "bar" {
 inputs = {
   name = dependency.bar.outputs.name
 }
-`), 0644))
-
-	barDir := filepath.Join(tmpDir, "bar")
-	require.NoError(t, os.MkdirAll(barDir, 0755))
-	require.NoError(t, os.WriteFile(
-		filepath.Join(barDir, config.DefaultTerragruntConfigPath),
-		[]byte(`inputs = {}`),
-		0644,
-	))
+`,
+	})
 
 	l := createLogger()
-	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+	ctx, pctx := newTestParsingContext(
+		t,
+		v,
+		filepath.Join(root, "foo", config.DefaultTerragruntConfigPath),
+	)
 
 	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
 	require.NoError(t, err)

--- a/pkg/config/remote_state_test.go
+++ b/pkg/config/remote_state_test.go
@@ -1,0 +1,314 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeUnitPair writes a `bar` unit and a `foo` unit beside it, and returns the path to foo's config.
+func writeUnitPair(t *testing.T, barHCL, fooHCL string) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+
+	for name, contents := range map[string]string{"bar": barHCL, "foo": fooHCL} {
+		unitDir := filepath.Join(tmpDir, name)
+		require.NoError(t, os.MkdirAll(unitDir, 0755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(unitDir, config.DefaultTerragruntConfigPath),
+			[]byte(contents),
+			0644,
+		))
+	}
+
+	return filepath.Join(tmpDir, "foo", config.DefaultTerragruntConfigPath)
+}
+
+func TestParseRemoteStateIgnoresUnappliedDependency(t *testing.T) {
+	t.Parallel()
+
+	fooPath := writeUnitPair(t, `inputs = {}`, `
+dependency "bar" {
+  config_path = "../bar"
+}
+
+remote_state {
+  backend = "s3"
+
+  config = {
+    bucket = "foo-state"
+    key    = "foo/tofu.tfstate"
+    region = "us-east-1"
+  }
+}
+
+inputs = {
+  name = dependency.bar.outputs.name
+}
+`)
+
+	l := createLogger()
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+
+	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
+	require.NoError(t, err)
+	require.NotNil(t, remoteState)
+
+	assert.Equal(t, "s3", remoteState.BackendName)
+	assert.Equal(t, "foo-state", remoteState.BackendConfig["bucket"])
+}
+
+func TestParseRemoteStateResolvesDependencyOutputs(t *testing.T) {
+	t.Parallel()
+
+	fooPath := writeUnitPair(t, `inputs = {}`, `
+dependency "bar" {
+  config_path  = "../bar"
+  skip_outputs = true
+
+  mock_outputs = {
+    bucket = "bar-state"
+  }
+}
+
+remote_state {
+  backend = "s3"
+
+  config = {
+    bucket = dependency.bar.outputs.bucket
+    key    = "foo/tofu.tfstate"
+    region = "us-east-1"
+  }
+}
+`)
+
+	l := createLogger()
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+
+	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
+	require.NoError(t, err)
+	require.NotNil(t, remoteState)
+
+	assert.Equal(t, "bar-state", remoteState.BackendConfig["bucket"])
+}
+
+func TestParseRemoteStateAsAttribute(t *testing.T) {
+	t.Parallel()
+
+	fooPath := writeUnitPair(t, `inputs = {}`, `
+dependency "bar" {
+  config_path = "../bar"
+}
+
+remote_state = {
+  backend = "s3"
+
+  config = {
+    bucket = "foo-state"
+    key    = "foo/tofu.tfstate"
+    region = "us-east-1"
+  }
+}
+
+inputs = {
+  name = dependency.bar.outputs.name
+}
+`)
+
+	l := createLogger()
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+
+	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
+	require.NoError(t, err)
+	require.NotNil(t, remoteState)
+
+	assert.Equal(t, "s3", remoteState.BackendName)
+	assert.Equal(t, "foo-state", remoteState.BackendConfig["bucket"])
+}
+
+func TestParseRemoteStateFromJSONConfig(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	fooPath := filepath.Join(tmpDir, config.DefaultTerragruntJSONConfigPath)
+	require.NoError(t, os.WriteFile(fooPath, []byte(`{
+  "remote_state": {
+    "backend": "s3",
+    "config": {
+      "bucket": "foo-state",
+      "key": "foo/tofu.tfstate",
+      "region": "us-east-1"
+    }
+  }
+}
+`), 0644))
+
+	l := createLogger()
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+
+	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
+	require.NoError(t, err)
+	require.NotNil(t, remoteState)
+
+	assert.Equal(t, "s3", remoteState.BackendName)
+	assert.Equal(t, "foo-state", remoteState.BackendConfig["bucket"])
+}
+
+func TestParseRemoteStateFromExposedInclude(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "root.hcl"), []byte(`
+locals {
+  bucket = "root-state"
+}
+`), 0644))
+
+	unitDir := filepath.Join(tmpDir, "foo")
+	require.NoError(t, os.MkdirAll(unitDir, 0755))
+
+	fooPath := filepath.Join(unitDir, config.DefaultTerragruntConfigPath)
+	require.NoError(t, os.WriteFile(fooPath, []byte(`
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+remote_state {
+  backend = "s3"
+
+  config = {
+    bucket = include.root.locals.bucket
+    key    = "foo/tofu.tfstate"
+    region = "us-east-1"
+  }
+}
+`), 0644))
+
+	l := createLogger()
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+
+	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
+	require.NoError(t, err)
+	require.NotNil(t, remoteState)
+
+	assert.Equal(t, "root-state", remoteState.BackendConfig["bucket"])
+}
+
+func TestParseRemoteStateFromIncludeReadingDependencyOutputs(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "root.hcl"), []byte(`
+remote_state {
+  backend = "s3"
+
+  config = {
+    bucket = dependency.bar.outputs.bucket
+    key    = "foo/tofu.tfstate"
+    region = "us-east-1"
+  }
+}
+`), 0644))
+
+	for _, name := range []string{"foo", "bar"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, name), 0755))
+	}
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, "bar", config.DefaultTerragruntConfigPath),
+		[]byte(`inputs = {}`),
+		0644,
+	))
+
+	fooPath := filepath.Join(tmpDir, "foo", config.DefaultTerragruntConfigPath)
+	require.NoError(t, os.WriteFile(fooPath, []byte(`
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+dependency "bar" {
+  config_path  = "../bar"
+  skip_outputs = true
+
+  mock_outputs = {
+    bucket = "bar-state"
+  }
+}
+`), 0644))
+
+	l := createLogger()
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+
+	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
+	require.NoError(t, err)
+	require.NotNil(t, remoteState)
+
+	assert.Equal(t, "bar-state", remoteState.BackendConfig["bucket"])
+}
+
+func TestParseRemoteStateFromIncludedConfig(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "root.hcl"), []byte(`
+locals {
+  bucket = "root-state"
+}
+
+remote_state {
+  backend = "s3"
+
+  config = {
+    bucket = local.bucket
+    key    = "tofu.tfstate"
+    region = "us-east-1"
+  }
+}
+`), 0644))
+
+	unitDir := filepath.Join(tmpDir, "foo")
+	require.NoError(t, os.MkdirAll(unitDir, 0755))
+
+	fooPath := filepath.Join(unitDir, config.DefaultTerragruntConfigPath)
+	require.NoError(t, os.WriteFile(fooPath, []byte(`
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+dependency "bar" {
+  config_path = "../bar"
+}
+
+inputs = {
+  name = dependency.bar.outputs.name
+}
+`), 0644))
+
+	barDir := filepath.Join(tmpDir, "bar")
+	require.NoError(t, os.MkdirAll(barDir, 0755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(barDir, config.DefaultTerragruntConfigPath),
+		[]byte(`inputs = {}`),
+		0644,
+	))
+
+	l := createLogger()
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), fooPath)
+
+	remoteState, err := config.ParseRemoteState(ctx, l, pctx)
+	require.NoError(t, err)
+	require.NotNil(t, remoteState)
+
+	assert.Equal(t, "root-state", remoteState.BackendConfig["bucket"])
+}

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -1137,15 +1137,15 @@ func (u *Unit) ReadOutputs(
 	pctx *ParsingContext,
 	unitDir string,
 ) (map[string]cty.Value, error) {
-	configPath := filepath.Join(unitDir, DefaultTerragruntConfigPath)
+	cfgPath := filepath.Join(unitDir, DefaultTerragruntConfigPath)
 	l.Debugf("Getting output from unit %s in %s", u.Name, unitDir)
 
-	jsonBytes, err := getOutputJSONWithCaching(ctx, pctx, l, configPath)
+	jsonBytes, err := getOutputJSONWithCaching(ctx, pctx, l, cfgPath)
 	if err != nil {
 		return nil, err
 	}
 
-	outputMap, err := TerraformOutputJSONToCtyValueMap(configPath, jsonBytes)
+	outputMap, err := TerraformOutputJSONToCtyValueMap(cfgPath, jsonBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -1183,7 +1183,7 @@ func ReadStackConfigString(
 	ctx context.Context,
 	l log.Logger,
 	pctx *ParsingContext,
-	configPath string,
+	cfgPath string,
 	configString string,
 	values *cty.Value,
 ) (*StackConfig, error) {
@@ -1192,7 +1192,7 @@ func ReadStackConfigString(
 	}
 
 	hclFile, err := hclparse.NewParser(pctx.ParserOptions...).
-		ParseFromString(configString, configPath)
+		ParseFromString(configString, cfgPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -1041,11 +1041,28 @@ func copyFiles(
 ) error {
 	if !isLocal(v.FS, cp.sourceDir, cp.src) {
 		if err := v.FS.MkdirAll(cp.dest, os.ModePerm); err != nil {
-			return fmt.Errorf("failed to create directory %s for %s %w", cp.dest, cp.identifier, err)
+			return fmt.Errorf(
+				"failed to create directory %s for %s %w",
+				cp.dest,
+				cp.identifier,
+				err,
+			)
 		}
 
-		if _, err := getter.GetAny(ctx, l, v, cp.dest, cp.src, stackGetterOptions(v, opts)...); err != nil {
-			return fmt.Errorf("failed to fetch %s %s for %s %w", cp.src, cp.dest, cp.identifier, err)
+		if _, err := getter.GetAny(
+			ctx,
+			l,
+			v,
+			cp.dest,
+			cp.src,
+			stackGetterOptions(v, opts)...); err != nil {
+			return fmt.Errorf(
+				"failed to fetch %s %s for %s %w",
+				cp.src,
+				cp.dest,
+				cp.identifier,
+				err,
+			)
 		}
 
 		return nil

--- a/pkg/config/telemetry.go
+++ b/pkg/config/telemetry.go
@@ -33,7 +33,7 @@ const (
 func TraceParseConfigFile(
 	ctx context.Context,
 	l log.Logger,
-	configPath string,
+	cfgPath string,
 	workingDir string,
 	isPartial bool,
 	decodeList []PartialDecodeSectionType,
@@ -42,7 +42,7 @@ func TraceParseConfigFile(
 	fn func(ctx context.Context, l log.Logger) error,
 ) error {
 	attrs := map[string]any{
-		AttrConfigPath:       configPath,
+		AttrConfigPath:       cfgPath,
 		AttrWorkingDir:       workingDir,
 		AttrIsPartial:        isPartial,
 		AttrCacheHit:         cacheHit,
@@ -65,14 +65,14 @@ func TraceParseConfigFile(
 func TraceParseDependencies(
 	ctx context.Context,
 	l log.Logger,
-	configPath string,
+	cfgPath string,
 	skipOutputsResolution bool,
 	dependencyCount int,
 	dependencyNames []string,
 	fn func(ctx context.Context, l log.Logger) error,
 ) error {
 	attrs := map[string]any{
-		AttrConfigPath:      configPath,
+		AttrConfigPath:      cfgPath,
 		AttrSkipOutputs:     skipOutputsResolution,
 		AttrDependencyCount: dependencyCount,
 	}

--- a/test/fixtures/backend-unapplied-dependency/bar/terragrunt.hcl
+++ b/test/fixtures/backend-unapplied-dependency/bar/terragrunt.hcl
@@ -1,0 +1,3 @@
+inputs = {
+  name = "bar"
+}

--- a/test/fixtures/backend-unapplied-dependency/foo/terragrunt.hcl
+++ b/test/fixtures/backend-unapplied-dependency/foo/terragrunt.hcl
@@ -1,0 +1,15 @@
+dependency "bar" {
+  config_path = "../bar"
+}
+
+remote_state {
+  backend = "local"
+
+  config = {
+    path = "foo.tfstate"
+  }
+}
+
+inputs = {
+  name = dependency.bar.outputs.name
+}

--- a/test/integration_backend_test.go
+++ b/test/integration_backend_test.go
@@ -1,0 +1,25 @@
+package test_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+const testFixtureBackendUnappliedDependency = "fixtures/backend-unapplied-dependency"
+
+func TestBackendBootstrapWithUnappliedDependency(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureBackendUnappliedDependency)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureBackendUnappliedDependency)
+	unitPath := filepath.Join(tmpEnvPath, testFixtureBackendUnappliedDependency, "foo")
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt backend bootstrap --non-interactive --working-dir "+unitPath,
+	)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #4627.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Backend bootstrap, migration, and deletion commands now avoid fetching unnecessary dependency outputs.
  - Unapplied dependencies no longer block remote-state operations.
  - Referenced dependency outputs continue to resolve correctly.
  - Improved support for remote-state configuration in HCL, JSON, attribute syntax, and included configurations.

- **Tests**
  - Added coverage for unapplied dependencies, included configurations, dependency output resolution, and backend bootstrap scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->