### PR TITLE
feat: Adding token storage

### DIFF
--- a/internal/portal/errors.go
+++ b/internal/portal/errors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 )
@@ -31,6 +32,48 @@ var ErrLoginExpired = errors.New("the login request expired before it was approv
 // allows. An ordinary login ends on that deadline first, so this reports a bug
 // here rather than anything the portal did.
 var ErrPollLimit = errors.New("the login poll ran past the attempts its request allows")
+
+// ErrUnusablePortalURL reports a portal base URL the CLI cannot address, and so
+// cannot file a credential under either. A caller matches it to tell a base URL
+// the user has to correct from a failure it can do nothing about.
+var ErrUnusablePortalURL = errors.New("unusable portal base URL")
+
+// ErrNoPortalHost reports a base URL naming no host, which is what a bare
+// hostname with no scheme in front of it parses as.
+var ErrNoPortalHost = fmt.Errorf("%w: it names no host", ErrUnusablePortalURL)
+
+// ErrPortalSchemeUnsupported reports a base URL the CLI cannot send a request
+// to, and whose credentials it therefore cannot keep apart from those of
+// another scheme.
+var ErrPortalSchemeUnsupported = fmt.Errorf("%w: only http and https are addressable", ErrUnusablePortalURL)
+
+// UnusablePortalURLError carries the address that could not be used. It unwraps
+// to the reason and, through that, to [ErrUnusablePortalURL], so a caller can
+// match either. [UnusablePortalURLError.Error] redacts the address, which may
+// carry a password.
+type UnusablePortalURLError struct {
+	Err error
+	URL string
+}
+
+func (e *UnusablePortalURLError) Error() string {
+	return fmt.Sprintf("%q: %v", redactURL(e.URL), e.Err)
+}
+
+func (e *UnusablePortalURLError) Unwrap() error {
+	return e.Err
+}
+
+// redactURL replaces the password in rawURL. An address [url.Parse] rejects is
+// returned unchanged.
+func redactURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	return parsed.Redacted()
+}
 
 // MissingFieldError reports a response that left out a field the CLI needs. It
 // unwraps to [ErrMalformedResponse], so a caller that does not care which field

--- a/internal/portal/portal.go
+++ b/internal/portal/portal.go
@@ -8,6 +8,11 @@
 // so the device code the portal issues is the only credential in the exchange,
 // and [Secret] keeps it out of terminal output and log lines.
 //
+// The credential a login yields is kept under the user's configuration
+// directory, readable by them alone, so a later command reaches the same org
+// without another approval. It expires and cannot be renewed: once it does, the
+// user logs in again.
+//
 // The device-authorization request is built here rather than through
 // golang.org/x/oauth2. Its Config.DeviceAuth sends a request carrying no
 // context, so a cancelled login cannot abandon a call already in flight.

--- a/internal/portal/store.go
+++ b/internal/portal/store.go
@@ -1,0 +1,306 @@
+package portal
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"maps"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+)
+
+const (
+	tokenStoreDirName  = "terragrunt"
+	tokenStoreFileName = "tokens.json"
+
+	// tokenStoreLockSuffix names the file the read-change-write in [SaveToken]
+	// is serialized on. It sits beside the store rather than on it, so the lock
+	// outlives the rename that publishes a new store.
+	tokenStoreLockSuffix = ".lock"
+
+	tokenStoreFileMode os.FileMode = 0o600
+	tokenStoreDirMode  os.FileMode = 0o700
+)
+
+// StoredToken is a credential an earlier login left on disk, together with what
+// it reaches and when it stops working. [Secret] keeps the credential out of
+// terminal output and log lines.
+type StoredToken struct {
+	ExpiresAt   time.Time
+	AccessToken Secret
+	TokenType   string
+	Scope       string
+	Org         Org
+	Account     Account
+}
+
+// tokenStore is the on-disk shape. A credential is filed under the portal it
+// came from and then the org's id, so signing in to a second org, or to a
+// preview portal alongside production, adds an entry instead of replacing one.
+type tokenStore struct {
+	Portals map[string]map[string]storedToken `json:"portals"`
+}
+
+// storedToken is the on-disk form of a credential. [Secret] redacts terminal
+// and log output, not JSON, so the credential is written in the clear and the
+// file's mode is what keeps it private.
+type storedToken struct {
+	ExpiresAt    time.Time `json:"expires_at"`
+	AccessToken  Secret    `json:"access_token"`
+	TokenType    string    `json:"token_type"`
+	Scope        string    `json:"scope"`
+	OrgName      string    `json:"org_name"`
+	AccountEmail string    `json:"account_email"`
+}
+
+// TokenStorePath reports the file the CLI keeps portal credentials in.
+func TokenStorePath(v *venv.Venv) (string, error) {
+	v.RequireUserConfigDir()
+
+	configDir, err := v.Platform.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("locating the user configuration directory: %w", err)
+	}
+
+	return filepath.Join(configDir, tokenStoreDirName, tokenStoreFileName), nil
+}
+
+// SaveToken records token as the credential for its org at the portal serving
+// baseURL, so a later command reaches that org without a browser. Orgs are
+// keyed by id, so a second save replaces the entry rather than adding one under
+// the org's new name.
+//
+// The write leaves the store readable only by its owner and drops any
+// credential that has expired.
+func SaveToken(l log.Logger, v *venv.Venv, baseURL string, token *Token) error {
+	v.RequireFS()
+
+	key, err := portalKey(baseURL)
+	if err != nil {
+		return err
+	}
+
+	path, err := TokenStorePath(v)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	if err := vfs.EnsureDirectory(v.FS, dir); err != nil {
+		return fmt.Errorf("creating the directory for the portal token store: %w", err)
+	}
+
+	// EnsureDirectory returns early on a directory that already exists, without
+	// touching its mode.
+	if err := v.FS.Chmod(dir, tokenStoreDirMode); err != nil {
+		return fmt.Errorf("restricting the directory holding the portal token store: %w", err)
+	}
+
+	// Two logins can be approved at once, and each rewrites the whole store.
+	unlock, err := vfs.Lock(v.FS, path+tokenStoreLockSuffix)
+	if err != nil {
+		return fmt.Errorf("locking the portal token store: %w", err)
+	}
+
+	defer func() {
+		if err := unlock.Unlock(); err != nil {
+			l.Warnf("Could not release the lock on the portal token store: %v", err)
+		}
+	}()
+
+	store, err := readTokenStore(l, v.FS, path)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+
+	store.dropExpired(now)
+	store.record(key, token, now)
+
+	data, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding the portal token store: %w", err)
+	}
+
+	return writeFileAtomic(v.FS, path, data, tokenStoreFileMode)
+}
+
+// LoadTokens returns the credentials held for the portal serving baseURL, keyed
+// by org id. An expired credential is left out.
+func LoadTokens(l log.Logger, v *venv.Venv, baseURL string) (map[string]StoredToken, error) {
+	v.RequireFS()
+
+	key, err := portalKey(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	path, err := TokenStorePath(v)
+	if err != nil {
+		return nil, err
+	}
+
+	store, err := readTokenStore(l, v.FS, path)
+	if err != nil {
+		return nil, err
+	}
+
+	return store.unexpired(key, time.Now()), nil
+}
+
+// unexpired returns the credentials the portal named by key still has, keyed by
+// org id.
+func (s *tokenStore) unexpired(key string, now time.Time) map[string]StoredToken {
+	orgs := s.Portals[key]
+	tokens := make(map[string]StoredToken, len(orgs))
+
+	for orgID, entry := range orgs {
+		if !entry.ExpiresAt.After(now) {
+			continue
+		}
+
+		tokens[orgID] = StoredToken{
+			ExpiresAt:   entry.ExpiresAt,
+			AccessToken: entry.AccessToken,
+			TokenType:   entry.TokenType,
+			Scope:       entry.Scope,
+			Org:         Org{ID: orgID, Name: entry.OrgName},
+			Account:     Account{Email: entry.AccountEmail},
+		}
+	}
+
+	return tokens
+}
+
+// record files token under the portal named by key, creating the maps on the
+// way down when the store has none yet.
+func (s *tokenStore) record(key string, token *Token, now time.Time) {
+	if s.Portals == nil {
+		s.Portals = map[string]map[string]storedToken{}
+	}
+
+	if s.Portals[key] == nil {
+		s.Portals[key] = map[string]storedToken{}
+	}
+
+	s.Portals[key][token.Org.ID] = storedToken{
+		ExpiresAt:    now.Add(token.ExpiresIn).UTC(),
+		AccessToken:  token.AccessToken,
+		TokenType:    token.TokenType,
+		Scope:        token.Scope,
+		OrgName:      token.Org.Name,
+		AccountEmail: token.Account.Email,
+	}
+}
+
+// dropExpired removes every credential that has run out, along with any portal
+// left holding none.
+func (s *tokenStore) dropExpired(now time.Time) {
+	for key, orgs := range s.Portals {
+		maps.DeleteFunc(orgs, func(_ string, entry storedToken) bool {
+			return !entry.ExpiresAt.After(now)
+		})
+
+		if len(orgs) == 0 {
+			delete(s.Portals, key)
+		}
+	}
+}
+
+// readTokenStore reads the store off disk.
+func readTokenStore(l log.Logger, fsys vfs.FS, path string) (tokenStore, error) {
+	data, err := vfs.ReadFile(fsys, path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return tokenStore{}, nil
+	}
+
+	if err != nil {
+		return tokenStore{}, fmt.Errorf("reading the portal token store: %w", err)
+	}
+
+	var store tokenStore
+	if err := json.Unmarshal(data, &store); err != nil {
+		l.Debugf("Discarding an unreadable portal token store: %v", err)
+
+		return tokenStore{}, nil
+	}
+
+	return store, nil
+}
+
+// writeFileAtomic writes a scratch file beside path and renames it over the
+// destination, so a run that dies midway leaves the previous file whole rather
+// than a truncated one. The rename also replaces a symlink at path instead of
+// following it. [vfs.CreateTemp] chooses the scratch file's mode, so perm is
+// applied before anything is written to it.
+//
+// NOTE: This duplicates vfs.WriteFileAtomic, which is not on main yet. Delete
+// it and call that instead once https://github.com/gruntwork-io/terragrunt/pull/6776
+// merges.
+func writeFileAtomic(fsys vfs.FS, path string, data []byte, perm os.FileMode) error {
+	file, err := vfs.CreateTemp(fsys, filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating a scratch file beside %s: %w", filepath.Base(path), err)
+	}
+
+	tmpPath := file.Name()
+
+	if err := fsys.Chmod(tmpPath, perm); err != nil {
+		return errors.Join(err, file.Close(), fsys.Remove(tmpPath))
+	}
+
+	if _, err := file.Write(data); err != nil {
+		return errors.Join(err, file.Close(), fsys.Remove(tmpPath))
+	}
+
+	if err := file.Close(); err != nil {
+		return errors.Join(err, fsys.Remove(tmpPath))
+	}
+
+	// The scratch file holds the credential too, so a rename that did not happen
+	// must not leave a second copy of it lying around.
+	if err := fsys.Rename(tmpPath, path); err != nil {
+		return errors.Join(err, fsys.Remove(tmpPath))
+	}
+
+	return nil
+}
+
+// portalKey is the key credentials are filed under. It carries the scheme, so a
+// credential issued over https is never handed back for a plaintext address
+// naming the same machine, and a port the scheme does not imply, so two portals
+// on one machine stay apart. The host is lowercased, so a portal written two
+// ways reaches the entry the earlier login wrote.
+func portalKey(baseURL string) (string, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", &UnusablePortalURLError{URL: baseURL, Err: fmt.Errorf("%w: %w", ErrUnusablePortalURL, err)}
+	}
+
+	host := strings.ToLower(parsed.Host)
+	if host == "" {
+		return "", &UnusablePortalURLError{URL: baseURL, Err: ErrNoPortalHost}
+	}
+
+	var defaultPort string
+
+	switch parsed.Scheme {
+	case "https":
+		defaultPort = ":443"
+	case "http":
+		defaultPort = ":80"
+	default:
+		return "", &UnusablePortalURLError{URL: baseURL, Err: ErrPortalSchemeUnsupported}
+	}
+
+	return parsed.Scheme + "://" + strings.TrimSuffix(host, defaultPort), nil
+}

--- a/internal/portal/store_test.go
+++ b/internal/portal/store_test.go
@@ -1,0 +1,495 @@
+package portal_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/portal"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+const previewPortalBaseURL = "https://preview.portal.example.com"
+
+// tokenLifetime is what the portal issues, so a saved token is unexpired for
+// the whole of a test that does not deliberately outlive it.
+const tokenLifetime = 30 * 24 * time.Hour
+
+func issuedToken(orgID, orgName string) *portal.Token {
+	return &portal.Token{
+		AccessToken: portal.Secret("fake-access-token-" + orgID),
+		TokenType:   "Bearer",
+		Scope:       portal.ScopeCatalogRead,
+		Org:         portal.Org{ID: orgID, Name: orgName},
+		Account:     portal.Account{Email: "someone@example.com"},
+		ExpiresIn:   tokenLifetime,
+	}
+}
+
+func saveToken(t *testing.T, v *venv.Venv, baseURL string, token *portal.Token) {
+	t.Helper()
+
+	require.NoError(t, portal.SaveToken(logger.CreateLogger(), v, baseURL, token))
+}
+
+func loadTokens(t *testing.T, v *venv.Venv, baseURL string) map[string]portal.StoredToken {
+	t.Helper()
+
+	tokens, err := portal.LoadTokens(logger.CreateLogger(), v, baseURL)
+	require.NoError(t, err)
+
+	return tokens
+}
+
+func storePath(t *testing.T, v *venv.Venv) string {
+	t.Helper()
+
+	path, err := portal.TokenStorePath(v)
+	require.NoError(t, err)
+
+	return path
+}
+
+func readStoreFile(t *testing.T, v *venv.Venv) string {
+	t.Helper()
+
+	data, err := vfs.ReadFile(v.FS, storePath(t, v))
+	require.NoError(t, err)
+
+	return string(data)
+}
+
+// lockingFS re-exposes the optional lock interface that wrapping a filesystem
+// in a struct otherwise hides, so a decorated filesystem is still one a save
+// can serialize on.
+type lockingFS struct {
+	vfs.FS
+}
+
+func (fsys lockingFS) Lock(name string) (vfs.Unlocker, error) {
+	return vfs.Lock(fsys.FS, name)
+}
+
+func (fsys lockingFS) TryLock(name string) (vfs.Unlocker, bool, error) {
+	return vfs.TryLock(fsys.FS, name)
+}
+
+func TestSaveTokenRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	saveToken(t, v, portalBaseURL, issuedToken("org_fake", "Acme"))
+
+	tokens := loadTokens(t, v, portalBaseURL)
+	require.Len(t, tokens, 1)
+
+	got := tokens["org_fake"]
+	assert.Equal(t, "fake-access-token-org_fake", got.AccessToken.Reveal())
+	assert.Equal(t, "Bearer", got.TokenType)
+	assert.Equal(t, portal.ScopeCatalogRead, got.Scope)
+	assert.Equal(t, portal.Org{ID: "org_fake", Name: "Acme"}, got.Org)
+	assert.Equal(t, portal.Account{Email: "someone@example.com"}, got.Account)
+	assert.True(t, got.ExpiresAt.After(time.Now()), "a token just saved has not run out")
+}
+
+// TestSaveTokenKeepsTheTokensForOtherOrgs pins that signing in to a second org
+// leaves the first one signed in. The two credentials reach different data, so
+// one cannot stand in for the other.
+func TestSaveTokenKeepsTheTokensForOtherOrgs(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	saveToken(t, v, portalBaseURL, issuedToken("org_one", "Acme"))
+	saveToken(t, v, portalBaseURL, issuedToken("org_two", "Initech"))
+
+	tokens := loadTokens(t, v, portalBaseURL)
+	require.Len(t, tokens, 2)
+	assert.Equal(t, "fake-access-token-org_one", tokens["org_one"].AccessToken.Reveal())
+	assert.Equal(t, "fake-access-token-org_two", tokens["org_two"].AccessToken.Reveal())
+	assert.Equal(t, "Initech", tokens["org_two"].Org.Name)
+}
+
+// TestSaveTokenKeepsBothCredentialsWithRacing pins that logins finishing at the
+// same moment all end up in the store. Each one reads the whole file, adds its
+// own org and writes the file back, so the last write would otherwise be the
+// only one that survived.
+func TestSaveTokenKeepsBothCredentialsWithRacing(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	orgIDs := []string{"org_one", "org_two", "org_three", "org_four", "org_five", "org_six"}
+
+	var group errgroup.Group
+
+	for _, orgID := range orgIDs {
+		group.Go(func() error {
+			return portal.SaveToken(logger.CreateLogger(), v, portalBaseURL, issuedToken(orgID, "Acme"))
+		})
+	}
+
+	require.NoError(t, group.Wait())
+
+	assert.Len(t, loadTokens(t, v, portalBaseURL), len(orgIDs))
+}
+
+// TestSaveTokenKeepsTheTokensForOtherPortals pins that a login against a preview
+// deployment does not sign the user out of production. A credential is only
+// good at the portal that issued it.
+func TestSaveTokenKeepsTheTokensForOtherPortals(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	saveToken(t, v, portalBaseURL, issuedToken("org_fake", "Acme"))
+	saveToken(t, v, previewPortalBaseURL, issuedToken("org_fake", "Acme"))
+
+	production := loadTokens(t, v, portalBaseURL)
+	require.Len(t, production, 1)
+
+	preview := loadTokens(t, v, previewPortalBaseURL)
+	require.Len(t, preview, 1)
+
+	assert.Empty(t, loadTokens(t, v, "https://third.portal.example.com"))
+}
+
+// TestLoadTokensKeepsTheSchemesApart pins that a token issued over https is not
+// handed back for a plaintext address naming the same machine. Handing it back
+// would put the credential in an Authorization header travelling in the clear.
+func TestLoadTokensKeepsTheSchemesApart(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	saveToken(t, v, "https://portal.example.com", issuedToken("org_fake", "Acme"))
+
+	assert.Empty(t, loadTokens(t, v, "http://portal.example.com"))
+	assert.Len(t, loadTokens(t, v, "https://portal.example.com"), 1)
+}
+
+// TestLoadTokensReadsOnePortalWrittenSeveralWays pins that the port a scheme
+// implies, a host in another case, and a path after the host all reach the
+// entry the login wrote, rather than reporting the user as logged out.
+func TestLoadTokensReadsOnePortalWrittenSeveralWays(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	saveToken(t, v, "https://portal.example.com", issuedToken("org_fake", "Acme"))
+
+	for _, baseURL := range []string{
+		"https://portal.example.com:443",
+		"https://PORTAL.example.com",
+		"https://portal.example.com/api/v1",
+	} {
+		assert.Len(t, loadTokens(t, v, baseURL), 1, baseURL)
+	}
+
+	assert.Empty(t, loadTokens(t, v, "https://portal.example.com:8443"), "another port is another portal")
+}
+
+// TestSaveTokenRefreshesTheOrgName pins that logging in again reads the org's
+// name afresh, so an org renamed in the portal keeps the entry it had rather
+// than gaining a second one under the new name.
+func TestSaveTokenRefreshesTheOrgName(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	saveToken(t, v, portalBaseURL, issuedToken("org_fake", "Acme"))
+	saveToken(t, v, portalBaseURL, issuedToken("org_fake", "Acme Holdings"))
+
+	tokens := loadTokens(t, v, portalBaseURL)
+	require.Len(t, tokens, 1)
+	assert.Equal(t, "Acme Holdings", tokens["org_fake"].Org.Name)
+}
+
+// TestLoadTokensLeavesOutAnExpiredToken pins that a token past its lifetime
+// reads as no token at all. The portal issues no way to renew one, so the only
+// answer is another login.
+func TestLoadTokensLeavesOutAnExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		v := venvtest.New()
+
+		saveToken(t, v, portalBaseURL, issuedToken("org_fake", "Acme"))
+		require.Len(t, loadTokens(t, v, portalBaseURL), 1)
+
+		time.Sleep(tokenLifetime + time.Hour)
+
+		assert.Empty(t, loadTokens(t, v, portalBaseURL))
+	})
+}
+
+// TestSaveTokenTakesAnExpiredTokenOffDisk pins that a credential the CLI has
+// stopped handing back is removed rather than carried forward into the next
+// save. The store is plaintext, so a backup or a synced configuration directory
+// would otherwise pick up every token the user has ever been issued.
+func TestSaveTokenTakesAnExpiredTokenOffDisk(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		v := venvtest.New()
+
+		saveToken(t, v, portalBaseURL, issuedToken("org_old", "Acme"))
+		saveToken(t, v, previewPortalBaseURL, issuedToken("org_old", "Acme"))
+
+		time.Sleep(tokenLifetime + time.Hour)
+
+		saveToken(t, v, portalBaseURL, issuedToken("org_new", "Initech"))
+
+		contents := readStoreFile(t, v)
+		assert.NotContains(t, contents, "fake-access-token-org_old")
+		assert.NotContains(t, contents, "org_old")
+		assert.NotContains(t, contents, "preview.portal.example.com", "a portal left holding nothing goes too")
+		assert.Contains(t, contents, "fake-access-token-org_new", "the live credential is still there to read back")
+	})
+}
+
+func TestSaveTokenWritesAnOwnerOnlyStore(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	saveToken(t, v, portalBaseURL, issuedToken("org_fake", "Acme"))
+
+	path := storePath(t, v)
+
+	info, err := v.FS.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "the token store must be owner-only")
+
+	dir, err := v.FS.Stat(filepath.Dir(path))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), dir.Mode().Perm(), "the directory holding it must be owner-only")
+}
+
+// wideCreateFS opens every new file readable by anyone, standing in for a
+// filesystem, or a scratch-file helper, that does not create one owner-only.
+type wideCreateFS struct {
+	lockingFS
+}
+
+func (fsys *wideCreateFS) OpenFile(name string, flag int, _ os.FileMode) (vfs.File, error) {
+	return fsys.FS.OpenFile(name, flag, 0o666)
+}
+
+// TestSaveTokenClosesAScratchFileCreatedWide pins that the store's mode is set
+// rather than inherited from whatever created the scratch file the save renames
+// into place.
+func TestSaveTokenClosesAScratchFileCreatedWide(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	saveToken(t, v.WithFS(&wideCreateFS{FS: v.FS}), portalBaseURL, issuedToken("org_fake", "Acme"))
+
+	info, err := v.FS.Stat(storePath(t, v))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+// TestSaveTokenTightensAStoreThatWasAlreadyThere pins that the owner-only mode
+// is enforced rather than requested. A store left behind by an earlier release,
+// or by a user who copied their config directory around, is closed on the next
+// save, and what it held survives.
+func TestSaveTokenTightensAStoreThatWasAlreadyThere(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	saveToken(t, v, portalBaseURL, issuedToken("org_one", "Acme"))
+
+	path := storePath(t, v)
+	require.NoError(t, v.FS.Chmod(path, 0o644))
+	require.NoError(t, v.FS.Chmod(filepath.Dir(path), 0o755))
+
+	saveToken(t, v, portalBaseURL, issuedToken("org_two", "Initech"))
+
+	info, err := v.FS.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "a store left readable by others must be closed")
+
+	dir, err := v.FS.Stat(filepath.Dir(path))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), dir.Mode().Perm(), "a directory left listable by others must be closed")
+
+	assert.Len(t, loadTokens(t, v, portalBaseURL), 2, "tightening the store must not lose what it held")
+}
+
+// TestSaveTokenWritesAnOwnerOnlyStoreOnDisk repeats the permission check against
+// the real filesystem, whose rename has to carry the mode set on the scratch
+// file over to the destination for the in-memory result to mean anything.
+func TestSaveTokenWritesAnOwnerOnlyStoreOnDisk(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("Windows file modes carry no owner-only bit to assert")
+	}
+
+	configDir := t.TempDir()
+	v := venvtest.NewWithOSFS().WithUserConfigDir(func() (string, error) { return configDir, nil })
+
+	saveToken(t, v, portalBaseURL, issuedToken("org_fake", "Acme"))
+
+	path := storePath(t, v)
+	require.NoError(t, v.FS.Chmod(path, 0o644))
+
+	saveToken(t, v, portalBaseURL, issuedToken("org_fake", "Acme"))
+
+	info, err := v.FS.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	dir, err := v.FS.Stat(filepath.Dir(path))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), dir.Mode().Perm())
+}
+
+// TestLoadTokensIgnoresAStoreItCannotRead pins that a file the CLI cannot make
+// sense of is treated as no tokens rather than as a failure. Nothing in it can
+// be recovered, and another login costs the user less than hunting down a file
+// every command refuses to run without.
+func TestLoadTokensIgnoresAStoreItCannotRead(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name     string
+		contents string
+	}{
+		{name: "not JSON", contents: "this is not a token store"},
+		{name: "truncated", contents: `{"portals":{"https://portal.example.com":{"org_fake":{"access_tok`},
+		{name: "empty", contents: ""},
+		{name: "wrong shape", contents: `{"portals":["org_fake"]}`},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := venvtest.New()
+			path := storePath(t, v)
+
+			require.NoError(t, vfs.EnsureDirectory(v.FS, filepath.Dir(path)))
+			require.NoError(t, vfs.WriteFile(v.FS, path, []byte(tt.contents), 0o600))
+
+			assert.Empty(t, loadTokens(t, v, portalBaseURL))
+
+			saveToken(t, v, portalBaseURL, issuedToken("org_fake", "Acme"))
+			assert.Len(t, loadTokens(t, v, portalBaseURL), 1, "the next login must write over it")
+		})
+	}
+}
+
+// errRenameFailed stands in for whatever stops a save from finishing.
+var errRenameFailed = errors.New("rename refused")
+
+// renameFailingFS is a filesystem that will not publish a scratch file, which is
+// the last step of a save and the only one that changes what a reader sees.
+type renameFailingFS struct {
+	lockingFS
+}
+
+func (fsys *renameFailingFS) Rename(_, _ string) error {
+	return errRenameFailed
+}
+
+// TestSaveTokenLeavesTheStoreIntactWhenTheWriteFails pins that a save that dies
+// partway costs the user nothing: the credentials already on disk still work,
+// and no half-written copy of the new one is left behind.
+func TestSaveTokenLeavesTheStoreIntactWhenTheWriteFails(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	saveToken(t, v, portalBaseURL, issuedToken("org_one", "Acme"))
+
+	blocked := v.WithFS(&renameFailingFS{FS: v.FS})
+	err := portal.SaveToken(logger.CreateLogger(), blocked, portalBaseURL, issuedToken("org_two", "Initech"))
+	require.ErrorIs(t, err, errRenameFailed)
+
+	tokens := loadTokens(t, v, portalBaseURL)
+	require.Len(t, tokens, 1)
+	assert.Equal(t, "fake-access-token-org_one", tokens["org_one"].AccessToken.Reveal())
+
+	assert.Equal(t, []string{"tokens.json"}, storeDirEntries(t, v), "a scratch file holds the credential too")
+}
+
+func storeDirEntries(t *testing.T, v *venv.Venv) []string {
+	t.Helper()
+
+	dir, err := v.FS.Open(filepath.Dir(storePath(t, v)))
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, dir.Close())
+	}()
+
+	names, err := dir.Readdirnames(-1)
+	require.NoError(t, err)
+
+	return names
+}
+
+func TestSaveTokenRejectsUnusableBaseURL(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	tc := []struct {
+		want    error
+		name    string
+		baseURL string
+	}{
+		{name: "unparseable", baseURL: "://portal.example.com", want: portal.ErrUnusablePortalURL},
+		{name: "no scheme", baseURL: "portal.example.com", want: portal.ErrNoPortalHost},
+		{name: "not addressable", baseURL: "ftp://portal.example.com", want: portal.ErrPortalSchemeUnsupported},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := portal.SaveToken(logger.CreateLogger(), v, tt.baseURL, issuedToken("org_fake", "Acme"))
+			require.ErrorIs(t, err, tt.want)
+			require.ErrorIs(t, err, portal.ErrUnusablePortalURL)
+
+			_, err = portal.LoadTokens(logger.CreateLogger(), v, tt.baseURL)
+			require.ErrorIs(t, err, tt.want)
+		})
+	}
+}
+
+// TestStoredTokenDoesNotReachFormattedOutput pins that a credential read back
+// off disk is as guarded as the one that came off the wire, so a struct dump
+// added while chasing a parse failure cannot carry it.
+func TestStoredTokenDoesNotReachFormattedOutput(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	saveToken(t, v, portalBaseURL, issuedToken("org_fake", "Acme"))
+
+	stored := loadTokens(t, v, portalBaseURL)["org_fake"]
+
+	assert.NotContains(t, fmt.Sprintf("%v", stored), "fake-access-token")
+	assert.NotContains(t, fmt.Sprintf("%+v", stored), "fake-access-token")
+
+	// %#v does not consult String, so GoString is what keeps a struct dump from
+	// carrying the credential.
+	assert.NotContains(t, fmt.Sprintf("%#v", stored), "fake-access-token")
+}

--- a/internal/venv/venv.go
+++ b/internal/venv/venv.go
@@ -105,19 +105,24 @@ var ErrVenvUserHomeDirUnset = errors.New("venv.Venv.Platform.UserHomeDir is requ
 // when UserCacheDir is nil.
 var ErrVenvUserCacheDirUnset = errors.New("venv.Venv.Platform.UserCacheDir is required but unset")
 
+// ErrVenvUserConfigDirUnset is the panic value [Venv.RequireUserConfigDir]
+// raises when UserConfigDir is nil.
+var ErrVenvUserConfigDirUnset = errors.New("venv.Venv.Platform.UserConfigDir is required but unset")
+
 // ErrVenvTempDirUnset is the panic value [Venv.RequireTempDir] raises when
 // TempDir is nil.
 var ErrVenvTempDirUnset = errors.New("venv.Venv.Platform.TempDir is required but unset")
 
 // Platform carries the operating-system handles used below the CLI boundary.
 type Platform struct {
-	UserHomeDir  func() (string, error)
-	UserCacheDir func() (string, error)
-	TempDir      func() string
-	Getwd        func() (string, error)
-	GetPID       func() int
-	GOOS         string
-	GOARCH       string
+	UserHomeDir   func() (string, error)
+	UserCacheDir  func() (string, error)
+	UserConfigDir func() (string, error)
+	TempDir       func() string
+	Getwd         func() (string, error)
+	GetPID        func() int
+	GOOS          string
+	GOARCH        string
 }
 
 // Terminal reports the console a run's output is adapting to: whether each
@@ -289,6 +294,19 @@ func (v *Venv) WithUserCacheDir(userCacheDir func() (string, error)) *Venv {
 
 	platform := *v.Platform
 	platform.UserCacheDir = userCacheDir
+
+	c := *v
+	c.Platform = &platform
+
+	return &c
+}
+
+// WithUserConfigDir returns a copy of v whose config-directory lookup is userConfigDir.
+func (v *Venv) WithUserConfigDir(userConfigDir func() (string, error)) *Venv {
+	v.RequirePlatform()
+
+	platform := *v.Platform
+	platform.UserConfigDir = userConfigDir
 
 	c := *v
 	c.Platform = &platform
@@ -469,6 +487,13 @@ func (v *Venv) RequireUserCacheDir() {
 	}
 }
 
+// RequireUserConfigDir panics with [ErrVenvUserConfigDirUnset] when UserConfigDir is nil.
+func (v *Venv) RequireUserConfigDir() {
+	if v.Platform == nil || v.Platform.UserConfigDir == nil {
+		panic(ErrVenvUserConfigDirUnset)
+	}
+}
+
 // RequireTempDir panics with [ErrVenvTempDirUnset] when TempDir is nil.
 func (v *Venv) RequireTempDir() {
 	if v.Platform == nil || v.Platform.TempDir == nil {
@@ -498,13 +523,14 @@ func OSVenv() *Venv {
 		Stdin:   os.Stdin,
 		Env:     ParseEnviron(os.Environ()),
 		Platform: &Platform{
-			UserHomeDir:  os.UserHomeDir,
-			UserCacheDir: os.UserCacheDir,
-			TempDir:      os.TempDir,
-			Getwd:        os.Getwd,
-			GetPID:       os.Getpid,
-			GOOS:         runtime.GOOS,
-			GOARCH:       runtime.GOARCH,
+			UserHomeDir:   os.UserHomeDir,
+			UserCacheDir:  os.UserCacheDir,
+			UserConfigDir: os.UserConfigDir,
+			TempDir:       os.TempDir,
+			Getwd:         os.Getwd,
+			GetPID:        os.Getpid,
+			GOOS:          runtime.GOOS,
+			GOARCH:        runtime.GOARCH,
 		},
 		Terminal: &Terminal{
 			StdinIsTTY:  func() bool { return term.IsTerminal(int(os.Stdin.Fd())) },

--- a/internal/venv/venv_test.go
+++ b/internal/venv/venv_test.go
@@ -140,6 +140,7 @@ func TestOSVenvProvidesPlatformHandles(t *testing.T) {
 	assert.Equal(t, runtime.GOOS, v.Platform.GOOS)
 	assert.Equal(t, runtime.GOARCH, v.Platform.GOARCH)
 	assert.NotNil(t, v.Platform.UserHomeDir)
+	assert.NotNil(t, v.Platform.UserConfigDir)
 }
 
 func TestVenvPlatformBuilders(t *testing.T) {
@@ -147,15 +148,19 @@ func TestVenvPlatformBuilders(t *testing.T) {
 
 	wantHomeErr := errors.New("home lookup failed")
 	homeDir := func() (string, error) { return "", wantHomeErr }
+	configDir := func() (string, error) { return "/tmp/config", nil }
 	original := venv.OSVenv()
 
-	got := original.WithGOOS("plan9").WithGOARCH("mips").WithUserHomeDir(homeDir)
+	got := original.WithGOOS("plan9").WithGOARCH("mips").WithUserHomeDir(homeDir).WithUserConfigDir(configDir)
 
 	require.NotNil(t, got.Platform)
 	assert.Equal(t, "plan9", got.Platform.GOOS)
 	assert.Equal(t, "mips", got.Platform.GOARCH)
 	_, err := got.Platform.UserHomeDir()
 	require.ErrorIs(t, err, wantHomeErr)
+	gotConfigDir, err := got.Platform.UserConfigDir()
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/config", gotConfigDir)
 	assert.Equal(t, runtime.GOOS, original.Platform.GOOS)
 	assert.Equal(t, runtime.GOARCH, original.Platform.GOARCH)
 }
@@ -197,6 +202,9 @@ func TestVenvPlatformRequirements(t *testing.T) {
 	assert.PanicsWithValue(t, venv.ErrVenvUserHomeDirUnset, func() {
 		(&venv.Venv{}).RequireUserHomeDir()
 	})
+	assert.PanicsWithValue(t, venv.ErrVenvUserConfigDirUnset, func() {
+		(&venv.Venv{}).RequireUserConfigDir()
+	})
 	assert.PanicsWithValue(t, venv.ErrVenvPlatformUnset, func() {
 		(&venv.Venv{}).RequirePlatform()
 	})
@@ -231,6 +239,9 @@ func TestVenvPlatformBuildersRequireAPlatform(t *testing.T) {
 	})
 	assert.PanicsWithValue(t, venv.ErrVenvPlatformUnset, func() {
 		(&venv.Venv{}).WithUserHomeDir(func() (string, error) { return "", nil })
+	})
+	assert.PanicsWithValue(t, venv.ErrVenvPlatformUnset, func() {
+		(&venv.Venv{}).WithUserConfigDir(func() (string, error) { return "", nil })
 	})
 	assert.PanicsWithValue(t, venv.ErrVenvPlatformUnset, func() {
 		(&venv.Venv{}).WithTempDir(func() string { return "" })

--- a/test/helpers/venvtest/venvtest.go
+++ b/test/helpers/venvtest/venvtest.go
@@ -1,8 +1,8 @@
 // Package venvtest builds in-memory [venv.Venv] values for tests. New seeds
 // the mem defaults; callers refine individual handles with venv.Venv's fluent
 // With methods (WithHandler, WithExec, WithFS, WithSops, WithBrowser, WithEnv,
-// WithGOOS, WithGOARCH, WithUserHomeDir). Production code builds venvs through
-// [venv.OSVenv] instead.
+// WithGOOS, WithGOARCH, WithUserHomeDir, WithUserConfigDir). Production code
+// builds venvs through [venv.OSVenv] instead.
 //
 // [NewFS] and [LoadFS] build the filesystems those venvs carry, from literals
 // and from an on-disk fixture tree.
@@ -35,9 +35,10 @@ var ErrNoListen = errors.New("venvtest: listening is not permitted")
 // machine uses, so a test that accidentally runs them against the OS filesystem
 // fails loudly instead of writing into the invoking user's directories.
 const (
-	memCacheDir = "/venvtest/cache"
-	memTempDir  = "/venvtest/tmp"
-	memWorkDir  = "/venvtest/work"
+	memCacheDir  = "/venvtest/cache"
+	memConfigDir = "/venvtest/config"
+	memTempDir   = "/venvtest/tmp"
+	memWorkDir   = "/venvtest/work"
 
 	// memPID is a fixed process id, so a crash report or log line carrying it
 	// compares equal between runs.
@@ -79,6 +80,9 @@ func New() *venv.Venv {
 			},
 			UserCacheDir: func() (string, error) {
 				return memCacheDir, nil
+			},
+			UserConfigDir: func() (string, error) {
+				return memConfigDir, nil
 			},
 			TempDir: func() string {
 				return memTempDir


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds the ability to store tokens for `login`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent portal credential storage, allowing users to reuse valid login credentials across commands.
  * Credentials are securely stored with expiration handling and support for multiple portals and organizations.
  * Added validation and clear errors for unsupported or unusable portal addresses.
  * Added user configuration directory support for platform environments.

* **Documentation**
  * Documented credential storage, reuse, and expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->