### PR TITLE
fix: Keep symlinked terragrunt.stack.hcl anchored to its own directory (#6441)

### DIFF
--- a/docs/src/data/changelog/v1.1.5/symlinked-stack-file-source-dir.mdx
+++ b/docs/src/data/changelog/v1.1.5/symlinked-stack-file-source-dir.mdx
@@ -1,0 +1,16 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### Symlinked `terragrunt.stack.hcl` keeps its own directory for relative reads
+
+A regression first shipped in v1.0.3 caused a `terragrunt.stack.hcl` that is a symlink to take its source directory from the symlink target's location instead of the directory the symlink lives in, because stack generation resolved the whole path, stack file included, through the symlink.
+
+Relative reads inside the stack file then looked in the wrong folder. [`read_terragrunt_config()`](/reference/hcl/functions#read_terragrunt_config), [`find_in_parent_folders()`](/reference/hcl/functions#find_in_parent_folders), and a relative `source` all resolved against the target's directory, so a file sitting next to the symlink could not be read:
+
+```
+Call to function "read_terragrunt_config" failed: You attempted to run terragrunt in a folder that does not contain a terragrunt.hcl file.
+```
+
+Terragrunt now canonicalizes only the stack file's directory and keeps the file anchored to its own location. [`get_terragrunt_dir()`](/reference/hcl/functions#get_terragrunt_dir) inside a symlinked stack file returns the directory the symlink lives in, matching a stack file that is not a symlink.

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -429,7 +429,23 @@ func addNewNodesToGraph(
 	}
 }
 
-// ListStackFiles returns canonical, symlink-resolved stack-file paths under the absolute opts.WorkingDir.
+// canonicalStackFilePath returns the canonical terragrunt.stack.hcl path for a discovered
+// component directory. The directory is resolved (symlinks included) so topology keys stay
+// consistent with the canonicalised working dir, but the stack-file name is joined afterwards.
+// This keeps a symlinked terragrunt.stack.hcl anchored to the directory it lives in as its
+// source dir, rather than resolving the symlink and rewriting the source dir to the symlink
+// target's directory (which broke read_terragrunt_config and other relative reads).
+func canonicalStackFilePath(fsys vfs.FS, componentDir, basePath string) (string, error) {
+	canonicalDir, err := util.CanonicalResolvedPath(fsys, componentDir, basePath)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(canonicalDir, config.DefaultStackFile), nil
+}
+
+// ListStackFiles returns canonical stack-file paths under the absolute opts.WorkingDir. The
+// directory portion is symlink-resolved; a symlinked terragrunt.stack.hcl keeps its own location.
 // For worktreeStacksOnly, stack files in the working directory are skipped and only worktree stacks are returned.
 func ListStackFiles(
 	ctx context.Context,
@@ -537,11 +553,7 @@ func collectStackAndExcludedPaths(
 	for _, c := range components {
 		switch v := c.(type) {
 		case *component.Stack:
-			canonical, err := util.CanonicalResolvedPath(
-				fsys,
-				filepath.Join(c.Path(), config.DefaultStackFile),
-				workingDir,
-			)
+			canonical, err := canonicalStackFilePath(fsys, c.Path(), workingDir)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -577,11 +589,7 @@ func appendStackFilePaths(
 			continue
 		}
 
-		canonical, err := util.CanonicalResolvedPath(
-			fsys,
-			filepath.Join(c.Path(), config.DefaultStackFile),
-			workingDir,
-		)
+		canonical, err := canonicalStackFilePath(fsys, c.Path(), workingDir)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/stacks/generate/generate_internal_test.go
+++ b/internal/stacks/generate/generate_internal_test.go
@@ -1,0 +1,74 @@
+package generate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCanonicalStackFilePathKeepsSymlinkDirectory reproduces the regression where a symlinked
+// terragrunt.stack.hcl had its source directory rewritten to the symlink target's directory,
+// so read_terragrunt_config and other relative reads looked in the wrong folder. The directory
+// portion must be canonicalised, but the stack file must stay anchored to the directory it
+// lives in rather than resolving through the symlink to its target's directory.
+func TestCanonicalStackFilePathKeepsSymlinkDirectory(t *testing.T) {
+	t.Parallel()
+
+	// Resolve the temp root up front so the assertion is not confused by e.g. /var -> /private/var.
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	// The real stack file lives in a "source" directory that is NOT where terragrunt is invoked.
+	sourceDir := filepath.Join(base, "source")
+	require.NoError(t, os.MkdirAll(sourceDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, config.DefaultStackFile), []byte("# stack\n"), 0644))
+
+	// The "live" directory holds a symlink to the real stack file plus the sibling file the stack
+	// would read relatively. read_terragrunt_config must resolve against liveDir, not sourceDir.
+	liveDir := filepath.Join(base, "live")
+	require.NoError(t, os.MkdirAll(liveDir, 0755))
+
+	symlink := filepath.Join(liveDir, config.DefaultStackFile)
+	require.NoError(t, os.Symlink(filepath.Join(sourceDir, config.DefaultStackFile), symlink))
+
+	got, err := canonicalStackFilePath(vfs.NewOSFS(), liveDir, base)
+	require.NoError(t, err)
+
+	// The generated source dir is filepath.Dir of the returned stack-file path. It must be the
+	// directory the symlink lives in, not the symlink target's directory.
+	assert.Equal(t, liveDir, filepath.Dir(got),
+		"symlinked stack file should keep its own directory as the source dir")
+	assert.NotEqual(t, sourceDir, filepath.Dir(got),
+		"symlinked stack file must not be rewritten to the symlink target's directory")
+}
+
+// TestCanonicalStackFilePathResolvesDirectory confirms the directory portion is still
+// symlink-resolved, so topology keys stay consistent with the canonicalised working dir.
+func TestCanonicalStackFilePathResolvesDirectory(t *testing.T) {
+	t.Parallel()
+
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	realDir := filepath.Join(base, "real")
+	require.NoError(t, os.MkdirAll(realDir, 0755))
+
+	// A symlinked directory should resolve to its target for a consistent, deduplicable key.
+	linkDir := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(realDir, linkDir))
+
+	got, err := canonicalStackFilePath(vfs.NewOSFS(), linkDir, base)
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(realDir, config.DefaultStackFile), got)
+	// Sanity check against the raw util helper on a non-symlinked directory.
+	direct, err := util.CanonicalResolvedPath(vfs.NewOSFS(), realDir, base)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(direct, config.DefaultStackFile), got)
+}

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -1173,3 +1173,80 @@ func readCachedFiles(t *testing.T, root, fileName string) []string {
 
 	return contents
 }
+
+// buildSymlinkedStackFileFixture lays out a tree where the terragrunt.stack.hcl in `live`
+// is a symlink to a real stack file in `source`. The real stack file reads a sibling config
+// with a path relative to get_terragrunt_dir(), and that sibling exists only next to the
+// symlink (in `live`), not next to the symlink target (in `source`). It returns the `live`
+// working directory and the value the sibling contributes to the generated unit's values.
+func buildSymlinkedStackFileFixture(t *testing.T) (liveDir, siblingData string) {
+	t.Helper()
+
+	rootDir := helpers.TmpDirWOSymlinks(t)
+	siblingData = "from-sibling"
+
+	// The unit source: a module dir carrying a terragrunt.hcl so generation's post-copy
+	// validation (which requires terragrunt.hcl at the generated unit root) passes.
+	moduleDir := filepath.Join(rootDir, "module")
+	require.NoError(t, os.Mkdir(moduleDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "terragrunt.hcl"),
+		[]byte("inputs = {\n  data = \"placeholder\"\n}\n"), 0644))
+
+	// The real stack file lives in `source` and reads its sibling relative to its own dir.
+	sourceDir := filepath.Join(rootDir, "source")
+	require.NoError(t, os.Mkdir(sourceDir, 0755))
+
+	stackHCL := `locals {
+  sibling = read_terragrunt_config("${get_terragrunt_dir()}/sibling.hcl")
+}
+
+unit "app" {
+  source = "${get_terragrunt_dir()}/../module"
+  path   = "app"
+  values = {
+    data = local.sibling.locals.data
+  }
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, config.DefaultStackFile), []byte(stackHCL), 0644))
+
+	// The `live` dir holds the symlink to the real stack file, plus the sibling it reads.
+	// The sibling exists here only, so generation succeeds only if reads resolve against
+	// `live` (where the symlink lives), not `source` (the symlink target's dir).
+	liveDir = filepath.Join(rootDir, "live")
+	require.NoError(t, os.Mkdir(liveDir, 0755))
+	require.NoError(t, os.Symlink(
+		filepath.Join(sourceDir, config.DefaultStackFile),
+		filepath.Join(liveDir, config.DefaultStackFile),
+	))
+	require.NoError(t, os.WriteFile(filepath.Join(liveDir, "sibling.hcl"),
+		[]byte("locals {\n  data = \""+siblingData+"\"\n}\n"), 0644))
+
+	return liveDir, siblingData
+}
+
+// TestStackGenerateSymlinkedStackFileReadsRelative is a regression test for a symlinked
+// terragrunt.stack.hcl whose relative read_terragrunt_config reads were resolved against the
+// symlink target's directory instead of the directory the symlink lives in. Stack generation
+// canonicalises the stack file's directory but must keep the file anchored to its own location,
+// so a sibling config read relative to get_terragrunt_dir() resolves next to the symlink.
+func TestStackGenerateSymlinkedStackFileReadsRelative(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("creating symlinks on Windows requires elevated privileges")
+	}
+
+	liveDir, siblingData := buildSymlinkedStackFileFixture(t)
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt stack generate --working-dir "+liveDir)
+	require.NoError(t, err, "stack generate should resolve the sibling read next to the symlink; stderr: %s", stderr)
+
+	// The generated unit's values must carry the value read from the sibling, proving the
+	// relative read resolved against the symlink's directory rather than its target's.
+	valuesPath := filepath.Join(liveDir, ".terragrunt-stack", "app", "terragrunt.values.hcl")
+	contents, readErr := os.ReadFile(valuesPath)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(contents), siblingData)
+}


### PR DESCRIPTION
Stack generation passed each discovered stack-file path through util.CanonicalResolvedPath, which runs filepath.EvalSymlinks on the full path including the symlinked terragrunt.stack.hcl itself. That rewrote the path to the symlink target's location, so GenerateStackFile derived stackSourceDir from the target directory rather than the directory the symlink lives in. Relative reads (read_terragrunt_config, find_in_parent_folders, relative source) then resolved against the wrong folder and failed.

Resolve/canonicalise only the stack file's directory (still needed for dedup and topology consistency with the canonicalised working dir), then join terragrunt.stack.hcl afterward via a new canonicalStackFilePath helper, so a symlinked stack file stays anchored to its own directory.

Adds an in-package regression test for canonicalStackFilePath, and a stack integration test that generates a stack from a symlinked terragrunt.stack.hcl reading a sibling config relative to get_terragrunt_dir(). The integration test lives with the other stack tests and skips on Windows at runtime (as the discovery-boundary symlink test does) rather than carrying a build tag.

Adds a v1.1.5 changelog entry under bug-fixes. No prose docs change: the documented behaviour of get_terragrunt_dir() already matches what this restores, so the docs were correct and the code was not.

Regression introduced after v0.99.3 (first shipped in v1.0.3, commit 16ad54f2c / #5962).

<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6441.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stack generation for symlinked `terragrunt.stack.hcl` files.
  * Relative file reads and `get_terragrunt_dir()` now resolve from the symlink’s directory, ensuring sibling configuration files are found correctly.
  * Improved handling of symlinked directories while preserving expected stack file locations.

* **Tests**
  * Added coverage for symlinked stack files, directory resolution, and relative configuration reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->