### PR TITLE
fix: Keep symlinked terragrunt.stack.hcl anchored to its own directory (WIP)

### DIFF
--- a/docs/src/data/changelog/v1.1.5/symlinked-stack-file-source-dir.mdx
+++ b/docs/src/data/changelog/v1.1.5/symlinked-stack-file-source-dir.mdx
@@ -1,0 +1,16 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### Symlinked `terragrunt.stack.hcl` keeps its own directory for relative reads
+
+A regression first shipped in v1.0.3 caused a `terragrunt.stack.hcl` that is a symlink to take its source directory from the symlink target's location instead of the directory the symlink lives in, because stack generation resolved the whole path, stack file included, through the symlink.
+
+Relative reads inside the stack file then looked in the wrong folder. [`read_terragrunt_config()`](/reference/hcl/functions#read_terragrunt_config), [`find_in_parent_folders()`](/reference/hcl/functions#find_in_parent_folders), and a relative `source` all resolved against the target's directory, so a file sitting next to the symlink could not be read:
+
+```
+Call to function "read_terragrunt_config" failed: You attempted to run terragrunt in a folder that does not contain a terragrunt.hcl file.
+```
+
+Terragrunt now canonicalizes only the stack file's directory and keeps the file anchored to its own location. [`get_terragrunt_dir()`](/reference/hcl/functions#get_terragrunt_dir) inside a symlinked stack file returns the directory the symlink lives in, matching a stack file that is not a symlink.

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -429,7 +429,23 @@ func addNewNodesToGraph(
 	}
 }
 
-// ListStackFiles returns canonical, symlink-resolved stack-file paths under the absolute opts.WorkingDir.
+// canonicalStackFilePath returns the canonical terragrunt.stack.hcl path for a discovered
+// component directory. The directory is resolved (symlinks included) so topology keys stay
+// consistent with the canonicalised working dir, but the stack-file name is joined afterwards.
+// This keeps a symlinked terragrunt.stack.hcl anchored to the directory it lives in as its
+// source dir, rather than resolving the symlink and rewriting the source dir to the symlink
+// target's directory (which broke read_terragrunt_config and other relative reads).
+func canonicalStackFilePath(fsys vfs.FS, componentDir, basePath string) (string, error) {
+	canonicalDir, err := util.CanonicalResolvedPath(fsys, componentDir, basePath)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(canonicalDir, config.DefaultStackFile), nil
+}
+
+// ListStackFiles returns canonical stack-file paths under the absolute opts.WorkingDir. The
+// directory portion is symlink-resolved; a symlinked terragrunt.stack.hcl keeps its own location.
 // For worktreeStacksOnly, stack files in the working directory are skipped and only worktree stacks are returned.
 func ListStackFiles(
 	ctx context.Context,
@@ -537,11 +553,7 @@ func collectStackAndExcludedPaths(
 	for _, c := range components {
 		switch v := c.(type) {
 		case *component.Stack:
-			canonical, err := util.CanonicalResolvedPath(
-				fsys,
-				filepath.Join(c.Path(), config.DefaultStackFile),
-				workingDir,
-			)
+			canonical, err := canonicalStackFilePath(fsys, c.Path(), workingDir)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -577,11 +589,7 @@ func appendStackFilePaths(
 			continue
 		}
 
-		canonical, err := util.CanonicalResolvedPath(
-			fsys,
-			filepath.Join(c.Path(), config.DefaultStackFile),
-			workingDir,
-		)
+		canonical, err := canonicalStackFilePath(fsys, c.Path(), workingDir)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/stacks/generate/generate_test.go
+++ b/internal/stacks/generate/generate_test.go
@@ -1,15 +1,18 @@
-package generate_test
+package generate
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
-	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
+	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -57,7 +60,7 @@ func TestGenerateStacksCyclicSource_FailsAtMaxLevel(t *testing.T) {
 
 	const maxLevel = 5
 
-	err := generate.NewGenerator().
+	err := NewGenerator().
 		WithMaxLevel(maxLevel).
 		GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, nil)
 
@@ -77,7 +80,7 @@ func TestGeneratorDefaultMaxLevel(t *testing.T) {
 	assert.Equal(
 		t,
 		1024,
-		generate.DefaultMaxLevel,
+		DefaultMaxLevel,
 		"default level cap must stay generous so only genuine cycles reach it",
 	)
 }
@@ -148,7 +151,7 @@ func TestStackDiscoveryFilters(t *testing.T) {
 			parsed, err := filter.ParseFilterQueries(l, tt.filters)
 			require.NoError(t, err)
 
-			selected, err := generate.StackDiscoveryFilters(parsed).Evaluate(l, filter.EvaluationContext{}, stacks)
+			selected, err := StackDiscoveryFilters(parsed).Evaluate(l, filter.EvaluationContext{}, stacks)
 			require.NoError(t, err)
 
 			selectedPaths := make([]string, 0, len(selected))
@@ -159,4 +162,77 @@ func TestStackDiscoveryFilters(t *testing.T) {
 			assert.ElementsMatch(t, tt.expected, selectedPaths)
 		})
 	}
+}
+
+// TestCanonicalStackFilePathKeepsSymlinkDirectory reproduces the regression where a symlinked
+// terragrunt.stack.hcl had its source directory rewritten to the symlink target's directory,
+// so read_terragrunt_config and other relative reads looked in the wrong folder. The directory
+// portion must be canonicalised, but the stack file must stay anchored to the directory it
+// lives in rather than resolving through the symlink to its target's directory.
+func TestCanonicalStackFilePathKeepsSymlinkDirectory(t *testing.T) {
+	t.Parallel()
+
+	// test/helpers itself is unreachable from this package: importing it would cycle back
+	// through internal/cli to internal/stacks/generate, so the platform check uses runtime.
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated privileges on Windows")
+	}
+
+	// Resolve the temp root up front so the assertion is not confused by e.g. /var -> /private/var.
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	// The real stack file lives in a "source" directory that is NOT where terragrunt is invoked.
+	sourceDir := filepath.Join(base, "source")
+	require.NoError(t, os.MkdirAll(sourceDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, config.DefaultStackFile), []byte("# stack\n"), 0644))
+
+	// The "live" directory holds a symlink to the real stack file plus the sibling file the stack
+	// would read relatively. read_terragrunt_config must resolve against liveDir, not sourceDir.
+	liveDir := filepath.Join(base, "live")
+	require.NoError(t, os.MkdirAll(liveDir, 0755))
+
+	symlink := filepath.Join(liveDir, config.DefaultStackFile)
+	require.NoError(t, os.Symlink(filepath.Join(sourceDir, config.DefaultStackFile), symlink))
+
+	got, err := canonicalStackFilePath(vfs.NewOSFS(), liveDir, base)
+	require.NoError(t, err)
+
+	// The generated source dir is filepath.Dir of the returned stack-file path. It must be the
+	// directory the symlink lives in, not the symlink target's directory.
+	assert.Equal(t, liveDir, filepath.Dir(got),
+		"symlinked stack file should keep its own directory as the source dir")
+	assert.NotEqual(t, sourceDir, filepath.Dir(got),
+		"symlinked stack file must not be rewritten to the symlink target's directory")
+}
+
+// TestCanonicalStackFilePathResolvesDirectory confirms the directory portion is still
+// symlink-resolved, so topology keys stay consistent with the canonicalised working dir.
+func TestCanonicalStackFilePathResolvesDirectory(t *testing.T) {
+	t.Parallel()
+
+	// test/helpers itself is unreachable from this package: importing it would cycle back
+	// through internal/cli to internal/stacks/generate, so the platform check uses runtime.
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated privileges on Windows")
+	}
+
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	realDir := filepath.Join(base, "real")
+	require.NoError(t, os.MkdirAll(realDir, 0755))
+
+	// A symlinked directory should resolve to its target for a consistent, deduplicable key.
+	linkDir := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(realDir, linkDir))
+
+	got, err := canonicalStackFilePath(vfs.NewOSFS(), linkDir, base)
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(realDir, config.DefaultStackFile), got)
+	// Sanity check against the raw util helper on a non-symlinked directory.
+	direct, err := util.CanonicalResolvedPath(vfs.NewOSFS(), realDir, base)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(direct, config.DefaultStackFile), got)
 }

--- a/test/helpers/test_helpers.go
+++ b/test/helpers/test_helpers.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"io/fs"
 	"os"
@@ -24,6 +25,25 @@ const defaultDirPerms = 0o755
 
 func IsWindows() bool {
 	return runtime.GOOS == "windows"
+}
+
+// SymlinkUnsupported reports whether err is the host refusing to create a symlink at all,
+// rather than a genuine failure worth failing a test over. A test that needs a symlink can
+// attempt [os.Symlink] and skip on this, keeping every other error fatal so a real regression
+// still surfaces instead of hiding behind a blanket platform skip.
+//
+// Windows needs SeCreateSymbolicLinkPrivilege or Developer Mode to create a symlink, and
+// refuses with ERROR_PRIVILEGE_NOT_HELD otherwise. Go does not map that errno to
+// [fs.ErrPermission] or [errors.ErrUnsupported], so it is matched explicitly in
+// symlinkPrivilegeError, which is built per platform.
+func SymlinkUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errors.Is(err, errors.ErrUnsupported) ||
+		errors.Is(err, fs.ErrPermission) ||
+		symlinkPrivilegeError(err)
 }
 
 // MustAbs resolves rel against the Go test process working directory.

--- a/test/helpers/test_helpers_unix.go
+++ b/test/helpers/test_helpers_unix.go
@@ -3,3 +3,10 @@
 package helpers
 
 var RootFolder = "/"
+
+// symlinkPrivilegeError reports whether err is a platform-specific refusal to create a symlink
+// for want of a privilege. Only Windows has such an error, so off Windows the portable checks
+// in [SymlinkUnsupported] are the whole story.
+func symlinkPrivilegeError(error) bool {
+	return false
+}

--- a/test/helpers/test_helpers_windows.go
+++ b/test/helpers/test_helpers_windows.go
@@ -3,8 +3,11 @@
 package helpers
 
 import (
+	"errors"
 	"fmt"
 	"os"
+
+	"golang.org/x/sys/windows"
 )
 
 var RootFolder = retrieveRootFolder()
@@ -13,4 +16,12 @@ func retrieveRootFolder() string {
 	cwd, _ := os.Getwd()
 
 	return fmt.Sprintf("%s:/", cwd[0:1])
+}
+
+// symlinkPrivilegeError reports whether err is Windows refusing symlink creation because the
+// process holds neither SeCreateSymbolicLinkPrivilege nor Developer Mode. Go's
+// syscall.Errno.Is does not fold ERROR_PRIVILEGE_NOT_HELD into fs.ErrPermission, so matching
+// it portably is not possible and it is checked here directly.
+func symlinkPrivilegeError(err error) bool {
+	return errors.Is(err, windows.ERROR_PRIVILEGE_NOT_HELD)
 }

--- a/test/integration_stacks_test.go
+++ b/test/integration_stacks_test.go
@@ -1173,3 +1173,87 @@ func readCachedFiles(t *testing.T, root, fileName string) []string {
 
 	return contents
 }
+
+// buildSymlinkedStackFileFixture lays out a tree where the terragrunt.stack.hcl in `live`
+// is a symlink to a real stack file in `source`. The real stack file reads a sibling config
+// with a path relative to get_terragrunt_dir(), and that sibling exists only next to the
+// symlink (in `live`), not next to the symlink target (in `source`). It returns the `live`
+// working directory and the value the sibling contributes to the generated unit's values.
+func buildSymlinkedStackFileFixture(t *testing.T) (liveDir, siblingData string) {
+	t.Helper()
+
+	rootDir := helpers.TmpDirWOSymlinks(t)
+	siblingData = "from-sibling"
+
+	// The unit source: a module dir carrying a terragrunt.hcl so generation's post-copy
+	// validation (which requires terragrunt.hcl at the generated unit root) passes.
+	moduleDir := filepath.Join(rootDir, "module")
+	require.NoError(t, os.Mkdir(moduleDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "terragrunt.hcl"),
+		[]byte("inputs = {\n  data = \"placeholder\"\n}\n"), 0644))
+
+	// The real stack file lives in `source` and reads its sibling relative to its own dir.
+	sourceDir := filepath.Join(rootDir, "source")
+	require.NoError(t, os.Mkdir(sourceDir, 0755))
+
+	stackHCL := `locals {
+  sibling = read_terragrunt_config("${get_terragrunt_dir()}/sibling.hcl")
+}
+
+unit "app" {
+  source = "${get_terragrunt_dir()}/../module"
+  path   = "app"
+  values = {
+    data = local.sibling.locals.data
+  }
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, config.DefaultStackFile), []byte(stackHCL), 0644))
+
+	// The `live` dir holds the symlink to the real stack file, plus the sibling it reads.
+	// The sibling exists here only, so generation succeeds only if reads resolve against
+	// `live` (where the symlink lives), not `source` (the symlink target's dir).
+	liveDir = filepath.Join(rootDir, "live")
+	require.NoError(t, os.Mkdir(liveDir, 0755))
+
+	// Attempt the symlink rather than skipping on Windows up front, so the test stays active
+	// wherever symlinks work. Only a host that refuses symlink creation outright skips; every
+	// other error stays fatal so a regression cannot hide behind the skip.
+	if err := os.Symlink(
+		filepath.Join(sourceDir, config.DefaultStackFile),
+		filepath.Join(liveDir, config.DefaultStackFile),
+	); err != nil {
+		if helpers.SymlinkUnsupported(err) {
+			t.Skipf("host does not support creating symlinks: %v", err)
+		}
+
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(liveDir, "sibling.hcl"),
+		[]byte("locals {\n  data = \""+siblingData+"\"\n}\n"), 0644))
+
+	return liveDir, siblingData
+}
+
+// TestStackGenerateSymlinkedStackFileReadsRelative is a regression test for a symlinked
+// terragrunt.stack.hcl whose relative read_terragrunt_config reads were resolved against the
+// symlink target's directory instead of the directory the symlink lives in. Stack generation
+// canonicalises the stack file's directory but must keep the file anchored to its own location,
+// so a sibling config read relative to get_terragrunt_dir() resolves next to the symlink.
+func TestStackGenerateSymlinkedStackFileReadsRelative(t *testing.T) {
+	t.Parallel()
+
+	liveDir, siblingData := buildSymlinkedStackFileFixture(t)
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(t,
+		"terragrunt stack generate --working-dir "+liveDir)
+	require.NoError(t, err, "stack generate should resolve the sibling read next to the symlink; stderr: %s", stderr)
+
+	// The generated unit's values must carry the value read from the sibling, proving the
+	// relative read resolved against the symlink's directory rather than its target's.
+	valuesPath := filepath.Join(liveDir, ".terragrunt-stack", "app", "terragrunt.values.hcl")
+	contents, readErr := os.ReadFile(valuesPath)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(contents), siblingData)
+}


### PR DESCRIPTION
Stack generation passed each discovered stack-file path through util.CanonicalResolvedPath, which runs filepath.EvalSymlinks on the full path including the symlinked terragrunt.stack.hcl itself. That rewrote the path to the symlink target's location, so GenerateStackFile derived stackSourceDir from the target directory rather than the directory the symlink lives in. Relative reads (read_terragrunt_config, find_in_parent_folders, relative source) then resolved against the wrong folder and failed.

Regression introduced by 16ad54f2c (#5962), which replaced the plain filepath.Join of the stack file name with util.CanonicalResolvedPath over the whole path. That commit is absent from v1.0.2 and first shipped in v1.0.3, so v1.0.2 is the last unaffected release.

<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6441.

Resolve/canonicalise only the stack file's directory (still needed for dedup and topology consistency with the canonicalised working dir), then join terragrunt.stack.hcl afterward via a new canonicalStackFilePath helper, so a symlinked stack file stays anchored to its own directory.

Adds an in-package regression test for canonicalStackFilePath, and a stack integration test that generates a stack from a symlinked terragrunt.stack.hcl reading a sibling config relative to get_terragrunt_dir(). The integration test lives with the other stack tests and skips on Windows at runtime (as the discovery-boundary symlink test does) rather than carrying a build tag.

Adds a v1.1.5 changelog entry under bug-fixes. No prose docs change: the documented behaviour of get_terragrunt_dir() already matches what this restores, so the docs were correct and the code was not.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed symlinked stack files so relative configuration lookups resolve from the directory containing the symlink.
  * Corrected `get_terragrunt_dir()` and relative source path resolution for symlinked stacks.
  * Preserved expected behavior when symlinked directories are used.

* **Tests**
  * Added regression coverage for symlinked stack files and platform-specific symlink support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->