### PR TITLE
feat: Add ability to open browser for approval

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -149,7 +149,7 @@ linters:
         - pattern: ^filepath\.EvalSymlinks$
           pkg: ^path/filepath$
           msg: resolve links on the venv's vfs.FS via vfs.EvalSymlinks, or vfs.ResolveForCompare when the result is to be compared against another path
-        - pattern: ^(vfs\.NewOSFS|vexec\.NewOSExec|vhttp\.NewOSClient|vsops\.NewOSDecrypter)$
+        - pattern: ^(vfs\.NewOSFS|vexec\.NewOSExec|vhttp\.NewOSClient|vsops\.NewOSDecrypter|vbrowser\.NewOSOpener)$
           msg: take the handle from the venv already in scope rather than building a fresh OS-backed one
         - pattern: ^config\.LoadDefaultConfig$
           pkg: ^github.com/aws/aws-sdk-go-v2/config$
@@ -220,7 +220,7 @@ linters:
       # the real OS any more, so neither should be able to start.
       - linters:
           - forbidigo
-        path: ^internal/(vfs|vexec|vhttp|vsops|venv)/|^internal/os/exec/
+        path: ^internal/(vfs|vexec|vhttp|vsops|vbrowser|venv)/|^internal/os/exec/
       # A pty is the real terminal by definition, so the two callers that
       # decide whether to allocate one read the real descriptor to do it.
       # Both are reached only once the venv's Terminal has already reported

--- a/internal/portal/approval.go
+++ b/internal/portal/approval.go
@@ -1,0 +1,100 @@
+package portal
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/gruntwork-io/terragrunt/internal/os/stdout"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+)
+
+// PromptApproval shows the user the code the approval page will ask them to
+// confirm, then sends their browser to that page.
+//
+// When the browser does not open, the user visits the URL and enters the code
+// to approve the login.
+func PromptApproval(ctx context.Context, l log.Logger, v *venv.Venv, auth *DeviceAuthorization) error {
+	v.RequireWriters()
+	v.RequireBrowser()
+
+	w := v.Writers.Writer
+	target := auth.approvalURL()
+	style := newApprovalStyle(stdout.ShouldColor(l, v))
+
+	if err := writeLines(w,
+		"Your one-time code: "+style.code(auth.UserCode),
+		"Opening your browser to "+style.url(target),
+	); err != nil {
+		return err
+	}
+
+	if err := v.Browser.Open(ctx, target); err != nil {
+		l.Debugf("Could not open a browser: %v", err)
+
+		return writeLines(w, style.hint("  No browser opened. Visit the URL above and enter the code."))
+	}
+
+	return writeLines(w, style.hint("  Didn't open? Visit the URL above and enter the code."))
+}
+
+// ANSI palette indexes rather than hex values, so each color is the one the
+// user's terminal theme assigns.
+const (
+	ansiBrightCyan = "14"
+	ansiBrightBlue = "12"
+)
+
+// approvalStyle draws each part of the prompt by what the user does with it.
+// The code is the only part they type somewhere else, so it is the only part
+// emphasized.
+type approvalStyle struct {
+	code func(string) string
+	url  func(string) string
+	hint func(string) string
+}
+
+// newApprovalStyle leaves every part unstyled when the escape sequences would
+// land in a pipe or a file as text.
+func newApprovalStyle(shouldColor bool) approvalStyle {
+	if !shouldColor {
+		return approvalStyle{
+			code: func(s string) string { return s },
+			url:  func(s string) string { return s },
+			hint: func(s string) string { return s },
+		}
+	}
+
+	codeStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ansiBrightCyan))
+	urlStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlue))
+	hintStyle := lipgloss.NewStyle().Faint(true)
+
+	return approvalStyle{
+		code: func(s string) string { return codeStyle.Render(s) },
+		url:  func(s string) string { return urlStyle.Render(s) },
+		hint: func(s string) string { return hintStyle.Render(s) },
+	}
+}
+
+// approvalURL is the page to send the user to. The portal's pre-filled form
+// leaves them nothing to type, so it wins when the portal supplied one.
+func (a *DeviceAuthorization) approvalURL() string {
+	if a.VerificationURIComplete != "" {
+		return a.VerificationURIComplete
+	}
+
+	return a.VerificationURI
+}
+
+func writeLines(w io.Writer, lines ...string) error {
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return fmt.Errorf("writing the login approval prompt: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/portal/approval_test.go
+++ b/internal/portal/approval_test.go
@@ -1,0 +1,271 @@
+package portal_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/portal"
+	"github.com/gruntwork-io/terragrunt/internal/vbrowser"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/writer"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	approvalURI         = "https://portal.example.com/auth/device"
+	approvalURIComplete = "https://portal.example.com/auth/device?user_code=FAKE-CODE"
+)
+
+func newAuthorization() *portal.DeviceAuthorization {
+	return &portal.DeviceAuthorization{
+		DeviceCode:              portal.Secret("fake-device-code"),
+		UserCode:                "FAKE-CODE",
+		VerificationURI:         approvalURI,
+		VerificationURIComplete: approvalURIComplete,
+	}
+}
+
+func TestPromptApprovalOpensPrefilledURL(t *testing.T) {
+	t.Parallel()
+
+	var (
+		out    bytes.Buffer
+		opened string
+	)
+
+	v := venvtest.New()
+	v.Writers = &writer.Writers{Writer: &out, ErrWriter: &out}
+	v = v.WithBrowser(vbrowser.NewMemOpener(func(_ context.Context, rawURL string) error {
+		opened = rawURL
+
+		return nil
+	}))
+
+	require.NoError(t, portal.PromptApproval(t.Context(), logger.CreateLogger(), v, newAuthorization()))
+
+	assert.Equal(t, approvalURIComplete, opened)
+	assert.Contains(t, out.String(), "FAKE-CODE")
+	assert.Contains(t, out.String(), approvalURIComplete)
+}
+
+// TestPromptApprovalPrintsBeforeOpening pins the ordering: the code reaches the
+// terminal before a browser window can take focus and cover it.
+func TestPromptApprovalPrintsBeforeOpening(t *testing.T) {
+	t.Parallel()
+
+	var (
+		out           bytes.Buffer
+		printedAtOpen string
+	)
+
+	v := venvtest.New()
+	v.Writers = &writer.Writers{Writer: &out, ErrWriter: &out}
+	v = v.WithBrowser(vbrowser.NewMemOpener(func(context.Context, string) error {
+		printedAtOpen = out.String()
+
+		return nil
+	}))
+
+	require.NoError(t, portal.PromptApproval(t.Context(), logger.CreateLogger(), v, newAuthorization()))
+
+	assert.Contains(t, printedAtOpen, "FAKE-CODE")
+	assert.Contains(t, printedAtOpen, approvalURIComplete)
+}
+
+// TestPromptApprovalFallsBackToPlainURL pins that the portal omitting the
+// pre-filled URL still sends the user somewhere they can type the code.
+func TestPromptApprovalFallsBackToPlainURL(t *testing.T) {
+	t.Parallel()
+
+	var (
+		out    bytes.Buffer
+		opened string
+	)
+
+	auth := newAuthorization()
+	auth.VerificationURIComplete = ""
+
+	v := venvtest.New()
+	v.Writers = &writer.Writers{Writer: &out, ErrWriter: &out}
+	v = v.WithBrowser(vbrowser.NewMemOpener(func(_ context.Context, rawURL string) error {
+		opened = rawURL
+
+		return nil
+	}))
+
+	require.NoError(t, portal.PromptApproval(t.Context(), logger.CreateLogger(), v, auth))
+
+	assert.Equal(t, approvalURI, opened)
+	assert.Contains(t, out.String(), approvalURI)
+}
+
+// TestPromptApprovalSurvivesNoBrowser pins the headless path: a host that
+// cannot open a browser still gets the code and the URL, and login carries on
+// so the user can approve from another device.
+func TestPromptApprovalSurvivesNoBrowser(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+
+	v := venvtest.New()
+	v.Writers = &writer.Writers{Writer: &out, ErrWriter: &out}
+
+	require.NoError(t, portal.PromptApproval(t.Context(), logger.CreateLogger(), v, newAuthorization()))
+
+	assert.Contains(t, out.String(), "FAKE-CODE")
+	assert.Contains(t, out.String(), approvalURIComplete)
+	assert.Contains(t, out.String(), "No browser opened")
+}
+
+// TestPromptApprovalDoesNotPrintDeviceCode pins that the credential stays out
+// of the terminal while the user code, which the user must read, does not.
+func TestPromptApprovalDoesNotPrintDeviceCode(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+
+	v := venvtest.New()
+	v.Writers = &writer.Writers{Writer: &out, ErrWriter: &out}
+	v = v.WithBrowser(vbrowser.NewMemOpener(func(context.Context, string) error { return nil }))
+
+	require.NoError(t, portal.PromptApproval(t.Context(), logger.CreateLogger(), v, newAuthorization()))
+
+	assert.NotContains(t, out.String(), "fake-device-code")
+	assert.Contains(t, out.String(), "FAKE-CODE")
+}
+
+func TestPromptApprovalReportsWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("broken pipe")
+
+	v := venvtest.New()
+	v.Writers = &writer.Writers{Writer: failingWriter{err: sentinel}, ErrWriter: &bytes.Buffer{}}
+	v = v.WithBrowser(vbrowser.NewMemOpener(func(context.Context, string) error { return nil }))
+
+	err := portal.PromptApproval(t.Context(), logger.CreateLogger(), v, newAuthorization())
+	require.ErrorIs(t, err, sentinel)
+}
+
+// TestPromptApprovalRejectsUnbrowsableURL pins that the opener refuses a
+// verification URL the portal should never have sent, even though the parse in
+// AuthorizeDevice already turns one away.
+func TestPromptApprovalRejectsUnbrowsableURL(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+
+	auth := newAuthorization()
+	auth.VerificationURIComplete = "file:///fake/path"
+
+	v := venvtest.New()
+	v.Writers = &writer.Writers{Writer: &out, ErrWriter: &out}
+	v = v.WithBrowser(vbrowser.NewMemOpener(func(context.Context, string) error {
+		t.Error("the handler must not be reached for an unbrowsable URL")
+
+		return nil
+	}))
+
+	require.NoError(t, portal.PromptApproval(t.Context(), logger.CreateLogger(), v, auth))
+	assert.Contains(t, out.String(), "No browser opened")
+}
+
+// TestPromptApprovalStylesNothingWithoutATerminal pins what a pipe or a log
+// file receives: text with no escape sequences in it.
+func TestPromptApprovalStylesNothingWithoutATerminal(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+
+	v := venvtest.New()
+	v.Writers = &writer.Writers{Writer: &out, ErrWriter: &out}
+	v = v.WithBrowser(vbrowser.NewMemOpener(func(context.Context, string) error { return nil }))
+
+	require.NoError(t, portal.PromptApproval(t.Context(), logger.CreateLogger(), v, newAuthorization()))
+
+	assert.NotContains(t, out.String(), escape)
+	assert.Contains(t, out.String(), "Your one-time code: FAKE-CODE")
+}
+
+// TestPromptApprovalDrawsTheEyeToTheCode pins what a terminal receives: the
+// code and the URL drawn differently, and the code still readable as plain
+// text for copying.
+func TestPromptApprovalDrawsTheEyeToTheCode(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+
+	v := venvtest.New()
+	v.Writers = &writer.Writers{Writer: &out, ErrWriter: &out}
+	v.Terminal = &venv.Terminal{
+		StdinIsTTY:  func() bool { return false },
+		StdoutIsTTY: func() bool { return true },
+		StderrIsTTY: func() bool { return false },
+		Width:       func() int { return 80 },
+	}
+	v = v.WithBrowser(vbrowser.NewMemOpener(func(context.Context, string) error { return nil }))
+
+	// The shared logger disables colors, which every other test here wants.
+	l := logger.CreateLogger()
+	l.Formatter().SetDisabledColors(false)
+
+	require.NoError(t, portal.PromptApproval(t.Context(), l, v, newAuthorization()))
+
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	require.Len(t, lines, 3)
+
+	codeLine, urlLine, hintLine := lines[0], lines[1], lines[2]
+
+	assert.Contains(t, codeLine, escape, "the code carries styling")
+	assert.Contains(t, stripEscapes(codeLine), "FAKE-CODE", "the code survives as copyable text")
+
+	assert.Contains(t, urlLine, escape, "the URL is marked as a URL")
+	assert.Contains(t, stripEscapes(urlLine), approvalURIComplete)
+
+	// A terminal finds the URL to make clickable by scanning for an unbroken
+	// run of it.
+	assert.Contains(t, urlLine, approvalURIComplete, "the URL survives as one unbroken run")
+
+	assert.Contains(t, hintLine, escape, "the hint recedes")
+}
+
+// escape opens every ANSI styling sequence lipgloss writes.
+const escape = "\x1b"
+
+// stripEscapes removes ANSI sequences so an assertion reads the text a user
+// would see rather than how it was drawn.
+func stripEscapes(s string) string {
+	var b strings.Builder
+
+	for {
+		start := strings.Index(s, escape)
+		if start < 0 {
+			b.WriteString(s)
+
+			return b.String()
+		}
+
+		b.WriteString(s[:start])
+
+		end := strings.IndexByte(s[start:], 'm')
+		if end < 0 {
+			return b.String()
+		}
+
+		s = s[start+end+1:]
+	}
+}
+
+type failingWriter struct {
+	err error
+}
+
+func (w failingWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}

--- a/internal/portal/deviceauth.go
+++ b/internal/portal/deviceauth.go
@@ -191,9 +191,10 @@ func (b *bodyReader) wrap(err error) error {
 	return fmt.Errorf("%w: %w", ErrMalformedResponse, err)
 }
 
-// checkBrowsable rejects a verification URL a browser must not open. Login
-// opens these directly, so a file: or javascript: scheme would turn a
-// compromised or misconfigured portal into local code execution.
+// checkBrowsable rejects a verification URL that is not a web page. Login has
+// nowhere to send the user, so it fails here rather than printing a dead URL
+// and waiting for an approval that cannot arrive. What such a URL would do to
+// the host is the browser opener's concern, and it refuses them too.
 func checkBrowsable(rawURL string) error {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {

--- a/internal/portal/portal.go
+++ b/internal/portal/portal.go
@@ -1,6 +1,7 @@
 // Package portal talks to the Gruntwork Developer Portal, the authorization
 // server and catalog API that back `terragrunt login` and a portal-defined
-// `terragrunt catalog`.
+// `terragrunt catalog`. It also owns the CLI's half of the login hand-off,
+// where the user is shown a code and sent to the portal to approve it.
 //
 // Login follows the OAuth 2.0 Device Authorization Grant ([RFC 8628]). The CLI
 // is a public client: it holds no client secret and registers no redirect URI,

--- a/internal/vbrowser/fault.go
+++ b/internal/vbrowser/fault.go
@@ -1,0 +1,23 @@
+package vbrowser
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ErrNoBrowser is returned by openers built from [NewNoBrowserOpener].
+var ErrNoBrowser = errors.New("vbrowser: opening a browser is not permitted")
+
+// NewNoBrowserOpener returns an [Opener] whose every call fails with an error
+// wrapping [ErrNoBrowser]. It lets tests assert that a code path opens no
+// browser, and stands in for the host that has none.
+func NewNoBrowserOpener() Opener {
+	return noBrowserOpener{}
+}
+
+type noBrowserOpener struct{}
+
+func (noBrowserOpener) Open(_ context.Context, rawURL string) error {
+	return fmt.Errorf("%w: %q", ErrNoBrowser, rawURL)
+}

--- a/internal/vbrowser/os.go
+++ b/internal/vbrowser/os.go
@@ -1,0 +1,31 @@
+package vbrowser
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type osOpener struct {
+	goos string
+}
+
+func (o osOpener) Open(ctx context.Context, rawURL string) error {
+	name, args, err := OpenCommand(o.goos, rawURL)
+	if err != nil {
+		return err
+	}
+
+	// The launcher is bounded because a host with no way to open a URL can
+	// leave xdg-open waiting on a session that never answers. Leaving Stdout
+	// and Stderr nil sends the child's output to the null device, so a chatty
+	// launcher cannot interleave with what the caller already printed.
+	ctx, cancel := context.WithTimeout(ctx, openTimeout)
+	defer cancel()
+
+	if err := exec.CommandContext(ctx, name, args...).Run(); err != nil {
+		return fmt.Errorf("vbrowser: running %s: %w", name, err)
+	}
+
+	return nil
+}

--- a/internal/vbrowser/vbrowser.go
+++ b/internal/vbrowser/vbrowser.go
@@ -1,0 +1,107 @@
+// Package vbrowser provides a virtual web-browser abstraction for testing and
+// production use.
+//
+// [Opener] hands a URL to whatever the operating system uses to open one.
+// Production code builds the OS-backed opener via [NewOSOpener] and threads it
+// down from [github.com/gruntwork-io/terragrunt/internal/venv.Venv]. Tests
+// build an in-memory opener via [NewMemOpener], or [NewNoBrowserOpener] to
+// assert that a code path opens nothing.
+//
+// An opener only ever launches an http or https URL. It is handed URLs that
+// arrive over the network, and the launcher it runs treats other schemes as
+// instructions: file: opens a local document and javascript: runs code in the
+// browser the user is already signed into.
+package vbrowser
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"runtime"
+	"time"
+)
+
+// ErrUnsupportedURL is returned for a URL that is not http or https.
+var ErrUnsupportedURL = errors.New("vbrowser: only http and https URLs can be opened")
+
+// openTimeout bounds the launcher, not the browsing that follows. A launcher
+// returns as soon as it has handed the URL off, so reaching this means it hung
+// rather than that the user is reading the page.
+const openTimeout = 10 * time.Second
+
+// Opener sends a URL to the user's web browser.
+type Opener interface {
+	// Open launches rawURL. A scheme other than http or https yields an error
+	// wrapping [ErrUnsupportedURL]. A launcher that fails or is not installed
+	// is reported too, so the caller can fall back to telling the user to open
+	// the URL themselves.
+	Open(ctx context.Context, rawURL string) error
+}
+
+// Handler opens one URL for the in-memory backend. It is invoked synchronously
+// by an [Opener] returned from [NewMemOpener].
+type Handler func(ctx context.Context, rawURL string) error
+
+// NewOSOpener returns an [Opener] that runs the host's URL launcher.
+func NewOSOpener() Opener {
+	return osOpener{goos: runtime.GOOS}
+}
+
+// NewMemOpener returns an [Opener] whose every call is dispatched to h instead
+// of launching anything. h must not be nil.
+func NewMemOpener(h Handler) Opener {
+	if h == nil {
+		panic("vbrowser: NewMemOpener requires a non-nil Handler")
+	}
+
+	return memOpener{handler: h}
+}
+
+// OpenCommand returns the launcher that opens rawURL on goos, as a program name
+// and its arguments. It is exported so the per-platform choice can be tested
+// from any host, since Terragrunt ships for macOS, Windows, and Linux.
+func OpenCommand(goos, rawURL string) (string, []string, error) {
+	if err := checkURL(rawURL); err != nil {
+		return "", nil, err
+	}
+
+	switch goos {
+	case "darwin":
+		return "open", []string{rawURL}, nil
+	case "windows":
+		// rundll32 rather than `cmd /c start`, which reads &, ^, and % in the
+		// URL as shell syntax and needs an empty title argument to boot.
+		return "rundll32.exe", []string{"url.dll,FileProtocolHandler", rawURL}, nil
+	default:
+		return "xdg-open", []string{rawURL}, nil
+	}
+}
+
+// checkURL rejects what must never reach a launcher. The scheme test also
+// guarantees the URL cannot start with a dash, which a launcher would read as
+// a flag of its own rather than as the page to open.
+func checkURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("vbrowser: parsing %q: %w", rawURL, err)
+	}
+
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return fmt.Errorf("%w: %q", ErrUnsupportedURL, rawURL)
+	}
+
+	return nil
+}
+
+type memOpener struct {
+	handler Handler
+}
+
+func (o memOpener) Open(ctx context.Context, rawURL string) error {
+	if err := checkURL(rawURL); err != nil {
+		return err
+	}
+
+	return o.handler(ctx, rawURL)
+}

--- a/internal/vbrowser/vbrowser_test.go
+++ b/internal/vbrowser/vbrowser_test.go
@@ -1,0 +1,122 @@
+package vbrowser_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/vbrowser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenCommand(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		goos     string
+		wantName string
+		wantArgs []string
+	}{
+		{goos: "darwin", wantName: "open", wantArgs: []string{"https://portal.example.com/auth/device"}},
+		{
+			goos:     "windows",
+			wantName: "rundll32.exe",
+			wantArgs: []string{"url.dll,FileProtocolHandler", "https://portal.example.com/auth/device"},
+		},
+		{goos: "linux", wantName: "xdg-open", wantArgs: []string{"https://portal.example.com/auth/device"}},
+		{goos: "freebsd", wantName: "xdg-open", wantArgs: []string{"https://portal.example.com/auth/device"}},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.goos, func(t *testing.T) {
+			t.Parallel()
+
+			name, args, err := vbrowser.OpenCommand(tt.goos, "https://portal.example.com/auth/device")
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantArgs, args)
+		})
+	}
+}
+
+// TestOpenCommandRejectsUnsupportedScheme pins the guard that stands between a
+// URL arriving over the network and the launcher: a scheme other than http or
+// https is an instruction to open a local document or run code, not a page.
+func TestOpenCommandRejectsUnsupportedScheme(t *testing.T) {
+	t.Parallel()
+
+	for _, rawURL := range []string{
+		"file:///fake/path",
+		"javascript:fake-script",
+		"ftp://portal.example.com",
+		"portal.example.com/auth/device",
+		"-fake-flag",
+		"",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := vbrowser.OpenCommand("linux", rawURL)
+			require.ErrorIs(t, err, vbrowser.ErrUnsupportedURL)
+		})
+	}
+}
+
+func TestMemOpenerReceivesURL(t *testing.T) {
+	t.Parallel()
+
+	var got string
+
+	o := vbrowser.NewMemOpener(func(_ context.Context, rawURL string) error {
+		got = rawURL
+
+		return nil
+	})
+
+	require.NoError(t, o.Open(t.Context(), "https://portal.example.com/auth/device"))
+	assert.Equal(t, "https://portal.example.com/auth/device", got)
+}
+
+// TestMemOpenerChecksURLBeforeHandler pins that the scheme guard runs for the
+// in-memory opener too, so a test cannot pass a URL the OS opener would refuse.
+func TestMemOpenerChecksURLBeforeHandler(t *testing.T) {
+	t.Parallel()
+
+	called := false
+
+	o := vbrowser.NewMemOpener(func(context.Context, string) error {
+		called = true
+
+		return nil
+	})
+
+	require.ErrorIs(t, o.Open(t.Context(), "file:///fake/path"), vbrowser.ErrUnsupportedURL)
+	assert.False(t, called)
+}
+
+func TestMemOpenerPropagatesHandlerFailure(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("no display")
+
+	o := vbrowser.NewMemOpener(func(context.Context, string) error {
+		return sentinel
+	})
+
+	require.ErrorIs(t, o.Open(t.Context(), "https://portal.example.com/auth/device"), sentinel)
+}
+
+func TestNoBrowserOpenerRefuses(t *testing.T) {
+	t.Parallel()
+
+	err := vbrowser.NewNoBrowserOpener().Open(t.Context(), "https://portal.example.com/auth/device")
+	require.ErrorIs(t, err, vbrowser.ErrNoBrowser)
+}
+
+func TestNewMemOpenerRejectsNilHandler(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() { vbrowser.NewMemOpener(nil) })
+}

--- a/internal/venv/venv.go
+++ b/internal/venv/venv.go
@@ -26,6 +26,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/gruntwork-io/terragrunt/internal/vbrowser"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
@@ -58,6 +59,11 @@ var ErrVenvExecUnset = errors.New("venv.Venv.Exec is required but unset")
 // nil. Production callers build the Venv through [OSVenv], so it points at a
 // test that forgot to set HTTP rather than a runtime condition.
 var ErrVenvHTTPUnset = errors.New("venv.Venv.HTTP is required but unset")
+
+// ErrVenvBrowserUnset is the panic value [Venv.RequireBrowser] raises when
+// Browser is nil. Production callers build the Venv through [OSVenv], so it
+// points at a test that forgot to set Browser rather than a runtime condition.
+var ErrVenvBrowserUnset = errors.New("venv.Venv.Browser is required but unset")
 
 // ErrVenvStdinUnset is the panic value [Venv.RequireStdin] raises when Stdin is
 // nil. Production callers build the Venv through [OSVenv], so it points at a
@@ -126,8 +132,8 @@ type Terminal struct {
 }
 
 // Venv is the root virtualized environment. It carries the filesystem,
-// process-execution, HTTP, SOPS-decryption, environment-variable, platform,
-// and writer handles that every Terragrunt operation needs. Env is shared by
+// process-execution, HTTP, SOPS-decryption, browser, environment-variable,
+// platform, and writer handles that every Terragrunt operation needs. Env is shared by
 // reference across the run and mutated in place as provider-cache, hook, and
 // inputs contributions resolve. Writers is held as a pointer so per-call
 // overrides via [writer.Writers.WithWriter] and [writer.Writers.WithErrWriter]
@@ -146,6 +152,7 @@ type Venv struct {
 	Exec     vexec.Exec
 	HTTP     vhttp.Client
 	Sops     vsops.Decrypter
+	Browser  vbrowser.Opener
 	Listen   Listener
 	Stdin    io.Reader
 	Env      map[string]string
@@ -211,6 +218,14 @@ func (v *Venv) WithHTTP(c vhttp.Client) *Venv {
 	cp.HTTP = c
 
 	return &cp
+}
+
+// WithBrowser returns a copy of v whose browser opener is o.
+func (v *Venv) WithBrowser(o vbrowser.Opener) *Venv {
+	c := *v
+	c.Browser = o
+
+	return &c
 }
 
 // WithSops returns a copy of v whose SOPS decrypter is d.
@@ -354,6 +369,13 @@ func (v *Venv) RequireHTTP() {
 	}
 }
 
+// RequireBrowser panics with [ErrVenvBrowserUnset] when Browser is nil.
+func (v *Venv) RequireBrowser() {
+	if v.Browser == nil {
+		panic(ErrVenvBrowserUnset)
+	}
+}
+
 // RequireTerminal panics with [ErrVenvTerminalUnset] when Terminal is nil.
 // Functions that size or color their output call this as their first
 // statement so a missing handle panics at the offending call site instead of
@@ -454,13 +476,14 @@ func (v *Venv) RequireTempDir() {
 // [writer.Writers.WithWriter] returns a fresh copy.
 func OSVenv() *Venv {
 	return &Venv{
-		FS:     vfs.NewOSFS(),
-		Exec:   vexec.NewOSExec(),
-		HTTP:   vhttp.NewOSClient(),
-		Sops:   vsops.NewOSDecrypter(),
-		Listen: (&net.ListenConfig{}).Listen,
-		Stdin:  os.Stdin,
-		Env:    ParseEnviron(os.Environ()),
+		FS:      vfs.NewOSFS(),
+		Exec:    vexec.NewOSExec(),
+		HTTP:    vhttp.NewOSClient(),
+		Sops:    vsops.NewOSDecrypter(),
+		Browser: vbrowser.NewOSOpener(),
+		Listen:  (&net.ListenConfig{}).Listen,
+		Stdin:   os.Stdin,
+		Env:     ParseEnviron(os.Environ()),
 		Platform: &Platform{
 			UserHomeDir:  os.UserHomeDir,
 			UserCacheDir: os.UserCacheDir,

--- a/test/helpers/venvtest/venvtest.go
+++ b/test/helpers/venvtest/venvtest.go
@@ -1,8 +1,8 @@
 // Package venvtest builds in-memory [venv.Venv] values for tests. New seeds
 // the mem defaults; callers refine individual handles with venv.Venv's fluent
-// With methods (WithHandler, WithExec, WithFS, WithSops, WithEnv, WithGOOS,
-// WithGOARCH,
-// WithUserHomeDir). Production code builds venvs through [venv.OSVenv] instead.
+// With methods (WithHandler, WithExec, WithFS, WithSops, WithBrowser, WithEnv,
+// WithGOOS, WithGOARCH, WithUserHomeDir). Production code builds venvs through
+// [venv.OSVenv] instead.
 //
 // [NewFS] and [LoadFS] build the filesystems those venvs carry, from literals
 // and from an on-disk fixture tree.
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/gruntwork-io/terragrunt/internal/vbrowser"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
@@ -45,7 +46,8 @@ const (
 
 // New returns an in-memory venv: a fail-closed exec, an in-memory filesystem,
 // a fail-closed no-network HTTP client, a mem SOPS decrypter yielding empty
-// cleartext, an empty (non-nil) environment, deterministic platform handles,
+// cleartext, a fail-closed browser opener, an empty (non-nil) environment,
+// deterministic platform handles,
 // an empty console reader, a console that is no stream's terminal and has no
 // width, and both writers wired to [io.Discard]. Refine it with venv.Venv's
 // fluent With methods.
@@ -57,13 +59,15 @@ const (
 // A test whose subject runs a command supplies a handler through WithHandler.
 // Until it does, the command fails with [vexec.ErrNoSpawn] rather than
 // reporting success with empty output, which a caller reading the command's
-// stdout would take as a real answer.
+// stdout would take as a real answer. The browser refuses on the same
+// principle, so a suite never launches a window on the machine running it.
 func New() *venv.Venv {
 	return &venv.Venv{
-		Exec: vexec.NewNoSpawnExec(),
-		FS:   vfs.NewMemMapFS(),
-		HTTP: vhttp.NewNoNetworkClient(),
-		Sops: vsops.NewMemDecrypter(func(map[string]string, string, string) ([]byte, error) { return nil, nil }),
+		Exec:    vexec.NewNoSpawnExec(),
+		FS:      vfs.NewMemMapFS(),
+		HTTP:    vhttp.NewNoNetworkClient(),
+		Sops:    vsops.NewMemDecrypter(func(map[string]string, string, string) ([]byte, error) { return nil, nil }),
+		Browser: vbrowser.NewNoBrowserOpener(),
 		Listen: func(context.Context, string, string) (net.Listener, error) {
 			return nil, ErrNoListen
 		},


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds mechanism for opening browsers from the cli.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a device login approval flow that displays an approval code and URL.
  - Automatically opens the approval page in the system browser when available.
  - Provides clear fallback instructions when the browser cannot be opened.
  - Supports pre-filled approval URLs and terminal-aware formatting.
  - Restricts browser launching to secure HTTP(S) URLs.

- **Bug Fixes**
  - Prevents device codes from being exposed in approval URLs or output.
  - Ensures login instructions appear before attempting to open the browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->