### PR TITLE
chore: Deterministic dependency order for `find --dependencies --json`

### DIFF
--- a/docs/src/data/changelog/v1.1.5/dependency-order.mdx
+++ b/docs/src/data/changelog/v1.1.5/dependency-order.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### `find --dependencies` lists dependencies in a stable order
+
+When a unit had more than one dependency, `terragrunt find --dependencies --json` could report them in a different order on each run, with no change to the configuration.
+
+The order is now fixed. `list`, `dag graph`, and `browse` sorted before rendering already, so their output is unchanged.

--- a/internal/discovery/helpers.go
+++ b/internal/discovery/helpers.go
@@ -255,7 +255,8 @@ func sanitizeReadFiles(files []string) []string {
 	return slices.Compact(files)
 }
 
-// extractDependencyPaths extracts all dependency paths from a Terragrunt configuration.
+// extractDependencyPaths extracts all dependency paths from a Terragrunt
+// configuration, sorted and deduplicated.
 func extractDependencyPaths(fsys vfs.FS, cfg *config.TerragruntConfig, c component.Component) ([]string, error) {
 	if cfg == nil {
 		return nil, nil
@@ -266,7 +267,7 @@ func extractDependencyPaths(fsys vfs.FS, cfg *config.TerragruntConfig, c compone
 		maxDedupLen += len(cfg.Dependencies.Paths)
 	}
 
-	deduped := make(map[string]struct{}, maxDedupLen)
+	depPaths := make([]string, 0, maxDedupLen)
 
 	errs := make([]error, 0, maxDedupLen)
 
@@ -289,7 +290,7 @@ func extractDependencyPaths(fsys vfs.FS, cfg *config.TerragruntConfig, c compone
 			depPath = filepath.Clean(filepath.Join(c.Path(), depPath))
 		}
 
-		deduped[vfs.ResolveForCompare(fsys, depPath)] = struct{}{}
+		depPaths = append(depPaths, vfs.ResolveForCompare(fsys, depPath))
 	}
 
 	if cfg.Dependencies != nil {
@@ -298,15 +299,13 @@ func extractDependencyPaths(fsys vfs.FS, cfg *config.TerragruntConfig, c compone
 				dependency = filepath.Clean(filepath.Join(c.Path(), dependency))
 			}
 
-			deduped[vfs.ResolveForCompare(fsys, dependency)] = struct{}{}
+			depPaths = append(depPaths, vfs.ResolveForCompare(fsys, dependency))
 		}
 	}
 
-	depPaths := make([]string, 0, len(deduped))
+	slices.Sort(depPaths)
 
-	for depPath := range deduped {
-		depPaths = append(depPaths, depPath)
-	}
+	depPaths = slices.Compact(depPaths)
 
 	if len(errs) > 0 {
 		return depPaths, errors.Join(errs...)

--- a/internal/discovery/phase_relationship_test.go
+++ b/internal/discovery/phase_relationship_test.go
@@ -1,0 +1,71 @@
+package discovery_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRelationshipPhase_SortsDependencies pins that a unit's dependencies come
+// back sorted by path. The unit below declares them in reverse alphabetical
+// order, split across a dependency block and a dependencies block, so config
+// order and sorted order are exact opposites.
+func TestRelationshipPhase_SortsDependencies(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	appDir := filepath.Join(tmpDir, "app")
+
+	v := memGitTopLevelVenv(t, tmpDir)
+
+	writeUnits(t, v.FS, map[string]string{
+		filepath.Join(tmpDir, "a-unit"): ``,
+		filepath.Join(tmpDir, "b-unit"): ``,
+		filepath.Join(tmpDir, "c-unit"): ``,
+		filepath.Join(tmpDir, "d-unit"): ``,
+		appDir: `
+dependency "d" {
+  config_path = "../d-unit"
+}
+
+dependency "c" {
+  config_path = "../c-unit"
+}
+
+dependencies {
+  paths = ["../b-unit", "../a-unit"]
+}
+`,
+	})
+
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
+	opts.WorkingDir = tmpDir
+	opts.RootWorkingDir = tmpDir
+
+	d := discovery.NewDiscovery(tmpDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
+		WithRelationships()
+
+	components, err := d.Discover(t.Context(), logger.CreateLogger(), v, opts)
+	require.NoError(t, err)
+
+	app := components.FilterByPath(appDir)
+	require.Len(t, app, 1)
+
+	want := []string{
+		filepath.Join(tmpDir, "a-unit"),
+		filepath.Join(tmpDir, "b-unit"),
+		filepath.Join(tmpDir, "c-unit"),
+		filepath.Join(tmpDir, "d-unit"),
+	}
+	assert.Equal(t, want, app[0].Dependencies().Paths())
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Prevents flakes in `find --dependencies --json` output values.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed JSON dependency output to use stable, alphabetical ordering.
  - Removed duplicate dependency paths from discovery results.
  - Dependency ordering is now consistent regardless of declaration order.

- **Documentation**
  - Added a v1.1.5 changelog entry describing the dependency-ordering fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->