### PR TITLE
fix: Sanitizing some untrusted input

### DIFF
--- a/docs/src/data/changelog/v1.1.5/catalog-sanitizes-repository-content.mdx
+++ b/docs/src/data/changelog/v1.1.5/catalog-sanitizes-repository-content.mdx
@@ -1,0 +1,17 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### `catalog` sanitizes the content it draws from a repository
+
+`terragrunt catalog` browses repositories you point it at, and drew their titles,
+descriptions, tags and READMEs to the terminal as it found them. Terminals act on escape
+sequences in that text, so a repository could move your cursor, set your window title, or
+write your clipboard while you browsed it. Content that was not valid UTF-8 could end the
+session outright, since the Markdown and syntax renderers reject it.
+
+`catalog` now sanitizes everything it draws, the way `terragrunt browse` already sanitized
+the files it previews. Control characters become the Unicode replacement character, so
+that content draws as visible placeholders. `--format jsonl` and `--format md` keep the
+text as the repository wrote it.

--- a/internal/cas/errors.go
+++ b/internal/cas/errors.go
@@ -111,6 +111,20 @@ func (e *GitStoreObjectMissingError) Error() string {
 	)
 }
 
+// TreeDepthExceededError is returned when materializing a tree hits the
+// nesting bound. Only a repository built to exhaust the stack reaches it.
+type TreeDepthExceededError struct {
+	Path     string
+	MaxDepth int
+}
+
+func (e *TreeDepthExceededError) Error() string {
+	return fmt.Sprintf(
+		"tree nesting at %s exceeds the maximum depth of %d",
+		e.Path, e.MaxDepth,
+	)
+}
+
 func (e *UpdateSourceWithCASRequiresCASError) Error() string {
 	subject := e.BlockType
 	if e.Name != "" {

--- a/internal/cas/tree.go
+++ b/internal/cas/tree.go
@@ -19,6 +19,11 @@ import (
 // unixPermMask isolates the user/group/other rwx bits from a git tree mode.
 const unixPermMask = os.FileMode(0o777)
 
+// defaultMaxTreeDepth stops a descent that the repository being materialized
+// would otherwise decide the length of, growing the stack and the worker count
+// together as every level opens an errgroup of its own.
+const defaultMaxTreeDepth = 64
+
 // Git stores the entry type in the high bits of a six-digit octal mode;
 // gitTypeMask isolates them so a symlink blob (120000) can be distinguished
 // from a regular blob (100644 / 100755) at materialization time.
@@ -31,6 +36,7 @@ const (
 type LinkTreeOption func(*linkTreeOpts)
 
 type linkTreeOpts struct {
+	maxDepth  int
 	forceCopy bool
 }
 
@@ -39,6 +45,22 @@ type linkTreeOpts struct {
 // mutate without affecting the shared store, at the cost of extra I/O.
 func WithForceCopy() LinkTreeOption {
 	return func(o *linkTreeOpts) { o.forceCopy = true }
+}
+
+// WithMaxTreeDepth sets how deep a tree is followed before materialization
+// gives up, in place of [defaultMaxTreeDepth].
+func WithMaxTreeDepth(depth int) LinkTreeOption {
+	return func(o *linkTreeOpts) { o.maxDepth = depth }
+}
+
+// maxTreeDepth returns the nesting bound to enforce, falling back to
+// [defaultMaxTreeDepth] when the caller leaves it unset.
+func (o *linkTreeOpts) maxTreeDepth() int {
+	if o.maxDepth > 0 {
+		return o.maxDepth
+	}
+
+	return defaultMaxTreeDepth
 }
 
 // LinkTree writes the tree to a target directory.
@@ -58,7 +80,7 @@ func LinkTree(
 		opt(&o)
 	}
 
-	return linkTree(ctx, l, v, blobStore, treeStore, t, targetDir, targetDir, &o)
+	return linkTree(ctx, l, v, blobStore, treeStore, t, targetDir, targetDir, 0, &o)
 }
 
 // linkTree is the recursive implementation behind LinkTree. rootDir is the
@@ -75,8 +97,13 @@ func linkTree(
 	t *git.Tree,
 	rootDir string,
 	targetDir string,
+	depth int,
 	o *linkTreeOpts,
 ) error {
+	if maxDepth := o.maxTreeDepth(); depth > maxDepth {
+		return &TreeDepthExceededError{MaxDepth: maxDepth, Path: targetDir}
+	}
+
 	blobContent := NewContent(blobStore)
 	treeContent := NewContent(treeStore)
 
@@ -201,7 +228,7 @@ func linkTree(
 					return fmt.Errorf("parse tree %s: %w", work.entry.Hash, err)
 				}
 
-				err = linkTree(ctx, l, v, blobStore, treeStore, subTree, rootDir, work.path, o)
+				err = linkTree(ctx, l, v, blobStore, treeStore, subTree, rootDir, work.path, depth+1, o)
 				if err != nil {
 					return fmt.Errorf("link subtree %s: %w", work.path, err)
 				}
@@ -229,7 +256,7 @@ func linkTree(
 					return fmt.Errorf("parse submodule tree %s: %w", work.entry.Hash, err)
 				}
 
-				err = linkTree(ctx, l, v, blobStore, treeStore, subTree, rootDir, work.path, o)
+				err = linkTree(ctx, l, v, blobStore, treeStore, subTree, rootDir, work.path, depth+1, o)
 				if err != nil {
 					return fmt.Errorf("link submodule %s: %w", work.path, err)
 				}

--- a/internal/cas/tree_test.go
+++ b/internal/cas/tree_test.go
@@ -1,6 +1,7 @@
 package cas_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -421,4 +422,87 @@ func TestLinkTree(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLinkTreeStopsAtNestingBound(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	v := venvtest.New()
+
+	require.NoError(t, v.FS.MkdirAll("/store", 0755))
+
+	store := cas.NewStore("/store")
+	content := cas.NewContent(store)
+
+	const (
+		maxDepth = 3
+		depth    = maxDepth + 1
+	)
+
+	hashes := make([]string, depth)
+	for i := range hashes {
+		hashes[i] = fmt.Sprintf("%010d", i)
+	}
+
+	for i := range depth - 1 {
+		subtree := fmt.Sprintf("040000 tree %s sub", hashes[i+1])
+		require.NoError(t, content.Store(l, v, hashes[i], []byte(subtree), cas.StoredFilePerms))
+	}
+
+	require.NoError(t, content.Store(l, v, hashes[depth-1], []byte(""), cas.StoredFilePerms))
+
+	tree, err := git.ParseTree([]byte("040000 tree "+hashes[0]+" sub"), "deep-repo")
+	require.NoError(t, err)
+
+	require.NoError(t, v.FS.MkdirAll("/target", 0755))
+
+	err = cas.LinkTree(t.Context(), l, v, store, store, tree, "/target", cas.WithMaxTreeDepth(maxDepth))
+
+	var depthErr *cas.TreeDepthExceededError
+
+	require.ErrorAs(t, err, &depthErr)
+	assert.Equal(t, maxDepth, depthErr.MaxDepth, "the configured cap is the one enforced")
+}
+
+func TestLinkTreeAcceptsTreeAtNestingBound(t *testing.T) {
+	t.Parallel()
+
+	l := logger.CreateLogger()
+	v := venvtest.New()
+
+	require.NoError(t, v.FS.MkdirAll("/store", 0755))
+
+	store := cas.NewStore("/store")
+	content := cas.NewContent(store)
+
+	const maxDepth = 3
+
+	hashes := make([]string, maxDepth)
+	for i := range hashes {
+		hashes[i] = fmt.Sprintf("%010d", i)
+	}
+
+	for i := range maxDepth - 1 {
+		subtree := fmt.Sprintf("040000 tree %s sub", hashes[i+1])
+		require.NoError(t, content.Store(l, v, hashes[i], []byte(subtree), cas.StoredFilePerms))
+	}
+
+	require.NoError(t, content.Store(
+		l, v, hashes[maxDepth-1], []byte("100644 blob deadbeef01 README.md"), cas.StoredFilePerms,
+	))
+	require.NoError(t, content.Store(l, v, "deadbeef01", []byte("hello"), cas.StoredFilePerms))
+
+	tree, err := git.ParseTree([]byte("040000 tree "+hashes[0]+" sub"), "deep-repo")
+	require.NoError(t, err)
+
+	require.NoError(t, v.FS.MkdirAll("/target", 0755))
+
+	require.NoError(t, cas.LinkTree(
+		t.Context(), l, v, store, store, tree, "/target", cas.WithMaxTreeDepth(maxDepth),
+	))
+
+	got, err := vfs.ReadFile(v.FS, filepath.Join("/target", "sub", "sub", "sub", "README.md"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), got)
 }

--- a/internal/cli/commands/catalog/tui/component_entry.go
+++ b/internal/cli/commands/catalog/tui/component_entry.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/component"
+	viewtui "github.com/gruntwork-io/terragrunt/internal/view/tui"
 )
 
 // ComponentEntry wraps a *Component with display-only metadata that the
@@ -41,13 +42,24 @@ func (e *ComponentEntry) WithSource(source string) *ComponentEntry {
 func (e *ComponentEntry) Kind() component.Kind { return e.Component.Kind }
 
 // FilterValue implements list.Item by delegating to the inner Component.
-func (e *ComponentEntry) FilterValue() string { return e.Component.FilterValue() }
+// Sanitized like [ComponentEntry.Title] so the match offsets the list computes
+// from it line up with the title the delegate draws.
+func (e *ComponentEntry) FilterValue() string {
+	return viewtui.SanitizeLabel(e.Component.FilterValue())
+}
 
 // Title implements list.DefaultItem by delegating to the inner Component.
-func (e *ComponentEntry) Title() string { return e.Component.Title() }
+// A title comes from a README in a cloned repository, so it is sanitized for
+// the terminal here. The inner Component keeps the text as written, for output
+// that never reaches a terminal.
+func (e *ComponentEntry) Title() string {
+	return viewtui.SanitizeLabel(e.Component.Title())
+}
 
 // Description implements list.DefaultItem by delegating to the inner Component.
-func (e *ComponentEntry) Description() string { return e.Component.Description() }
+func (e *ComponentEntry) Description() string {
+	return viewtui.SanitizeLabel(e.Component.Description())
+}
 
 // Tags returns the component's tags, cached on first call so the list
 // delegate doesn't re-parse the README on every render.

--- a/internal/cli/commands/catalog/tui/component_entry_test.go
+++ b/internal/cli/commands/catalog/tui/component_entry_test.go
@@ -1,0 +1,47 @@
+package tui_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/catalog/tui"
+	"github.com/gruntwork-io/terragrunt/internal/services/catalog/component"
+)
+
+// unsanitizedReadme puts escape sequences where the catalog reads a
+// component's title and description from, the first heading and the paragraph
+// under it. A terminal acts on both of them, clearing a line and setting the
+// window title.
+const unsanitizedReadme = "# VPC\x1b[2K App\n\nA VPC\x1b]0;title\x07 for application workloads.\n"
+
+func TestComponentEntrySanitizesWhatTheListDraws(t *testing.T) {
+	t.Parallel()
+
+	c := tui.NewComponentForTest(component.KindModule, "github.com/acme/repo", "modules/vpc", unsanitizedReadme)
+	entry := tui.NewComponentEntry(c)
+
+	assert.NotContains(t, entry.Title(), "\x1b")
+	assert.NotContains(t, entry.Description(), "\x1b")
+
+	// The list matches against FilterValue and highlights the offsets it
+	// returns in the drawn title, so the two have to agree.
+	assert.Equal(t, entry.Title(), entry.FilterValue())
+
+	assert.Contains(t, c.Title(), "\x1b", "the component keeps the text as written for non-terminal output")
+}
+
+func TestRenderTagPillsSanitizesTags(t *testing.T) {
+	t.Parallel()
+
+	tags := []string{"net\x1b]0;title\x07work", "module"}
+
+	assert.NotContains(t, tui.RenderTagPills(tags, 200, false), "\x1b]")
+	assert.NotContains(t, tui.RenderDetailTagPills(tags), "\x1b]")
+}
+
+func TestRenderTagPillsKeepsTagText(t *testing.T) {
+	t.Parallel()
+
+	assert.Contains(t, tui.RenderDetailTagPills([]string{"networking"}), "networking")
+}

--- a/internal/cli/commands/catalog/tui/tag_pills.go
+++ b/internal/cli/commands/catalog/tui/tag_pills.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/component"
+	viewtui "github.com/gruntwork-io/terragrunt/internal/view/tui"
 )
 
 // KindForTag returns the component.Kind that tag names case-insensitively,
@@ -115,7 +116,7 @@ func RenderTagPills(tags []string, maxWidth int, selected bool) string {
 		return ""
 	}
 
-	sorted := sortPrivilegedFirst(tags)
+	sorted := sortPrivilegedFirst(sanitizeTags(tags))
 
 	// Reserve against the widest possible +N so the indicator always fits.
 	worstOverflowText := fmt.Sprintf("+%d", len(sorted))
@@ -181,7 +182,7 @@ func RenderDetailTagPills(tags []string) string {
 		return ""
 	}
 
-	sorted := sortPrivilegedFirst(tags)
+	sorted := sortPrivilegedFirst(sanitizeTags(tags))
 	rendered := make([]string, 0, len(sorted))
 
 	for _, tag := range sorted {
@@ -211,6 +212,17 @@ func TagsMarkdownSection(tags []string) string {
 	}
 
 	return b.String()
+}
+
+// sanitizeTags returns tags ready to draw. A pill is measured before it is
+// placed, so the text is sanitized before any width is taken from it.
+func sanitizeTags(tags []string) []string {
+	out := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		out = append(out, viewtui.SanitizeLabel(tag))
+	}
+
+	return out
 }
 
 // sortPrivilegedFirst returns tags reordered so kind-matching ones come

--- a/internal/cli/commands/catalog/tui/update.go
+++ b/internal/cli/commands/catalog/tui/update.go
@@ -346,14 +346,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // renderComponentContent prepares the pager body, prepending tag pills
 // when configured. Markdown components run through the model's cached
-// renderer, which may itself be (re)allocated.
+// renderer, which may itself be (re)allocated. Content comes from a cloned
+// repository, so it is sanitized before it is rendered.
 func (m Model) renderComponentContent(
 	c *Component,
 	tagsStyle TagsDetailStyle,
 	tags []string,
 ) (Model, string, error) {
 	if !c.IsMarkDown() {
-		content := c.Content(true)
+		content := viewtui.SanitizeText(c.Content(true))
 		if pills := RenderDetailTagPills(tags); pills != "" {
 			content = pills + "\n\n" + content
 		}
@@ -371,7 +372,7 @@ func (m Model) renderComponentContent(
 		body += TagsMarkdownSection(tags)
 	}
 
-	rendered, err := renderer.Render(body)
+	rendered, err := renderer.Render(viewtui.SanitizeText(body))
 	if err != nil {
 		return m, "", err
 	}
@@ -463,8 +464,8 @@ func formatSourceFailureNotice(err error, accent string) string {
 		for _, f := range srcErr.Failures {
 			rows = append(rows,
 				"",
-				valuesBoxPathStyle.Render(f.URL),
-				valuesBoxMuteStyle.Render(f.Err.Error()),
+				valuesBoxPathStyle.Render(viewtui.SanitizeLabel(f.URL)),
+				valuesBoxMuteStyle.Render(viewtui.SanitizeLabel(f.Err.Error())),
 			)
 		}
 	}
@@ -713,7 +714,7 @@ func discoverModuleFields(
 	fields := form.FieldsFromParsedVariables(plan.Required, plan.Optional)
 
 	return formReadyMsg{
-		form: form.NewModel(c.Title(), fields),
+		form: form.NewModel(viewtui.SanitizeLabel(c.Title()), fields),
 		plan: plan,
 	}
 }
@@ -740,7 +741,7 @@ func discoverValuesFields(v *venv.Venv, c *Component) tea.Msg {
 	fields := form.FieldsFromValuesReferences(refs)
 
 	return formReadyMsg{
-		form: form.NewModel(c.Title(), fields),
+		form: form.NewModel(viewtui.SanitizeLabel(c.Title()), fields),
 		refs: &refs,
 	}
 }

--- a/internal/cli/commands/catalog/tui/view.go
+++ b/internal/cli/commands/catalog/tui/view.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	viewtui "github.com/gruntwork-io/terragrunt/internal/view/tui"
 	"github.com/gruntwork-io/terragrunt/internal/view/tui/form"
 )
 
@@ -61,7 +62,7 @@ func (m Model) listView() string {
 	// height math in the WindowSizeMsg handler stays unchanged.
 	notice := ""
 	if m.loadErr != nil {
-		notice = loadNoticeStyle.Render("⚠ " + m.loadErr.Error())
+		notice = loadNoticeStyle.Render("⚠ " + viewtui.SanitizeLabel(m.loadErr.Error()))
 	}
 
 	return lipgloss.JoinVertical(lipgloss.Left, bar, notice, active.View())

--- a/internal/cli/commands/catalog/tui/welcome.go
+++ b/internal/cli/commands/catalog/tui/welcome.go
@@ -326,7 +326,7 @@ func (m WelcomeModel) discoveryErrorView() string {
 func (m WelcomeModel) discoveryErrorDetail() []string {
 	errMsg := "unknown error"
 	if m.lastDiscoveryErr != nil {
-		errMsg = m.lastDiscoveryErr.Error()
+		errMsg = viewtui.SanitizeLabel(m.lastDiscoveryErr.Error())
 	}
 
 	var srcErr *SourceLoadError
@@ -339,8 +339,8 @@ func (m WelcomeModel) discoveryErrorDetail() []string {
 	for _, f := range srcErr.Failures {
 		rows = append(rows,
 			"",
-			welcomeCodeStyle.Render("    "+f.URL),
-			welcomeHintStyle.Render("      "+f.Err.Error()),
+			welcomeCodeStyle.Render("    "+viewtui.SanitizeLabel(f.URL)),
+			welcomeHintStyle.Render("      "+viewtui.SanitizeLabel(f.Err.Error())),
 		)
 	}
 

--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -26,6 +26,10 @@ import (
 const (
 	serviceDiscoveryPath = "/.well-known/terraform.json"
 	authTokenEnvName     = "TG_TF_REGISTRY_TOKEN"
+
+	// maxRegistryResponseBytes bounds a registry response. The largest of them
+	// lists a module's versions, which stays well under this.
+	maxRegistryResponseBytes = 1 << 20
 )
 
 // RegistryServicePath is the modules service path returned by service discovery.
@@ -720,7 +724,7 @@ func httpGETAndGetResponse(
 		return nil, nil, RegistryAPIErr{url: getURL.String(), statusCode: resp.StatusCode}
 	}
 
-	bodyData, err := io.ReadAll(resp.Body)
+	bodyData, err := io.ReadAll(io.LimitReader(resp.Body, maxRegistryResponseBytes))
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading registry response body from %s: %w", getURL, err)
 	}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -21,6 +21,10 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
+// maxAPIResponseBytes bounds an API response. The one response read here
+// describes a single release.
+const maxAPIResponseBytes = 1 << 20
+
 // GitHubAPIClient represents a GitHub API client.
 type GitHubAPIClient struct {
 	baseURL        string
@@ -148,7 +152,7 @@ func (c *GitHubAPIClient) GetLatestRelease(
 		)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/internal/tf/cache/handlers/registry_urls.go
+++ b/internal/tf/cache/handlers/registry_urls.go
@@ -16,6 +16,10 @@ import (
 const (
 	// well-known address for discovery URLs
 	wellKnownURL = ".well-known/terraform.json"
+
+	// maxDiscoveryResponseBytes bounds the discovery document. It names two
+	// service paths and runs to a few hundred bytes.
+	maxDiscoveryResponseBytes = 1 << 20
 )
 
 var (
@@ -62,7 +66,7 @@ func DiscoveryURL(ctx context.Context, c vhttp.Client, registryName string) (*Re
 		return nil, fmt.Errorf("%s returned %s", url, resp.Status)
 	}
 
-	content, err := io.ReadAll(resp.Body)
+	content, err := io.ReadAll(io.LimitReader(resp.Body, maxDiscoveryResponseBytes))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tf/cache/helpers/http.go
+++ b/internal/tf/cache/helpers/http.go
@@ -16,9 +16,26 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 )
 
-// Fetch dispatches req through c and copies the (possibly
-// gzip-decoded) response body into dst.
-func Fetch(ctx context.Context, c vhttp.Client, req *http.Request, dst io.Writer) error {
+// MaxJSONResponseBytes bounds what [ResponseBuffer] reads into memory.
+// Everything it reads is registry metadata, orders of magnitude smaller than
+// this.
+const MaxJSONResponseBytes = 1 << 20
+
+// ResponseTooLargeError is returned when a response outgrows the limit it was
+// read under.
+type ResponseTooLargeError struct {
+	Limit int64
+}
+
+func (err ResponseTooLargeError) Error() string {
+	return fmt.Sprintf("response exceeds the limit of %d bytes", err.Limit)
+}
+
+// Fetch dispatches req through c and copies the (possibly gzip-decoded)
+// response body into dst, up to limit bytes. The limit applies after decoding,
+// because the server decides how far a compressed response expands and the
+// declared content length says nothing about it.
+func Fetch(ctx context.Context, c vhttp.Client, req *http.Request, dst io.Writer, limit int64) error {
 	req.Header.Add("Accept-Encoding", "gzip")
 
 	resp, err := c.Do(req)
@@ -36,9 +53,18 @@ func Fetch(ctx context.Context, c vhttp.Client, req *http.Request, dst io.Writer
 		return err
 	}
 
-	if written, err := util.Copy(ctx, dst, reader); err != nil {
+	// Read one byte past the limit to tell a response that outgrew it from one
+	// that ends exactly on it.
+	written, err := util.Copy(ctx, dst, io.LimitReader(reader, limit+1))
+	if err != nil {
 		return err
-	} else if resp.ContentLength != -1 && written != resp.ContentLength {
+	}
+
+	if written > limit {
+		return fmt.Errorf("fetching %s: %w", req.URL, ResponseTooLargeError{Limit: limit})
+	}
+
+	if resp.ContentLength != -1 && written != resp.ContentLength {
 		return fmt.Errorf(
 			"incorrect response size: expected %d bytes, but got %d bytes",
 			resp.ContentLength,
@@ -49,8 +75,16 @@ func Fetch(ctx context.Context, c vhttp.Client, req *http.Request, dst io.Writer
 	return nil
 }
 
-// FetchToFile downloads req's response through c into the file at dst.
-func FetchToFile(ctx context.Context, c vhttp.Client, fsys vfs.FS, req *http.Request, dst string) (err error) {
+// FetchToFile downloads req's response through c into the file at dst, up to
+// limit bytes.
+func FetchToFile(
+	ctx context.Context,
+	c vhttp.Client,
+	fsys vfs.FS,
+	req *http.Request,
+	dst string,
+	limit int64,
+) (err error) {
 	file, err := fsys.Create(dst)
 	if err != nil {
 		return err
@@ -62,7 +96,7 @@ func FetchToFile(ctx context.Context, c vhttp.Client, fsys vfs.FS, req *http.Req
 		}
 	}()
 
-	if err := Fetch(ctx, c, req, file); err != nil {
+	if err := Fetch(ctx, c, req, file, limit); err != nil {
 		return err
 	}
 
@@ -93,6 +127,8 @@ func ResponseReader(resp *http.Response) (io.ReadCloser, error) {
 	}
 }
 
+// ResponseBuffer reads resp's (possibly gzip-decoded) body into a buffer,
+// refusing a body that outgrows [MaxJSONResponseBytes].
 func ResponseBuffer(resp *http.Response) (*bytes.Buffer, error) {
 	reader, err := ResponseReader(resp)
 	if err != nil {
@@ -102,8 +138,13 @@ func ResponseBuffer(resp *http.Response) (*bytes.Buffer, error) {
 
 	buffer := new(bytes.Buffer)
 
-	if _, err := buffer.ReadFrom(reader); err != nil {
+	read, err := buffer.ReadFrom(io.LimitReader(reader, MaxJSONResponseBytes+1))
+	if err != nil {
 		return nil, err
+	}
+
+	if read > MaxJSONResponseBytes {
+		return nil, ResponseTooLargeError{Limit: MaxJSONResponseBytes}
 	}
 
 	return buffer, nil

--- a/internal/tf/cache/helpers/http_test.go
+++ b/internal/tf/cache/helpers/http_test.go
@@ -1,0 +1,105 @@
+package helpers_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache/helpers"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+)
+
+// gzipped returns size bytes of compressible filler, gzip-encoded. Whatever
+// size the caller asks for arrives as a few hundred bytes on the wire.
+func gzipped(t *testing.T, size int) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	w := gzip.NewWriter(&buf)
+
+	_, err := w.Write(bytes.Repeat([]byte("a"), size))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	return buf.Bytes()
+}
+
+func gzipClient(t *testing.T, decodedSize int) vhttp.Client {
+	t.Helper()
+
+	body := gzipped(t, decodedSize)
+
+	return vhttp.NewMemClient(func(_ context.Context, _ *http.Request) (*http.Response, error) {
+		return vhttp.Respond(http.StatusOK, body, http.Header{"Content-Encoding": []string{"gzip"}}), nil
+	})
+}
+
+func TestFetchRefusesBodyPastLimit(t *testing.T) {
+	t.Parallel()
+
+	const limit = 1 << 10
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://registry.test/sums", nil)
+	require.NoError(t, err)
+
+	var dst bytes.Buffer
+
+	err = helpers.Fetch(t.Context(), gzipClient(t, limit*64), req, &dst, limit)
+
+	var tooLarge helpers.ResponseTooLargeError
+
+	require.ErrorAs(t, err, &tooLarge)
+	require.Equal(t, int64(limit), tooLarge.Limit)
+}
+
+func TestFetchAcceptsBodyAtLimit(t *testing.T) {
+	t.Parallel()
+
+	const limit = 1 << 10
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://registry.test/sums", nil)
+	require.NoError(t, err)
+
+	var dst bytes.Buffer
+
+	require.NoError(t, helpers.Fetch(t.Context(), gzipClient(t, limit), req, &dst, limit))
+	require.Equal(t, limit, dst.Len())
+}
+
+func TestResponseBufferRefusesBodyPastLimit(t *testing.T) {
+	t.Parallel()
+
+	resp := vhttp.Respond(
+		http.StatusOK,
+		gzipped(t, helpers.MaxJSONResponseBytes+1),
+		http.Header{"Content-Encoding": []string{"gzip"}},
+	)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	buffer, err := helpers.ResponseBuffer(resp)
+
+	var tooLarge helpers.ResponseTooLargeError
+
+	require.ErrorAs(t, err, &tooLarge)
+	require.Nil(t, buffer)
+}
+
+func TestResponseBufferReadsBodyWithinLimit(t *testing.T) {
+	t.Parallel()
+
+	resp := vhttp.Respond(http.StatusOK, gzipped(t, 64), http.Header{"Content-Encoding": []string{"gzip"}})
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	buffer, err := helpers.ResponseBuffer(resp)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(buffer)
+	require.NoError(t, err)
+	require.Len(t, body, 64)
+}

--- a/internal/tf/cache/services/provider_cache.go
+++ b/internal/tf/cache/services/provider_cache.go
@@ -48,6 +48,11 @@ const (
 
 	// DefaultProviderFilesLimit is the maximum number of files in a provider archive
 	DefaultProviderFilesLimit = 100
+
+	// maxProviderMetadataBytes bounds the checksum document and the signature
+	// that authenticate an archive. Both are read into memory, and both run to
+	// a few kilobytes.
+	maxProviderMetadataBytes = 1 << 20
 )
 
 type ProviderCaches []*ProviderCache
@@ -287,7 +292,7 @@ func (cache *ProviderCache) setDocumentSHA256Sums(ctx context.Context) ([]byte, 
 		return nil, err
 	}
 
-	if err := helpers.Fetch(ctx, cache.HTTPClient(), req, documentSHA256Sums); err != nil {
+	if err := helpers.Fetch(ctx, cache.HTTPClient(), req, documentSHA256Sums, maxProviderMetadataBytes); err != nil {
 		return nil, fmt.Errorf(
 			"failed to retrieve authentication checksums for provider %q: %w",
 			cache.Provider,
@@ -322,7 +327,7 @@ func (cache *ProviderCache) setSignature(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 
-	if err := helpers.Fetch(ctx, cache.HTTPClient(), req, signature); err != nil {
+	if err := helpers.Fetch(ctx, cache.HTTPClient(), req, signature, maxProviderMetadataBytes); err != nil {
 		return nil, fmt.Errorf(
 			"failed to retrieve authentication signature for provider %q: %w",
 			cache.Provider,
@@ -409,13 +414,25 @@ func (cache *ProviderCache) warmUp(ctx context.Context) error {
 					return err
 				}
 
-				return helpers.FetchToFile(ctx, cache.HTTPClient(), cache.ProviderService.FS(), req, cache.archivePath)
+				return helpers.FetchToFile(
+					ctx,
+					cache.HTTPClient(),
+					cache.ProviderService.FS(),
+					req,
+					cache.archivePath,
+					DefaultProviderFileSizeLimit,
+				)
 			},
 		); err != nil {
 			return err
 		}
 
 		cache.archiveCached = true
+	}
+
+	auth, err := cache.AuthenticatePackage(ctx)
+	if err != nil {
+		return err
 	}
 
 	cache.logger.Debugf("Unpack provider archive %s", cache.archivePath)
@@ -430,11 +447,6 @@ func (cache *ProviderCache) warmUp(ctx context.Context) error {
 		cache.archivePath,
 		unzipFileMode,
 	); err != nil {
-		return err
-	}
-
-	auth, err := cache.AuthenticatePackage(ctx)
-	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Sanitizes some input we weren't validating earlier.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized repository-derived catalog content before terminal display, including titles, descriptions, tags, URLs, and error messages.
  * Preserved original repository text in JSONL and Markdown output.
  * Prevented excessively deep repository trees from exceeding safe traversal limits.
  * Added size limits for registry, GitHub, Terraform, and provider downloads.
  * Provider archives are now authenticated before extraction.
* **Documentation**
  * Added release documentation for catalog content sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->