### PR TITLE
chore: Enabling `nolintlint`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -197,6 +197,8 @@ linters:
         - -SA9005
         - -QF1008
         - -ST1001
+        # Strict-control and config errors are shown to users as sentences.
+        - -ST1005
     unparam:
       check-exported: false
     wsl_v5:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ linters:
     - nilerr
     - nilnesserr
     - noctx
+    - nolintlint
     - paralleltest
     - perfsprint
     - prealloc
@@ -187,6 +188,9 @@ linters:
         - unusedwrite
     nakedret:
       max-func-lines: 20
+    nolintlint:
+      require-explanation: true
+      require-specific: true
     staticcheck:
       checks:
         - all

--- a/internal/awshelper/config.go
+++ b/internal/awshelper/config.go
@@ -215,7 +215,7 @@ func (b *AWSConfigBuilder) BuildS3Client(
 		return s3.NewFromConfig(cfg), nil
 	}
 
-	customFN := make([]func(*s3.Options), 0, 2) //nolint:mnd
+	customFN := make([]func(*s3.Options), 0, 2) //nolint:mnd // at most two S3 option overrides are appended below
 
 	if b.sessionConfig.CustomS3Endpoint != "" {
 		customFN = append(customFN, func(o *s3.Options) {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -81,7 +81,7 @@ func (app *App) registerGracefullyShutdown(ctx context.Context, l log.Logger) co
 
 	signal.NotifierWithContext(ctx, func(sig os.Signal) {
 		// Carriage return helps prevent "^C" from being printed
-		fmt.Fprint(app.Writer, "\r") //nolint:errcheck
+		fmt.Fprint(app.Writer, "\r") //nolint:errcheck // best-effort cosmetic write
 		l.Infof(
 			"%s signal received. Gracefully shutting down...",
 			cases.Title(language.English).String(sig.String()),

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -81,7 +81,10 @@ func (app *App) registerGracefullyShutdown(ctx context.Context, l log.Logger) co
 
 	signal.NotifierWithContext(ctx, func(sig os.Signal) {
 		// Carriage return helps prevent "^C" from being printed
-		fmt.Fprint(app.Writer, "\r") //nolint:errcheck // best-effort cosmetic write
+		if _, err := fmt.Fprint(app.Writer, "\r"); err != nil {
+			l.Debugf("Failed to write to the output on %s: %v", sig, err)
+		}
+
 		l.Infof(
 			"%s signal received. Gracefully shutting down...",
 			cases.Title(language.English).String(sig.String()),

--- a/internal/cli/commands/browse/tui/view.go
+++ b/internal/cli/commands/browse/tui/view.go
@@ -39,7 +39,7 @@ const (
 )
 
 var (
-	appStyle      = lipgloss.NewStyle().Padding(1, 2) //nolint:mnd
+	appStyle      = lipgloss.NewStyle().Padding(1, 2) //nolint:mnd // one row of vertical padding, two of horizontal
 	itemStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(itemColor))
 	selectedStyle = lipgloss.NewStyle().Bold(true).
 			Foreground(lipgloss.Color(viewtui.SelectionText)).
@@ -108,7 +108,7 @@ func (m Model) paneSizes(header, footer string) (sideWidth, previewWidth, paneHe
 	_, frameV := appStyle.GetFrameSize()
 
 	content := m.contentWidth()
-	sideWidth = content / 4 //nolint:mnd
+	sideWidth = content / 4 //nolint:mnd // the side pane takes a quarter of the content width
 	previewWidth = content - sideWidth*(columnCount-1)
 
 	paneHeight = max(m.height-frameV-lipgloss.Height(header)-lipgloss.Height(footer), 0)

--- a/internal/cli/commands/browse/tui/view.go
+++ b/internal/cli/commands/browse/tui/view.go
@@ -28,6 +28,16 @@ const paneBorderHeight = 2
 const panePadWidth = 2
 
 const (
+	// appPadHeight is the rows of padding above and below the app.
+	appPadHeight = 1
+	// appPadWidth is the columns of padding either side of the app.
+	appPadWidth = 2
+)
+
+// sidePaneDivisor gives each side column a quarter of the content width, leaving half for the preview.
+const sidePaneDivisor = 4
+
+const (
 	// itemColor renders unselected entries in bright white.
 	itemColor = "15"
 	// dimColor is used for borders, help text, and empty-state placeholders.
@@ -39,7 +49,7 @@ const (
 )
 
 var (
-	appStyle      = lipgloss.NewStyle().Padding(1, 2) //nolint:mnd // one row of vertical padding, two of horizontal
+	appStyle      = lipgloss.NewStyle().Padding(appPadHeight, appPadWidth)
 	itemStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(itemColor))
 	selectedStyle = lipgloss.NewStyle().Bold(true).
 			Foreground(lipgloss.Color(viewtui.SelectionText)).
@@ -108,7 +118,7 @@ func (m Model) paneSizes(header, footer string) (sideWidth, previewWidth, paneHe
 	_, frameV := appStyle.GetFrameSize()
 
 	content := m.contentWidth()
-	sideWidth = content / 4 //nolint:mnd // the side pane takes a quarter of the content width
+	sideWidth = content / sidePaneDivisor
 	previewWidth = content - sideWidth*(columnCount-1)
 
 	paneHeight = max(m.height-frameV-lipgloss.Height(header)-lipgloss.Height(footer), 0)

--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -80,7 +80,7 @@ func New(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) clihelper.
 	}.SetCategory(
 		&clihelper.Category{
 			Name:  MainCommandsCategoryName,
-			Order: 10, //nolint: mnd
+			Order: 10, //nolint:mnd // help categories are ordered in steps of ten
 		},
 	)
 
@@ -90,7 +90,7 @@ func New(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) clihelper.
 	}.SetCategory(
 		&clihelper.Category{
 			Name:  CatalogCommandsCategoryName,
-			Order: 20, //nolint: mnd
+			Order: 20, //nolint:mnd // help categories are ordered in steps of ten
 		},
 	)
 
@@ -101,7 +101,7 @@ func New(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) clihelper.
 	}.SetCategory(
 		&clihelper.Category{
 			Name:  DiscoveryCommandsCategoryName,
-			Order: 30, //nolint: mnd
+			Order: 30, //nolint:mnd // help categories are ordered in steps of ten
 		},
 	)
 
@@ -116,14 +116,14 @@ func New(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) clihelper.
 	}.SetCategory(
 		&clihelper.Category{
 			Name:  ConfigurationCommandsCategoryName,
-			Order: 40, //nolint: mnd
+			Order: 40, //nolint:mnd // help categories are ordered in steps of ten
 		},
 	)
 
 	shortcutsCommands := NewShortcutsCommands(l, opts, v).SetCategory(
 		&clihelper.Category{
 			Name:  ShortcutsCommandsCategoryName,
-			Order: 50, //nolint: mnd
+			Order: 50, //nolint:mnd // help categories are ordered in steps of ten
 		},
 	)
 
@@ -259,7 +259,7 @@ func GiveWindowsSymlinksTip(
 	source := filepath.Join(tmp, "source")
 	target := filepath.Join(tmp, "target")
 
-	if err := fsys.Mkdir(source, 0755); err != nil { //nolint:mnd
+	if err := fsys.Mkdir(source, 0755); err != nil { //nolint:mnd // 0755 is the usual directory mode
 		l.Debugf("Failed to create source directory for testing symlink: %v", err)
 		return
 	}
@@ -346,7 +346,7 @@ func RunAction(
 		if err != nil {
 			return err
 		}
-		defer ln.Close() //nolint:errcheck
+		defer ln.Close() //nolint:errcheck // best-effort close of the cache server's listener
 
 		actionCtx = tf.ContextWithTerraformCommandHook(actionCtx, server.TerraformCommandHook)
 

--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -4,6 +4,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"net"
 	"path/filepath"
 	"runtime/debug"
 	"slices"
@@ -69,8 +70,16 @@ const (
 	ShortcutsCommandsCategoryName = "OpenTofu shortcuts"
 )
 
+// Command categories appear in help in the order declared here.
+const (
+	mainCommandsOrder = iota + 1
+	catalogCommandsOrder
+	discoveryCommandsOrder
+	configurationCommandsOrder
+	shortcutsCommandsOrder
+)
+
 // New returns the set of Terragrunt commands, grouped into categories.
-// Categories are ordered in increments of 10 for easy insertion of new categories.
 func New(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) clihelper.Commands {
 	mainCommands := clihelper.Commands{
 		runcmd.NewCommand(l, opts, v),  // run
@@ -80,7 +89,7 @@ func New(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) clihelper.
 	}.SetCategory(
 		&clihelper.Category{
 			Name:  MainCommandsCategoryName,
-			Order: 10, //nolint:mnd // help categories are ordered in steps of ten
+			Order: mainCommandsOrder,
 		},
 	)
 
@@ -90,7 +99,7 @@ func New(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) clihelper.
 	}.SetCategory(
 		&clihelper.Category{
 			Name:  CatalogCommandsCategoryName,
-			Order: 20, //nolint:mnd // help categories are ordered in steps of ten
+			Order: catalogCommandsOrder,
 		},
 	)
 
@@ -101,7 +110,7 @@ func New(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) clihelper.
 	}.SetCategory(
 		&clihelper.Category{
 			Name:  DiscoveryCommandsCategoryName,
-			Order: 30, //nolint:mnd // help categories are ordered in steps of ten
+			Order: discoveryCommandsOrder,
 		},
 	)
 
@@ -116,14 +125,14 @@ func New(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv) clihelper.
 	}.SetCategory(
 		&clihelper.Category{
 			Name:  ConfigurationCommandsCategoryName,
-			Order: 40, //nolint:mnd // help categories are ordered in steps of ten
+			Order: configurationCommandsOrder,
 		},
 	)
 
 	shortcutsCommands := NewShortcutsCommands(l, opts, v).SetCategory(
 		&clihelper.Category{
 			Name:  ShortcutsCommandsCategoryName,
-			Order: 50, //nolint:mnd // help categories are ordered in steps of ten
+			Order: shortcutsCommandsOrder,
 		},
 	)
 
@@ -210,6 +219,9 @@ func WrapWithTelemetry(
 	}
 }
 
+// probeDirPerms is the mode of the throwaway directory the symlink probe creates.
+const probeDirPerms = 0o755
+
 // GiveWindowsSymlinksTip warns Windows users that OpenTofu/Terraform may not create symlinks
 // for provider plugins installed in the local cache directory.
 //
@@ -259,7 +271,7 @@ func GiveWindowsSymlinksTip(
 	source := filepath.Join(tmp, "source")
 	target := filepath.Join(tmp, "target")
 
-	if err := fsys.Mkdir(source, 0755); err != nil { //nolint:mnd // 0755 is the usual directory mode
+	if err := fsys.Mkdir(source, probeDirPerms); err != nil {
 		l.Debugf("Failed to create source directory for testing symlink: %v", err)
 		return
 	}
@@ -346,7 +358,11 @@ func RunAction(
 		if err != nil {
 			return err
 		}
-		defer ln.Close() //nolint:errcheck // best-effort close of the cache server's listener
+		defer func() {
+			if err := ln.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+				l.Debugf("Failed to close the provider cache listener: %v", err)
+			}
+		}()
 
 		actionCtx = tf.ContextWithTerraformCommandHook(actionCtx, server.TerraformCommandHook)
 

--- a/internal/cli/commands/hcl/format/bytes_diff_test.go
+++ b/internal/cli/commands/hcl/format/bytes_diff_test.go
@@ -1,9 +1,10 @@
-//nolint:testpackage // needs access to unexported bytesDiff
-package format
+package format_test
 
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/commands/hcl/format"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -62,7 +63,7 @@ func TestBytesDiff(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := string(bytesDiff([]byte(tc.before), []byte(tc.after), tc.path))
+			got := string(format.BytesDiff([]byte(tc.before), []byte(tc.after), tc.path))
 
 			if tc.wantEmpty {
 				assert.Empty(t, got, "expected no diff output for identical inputs")

--- a/internal/cli/commands/hcl/format/format.go
+++ b/internal/cli/commands/hcl/format/format.go
@@ -217,7 +217,7 @@ func formatFromStdin(l log.Logger, v *venv.Venv, opts *options.TerragruntOptions
 	needsFormatting := !bytes.Equal(newContents, contents)
 
 	if opts.Diff && needsFormatting {
-		if _, err := v.Writers.Writer.Write(bytesDiff(contents, newContents, stdinPath)); err != nil {
+		if _, err := v.Writers.Writer.Write(BytesDiff(contents, newContents, stdinPath)); err != nil {
 			l.Errorf("Failed to print diff for stdin")
 
 			return err
@@ -282,7 +282,7 @@ func formatTgHCL(
 	fileUpdated := !bytes.Equal(newContents, contents)
 
 	if opts.Diff && fileUpdated {
-		if _, err := v.Writers.Writer.Write(bytesDiff(contents, newContents, tgHclFile)); err != nil {
+		if _, err := v.Writers.Writer.Write(BytesDiff(contents, newContents, tgHclFile)); err != nil {
 			l.Errorf("Failed to print diff for %s", tgHclFile)
 			return err
 		}
@@ -320,8 +320,8 @@ func checkErrors(l log.Logger, v *venv.Venv, contents []byte, tgHclFile string) 
 	return nil
 }
 
-// bytesDiff returns a unified diff between the original and formatted HCL contents.
-func bytesDiff(b1, b2 []byte, name string) []byte {
+// BytesDiff returns a unified diff between the original and formatted HCL contents.
+func BytesDiff(b1, b2 []byte, name string) []byte {
 	// Diff labels are slash separated on every platform, so that consumers of the diff don't have to
 	// handle a Windows-specific spelling of the same label.
 	name = filepath.ToSlash(name)

--- a/internal/cli/commands/list/list_test.go
+++ b/internal/cli/commands/list/list_test.go
@@ -61,7 +61,7 @@ func TestBasicDiscovery(t *testing.T) {
 
 	// Create options
 	opts := list.NewOptions(tgOpts)
-	opts.Format = "text" //nolint: goconst
+	opts.Format = "text"
 	opts.Mode = "normal"
 	opts.NoHidden = true
 	opts.Dependencies = false
@@ -221,7 +221,7 @@ dependency "unit2" {
 	// Create options
 	opts := list.NewOptions(tgOpts)
 	opts.Format = "text"
-	opts.Mode = "dag" //nolint: goconst
+	opts.Mode = "dag"
 	opts.Dependencies = true
 
 	// Create a pipe to capture output
@@ -296,7 +296,7 @@ dependency "unit3" {
 	// Create options
 	opts := list.NewOptions(tgOpts)
 	opts.Format = "text"
-	opts.Mode = "dag" //nolint: goconst
+	opts.Mode = "dag"
 	opts.Dependencies = true
 
 	// Create a pipe to capture output
@@ -410,7 +410,7 @@ dependency "C" {
 	// Create options
 	opts := list.NewOptions(tgOpts)
 	opts.Format = "text"
-	opts.Mode = "dag" //nolint: goconst
+	opts.Mode = "dag"
 	opts.Dependencies = true
 
 	// Create a pipe to capture output

--- a/internal/cli/commands/run/help.go
+++ b/internal/cli/commands/run/help.go
@@ -77,7 +77,7 @@ func runTFHelp(
 		configbridge.TFRunOptsFromOpts(v.Env, opts),
 		terraformHelpCmd...)
 	if err != nil {
-		var processError util.ProcessExecutionError
+		var processError *util.ProcessExecutionError
 		if ok := errors.As(err, &processError); ok {
 			err = processError.Err
 		}

--- a/internal/cli/commands/stack/output.go
+++ b/internal/cli/commands/stack/output.go
@@ -112,7 +112,6 @@ func traverseNestedObject(topKey string, topValue cty.Value) (cty.Value, error) 
 func writePrimitiveValue(writer io.Writer, value cty.Value, path string) error {
 	// Check if the value is null
 	if value.IsNull() {
-		//nolint:staticcheck // user-facing message intentionally written as full sentences
 		return errors.New("Error: Unsupported value for raw output\n\n" +
 			"The -raw option only supports strings, numbers, and boolean values, but the output value is null.\n\n" +
 			"Use the -json option for machine-readable representations of output values that have complex types.")

--- a/internal/cli/flags/flag.go
+++ b/internal/cli/flags/flag.go
@@ -95,7 +95,7 @@ func (newFlag *Flag) Value() clihelper.FlagValue {
 
 			newFlag.Flag.Value().
 				Getter(deprecatedFlagValue.GetName()).
-				Set(newValue) //nolint:errcheck
+				Set(newValue) //nolint:errcheck // TODO: report a value the deprecated flag can't carry over
 		}
 	}
 

--- a/internal/cli/flags/flag.go
+++ b/internal/cli/flags/flag.go
@@ -21,6 +21,7 @@ type EvaluateWrapperFunc func(ctx context.Context, evalFn func(ctx context.Conte
 // Flag is a wrapper for `clihelper.Flag` that avoids displaying deprecated flags in help, but registers their flag names and environment variables.
 type Flag struct {
 	clihelper.Flag
+	deprecatedErr   error
 	evaluateWrapper EvaluateWrapperFunc
 	deprecatedFlags DeprecatedFlags
 }
@@ -73,33 +74,41 @@ func (newFlag *Flag) DeprecatedNames() []string {
 }
 
 // Value implements `clihelper.Flag` interface.
+//
+// A deprecated flag's value is carried over to this flag, so that reading this
+// flag is enough to see a value the user gave by an old name. A value already
+// set under the current name wins: the carry-over only fills an empty flag.
 func (newFlag *Flag) Value() clihelper.FlagValue {
+	value := newFlag.Flag.Value()
+
 	for _, deprecatedFlag := range newFlag.deprecatedFlags {
-		if deprecatedFlag.Flag == newFlag.Flag {
+		if deprecatedFlag.Flag == newFlag.Flag || value.IsSet() {
 			continue
 		}
 
-		if deprecatedFlagValue := deprecatedFlag.Value(); deprecatedFlagValue != nil &&
-			deprecatedFlagValue.IsSet() {
-			newValue := deprecatedFlagValue.String()
+		deprecatedFlagValue := deprecatedFlag.Value()
+		if deprecatedFlagValue == nil || !deprecatedFlagValue.IsSet() {
+			continue
+		}
 
-			if newFlag.Flag.Value().IsNegativeBoolFlag() && deprecatedFlagValue.IsBoolFlag() {
-				if v, ok := deprecatedFlagValue.Get().(bool); ok {
-					newValue = strconv.FormatBool(!v)
-				}
+		newValue := deprecatedFlagValue.String()
+
+		if value.IsNegativeBoolFlag() && deprecatedFlagValue.IsBoolFlag() {
+			if v, ok := deprecatedFlagValue.Get().(bool); ok {
+				newValue = strconv.FormatBool(!v)
 			}
+		}
 
-			if deprecatedFlag.newValueFn != nil {
-				newValue = deprecatedFlag.newValueFn(deprecatedFlagValue)
-			}
+		if deprecatedFlag.newValueFn != nil {
+			newValue = deprecatedFlag.newValueFn(deprecatedFlagValue)
+		}
 
-			newFlag.Flag.Value().
-				Getter(deprecatedFlagValue.GetName()).
-				Set(newValue) //nolint:errcheck // TODO: report a value the deprecated flag can't carry over
+		if err := value.Getter(deprecatedFlagValue.GetName()).Set(newValue); err != nil {
+			newFlag.deprecatedErr = errors.Join(newFlag.deprecatedErr, err)
 		}
 	}
 
-	return newFlag.Flag.Value()
+	return value
 }
 
 // Apply implements `clihelper.Flag` interface.
@@ -127,6 +136,10 @@ func (newFlag *Flag) Apply(set *flag.FlagSet, env map[string]string) error {
 
 // RunAction implements `clihelper.Flag` interface.
 func (newFlag *Flag) RunAction(ctx context.Context, cliCtx *clihelper.Context) error {
+	if newFlag.deprecatedErr != nil {
+		return newFlag.deprecatedErr
+	}
+
 	for _, deprecated := range newFlag.deprecatedFlags {
 		if err := newFlag.evaluateWrapper(ctx, deprecated.Evaluate); err != nil {
 			return err

--- a/internal/cli/flags/flag_test.go
+++ b/internal/cli/flags/flag_test.go
@@ -74,6 +74,76 @@ func TestFlag_TakesValue(t *testing.T) {
 	}
 }
 
+// newDeprecatedAliasFlag mirrors the shape of `--no-auto-init`: a negative bool flag
+// whose deprecated alias is a separate flag carrying the opposite sense.
+func newDeprecatedAliasFlag(dest *bool) *flags.Flag {
+	return flags.NewFlag(
+		&clihelper.BoolFlag{
+			Name:        "no-auto-init",
+			Negative:    true,
+			Destination: dest,
+		},
+		flags.WithDeprecatedFlag(&clihelper.BoolFlag{
+			EnvVars: []string{"TERRAGRUNT_AUTO_INIT"},
+		}, nil, strict.Controls{}),
+	)
+}
+
+// TestFlag_ValueCarriesDeprecatedAlias pins that a value given only by a deprecated
+// alias reaches the flag, and that reading the flag repeatedly does not change it.
+func TestFlag_ValueCarriesDeprecatedAlias(t *testing.T) {
+	t.Parallel()
+
+	dest := new(true)
+	testFlag := newDeprecatedAliasFlag(dest)
+
+	require.NoError(t, testFlag.Parse(nil, map[string]string{"TERRAGRUNT_AUTO_INIT": "false"}))
+
+	assert.Equal(t, false, testFlag.Value().Get())
+	assert.Equal(t, false, testFlag.Value().Get(), "reading the flag again must not change its value")
+	assert.False(t, *dest)
+}
+
+// TestFlag_ValueKeepsExplicitOverDeprecatedAlias pins that a value given under the
+// flag's current name wins over the same setting given by a deprecated alias.
+func TestFlag_ValueKeepsExplicitOverDeprecatedAlias(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		env      map[string]string
+		name     string
+		args     []string
+		expected bool
+	}{
+		{
+			name:     "flag turns auto-init off, alias turns it on",
+			args:     []string{"--no-auto-init"},
+			env:      map[string]string{"TERRAGRUNT_AUTO_INIT": "true"},
+			expected: false,
+		},
+		{
+			name:     "flag turns auto-init on, alias turns it off",
+			args:     []string{"--no-auto-init=false"},
+			env:      map[string]string{"TERRAGRUNT_AUTO_INIT": "false"},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dest := new(true)
+			testFlag := newDeprecatedAliasFlag(dest)
+
+			require.NoError(t, testFlag.Parse(tc.args, tc.env))
+
+			assert.Equal(t, tc.expected, testFlag.Value().Get())
+			assert.Equal(t, tc.expected, *dest)
+		})
+	}
+}
+
 func TestFlag_Evaluate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/clihelper/autocomplete.go
+++ b/internal/clihelper/autocomplete.go
@@ -25,7 +25,7 @@ const (
 	maxDashesInFlag = 2
 )
 
-var DefaultComplete = defaultComplete //nolint:gochecknoglobals
+var DefaultComplete = defaultComplete
 
 // AutocompleteInstaller is an interface to be implemented to perform the
 // autocomplete installation and uninstallation with a CLI.

--- a/internal/cloner/clone.go
+++ b/internal/cloner/clone.go
@@ -4,7 +4,7 @@ package cloner
 import "reflect"
 
 // Clone returns a deep cloned instance of the given `src` variable.
-func Clone[T any](src T, opts ...Option) T { //nolint:ireturn
+func Clone[T any](src T, opts ...Option) T {
 	conf := &Config{}
 	for _, opt := range opts {
 		opt(conf)

--- a/internal/codegen/generate.go
+++ b/internal/codegen/generate.go
@@ -258,7 +258,7 @@ func shouldContinueWithFileExists(
 	path string,
 	ifExists GenerateConfigExists,
 ) (bool, error) {
-	switch ifExists { //nolint:exhaustive // TODO: enumerate the rest; the default branch handles them
+	switch ifExists {
 	case ExistsError:
 		return false, GenerateFileExistsError{path: path}
 	case ExistsSkip:
@@ -297,8 +297,9 @@ func shouldContinueWithFileExists(
 			" \"overwrite_terragrunt\", regenerating file.", path)
 
 		return true, nil
+	case ExistsUnknown:
+		return false, UnknownGenerateIfExistsVal{""}
 	default:
-		// This shouldn't happen, but we add this case anyway for defensive coding.
 		return false, UnknownGenerateIfExistsVal{""}
 	}
 }
@@ -310,7 +311,7 @@ func shouldRemoveWithFileExists(
 	path string,
 	ifDisable GenerateConfigDisabled,
 ) (bool, error) {
-	switch ifDisable { //nolint:exhaustive // TODO: enumerate the rest; the default branch handles them
+	switch ifDisable {
 	case DisabledSkip:
 		// Do nothing since skip was configured.
 		l.Debugf("The file path %s already exists and if_disabled for code"+
@@ -347,8 +348,9 @@ func shouldRemoveWithFileExists(
 			" to \"remove_terragrunt\", removing file.", path)
 
 		return true, nil
+	case DisabledUnknown:
+		return false, UnknownGenerateIfDisabledVal{""}
 	default:
-		// This shouldn't happen, but we add this case anyway for defensive coding.
 		return false, UnknownGenerateIfDisabledVal{""}
 	}
 }

--- a/internal/codegen/generate.go
+++ b/internal/codegen/generate.go
@@ -258,8 +258,7 @@ func shouldContinueWithFileExists(
 	path string,
 	ifExists GenerateConfigExists,
 ) (bool, error) {
-	// TODO: Make exhaustive
-	switch ifExists { //nolint:exhaustive
+	switch ifExists { //nolint:exhaustive // TODO: enumerate the rest; the default branch handles them
 	case ExistsError:
 		return false, GenerateFileExistsError{path: path}
 	case ExistsSkip:
@@ -311,8 +310,7 @@ func shouldRemoveWithFileExists(
 	path string,
 	ifDisable GenerateConfigDisabled,
 ) (bool, error) {
-	// TODO: Make exhaustive
-	switch ifDisable { //nolint:exhaustive
+	switch ifDisable { //nolint:exhaustive // TODO: enumerate the rest; the default branch handles them
 	case DisabledSkip:
 		// Do nothing since skip was configured.
 		l.Debugf("The file path %s already exists and if_disabled for code"+

--- a/internal/ctyhelper/helper.go
+++ b/internal/ctyhelper/helper.go
@@ -1,6 +1,4 @@
 // Package ctyhelper providers helpful tools for working with cty values.
-//
-//nolint:dupl
 package ctyhelper
 
 import (

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -473,7 +473,7 @@ func (d *Discovery) runGraphPhase(
 
 		var buildErrs []error
 
-		telemetry.TelemeterFromContext(ctx).Collect( //nolint:errcheck
+		telemetry.TelemeterFromContext(ctx).Collect( //nolint:errcheck // the closure records its errors in buildErrs
 			ctx, l, "discover_dependents", map[string]any{},
 			func(childCtx context.Context, l log.Logger) error {
 				buildErrs = d.buildDependencyGraph(childCtx, l, v, opts, allComponents)
@@ -495,7 +495,7 @@ func (d *Discovery) runGraphPhase(
 		err    error
 	)
 
-	telemetry.TelemeterFromContext(ctx).Collect( //nolint:errcheck
+	telemetry.TelemeterFromContext(ctx).Collect( //nolint:errcheck // the closure records its error in err
 		ctx, l, "discover_dependencies", map[string]any{},
 		func(childCtx context.Context, l log.Logger) error {
 			result, err = phase.Run(childCtx, l, v, &PhaseInput{

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -471,34 +471,30 @@ func (d *Discovery) runGraphPhase(
 		allComponents := resultsToComponents(discovered)
 		allComponents = append(allComponents, resultsToComponents(candidates)...)
 
-		var buildErrs []error
-
-		telemetry.TelemeterFromContext(ctx).Collect( //nolint:errcheck // the closure records its errors in buildErrs
+		buildErr := telemetry.TelemeterFromContext(ctx).Collect(
 			ctx, l, "discover_dependents", map[string]any{},
 			func(childCtx context.Context, l log.Logger) error {
-				buildErrs = d.buildDependencyGraph(childCtx, l, v, opts, allComponents)
-				return errors.Join(buildErrs...)
+				return errors.Join(d.buildDependencyGraph(childCtx, l, v, opts, allComponents)...)
 			})
 
-		if len(buildErrs) > 0 && !d.suppressParseErrors {
+		if buildErr != nil && !d.suppressParseErrors {
 			return &PhaseResults{
 				Discovered: discovered,
 				Candidates: candidates,
-			}, errors.Join(buildErrs...)
+			}, buildErr
 		}
 	}
 
 	phase := NewGraphPhase(d.numWorkers, d.maxDependencyDepth)
 
-	var (
-		result *PhaseResults
-		err    error
-	)
+	var result *PhaseResults
 
-	telemetry.TelemeterFromContext(ctx).Collect( //nolint:errcheck // the closure records its error in err
+	err := telemetry.TelemeterFromContext(ctx).Collect(
 		ctx, l, "discover_dependencies", map[string]any{},
 		func(childCtx context.Context, l log.Logger) error {
-			result, err = phase.Run(childCtx, l, v, &PhaseInput{
+			var runErr error
+
+			result, runErr = phase.Run(childCtx, l, v, &PhaseInput{
 				Opts:       opts,
 				Components: resultsToComponents(discovered),
 				Candidates: candidates,
@@ -506,7 +502,7 @@ func (d *Discovery) runGraphPhase(
 				Discovery:  d,
 			})
 
-			return err
+			return runErr
 		})
 
 	allDiscovered := discovered

--- a/internal/discovery/phase_parse.go
+++ b/internal/discovery/phase_parse.go
@@ -212,7 +212,7 @@ func (p *ParsePhase) Run(
 
 				errMu.Unlock()
 				// Return nil to continue processing other components
-				return nil //nolint:nilerr
+				return nil
 			}
 
 			if result == nil {

--- a/internal/discovery/phase_worktree.go
+++ b/internal/discovery/phase_worktree.go
@@ -446,11 +446,11 @@ func (p *WorktreePhase) walkChangedStack(
 
 	discoveryGroup, discoveryCtx := errgroup.WithContext(ctx)
 	// Run at most 2 discovery tasks (from/to) in parallel, capped by available CPUs.
-	discoveryGroup.SetLimit(min(runtime.GOMAXPROCS(0), 2)) //nolint:mnd
+	discoveryGroup.SetLimit(min(runtime.GOMAXPROCS(0), 2)) //nolint:mnd // 2: the from and to discoveries
 
 	var (
 		mu   sync.Mutex
-		errs = make([]error, 0, 2) //nolint:mnd
+		errs = make([]error, 0, 2) //nolint:mnd // 2: one error per discovery task
 	)
 
 	parentFilters := discovery.filters.ExcludingGitFilters()
@@ -549,7 +549,7 @@ func (p *WorktreePhase) walkChangedStack(
 
 		shaGroup, _ := errgroup.WithContext(ctx)
 		// Hash from/to directories in parallel (at most 2), capped by available CPUs.
-		shaGroup.SetLimit(min(runtime.GOMAXPROCS(0), 2)) //nolint:mnd
+		shaGroup.SetLimit(min(runtime.GOMAXPROCS(0), 2)) //nolint:mnd // 2: the from and to directories
 
 		shaGroup.Go(func() error {
 			var localErr error

--- a/internal/discovery/phase_worktree.go
+++ b/internal/discovery/phase_worktree.go
@@ -25,6 +25,9 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// fromToTasks is the number of tasks a worktree comparison splits into: one for the from side, one for the to side.
+const fromToTasks = 2
+
 // WorktreePhase discovers components in Git worktrees for Git-based filters.
 type WorktreePhase struct {
 	// gitExpressions contains Git filter expressions that require worktree discovery.
@@ -445,12 +448,11 @@ func (p *WorktreePhase) walkChangedStack(
 	var fromComponents, toComponents component.Components
 
 	discoveryGroup, discoveryCtx := errgroup.WithContext(ctx)
-	// Run at most 2 discovery tasks (from/to) in parallel, capped by available CPUs.
-	discoveryGroup.SetLimit(min(runtime.GOMAXPROCS(0), 2)) //nolint:mnd // 2: the from and to discoveries
+	discoveryGroup.SetLimit(min(runtime.GOMAXPROCS(0), fromToTasks))
 
 	var (
 		mu   sync.Mutex
-		errs = make([]error, 0, 2) //nolint:mnd // 2: one error per discovery task
+		errs = make([]error, 0, fromToTasks)
 	)
 
 	parentFilters := discovery.filters.ExcludingGitFilters()
@@ -548,8 +550,7 @@ func (p *WorktreePhase) walkChangedStack(
 		var fromSHA, toSHA string
 
 		shaGroup, _ := errgroup.WithContext(ctx)
-		// Hash from/to directories in parallel (at most 2), capped by available CPUs.
-		shaGroup.SetLimit(min(runtime.GOMAXPROCS(0), 2)) //nolint:mnd // 2: the from and to directories
+		shaGroup.SetLimit(min(runtime.GOMAXPROCS(0), fromToTasks))
 
 		shaGroup.Go(func() error {
 			var localErr error

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1065,7 +1065,7 @@ func invoke(
 		l.Debugf("Engine execution done in %v", runOptions.CacheDir)
 
 		if resultCode != 0 {
-			err = util.ProcessExecutionError{
+			err = &util.ProcessExecutionError{
 				Err:             fmt.Errorf("command failed with exit code %d", resultCode),
 				Output:          output,
 				WorkingDir:      runOptions.CacheDir,

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1322,8 +1322,8 @@ func ReadEngineOutput(v *venv.Venv, forceStdErr bool, output outputFn) error {
 			}
 		}
 	}
-	// TODO: Why does this lint need to be ignored?
-	return nil //nolint:nilerr
+
+	return nil //nolint:nilerr // the loop breaks when the stream ends; only init and shutdown failures are errors
 }
 
 // ConvertMetaToProtobuf converts metadata map to protobuf map

--- a/internal/errorconfig/types.go
+++ b/internal/errorconfig/types.go
@@ -132,7 +132,7 @@ func ExtractErrorMessage(err error) string {
 
 	// For ProcessExecutionError, match only against stderr and the underlying error,
 	// not the full command string with flags.
-	if processErr, ok := errors.AsType[util.ProcessExecutionError](err); ok {
+	if processErr, ok := errors.AsType[*util.ProcessExecutionError](err); ok {
 		errText = processErr.Output.Stderr.String() + "\n" + processErr.Err.Error()
 	} else {
 		errText = err.Error()

--- a/internal/errorconfig/types_test.go
+++ b/internal/errorconfig/types_test.go
@@ -18,7 +18,7 @@ func TestExtractErrorMessage_ExcludesCommandFlags(t *testing.T) {
 	var stderr bytes.Buffer
 	stderr.WriteString("flag provided but not defined: -abc")
 
-	err := util.ProcessExecutionError{
+	err := &util.ProcessExecutionError{
 		Err:        errors.New("exit status 1"),
 		Command:    "tofu",
 		Args:       []string{"plan", "-lock-timeout=120m", "-input=false"},
@@ -45,7 +45,7 @@ func TestExtractErrorMessage_DoesNotFalselyMatchTimeout(t *testing.T) {
 	var stderr bytes.Buffer
 	stderr.WriteString("flag provided but not defined: -abc")
 
-	err := util.ProcessExecutionError{
+	err := &util.ProcessExecutionError{
 		Err:        errors.New("exit status 1"),
 		Command:    "tofu",
 		Args:       []string{"plan", "-lock-timeout=120m", "-input=false", "-fes"},
@@ -78,7 +78,7 @@ func TestExtractErrorMessage_StillMatchesRealTimeout(t *testing.T) {
 	var stderr bytes.Buffer
 	stderr.WriteString("Error: timeout waiting for resource to become available")
 
-	err := util.ProcessExecutionError{
+	err := &util.ProcessExecutionError{
 		Err:        errors.New("exit status 1"),
 		Command:    "tofu",
 		Args:       []string{"apply", "-auto-approve"},
@@ -109,7 +109,7 @@ func TestExtractErrorMessage_StillMatchesTimeoutInStderrWithFlags(t *testing.T) 
 	var stderr bytes.Buffer
 	stderr.WriteString("Error: timeout waiting for state lock")
 
-	err := util.ProcessExecutionError{
+	err := &util.ProcessExecutionError{
 		Err:        errors.New("exit status 1"),
 		Command:    "tofu",
 		Args:       []string{"plan", "-lock-timeout=120m", "-input=false"},

--- a/internal/filter/errors.go
+++ b/internal/filter/errors.go
@@ -44,10 +44,7 @@ type ParseError struct {
 
 // Error returns a string representation of the error.
 //
-// We suppress the gocritic "hugeParam" warning because this is a very large struct,
-// but we need it to implement the error interface, not its pointer.
-//
-//nolint:gocritic
+//nolint:gocritic // hugeParam: ParseError implements error by value, not by pointer
 func (e ParseError) Error() string {
 	return fmt.Sprintf("Parse error at position %d: %s", e.Position, e.Message)
 }

--- a/internal/getter/s3_test.go
+++ b/internal/getter/s3_test.go
@@ -15,8 +15,8 @@ import (
 
 	// The pinned go-getter/s3/v2 builds its S3 client on aws-sdk-go v1, so the
 	// dependency-contract tests below have to drive the deprecated v1 chain.
-	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
-	"github.com/aws/aws-sdk-go/aws/session" //nolint:staticcheck
+	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck // deprecated v1 SDK, per the note above
+	"github.com/aws/aws-sdk-go/aws/session" //nolint:staticcheck // deprecated v1 SDK, per the note above
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	gogetter "github.com/hashicorp/go-getter/v2"

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -789,12 +789,9 @@ func (g *GitRunner) GetDefaultBranchRemote(ctx context.Context) (string, error) 
 			continue
 		}
 
-		if strings.HasPrefix(line, "ref:") {
-			parts := strings.Fields(line)
-			if len(parts) >= 2 { //nolint:mnd // "ref: refs/heads/<name>" is two fields
-				ref := parts[1]
-
-				if after, ok := strings.CutPrefix(ref, "refs/heads/"); ok {
+		if symref, ok := strings.CutPrefix(line, "ref:"); ok {
+			if fields := strings.Fields(symref); len(fields) > 0 {
+				if after, ok := strings.CutPrefix(fields[0], "refs/heads/"); ok {
 					return after, nil
 				}
 			}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -791,7 +791,7 @@ func (g *GitRunner) GetDefaultBranchRemote(ctx context.Context) (string, error) 
 
 		if strings.HasPrefix(line, "ref:") {
 			parts := strings.Fields(line)
-			if len(parts) >= 2 { //nolint:mnd
+			if len(parts) >= 2 { //nolint:mnd // "ref: refs/heads/<name>" is two fields
 				ref := parts[1]
 
 				if after, ok := strings.CutPrefix(ref, "refs/heads/"); ok {
@@ -848,8 +848,7 @@ func (g *GitRunner) ObjectFormat(ctx context.Context) (string, error) {
 	cmd.SetStderr(&stderr)
 
 	if err := cmd.Run(); err != nil {
-		// Older Git versions don't support --show-object-format; default to sha1.
-		return "sha1", nil //nolint:nilerr
+		return "sha1", nil //nolint:nilerr // older Git lacks --show-object-format, and only ever wrote sha1
 	}
 
 	return strings.TrimSpace(stdout.String()), nil

--- a/internal/locks/lock.go
+++ b/internal/locks/lock.go
@@ -8,4 +8,4 @@ import "sync"
 //
 // When possible, prefer to spawn a new process with the environment variables
 // you want, or avoid setting environment variables instead of using this lock.
-var EnvLock sync.Mutex //nolint:gochecknoglobals
+var EnvLock sync.Mutex

--- a/internal/os/signal/signal_unix.go
+++ b/internal/os/signal/signal_unix.go
@@ -8,7 +8,7 @@ import (
 )
 
 // InterruptSignal is an interrupt signal.
-var InterruptSignal = syscall.SIGINT //nolint:gochecknoglobals
+var InterruptSignal = syscall.SIGINT
 
 // InterruptSignals contains a list of signals that are treated as interrupts.
-var InterruptSignals = []os.Signal{syscall.SIGTERM, syscall.SIGINT} //nolint:gochecknoglobals
+var InterruptSignals = []os.Signal{syscall.SIGTERM, syscall.SIGINT}

--- a/internal/os/signal/signal_windows.go
+++ b/internal/os/signal/signal_windows.go
@@ -8,7 +8,7 @@ import (
 
 // InterruptSignal is the signal sent to ask a process to stop. Windows has no interrupt
 // one process can deliver to another, so termination is the only thing that lands.
-var InterruptSignal os.Signal = os.Kill //nolint:gochecknoglobals
+var InterruptSignal os.Signal = os.Kill
 
 // InterruptSignals contains a list of signals that are treated as interrupts.
 var InterruptSignals []os.Signal = []os.Signal{}

--- a/internal/panicreport/panicreport_test.go
+++ b/internal/panicreport/panicreport_test.go
@@ -353,7 +353,7 @@ func TestIsPanic(t *testing.T) {
 
 			var arr []int
 
-			_ = arr[5] //nolint:staticcheck // intentional out-of-bounds to obtain a runtime.Error
+			_ = arr[5] // intentional out-of-bounds to obtain a runtime.Error
 		}()
 
 		assert.NotNil(t, rerr, "test setup: expected runtime panic")

--- a/internal/remotestate/backend/config_test.go
+++ b/internal/remotestate/backend/config_test.go
@@ -11,7 +11,7 @@ import (
 func TestConfig_IsEqual(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint: govet
+	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
 		name            string
 		existingBackend backend.Config
 		cfg             backend.Config

--- a/internal/remotestate/backend/config_test.go
+++ b/internal/remotestate/backend/config_test.go
@@ -11,129 +11,129 @@ import (
 func TestConfig_IsEqual(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
-		name            string
+	testCases := []struct {
 		existingBackend backend.Config
 		cfg             backend.Config
+		name            string
 		expected        bool
 	}{
 		{
-			"both empty",
-			backend.Config{},
-			backend.Config{},
-			true,
+			name:            "both empty",
+			existingBackend: backend.Config{},
+			cfg:             backend.Config{},
+			expected:        true,
 		},
 		{
-			"identical S3 configs",
-			backend.Config{"bucket": "foo", "key": "bar", "region": "us-east-1"},
-			backend.Config{"bucket": "foo", "key": "bar", "region": "us-east-1"},
-			true,
+			name:            "identical S3 configs",
+			existingBackend: backend.Config{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+			cfg:             backend.Config{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+			expected:        true,
 		},
 		{
-			"identical GCS configs",
-			backend.Config{
+			name: "identical GCS configs",
+			existingBackend: backend.Config{
 				"project":  "foo-123456",
 				"location": "europe-west3",
 				"bucket":   "foo",
 				"prefix":   "bar",
 			},
-			backend.Config{
+			cfg: backend.Config{
 				"project":  "foo-123456",
 				"location": "europe-west3",
 				"bucket":   "foo",
 				"prefix":   "bar",
 			},
-			true,
+			expected: true,
 		},
 		{
-			"different s3 bucket values",
-			backend.Config{"bucket": "foo", "key": "bar", "region": "us-east-1"},
-			backend.Config{"bucket": "different", "key": "bar", "region": "us-east-1"},
-			false,
+			name:            "different s3 bucket values",
+			existingBackend: backend.Config{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+			cfg:             backend.Config{"bucket": "different", "key": "bar", "region": "us-east-1"},
+			expected:        false,
 		},
 		{
-			"different gcs bucket values",
-			backend.Config{
+			name: "different gcs bucket values",
+			existingBackend: backend.Config{
 				"project":  "foo-123456",
 				"location": "europe-west3",
 				"bucket":   "foo",
 				"prefix":   "bar",
 			},
-			backend.Config{
+			cfg: backend.Config{
 				"project":  "foo-123456",
 				"location": "europe-west3",
 				"bucket":   "different",
 				"prefix":   "bar",
 			},
-			false,
+			expected: false,
 		},
 		{
-			"different s3 key values",
-			backend.Config{"bucket": "foo", "key": "bar", "region": "us-east-1"},
-			backend.Config{"bucket": "foo", "key": "different", "region": "us-east-1"},
-			false,
+			name:            "different s3 key values",
+			existingBackend: backend.Config{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+			cfg:             backend.Config{"bucket": "foo", "key": "different", "region": "us-east-1"},
+			expected:        false,
 		},
 		{
-			"different gcs prefix values",
-			backend.Config{
+			name: "different gcs prefix values",
+			existingBackend: backend.Config{
 				"project":  "foo-123456",
 				"location": "europe-west3",
 				"bucket":   "foo",
 				"prefix":   "bar",
 			},
-			backend.Config{
+			cfg: backend.Config{
 				"project":  "foo-123456",
 				"location": "europe-west3",
 				"bucket":   "foo",
 				"prefix":   "different",
 			},
-			false,
+			expected: false,
 		},
 		{
-			"different s3 region values",
-			backend.Config{"bucket": "foo", "key": "bar", "region": "us-east-1"},
-			backend.Config{"bucket": "foo", "key": "bar", "region": "different"},
-			false,
+			name:            "different s3 region values",
+			existingBackend: backend.Config{"bucket": "foo", "key": "bar", "region": "us-east-1"},
+			cfg:             backend.Config{"bucket": "foo", "key": "bar", "region": "different"},
+			expected:        false,
 		},
 		{
-			"different gcs location values",
-			backend.Config{
+			name: "different gcs location values",
+			existingBackend: backend.Config{
 				"project":  "foo-123456",
 				"location": "europe-west3",
 				"bucket":   "foo",
 				"prefix":   "bar",
 			},
-			backend.Config{
+			cfg: backend.Config{
 				"project":  "foo-123456",
 				"location": "different",
 				"bucket":   "foo",
 				"prefix":   "bar",
 			},
-			false,
+			expected: false,
 		},
 		{
-			"different boolean values and boolean conversion",
-			backend.Config{"something": "true"},
-			backend.Config{"something": false},
-			false,
+			name:            "different boolean values and boolean conversion",
+			existingBackend: backend.Config{"something": "true"},
+			cfg:             backend.Config{"something": false},
+			expected:        false,
 		},
 		{
-			"different gcs boolean values and boolean conversion",
-			backend.Config{"something": "true"},
-			backend.Config{"something": false},
-			false,
+			name:            "different gcs boolean values and boolean conversion",
+			existingBackend: backend.Config{"something": "true"},
+			cfg:             backend.Config{"something": false},
+			expected:        false,
 		},
 		{
-			"null values ignored",
-			backend.Config{"something": "foo", "set-to-nil-should-be-ignored": nil},
-			backend.Config{"something": "foo"},
-			true,
+			name:            "null values ignored",
+			existingBackend: backend.Config{"something": "foo", "set-to-nil-should-be-ignored": nil},
+			cfg:             backend.Config{"something": "foo"},
+			expected:        true,
 		},
 		{
-			"gcs null values ignored",
-			backend.Config{"something": "foo", "set-to-nil-should-be-ignored": nil},
-			backend.Config{"something": "foo"},
-			true,
+			name:            "gcs null values ignored",
+			existingBackend: backend.Config{"something": "foo", "set-to-nil-should-be-ignored": nil},
+			cfg:             backend.Config{"something": "foo"},
+			expected:        true,
 		},
 	}
 

--- a/internal/remotestate/backend/gcs/config_test.go
+++ b/internal/remotestate/backend/gcs/config_test.go
@@ -14,7 +14,7 @@ func TestConfig_IsEqual(t *testing.T) {
 
 	logger := logger.CreateLogger()
 
-	testCases := []struct { //nolint: govet
+	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
 		name          string
 		cfg           gcs.Config
 		comparableCfg gcs.Config
@@ -110,7 +110,7 @@ func TestConfig_IsEqual(t *testing.T) {
 func TestParseExtendedGCSConfig_StringBoolCoercion(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint: govet
+	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
 		name   string
 		config gcs.Config
 		check  func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS)

--- a/internal/remotestate/backend/gcs/config_test.go
+++ b/internal/remotestate/backend/gcs/config_test.go
@@ -14,83 +14,83 @@ func TestConfig_IsEqual(t *testing.T) {
 
 	logger := logger.CreateLogger()
 
-	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
-		name          string
+	testCases := []struct {
 		cfg           gcs.Config
 		comparableCfg gcs.Config
+		name          string
 		shouldBeEqual bool
 	}{
 		{
-			"equal-both-empty",
-			gcs.Config{},
-			gcs.Config{},
-			true,
+			name:          "equal-both-empty",
+			cfg:           gcs.Config{},
+			comparableCfg: gcs.Config{},
+			shouldBeEqual: true,
 		},
 		{
-			"equal-empty-and-nil",
-			gcs.Config{},
-			nil,
-			true,
+			name:          "equal-empty-and-nil",
+			cfg:           gcs.Config{},
+			comparableCfg: nil,
+			shouldBeEqual: true,
 		},
 		{
-			"equal-one-key",
-			gcs.Config{"foo": "bar"},
-			gcs.Config{"foo": "bar"},
-			true,
+			name:          "equal-one-key",
+			cfg:           gcs.Config{"foo": "bar"},
+			comparableCfg: gcs.Config{"foo": "bar"},
+			shouldBeEqual: true,
 		},
 		{
-			"equal-multiple-keys",
-			gcs.Config{"foo": "bar", "baz": []string{"a", "b", "c"}, "blah": 123, "bool": true},
-			gcs.Config{"foo": "bar", "baz": []string{"a", "b", "c"}, "blah": 123, "bool": true},
-			true,
+			name:          "equal-multiple-keys",
+			cfg:           gcs.Config{"foo": "bar", "baz": []string{"a", "b", "c"}, "blah": 123, "bool": true},
+			comparableCfg: gcs.Config{"foo": "bar", "baz": []string{"a", "b", "c"}, "blah": 123, "bool": true},
+			shouldBeEqual: true,
 		},
 		{
-			"equal-encrypt-bool-handling",
-			gcs.Config{"encrypt": true},
-			gcs.Config{"encrypt": "true"},
-			true,
+			name:          "equal-encrypt-bool-handling",
+			cfg:           gcs.Config{"encrypt": true},
+			comparableCfg: gcs.Config{"encrypt": "true"},
+			shouldBeEqual: true,
 		},
 		{
-			"equal-general-bool-handling",
-			gcs.Config{"something": true, "encrypt": true},
-			gcs.Config{"something": "true", "encrypt": "true"},
-			true,
+			name:          "equal-general-bool-handling",
+			cfg:           gcs.Config{"something": true, "encrypt": true},
+			comparableCfg: gcs.Config{"something": "true", "encrypt": "true"},
+			shouldBeEqual: true,
 		},
 		{
-			"equal-ignore-gcs-labels",
-			gcs.Config{"foo": "bar", "gcs_bucket_labels": []map[string]string{{"foo": "bar"}}},
-			gcs.Config{"foo": "bar"},
-			true,
+			name:          "equal-ignore-gcs-labels",
+			cfg:           gcs.Config{"foo": "bar", "gcs_bucket_labels": []map[string]string{{"foo": "bar"}}},
+			comparableCfg: gcs.Config{"foo": "bar"},
+			shouldBeEqual: true,
 		},
 		{
-			"unequal-values",
-			gcs.Config{"foo": "bar"},
-			gcs.Config{"foo": "different"},
-			false,
+			name:          "unequal-values",
+			cfg:           gcs.Config{"foo": "bar"},
+			comparableCfg: gcs.Config{"foo": "different"},
+			shouldBeEqual: false,
 		},
 		{
-			"unequal-non-empty-cfg-nil",
-			gcs.Config{"foo": "bar"},
-			nil,
-			false,
+			name:          "unequal-non-empty-cfg-nil",
+			cfg:           gcs.Config{"foo": "bar"},
+			comparableCfg: nil,
+			shouldBeEqual: false,
 		},
 		{
-			"unequal-general-bool-handling",
-			gcs.Config{"something": true},
-			gcs.Config{"something": "false"},
-			false,
+			name:          "unequal-general-bool-handling",
+			cfg:           gcs.Config{"something": true},
+			comparableCfg: gcs.Config{"something": "false"},
+			shouldBeEqual: false,
 		},
 		{
-			"equal-null-ignored",
-			gcs.Config{"something": "foo"},
-			gcs.Config{"something": "foo", "ignored-because-null": nil},
-			true,
+			name:          "equal-null-ignored",
+			cfg:           gcs.Config{"something": "foo"},
+			comparableCfg: gcs.Config{"something": "foo", "ignored-because-null": nil},
+			shouldBeEqual: true,
 		},
 		{
-			"terragrunt-only-configs-remain-intact",
-			gcs.Config{"something": "foo", "skip_bucket_creation": true},
-			gcs.Config{"something": "foo"},
-			true,
+			name:          "terragrunt-only-configs-remain-intact",
+			cfg:           gcs.Config{"something": "foo", "skip_bucket_creation": true},
+			comparableCfg: gcs.Config{"something": "foo"},
+			shouldBeEqual: true,
 		},
 	}
 
@@ -110,84 +110,84 @@ func TestConfig_IsEqual(t *testing.T) {
 func TestParseExtendedGCSConfig_StringBoolCoercion(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
-		name   string
+	testCases := []struct {
 		config gcs.Config
 		check  func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS)
+		name   string
 	}{
 		{
-			"skip-bucket-versioning-string-true",
-			gcs.Config{
+			name: "skip-bucket-versioning-string-true",
+			config: gcs.Config{
 				"bucket":                 "my-bucket",
 				"skip_bucket_versioning": "true",
 			},
-			func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
+			check: func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
 				t.Helper()
 				assert.True(t, cfg.SkipBucketVersioning)
 			},
 		},
 		{
-			"skip-bucket-versioning-string-false",
-			gcs.Config{
+			name: "skip-bucket-versioning-string-false",
+			config: gcs.Config{
 				"bucket":                 "my-bucket",
 				"skip_bucket_versioning": "false",
 			},
-			func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
+			check: func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
 				t.Helper()
 				assert.False(t, cfg.SkipBucketVersioning)
 			},
 		},
 		{
-			"skip-bucket-creation-string-true",
-			gcs.Config{
+			name: "skip-bucket-creation-string-true",
+			config: gcs.Config{
 				"bucket":               "my-bucket",
 				"skip_bucket_creation": "true",
 			},
-			func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
+			check: func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
 				t.Helper()
 				assert.True(t, cfg.SkipBucketCreation)
 			},
 		},
 		{
-			"enable-bucket-policy-only-string-true",
-			gcs.Config{
+			name: "enable-bucket-policy-only-string-true",
+			config: gcs.Config{
 				"bucket":                    "my-bucket",
 				"enable_bucket_policy_only": "true",
 			},
-			func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
+			check: func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
 				t.Helper()
 				assert.True(t, cfg.EnableBucketPolicyOnly)
 			},
 		},
 		{
-			"native-bool-still-works",
-			gcs.Config{
+			name: "native-bool-still-works",
+			config: gcs.Config{
 				"bucket":                 "my-bucket",
 				"skip_bucket_versioning": true,
 			},
-			func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
+			check: func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
 				t.Helper()
 				assert.True(t, cfg.SkipBucketVersioning)
 			},
 		},
 		{
-			"empty-string-coerces-to-false",
-			gcs.Config{
+			name: "empty-string-coerces-to-false",
+			config: gcs.Config{
 				"bucket":                 "my-bucket",
 				"skip_bucket_versioning": "",
 			},
-			func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
+			check: func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
 				t.Helper()
 				assert.False(t, cfg.SkipBucketVersioning)
 			},
 		},
 		{
-			"numeric-one-coerces-to-true",
-			gcs.Config{
+			name: "numeric-one-coerces-to-true",
+			config: gcs.Config{
 				"bucket":                 "my-bucket",
 				"skip_bucket_versioning": "1",
 			},
-			func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
+			check: func(t *testing.T, cfg *gcs.ExtendedRemoteStateConfigGCS) {
 				t.Helper()
 				assert.True(t, cfg.SkipBucketVersioning)
 			},

--- a/internal/remotestate/backend/s3/backend_test.go
+++ b/internal/remotestate/backend/s3/backend_test.go
@@ -14,37 +14,37 @@ func TestBackend_GetTFInitArgs(t *testing.T) {
 
 	remoteBackend := s3backend.NewBackend()
 
-	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
-		name          string
+	testCases := []struct {
 		config        backend.Config
 		expected      map[string]any
+		name          string
 		shouldBeEqual bool
 	}{
 		{
-			"empty-no-values",
-			backend.Config{},
-			map[string]any{},
-			true,
+			name:          "empty-no-values",
+			config:        backend.Config{},
+			expected:      map[string]any{},
+			shouldBeEqual: true,
 		},
 		{
-			"valid-s3-configuration-keys",
-			backend.Config{
+			name: "valid-s3-configuration-keys",
+			config: backend.Config{
 				"bucket":  "foo",
 				"encrypt": "bar",
 				"key":     "baz",
 				"region":  "quux",
 			},
-			map[string]any{
+			expected: map[string]any{
 				"bucket":  "foo",
 				"encrypt": "bar",
 				"key":     "baz",
 				"region":  "quux",
 			},
-			true,
+			shouldBeEqual: true,
 		},
 		{
-			"terragrunt-keys-filtered",
-			backend.Config{
+			name: "terragrunt-keys-filtered",
+			config: backend.Config{
 				"bucket":                      "foo",
 				"encrypt":                     "bar",
 				"key":                         "baz",
@@ -52,18 +52,18 @@ func TestBackend_GetTFInitArgs(t *testing.T) {
 				"skip_credentials_validation": true,
 				"s3_bucket_tags":              map[string]string{},
 			},
-			map[string]any{
+			expected: map[string]any{
 				"bucket":                      "foo",
 				"encrypt":                     "bar",
 				"key":                         "baz",
 				"region":                      "quux",
 				"skip_credentials_validation": true,
 			},
-			true,
+			shouldBeEqual: true,
 		},
 		{
-			"empty-no-values-all-terragrunt-keys-filtered",
-			backend.Config{
+			name: "empty-no-values-all-terragrunt-keys-filtered",
+			config: backend.Config{
 				"s3_bucket_tags":                                    map[string]string{},
 				"dynamodb_table_tags":                               map[string]string{},
 				"accesslogging_bucket_tags":                         map[string]string{},
@@ -83,48 +83,48 @@ func TestBackend_GetTFInitArgs(t *testing.T) {
 				"skip_accesslogging_bucket_public_access_blocking":  false,
 				"skip_accesslogging_bucket_ssencryption":            false,
 			},
-			map[string]any{},
-			true,
+			expected:      map[string]any{},
+			shouldBeEqual: true,
 		},
 		{
-			"lock-table-replaced-with-dynamodb-table",
-			backend.Config{
+			name: "lock-table-replaced-with-dynamodb-table",
+			config: backend.Config{
 				"bucket":     "foo",
 				"encrypt":    "bar",
 				"key":        "baz",
 				"region":     "quux",
 				"lock_table": "xyzzy",
 			},
-			map[string]any{
+			expected: map[string]any{
 				"bucket":         "foo",
 				"encrypt":        "bar",
 				"key":            "baz",
 				"region":         "quux",
 				"dynamodb_table": "xyzzy",
 			},
-			true,
+			shouldBeEqual: true,
 		},
 		{
-			"dynamodb-table-not-replaced-with-lock-table",
-			backend.Config{
+			name: "dynamodb-table-not-replaced-with-lock-table",
+			config: backend.Config{
 				"bucket":         "foo",
 				"encrypt":        "bar",
 				"key":            "baz",
 				"region":         "quux",
 				"dynamodb_table": "xyzzy",
 			},
-			map[string]any{
+			expected: map[string]any{
 				"bucket":     "foo",
 				"encrypt":    "bar",
 				"key":        "baz",
 				"region":     "quux",
 				"lock_table": "xyzzy",
 			},
-			false,
+			shouldBeEqual: false,
 		},
 		{
-			"assume-role",
-			backend.Config{
+			name: "assume-role",
+			config: backend.Config{
 				"bucket": "foo",
 				"assume_role": map[string]any{
 					"role_arn":     "arn:aws:iam::123:role/role",
@@ -132,111 +132,111 @@ func TestBackend_GetTFInitArgs(t *testing.T) {
 					"session_name": "qwe",
 				},
 			},
-			map[string]any{
+			expected: map[string]any{
 				"bucket":      "foo",
 				"assume_role": "{external_id=\"123\",role_arn=\"arn:aws:iam::123:role/role\",session_name=\"qwe\"}",
 			},
-			true,
+			shouldBeEqual: true,
 		},
 		{
-			"use-lockfile-native-s3-locking",
-			backend.Config{
+			name: "use-lockfile-native-s3-locking",
+			config: backend.Config{
 				"bucket":       "foo",
 				"key":          "bar",
 				"region":       "us-east-1",
 				"use_lockfile": true,
 			},
-			map[string]any{
+			expected: map[string]any{
 				"bucket":       "foo",
 				"key":          "bar",
 				"region":       "us-east-1",
 				"use_lockfile": true,
 			},
-			true,
+			shouldBeEqual: true,
 		},
 		{
-			"use-lockfile-false",
-			backend.Config{
+			name: "use-lockfile-false",
+			config: backend.Config{
 				"bucket":       "foo",
 				"key":          "bar",
 				"region":       "us-east-1",
 				"use_lockfile": false,
 			},
-			map[string]any{
+			expected: map[string]any{
 				"bucket":       "foo",
 				"key":          "bar",
 				"region":       "us-east-1",
 				"use_lockfile": false,
 			},
-			true,
+			shouldBeEqual: true,
 		},
 		{
-			"dual-locking-dynamodb-and-s3",
-			backend.Config{
+			name: "dual-locking-dynamodb-and-s3",
+			config: backend.Config{
 				"bucket":         "foo",
 				"key":            "bar",
 				"region":         "us-east-1",
 				"dynamodb_table": "my-lock-table",
 				"use_lockfile":   true,
 			},
-			map[string]any{
+			expected: map[string]any{
 				"bucket":         "foo",
 				"key":            "bar",
 				"region":         "us-east-1",
 				"dynamodb_table": "my-lock-table",
 				"use_lockfile":   true,
 			},
-			true,
+			shouldBeEqual: true,
 		},
 		{
-			"string-bool-use-lockfile-true",
-			backend.Config{
+			name: "string-bool-use-lockfile-true",
+			config: backend.Config{
 				"bucket":       "foo",
 				"key":          "bar",
 				"region":       "us-east-1",
 				"use_lockfile": "true",
 			},
-			map[string]any{
+			expected: map[string]any{
 				"bucket":       "foo",
 				"key":          "bar",
 				"region":       "us-east-1",
 				"use_lockfile": true,
 			},
-			true,
+			shouldBeEqual: true,
 		},
 		{
-			"string-bool-use-lockfile-false",
-			backend.Config{
+			name: "string-bool-use-lockfile-false",
+			config: backend.Config{
 				"bucket":       "foo",
 				"key":          "bar",
 				"region":       "us-east-1",
 				"use_lockfile": "false",
 			},
-			map[string]any{
+			expected: map[string]any{
 				"bucket":       "foo",
 				"key":          "bar",
 				"region":       "us-east-1",
 				"use_lockfile": false,
 			},
-			true,
+			shouldBeEqual: true,
 		},
 		{
-			"string-bool-encrypt-and-use-lockfile",
-			backend.Config{
+			name: "string-bool-encrypt-and-use-lockfile",
+			config: backend.Config{
 				"bucket":       "foo",
 				"key":          "bar",
 				"region":       "us-east-1",
 				"encrypt":      "true",
 				"use_lockfile": "true",
 			},
-			map[string]any{
+			expected: map[string]any{
 				"bucket":       "foo",
 				"key":          "bar",
 				"region":       "us-east-1",
 				"encrypt":      true,
 				"use_lockfile": true,
 			},
-			true,
+			shouldBeEqual: true,
 		},
 	}
 

--- a/internal/remotestate/backend/s3/backend_test.go
+++ b/internal/remotestate/backend/s3/backend_test.go
@@ -14,7 +14,7 @@ func TestBackend_GetTFInitArgs(t *testing.T) {
 
 	remoteBackend := s3backend.NewBackend()
 
-	testCases := []struct { //nolint: govet
+	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
 		name          string
 		config        backend.Config
 		expected      map[string]any

--- a/internal/remotestate/backend/s3/config_test.go
+++ b/internal/remotestate/backend/s3/config_test.go
@@ -14,111 +14,111 @@ import (
 func TestParseExtendedS3Config_StringBoolCoercion(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
-		name   string
+	testCases := []struct {
 		config s3backend.Config
 		check  func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3)
+		name   string
 	}{
 		{
-			"use-lockfile-string-true",
-			s3backend.Config{
+			name: "use-lockfile-string-true",
+			config: s3backend.Config{
 				"bucket":       "my-bucket",
 				"key":          "my-key",
 				"region":       "us-east-1",
 				"use_lockfile": "true",
 			},
-			func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
+			check: func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
 				t.Helper()
 				assert.True(t, cfg.RemoteStateConfigS3.UseLockfile)
 			},
 		},
 		{
-			"use-lockfile-string-false",
-			s3backend.Config{
+			name: "use-lockfile-string-false",
+			config: s3backend.Config{
 				"bucket":       "my-bucket",
 				"key":          "my-key",
 				"region":       "us-east-1",
 				"use_lockfile": "false",
 			},
-			func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
+			check: func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
 				t.Helper()
 				assert.False(t, cfg.RemoteStateConfigS3.UseLockfile)
 			},
 		},
 		{
-			"encrypt-string-true",
-			s3backend.Config{
+			name: "encrypt-string-true",
+			config: s3backend.Config{
 				"bucket":  "my-bucket",
 				"key":     "my-key",
 				"region":  "us-east-1",
 				"encrypt": "true",
 			},
-			func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
+			check: func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
 				t.Helper()
 				assert.True(t, cfg.RemoteStateConfigS3.Encrypt)
 			},
 		},
 		{
-			"force-path-style-string-true",
-			s3backend.Config{
+			name: "force-path-style-string-true",
+			config: s3backend.Config{
 				"bucket":           "my-bucket",
 				"key":              "my-key",
 				"region":           "us-east-1",
 				"force_path_style": "true",
 			},
-			func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
+			check: func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
 				t.Helper()
 				assert.True(t, cfg.RemoteStateConfigS3.S3ForcePathStyle)
 			},
 		},
 		{
-			"skip-bucket-versioning-string-true",
-			s3backend.Config{
+			name: "skip-bucket-versioning-string-true",
+			config: s3backend.Config{
 				"bucket":                 "my-bucket",
 				"key":                    "my-key",
 				"region":                 "us-east-1",
 				"skip_bucket_versioning": "true",
 			},
-			func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
+			check: func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
 				t.Helper()
 				assert.True(t, cfg.SkipBucketVersioning)
 			},
 		},
 		{
-			"native-bool-still-works",
-			s3backend.Config{
+			name: "native-bool-still-works",
+			config: s3backend.Config{
 				"bucket":       "my-bucket",
 				"key":          "my-key",
 				"region":       "us-east-1",
 				"use_lockfile": true,
 			},
-			func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
+			check: func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
 				t.Helper()
 				assert.True(t, cfg.RemoteStateConfigS3.UseLockfile)
 			},
 		},
 		{
-			"empty-string-coerces-to-false",
-			s3backend.Config{
+			name: "empty-string-coerces-to-false",
+			config: s3backend.Config{
 				"bucket":       "my-bucket",
 				"key":          "my-key",
 				"region":       "us-east-1",
 				"use_lockfile": "",
 			},
-			func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
+			check: func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
 				t.Helper()
 				assert.False(t, cfg.RemoteStateConfigS3.UseLockfile)
 			},
 		},
 		{
-			"numeric-one-coerces-to-true",
-			s3backend.Config{
+			name: "numeric-one-coerces-to-true",
+			config: s3backend.Config{
 				"bucket":       "my-bucket",
 				"key":          "my-key",
 				"region":       "us-east-1",
 				"use_lockfile": "1",
 			},
-			func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
+			check: func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3) {
 				t.Helper()
 				assert.True(t, cfg.RemoteStateConfigS3.UseLockfile)
 			},

--- a/internal/remotestate/backend/s3/config_test.go
+++ b/internal/remotestate/backend/s3/config_test.go
@@ -14,7 +14,7 @@ import (
 func TestParseExtendedS3Config_StringBoolCoercion(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint: govet
+	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
 		name   string
 		config s3backend.Config
 		check  func(t *testing.T, cfg *s3backend.ExtendedRemoteStateConfigS3)

--- a/internal/remotestate/backend/s3/remote_state_config_test.go
+++ b/internal/remotestate/backend/s3/remote_state_config_test.go
@@ -130,25 +130,25 @@ func TestConfig_CreateS3LoggingInput(t *testing.T) {
 func TestConfig_ForcePathStyleClientSession(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
-		name     string
+	testCases := []struct {
 		config   s3backend.Config
+		name     string
 		expected bool
 	}{
 		{
-			"path-style-true",
-			s3backend.Config{"force_path_style": true},
-			true,
+			name:     "path-style-true",
+			config:   s3backend.Config{"force_path_style": true},
+			expected: true,
 		},
 		{
-			"path-style-false",
-			s3backend.Config{"force_path_style": false},
-			false,
+			name:     "path-style-false",
+			config:   s3backend.Config{"force_path_style": false},
+			expected: false,
 		},
 		{
-			"path-style-non-existent",
-			s3backend.Config{},
-			false,
+			name:     "path-style-non-existent",
+			config:   s3backend.Config{},
+			expected: false,
 		},
 	}
 
@@ -170,10 +170,10 @@ func TestConfig_ForcePathStyleClientSession(t *testing.T) {
 func TestConfig_CustomStateEndpoints(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
-		name     string
+	testCases := []struct {
 		config   s3backend.Config
 		expected *awshelper.AwsSessionConfig
+		name     string
 	}{
 		{
 			name:   "using pre 1.6.x settings only",
@@ -215,13 +215,13 @@ func TestConfig_CustomStateEndpoints(t *testing.T) {
 func TestConfig_GetAwsSessionConfig(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
-		name   string
+	testCases := []struct {
 		config s3backend.Config
+		name   string
 	}{
 		{
-			"all-values",
-			s3backend.Config{
+			name: "all-values",
+			config: s3backend.Config{
 				"region":                  "foo",
 				"endpoint":                "bar",
 				"profile":                 "baz",
@@ -231,12 +231,12 @@ func TestConfig_GetAwsSessionConfig(t *testing.T) {
 			},
 		},
 		{
-			"no-values",
-			s3backend.Config{},
+			name:   "no-values",
+			config: s3backend.Config{},
 		},
 		{
-			"extra-values",
-			s3backend.Config{
+			name: "extra-values",
+			config: s3backend.Config{
 				"something":               "unexpected",
 				"region":                  "foo",
 				"endpoint":                "bar",
@@ -276,13 +276,13 @@ func TestConfig_GetAwsSessionConfig(t *testing.T) {
 func TestConfig_GetAwsSessionConfigWithAssumeRole(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
-		name   string
+	testCases := []struct {
 		config s3backend.Config
+		name   string
 	}{
 		{
-			"all-values",
-			s3backend.Config{
+			name: "all-values",
+			config: s3backend.Config{
 				"role_arn":     "arn::it",
 				"external_id":  "123",
 				"session_name": "foobar",
@@ -290,8 +290,8 @@ func TestConfig_GetAwsSessionConfigWithAssumeRole(t *testing.T) {
 			},
 		},
 		{
-			"no-tags",
-			s3backend.Config{"role_arn": "arn::it", "external_id": "123", "session_name": "foobar"},
+			name:   "no-tags",
+			config: s3backend.Config{"role_arn": "arn::it", "external_id": "123", "session_name": "foobar"},
 		},
 	}
 

--- a/internal/remotestate/backend/s3/remote_state_config_test.go
+++ b/internal/remotestate/backend/s3/remote_state_config_test.go
@@ -20,7 +20,7 @@ import (
 func TestConfig_CreateS3LoggingInput(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint: govet
+	testCases := []struct {
 		name          string
 		config        s3backend.Config
 		loggingInput  s3.PutBucketLoggingInput
@@ -130,7 +130,7 @@ func TestConfig_CreateS3LoggingInput(t *testing.T) {
 func TestConfig_ForcePathStyleClientSession(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint: govet
+	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
 		name     string
 		config   s3backend.Config
 		expected bool
@@ -170,7 +170,7 @@ func TestConfig_ForcePathStyleClientSession(t *testing.T) {
 func TestConfig_CustomStateEndpoints(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint: govet
+	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
 		name     string
 		config   s3backend.Config
 		expected *awshelper.AwsSessionConfig
@@ -215,7 +215,7 @@ func TestConfig_CustomStateEndpoints(t *testing.T) {
 func TestConfig_GetAwsSessionConfig(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint: govet
+	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
 		name   string
 		config s3backend.Config
 	}{
@@ -276,7 +276,7 @@ func TestConfig_GetAwsSessionConfig(t *testing.T) {
 func TestConfig_GetAwsSessionConfigWithAssumeRole(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct { //nolint: govet
+	testCases := []struct { //nolint:govet // fieldalignment: readability beats packing in a test table
 		name   string
 		config s3backend.Config
 	}{

--- a/internal/remotestate/remote_state.go
+++ b/internal/remotestate/remote_state.go
@@ -236,7 +236,7 @@ func (remote *RemoteState) pullState(
 	l log.Logger,
 	v *venv.Venv,
 	tfOpts *tf.TFOptions,
-) (string, error) {
+) (path string, err error) {
 	l.Debugf("Pulling state from %s backend", remote.BackendName)
 
 	args := []string{tf.CommandNameState, tf.CommandNamePull}
@@ -254,7 +254,9 @@ func (remote *RemoteState) pullState(
 	}
 
 	defer func() {
-		file.Close() //nolint:errcheck // best-effort close of the temp state file
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
 	}()
 
 	if _, err := file.Write(output.Stdout.Bytes()); err != nil {

--- a/internal/remotestate/remote_state.go
+++ b/internal/remotestate/remote_state.go
@@ -254,7 +254,7 @@ func (remote *RemoteState) pullState(
 	}
 
 	defer func() {
-		file.Close() // nolint: errcheck
+		file.Close() //nolint:errcheck // best-effort close of the temp state file
 	}()
 
 	if _, err := file.Write(output.Stdout.Bytes()); err != nil {

--- a/internal/report/writer.go
+++ b/internal/report/writer.go
@@ -34,7 +34,7 @@ type JSONRun struct {
 	// Ended is the time when the run ended.
 	Ended time.Time `json:"Ended" jsonschema:"required"`
 	// Reason is the reason for the run result, if any.
-	//nolint:lll
+	//nolint:lll // the jsonschema enum list can't be wrapped
 	Reason *string `json:"Reason,omitempty" jsonschema:"enum=retry succeeded,enum=error ignored,enum=run error,enum=exclude block,enum=ancestor error"`
 	// Cause is the cause of the run result, if any.
 	Cause *string `json:"Cause,omitempty"`

--- a/internal/runner/run/creds/getter_test.go
+++ b/internal/runner/run/creds/getter_test.go
@@ -230,7 +230,7 @@ func TestObtainCredsForParsingReportsCommandFailure(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, getter)
 
-	var procErr util.ProcessExecutionError
+	var procErr *util.ProcessExecutionError
 
 	require.ErrorAs(t, err, &procErr)
 	assert.Equal(t, map[string]string{"UNRELATED": "kept"}, v.Env)

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -499,9 +499,7 @@ func TestDownloadInvalidPathToFilePath(t *testing.T) {
 	assert.True(t, ok)
 }
 
-// The test cases are run sequentially because they depend on each other.
-//
-//nolint:tparallel
+//nolint:tparallel // the subtests build on each other and run in sequence
 func TestDownloadTerraformSourceFromLocalFolderWithManifest(t *testing.T) {
 	t.Parallel()
 
@@ -566,9 +564,7 @@ func TestDownloadTerraformSourceFromLocalFolderWithManifest(t *testing.T) {
 		},
 	}
 
-	// The test cases are run sequentially because they depend on each other.
-	//
-	//nolint:paralleltest
+	//nolint:paralleltest // the subtests build on each other and run in sequence
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			copyFolder(t, tc.sourceURL, downloadDir)

--- a/internal/runner/run/hook.go
+++ b/internal/runner/run/hook.go
@@ -136,7 +136,7 @@ func ProcessErrorHooks(
 		errorMessage := e.Error()
 		// Process execution errors carry stdout that hook patterns need to match against.
 		// https://github.com/gruntwork-io/terragrunt/issues/2045
-		if processError, ok := errors.AsType[util.ProcessExecutionError](e); ok {
+		if processError, ok := errors.AsType[*util.ProcessExecutionError](e); ok {
 			errorMessage = fmt.Sprintf(
 				"%s\n%s",
 				processError.Error(),
@@ -198,7 +198,7 @@ func ProcessErrorHooks(
 // hookErrorMessage extracts command, args and output from the error
 // so users see WHY a hook failed, not just the exit code.
 func hookErrorMessage(hookName string, err error) string {
-	var processErr util.ProcessExecutionError
+	var processErr *util.ProcessExecutionError
 	if !errors.As(err, &processErr) {
 		return fmt.Sprintf("Hook %q failed to execute: %v", hookName, err)
 	}

--- a/internal/runner/run/hook_internal_test.go
+++ b/internal/runner/run/hook_internal_test.go
@@ -18,7 +18,7 @@ func TestHookErrorMessage_WithStderr(t *testing.T) {
 	var output util.CmdOutput
 	output.Stderr.WriteString("resource missing required tags")
 
-	err := util.ProcessExecutionError{
+	err := &util.ProcessExecutionError{
 		Err:        stubExitErr{code: 2},
 		Command:    "tflint",
 		Args:       []string{"--config", ".tflint.hcl"},
@@ -39,7 +39,7 @@ func TestHookErrorMessage_StdoutFallback(t *testing.T) {
 	var output util.CmdOutput
 	output.Stdout.WriteString("warning: deprecated feature")
 
-	err := util.ProcessExecutionError{
+	err := &util.ProcessExecutionError{
 		Err:        stubExitErr{code: 1},
 		Command:    "custom-lint",
 		Args:       []string{"--fix"},
@@ -57,7 +57,7 @@ func TestHookErrorMessage_StdoutFallback(t *testing.T) {
 func TestHookErrorMessage_NoOutput(t *testing.T) {
 	t.Parallel()
 
-	err := util.ProcessExecutionError{
+	err := &util.ProcessExecutionError{
 		Err:        stubExitErr{code: 3},
 		Command:    "check",
 		Args:       []string{"-strict"},
@@ -76,7 +76,7 @@ func TestHookErrorMessage_TflintWrapped(t *testing.T) {
 	var output util.CmdOutput
 	output.Stderr.WriteString("3 issue(s) found")
 
-	processErr := util.ProcessExecutionError{
+	processErr := &util.ProcessExecutionError{
 		Err:        stubExitErr{code: 2},
 		Command:    "tflint",
 		Args:       []string{"--config", ".tflint.hcl"},
@@ -167,7 +167,7 @@ func FuzzHookErrorMessage(f *testing.F) {
 			output.Stderr.WriteString(stderr)
 			output.Stdout.WriteString(stdout)
 
-			feed = util.ProcessExecutionError{
+			feed = &util.ProcessExecutionError{
 				Err:        stubExitErr{code: exitCode},
 				Command:    command,
 				Args:       args,

--- a/internal/runner/run/version_check_test.go
+++ b/internal/runner/run/version_check_test.go
@@ -1,4 +1,3 @@
-//nolint:unparam
 package run_test
 
 import (

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -664,7 +664,7 @@ func (rnr *Runner) Run(
 					}
 				}
 
-				switch entry.Status { //nolint:exhaustive
+				switch entry.Status { //nolint:exhaustive // only failed and early-exit runs are ended here
 				case queue.StatusEarlyExit:
 					endOpts := []report.EndOption{
 						report.WithResult(report.ResultEarlyExit),

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -664,7 +664,7 @@ func (rnr *Runner) Run(
 					}
 				}
 
-				switch entry.Status { //nolint:exhaustive // only failed and early-exit runs are ended here
+				switch entry.Status {
 				case queue.StatusEarlyExit:
 					endOpts := []report.EndOption{
 						report.WithResult(report.ResultEarlyExit),
@@ -696,6 +696,8 @@ func (rnr *Runner) Run(
 					if endErr := r.EndRun(l, run.Path, endOpts...); endErr != nil {
 						l.Errorf("Error ending run for failed unit %s: %v", unitPath, endErr)
 					}
+				case queue.StatusPending, queue.StatusBlocked, queue.StatusUnsorted,
+					queue.StatusReady, queue.StatusRunning, queue.StatusSucceeded:
 				}
 			}
 		}

--- a/internal/shell/error_explainer.go
+++ b/internal/shell/error_explainer.go
@@ -44,7 +44,7 @@ func ExplainError(err error) string {
 		message := err.Error()
 
 		// extract process output, if it is the case
-		var processError util.ProcessExecutionError
+		var processError *util.ProcessExecutionError
 		if ok := errors.As(err, &processError); ok {
 			errorOutput := processError.Output.Stderr.String()
 			stdOut := processError.Output.Stdout.String()

--- a/internal/shell/error_explainer_test.go
+++ b/internal/shell/error_explainer_test.go
@@ -47,7 +47,7 @@ func TestExplainError(t *testing.T) {
 			output := util.CmdOutput{
 				Stderr: *bytes.NewBufferString(tt.errorOutput)}
 
-			errs := errors.Join(util.ProcessExecutionError{
+			errs := errors.Join(&util.ProcessExecutionError{
 				Err:    errors.New(""),
 				Output: output,
 			})

--- a/internal/shell/run_cmd.go
+++ b/internal/shell/run_cmd.go
@@ -352,7 +352,7 @@ func runCommand(
 
 	//nolint:contextcheck // context already passed to exec.Command
 	if err := cmd.Start(l); err != nil {
-		err = util.ProcessExecutionError{
+		err = &util.ProcessExecutionError{
 			Err:             err,
 			Args:            cmdOpts.Args,
 			Command:         cmdOpts.Command,
@@ -369,7 +369,7 @@ func runCommand(
 	defer cancelShutdown()
 
 	if err := cmd.Wait(); err != nil {
-		err = util.ProcessExecutionError{
+		err = &util.ProcessExecutionError{
 			Err:             err,
 			Args:            cmdOpts.Args,
 			Command:         cmdOpts.Command,

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -31,6 +31,9 @@ import (
 // purpose: real stack trees stay far below it.
 const DefaultMaxLevel = 1024
 
+// worktreesPerPair is the number of worktrees in a comparison pair: the from worktree and the to worktree.
+const worktreesPerPair = 2
+
 // Generator owns the per-working-directory lock for in-process GenerateStacks calls.
 type Generator struct {
 	locks    *util.KeyLocks
@@ -634,8 +637,7 @@ func worktreeStacksToGenerate(
 	// can walk them for unit-level changes.
 
 	g, ctx := errgroup.WithContext(ctx)
-	// Allow up to 2 generation tasks per worktree pair (at least 1), capped by available CPUs.
-	g.SetLimit(min(runtime.GOMAXPROCS(0), max(1, len(w.WorktreePairs)*2))) //nolint:mnd // two tasks per pair
+	g.SetLimit(min(runtime.GOMAXPROCS(0), max(1, len(w.WorktreePairs)*worktreesPerPair)))
 
 	var (
 		mu              sync.Mutex

--- a/internal/stacks/generate/generate.go
+++ b/internal/stacks/generate/generate.go
@@ -635,7 +635,7 @@ func worktreeStacksToGenerate(
 
 	g, ctx := errgroup.WithContext(ctx)
 	// Allow up to 2 generation tasks per worktree pair (at least 1), capped by available CPUs.
-	g.SetLimit(min(runtime.GOMAXPROCS(0), max(1, len(w.WorktreePairs)*2))) //nolint:mnd
+	g.SetLimit(min(runtime.GOMAXPROCS(0), max(1, len(w.WorktreePairs)*2))) //nolint:mnd // two tasks per pair
 
 	var (
 		mu              sync.Mutex

--- a/internal/strict/controls/controls.go
+++ b/internal/strict/controls/controls.go
@@ -113,7 +113,6 @@ func IsFastCopyEnabled(strictControls strict.Controls) bool {
 	return len(strictControls.FilterByNames(FastCopy).FilterByEnabled()) > 0
 }
 
-//nolint:lll
 func New() strict.Controls {
 	skipDependenciesInputsControl := &Control{
 		Name:        SkipDependenciesInputs,

--- a/internal/strict/controls/controls.go
+++ b/internal/strict/controls/controls.go
@@ -117,7 +117,7 @@ func New() strict.Controls {
 	skipDependenciesInputsControl := &Control{
 		Name:        SkipDependenciesInputs,
 		Description: "Controls whether to allow the deprecated dependency inputs feature. Dependency inputs are now disabled by default for performance. Use dependency outputs instead.",
-		Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+		Error: errors.New(
 			"reading inputs from dependencies is no longer supported. To acquire values from dependencies, use outputs.",
 		),
 		Warning: "Reading inputs from dependencies has been deprecated and is now disabled by default for performance. Use dependency outputs instead.",
@@ -127,7 +127,7 @@ func New() strict.Controls {
 	requireExplicitBootstrapControl := &Control{
 		Name:        RequireExplicitBootstrap,
 		Description: "Don't bootstrap backends by default. When enabled, users must supply `--backend-bootstrap` explicitly to automatically bootstrap backend resources.",
-		Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+		Error: errors.New(
 			"bootstrap backend for remote state by default is no longer supported. Use `--backend-bootstrap` flag instead.",
 		),
 		Warning: "Bootstrapping backend resources by default is deprecated functionality, and will not be the default behavior in a future version of Terragrunt. Use the explicit `--backend-bootstrap` flag to automatically provision backend resources before they're needed.",
@@ -222,7 +222,7 @@ func New() strict.Controls {
 		&Control{
 			Name:        RootTerragruntHCL,
 			Description: "Throw an error when users try to reference a root terragrunt.hcl file using find_in_parent_folders.",
-			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+			Error: errors.New(
 				"Using `terragrunt.hcl` as the root of Terragrunt configurations is an anti-pattern, and no longer supported. Use a differently named file like `root.hcl` instead. For more information, see https://docs.terragrunt.com/migrate/migrating-from-root-terragrunt-hcl",
 			),
 			Warning: "Using `terragrunt.hcl` as the root of Terragrunt configurations is an anti-pattern, and no longer recommended. In a future version of Terragrunt, this will result in an error. You are advised to use a differently named file like `root.hcl` instead. For more information, see https://docs.terragrunt.com/migrate/migrating-from-root-terragrunt-hcl",
@@ -231,7 +231,7 @@ func New() strict.Controls {
 		&Control{
 			Name:        BareInclude,
 			Description: "Prevents the use of the `include` block without a label.",
-			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+			Error: errors.New(
 				"Using an `include` block without a label is deprecated. Please use the `include` block with a label instead.",
 			),
 			Warning: "Using an `include` block without a label is deprecated. Please use the `include` block with a label instead. For more information, see https://docs.terragrunt.com/migrate/bare-include/",
@@ -240,7 +240,7 @@ func New() strict.Controls {
 		&Control{
 			Name:        DuplicateDependencyLabels,
 			Description: "Prevents two `dependency` blocks in one configuration from addressing the same dependency, whether by sharing a label or a `config_path`.",
-			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+			Error: errors.New(
 				"Two `dependency` blocks address the same dependency, by sharing a label or a `config_path`. Declare each dependency once.",
 			),
 			Warning: "Two `dependency` blocks address the same dependency, by sharing a label or a `config_path`. Only the last block with a given label can be referenced, and two blocks for one `config_path` declare the same unit twice. Declare each dependency once. In a future version of Terragrunt, this will result in an error.",
@@ -249,7 +249,7 @@ func New() strict.Controls {
 		&Control{
 			Name:        DoubleStar,
 			Description: "Use the `**` glob pattern to select all files in a directory and its subdirectories.",
-			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+			Error: errors.New(
 				"Using `**` to select all files in a directory and its subdirectories is enabled. **/* now matches subdirectories with at least a depth of one.",
 			),
 			Warning: "Using `**` to select all files in a directory and its subdirectories is enabled. **/* now matches subdirectories with at least a depth of one.",
@@ -258,7 +258,7 @@ func New() strict.Controls {
 		&Control{
 			Name:        QueueExcludeExternal,
 			Description: "Prevents the use of the deprecated `--queue-exclude-external` flag.",
-			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+			Error: errors.New(
 				"The `--queue-exclude-external` flag is no longer supported. External dependencies are now excluded by default. Use --queue-include-external to include them.",
 			),
 			Warning: "The `--queue-exclude-external` flag is deprecated and will be removed in a future version of Terragrunt. External dependencies are now excluded by default.",
@@ -266,7 +266,7 @@ func New() strict.Controls {
 		&Control{
 			Name:        QueueStrictInclude,
 			Description: "Prevents the use of the deprecated `--queue-strict-include` flag.",
-			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+			Error: errors.New(
 				"The `--queue-strict-include` flag is no longer supported. The behavior of Terragrunt when using `--queue-strict-include` is now the default behavior.",
 			),
 			Warning: "The `--queue-strict-include` flag is deprecated and will be removed in a future version of Terragrunt. The behavior of Terragrunt when using `--queue-strict-include` is now the default behavior.",
@@ -274,7 +274,7 @@ func New() strict.Controls {
 		&Control{
 			Name:        UnitsThatInclude,
 			Description: "Prevents the use of the deprecated `--units-that-include` flag.",
-			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+			Error: errors.New(
 				"The `--units-that-include` flag is no longer supported. Use `--filter='reading=<path>'` to include units that include or read the specified configuration.",
 			),
 			Warning: "The `--units-that-include` flag is deprecated and will be removed in a future version of Terragrunt. Use `--filter='reading=<path>'` to include units that include or read the specified configuration.",
@@ -282,7 +282,7 @@ func New() strict.Controls {
 		&Control{
 			Name:        DisableCommandValidation,
 			Description: "Prevents the use of the deprecated `--disable-command-validation` flag. Command validation has been removed entirely.",
-			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+			Error: errors.New(
 				"The `--disable-command-validation` flag is no longer supported. Command validation has been removed entirely, and you can pass any command to `terragrunt run`.",
 			),
 			Warning: "The `--disable-command-validation` flag is deprecated and will be removed in a future version of Terragrunt. Command validation has been removed entirely, and you can pass any command to `terragrunt run`.",
@@ -290,7 +290,7 @@ func New() strict.Controls {
 		&Control{
 			Name:        NoDestroyDependenciesCheck,
 			Description: "Prevents the use of the deprecated `--no-destroy-dependencies-check` flag. This flag is now ignored. Use `--destroy-dependencies-check` to enable dependency checks during destroy operations.",
-			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+			Error: errors.New(
 				"The `--no-destroy-dependencies-check` flag is no longer supported. Use `--destroy-dependencies-check` to enable dependency checks during destroy operations.",
 			),
 			Warning: "The `--no-destroy-dependencies-check` flag is deprecated and will be removed in a future version of Terragrunt. This flag is now ignored. Use `--destroy-dependencies-check` to enable dependency checks during destroy operations.",
@@ -298,7 +298,7 @@ func New() strict.Controls {
 		&Control{
 			Name:        InternalTFLint,
 			Description: "Prevents the use of the deprecated embedded version of tflint, instead treating `tflint` as a normal hook.",
-			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+			Error: errors.New(
 				"The embedded version of tflint is no longer supported. Use the `--terragrunt-external-tflint` flag in your hook to opt in to running tflint externally.",
 			),
 			Warning: "The embedded version of tflint is deprecated and will be removed in a future version of Terragrunt. Use the `--terragrunt-external-tflint` flag in your hook to opt in to running tflint externally and avoid this warning.",
@@ -306,7 +306,7 @@ func New() strict.Controls {
 		&Control{
 			Name:        DeprecatedHiddenFlag,
 			Description: "Prevents the use of the deprecated `--hidden` flag.",
-			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+			Error: errors.New(
 				"The `--hidden` flag is no longer supported. Hidden directories are now included by default. Use `--no-hidden` to exclude them.",
 			),
 			Warning: "The `--hidden` flag is deprecated and will be removed in a future version of Terragrunt. Hidden directories are now included by default. Use `--no-hidden` to exclude them.",
@@ -314,7 +314,7 @@ func New() strict.Controls {
 		&Control{
 			Name:        DisableDependentModules,
 			Description: "Prevents the use of the deprecated `--disable-dependent-modules` flag.",
-			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+			Error: errors.New(
 				"The `--disable-dependent-modules` flag is no longer supported. Dependent modules discovery has been removed from `terragrunt render`.",
 			),
 			Warning: "The `--disable-dependent-modules` flag is deprecated and will be removed in a future version of Terragrunt. Dependent modules discovery has been removed from `terragrunt render`, so this flag has no effect.",

--- a/internal/telemetry/logger.go
+++ b/internal/telemetry/logger.go
@@ -60,8 +60,8 @@ func NewLogger(
 }
 
 // NewLogsExporter creates a new logs exporter based on the telemetry options.
-// The structure mirrors NewMetricsExporter and NewTraceExporter; the per-signal
-// OTLP option types prevent sharing a single implementation.
+//
+//nolint:dupl // the per-signal OTLP option types prevent sharing one implementation
 func NewLogsExporter(ctx context.Context, writer io.Writer, opts *Options) (log.Exporter, error) {
 	exporterType := logsExporterType(opts.LogsExporter)
 	if exporterType == "" {

--- a/internal/telemetry/logger.go
+++ b/internal/telemetry/logger.go
@@ -62,8 +62,6 @@ func NewLogger(
 // NewLogsExporter creates a new logs exporter based on the telemetry options.
 // The structure mirrors NewMetricsExporter and NewTraceExporter; the per-signal
 // OTLP option types prevent sharing a single implementation.
-//
-//nolint:dupl
 func NewLogsExporter(ctx context.Context, writer io.Writer, opts *Options) (log.Exporter, error) {
 	exporterType := logsExporterType(opts.LogsExporter)
 	if exporterType == "" {

--- a/internal/telemetry/meter.go
+++ b/internal/telemetry/meter.go
@@ -124,8 +124,8 @@ func (meter *Meter) Count(ctx context.Context, name string, value int64) {
 }
 
 // NewMetricsExporter - create a new exporter based on the telemetry options.
-// The structure mirrors NewLogsExporter and NewTraceExporter; the per-signal
-// OTLP option types prevent sharing a single implementation.
+//
+//nolint:dupl // the per-signal OTLP option types prevent sharing one implementation
 func NewMetricsExporter(
 	ctx context.Context,
 	writer io.Writer,
@@ -136,7 +136,7 @@ func NewMetricsExporter(
 		exporterType = noneMetricsExporterType
 	}
 
-	switch exporterType { //nolint:exhaustive // the default branch handles the rest
+	switch exporterType {
 	case oltpHTTPMetricsExporterType:
 		var config []otlpmetrichttp.Option
 		if opts.MetricExporterInsecureEndpoint {
@@ -153,6 +153,8 @@ func NewMetricsExporter(
 		return otlpmetricgrpc.New(ctx, config...)
 	case consoleMetricsExporterType:
 		return stdoutmetric.New(stdoutmetric.WithWriter(writer))
+	case noneMetricsExporterType:
+		return nil, nil
 	default:
 		return nil, nil
 	}

--- a/internal/telemetry/meter.go
+++ b/internal/telemetry/meter.go
@@ -126,8 +126,6 @@ func (meter *Meter) Count(ctx context.Context, name string, value int64) {
 // NewMetricsExporter - create a new exporter based on the telemetry options.
 // The structure mirrors NewLogsExporter and NewTraceExporter; the per-signal
 // OTLP option types prevent sharing a single implementation.
-//
-//nolint:dupl
 func NewMetricsExporter(
 	ctx context.Context,
 	writer io.Writer,
@@ -138,8 +136,7 @@ func NewMetricsExporter(
 		exporterType = noneMetricsExporterType
 	}
 
-	// TODO: Remove this lint suppression
-	switch exporterType { //nolint:exhaustive
+	switch exporterType { //nolint:exhaustive // the default branch handles the rest
 	case oltpHTTPMetricsExporterType:
 		var config []otlpmetrichttp.Option
 		if opts.MetricExporterInsecureEndpoint {

--- a/internal/telemetry/tracer.go
+++ b/internal/telemetry/tracer.go
@@ -159,8 +159,7 @@ func NewTraceExporter(
 		exporterType = noneTraceExporterType
 	}
 
-	// TODO: Remove lint suppression
-	switch exporterType { //nolint:exhaustive
+	switch exporterType { //nolint:exhaustive // the default branch handles the rest
 	case httpTraceExporterType:
 		if opts.TraceExporterHTTPEndpoint == "" {
 			return nil, &ErrorMissingEnvVariable{
@@ -256,14 +255,9 @@ func (tracer *Tracer) openSpan(
 		}
 	}
 
-	// This lint is suppressed because we definitely do close the span
-	// in a defer statement everywhere openSpan is called. It seems like
-	// a useful lint, though. We should consider removing the suppression
-	// and fixing the lint.
-
-	ctx, span := tracer.Start(ctx, name) // nolint:spancheck
+	ctx, span := tracer.Start(ctx, name) //nolint:spancheck // every openSpan caller closes the span in a defer
 	// convert attrs map to span.SetAttributes
 	span.SetAttributes(mapToAttributes(attrs)...)
 
-	return ctx, span //nolint:spancheck
+	return ctx, span //nolint:spancheck // as above: the caller closes the span
 }

--- a/internal/telemetry/tracer.go
+++ b/internal/telemetry/tracer.go
@@ -159,7 +159,7 @@ func NewTraceExporter(
 		exporterType = noneTraceExporterType
 	}
 
-	switch exporterType { //nolint:exhaustive // the default branch handles the rest
+	switch exporterType {
 	case httpTraceExporterType:
 		if opts.TraceExporterHTTPEndpoint == "" {
 			return nil, &ErrorMissingEnvVariable{
@@ -191,6 +191,8 @@ func NewTraceExporter(
 		return otlptracegrpc.New(ctx, config...)
 	case consoleTraceExporterType:
 		return stdouttrace.New(stdouttrace.WithWriter(writer))
+	case noneTraceExporterType:
+		return nil, nil
 	default:
 		return nil, nil
 	}
@@ -255,9 +257,9 @@ func (tracer *Tracer) openSpan(
 		}
 	}
 
-	ctx, span := tracer.Start(ctx, name) //nolint:spancheck // every openSpan caller closes the span in a defer
+	ctx, span := tracer.Start(ctx, name) //nolint:spancheck // Trace, the only caller, defers span.End
 	// convert attrs map to span.SetAttributes
 	span.SetAttributes(mapToAttributes(attrs)...)
 
-	return ctx, span //nolint:spancheck // as above: the caller closes the span
+	return ctx, span //nolint:spancheck // Trace, the only caller, defers span.End
 }

--- a/internal/tf/cache/handlers/direct_provider.go
+++ b/internal/tf/cache/handlers/direct_provider.go
@@ -40,8 +40,6 @@ func (handler *DirectProviderHandler) String() string {
 
 // GetVersions implements ProviderHandler.GetVersions
 // https://developer.hashicorp.com/terraform/cloud-docs/api-docs/private-registry/provider-versions-platforms#get-all-versions-for-a-single-provider
-//
-//nolint:lll
 func (handler *DirectProviderHandler) GetVersions(
 	ctx context.Context,
 	provider *models.Provider,

--- a/internal/tf/cache/handlers/proxy_provider.go
+++ b/internal/tf/cache/handlers/proxy_provider.go
@@ -62,8 +62,6 @@ func (handler *ProxyProviderHandler) String() string {
 
 // GetVersions implements ProviderHandler.GetVersions
 // https://developer.hashicorp.com/terraform/cloud-docs/api-docs/private-registry/provider-versions-platforms#get-all-versions-for-a-single-provider
-//
-//nolint:lll
 func (handler *ProxyProviderHandler) GetVersions(
 	ctx echo.Context,
 	provider *models.Provider,

--- a/internal/tf/cache/handlers/registry_urls.go
+++ b/internal/tf/cache/handlers/registry_urls.go
@@ -52,7 +52,7 @@ func DiscoveryURL(ctx context.Context, c vhttp.Client, registryName string) (*Re
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer resp.Body.Close() //nolint:errcheck // best-effort close of the response body
 
 	switch resp.StatusCode {
 	case http.StatusNotFound, http.StatusInternalServerError:

--- a/internal/tf/cache/helpers/client.go
+++ b/internal/tf/cache/helpers/client.go
@@ -54,7 +54,7 @@ func (client *Client) Do(ctx context.Context, method, reqURL string, value any) 
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer resp.Body.Close() //nolint:errcheck // best-effort close of the response body
 
 	bodyBytes, err := decodeResponse(resp)
 	if err != nil {

--- a/internal/tf/cache/helpers/http.go
+++ b/internal/tf/cache/helpers/http.go
@@ -50,12 +50,17 @@ func Fetch(ctx context.Context, c vhttp.Client, req *http.Request, dst io.Writer
 }
 
 // FetchToFile downloads req's response through c into the file at dst.
-func FetchToFile(ctx context.Context, c vhttp.Client, fsys vfs.FS, req *http.Request, dst string) error {
+func FetchToFile(ctx context.Context, c vhttp.Client, fsys vfs.FS, req *http.Request, dst string) (err error) {
 	file, err := fsys.Create(dst)
 	if err != nil {
 		return err
 	}
-	defer file.Close() //nolint:errcheck // best-effort close of the downloaded file
+
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
 
 	if err := Fetch(ctx, c, req, file); err != nil {
 		return err

--- a/internal/tf/cache/helpers/http.go
+++ b/internal/tf/cache/helpers/http.go
@@ -25,7 +25,7 @@ func Fetch(ctx context.Context, c vhttp.Client, req *http.Request, dst io.Writer
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer resp.Body.Close() //nolint:errcheck // best-effort close of the response body
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("%s returned from %s", resp.Status, req.URL)
@@ -55,7 +55,7 @@ func FetchToFile(ctx context.Context, c vhttp.Client, fsys vfs.FS, req *http.Req
 	if err != nil {
 		return err
 	}
-	defer file.Close() //nolint:errcheck
+	defer file.Close() //nolint:errcheck // best-effort close of the downloaded file
 
 	if err := Fetch(ctx, c, req, file); err != nil {
 		return err
@@ -93,7 +93,7 @@ func ResponseBuffer(resp *http.Response) (*bytes.Buffer, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer reader.Close() //nolint:errcheck
+	defer reader.Close() //nolint:errcheck // best-effort close of the response reader
 
 	buffer := new(bytes.Buffer)
 

--- a/internal/tf/cliconfig/provider_installation.go
+++ b/internal/tf/cliconfig/provider_installation.go
@@ -183,8 +183,7 @@ func (method *ProviderInstallationDirect) RemoveInclude(addrs []string) {
 }
 
 func (method *ProviderInstallationDirect) String() string {
-	// Odd that this err isn't checked. There should be an explanation why.
-	b, _ := json.Marshal(method) //nolint:errchkjson
+	b, _ := json.Marshal(method) //nolint:errchkjson // the string fields can't form a cycle, so Marshal can't fail
 	return string(b)
 }
 
@@ -305,8 +304,7 @@ func (method *ProviderInstallationFilesystemMirror) RemoveInclude(addrs []string
 }
 
 func (method *ProviderInstallationFilesystemMirror) String() string {
-	// Odd that this err isn't checked. There should be an explanation why.
-	b, _ := json.Marshal(method) //nolint:errchkjson
+	b, _ := json.Marshal(method) //nolint:errchkjson // the string fields can't form a cycle, so Marshal can't fail
 	return string(b)
 }
 
@@ -427,7 +425,6 @@ func (method *ProviderInstallationNetworkMirror) RemoveInclude(addrs []string) {
 }
 
 func (method *ProviderInstallationNetworkMirror) String() string {
-	// Odd that this err isn't checked. There should be an explanation why.
-	b, _ := json.Marshal(method) //nolint:errchkjson
+	b, _ := json.Marshal(method) //nolint:errchkjson // the string fields can't form a cycle, so Marshal can't fail
 	return string(b)
 }

--- a/internal/tf/source.go
+++ b/internal/tf/source.go
@@ -397,28 +397,25 @@ func IsLocalSource(sourceURL *url.URL) bool {
 // rather than the path.
 func SplitSourceURL(l log.Logger, fsys vfs.FS, sourceURL *url.URL) (*url.URL, string, error) {
 	if sourceURL.Opaque != "" {
-		opaqueSplitOnDoubleSlash := strings.SplitN(sourceURL.Opaque, "//", 2) //nolint:mnd // 2: the source and the subdirectory after "//"
-		if len(opaqueSplitOnDoubleSlash) > 1 {
+		if root, subDir, found := strings.Cut(sourceURL.Opaque, "//"); found {
 			rootSourceURL := *sourceURL
-			rootSourceURL.Opaque = opaqueSplitOnDoubleSlash[0]
+			rootSourceURL.Opaque = root
 
-			return &rootSourceURL, opaqueSplitOnDoubleSlash[1], nil
+			return &rootSourceURL, subDir, nil
 		}
 
 		return sourceURL, "", nil
 	}
 
-	pathSplitOnDoubleSlash := strings.SplitN(sourceURL.Path, "//", 2) //nolint:mnd // 2: the path and the subdirectory after "//"
-
-	if len(pathSplitOnDoubleSlash) > 1 {
+	if root, subDir, found := strings.Cut(sourceURL.Path, "//"); found {
 		sourceURLModifiedPath, err := parseSourceURL(sourceURL.String())
 		if err != nil {
 			return nil, "", err
 		}
 
-		sourceURLModifiedPath.Path = pathSplitOnDoubleSlash[0]
+		sourceURLModifiedPath.Path = root
 
-		return sourceURLModifiedPath, pathSplitOnDoubleSlash[1], nil
+		return sourceURLModifiedPath, subDir, nil
 	}
 	// check if path is remote URL
 	if sourceURL.Scheme != "" {

--- a/internal/tf/source.go
+++ b/internal/tf/source.go
@@ -397,7 +397,7 @@ func IsLocalSource(sourceURL *url.URL) bool {
 // rather than the path.
 func SplitSourceURL(l log.Logger, fsys vfs.FS, sourceURL *url.URL) (*url.URL, string, error) {
 	if sourceURL.Opaque != "" {
-		opaqueSplitOnDoubleSlash := strings.SplitN(sourceURL.Opaque, "//", 2) //nolint:mnd
+		opaqueSplitOnDoubleSlash := strings.SplitN(sourceURL.Opaque, "//", 2) //nolint:mnd // 2: the source and the subdirectory after "//"
 		if len(opaqueSplitOnDoubleSlash) > 1 {
 			rootSourceURL := *sourceURL
 			rootSourceURL.Opaque = opaqueSplitOnDoubleSlash[0]
@@ -408,7 +408,7 @@ func SplitSourceURL(l log.Logger, fsys vfs.FS, sourceURL *url.URL) (*url.URL, st
 		return sourceURL, "", nil
 	}
 
-	pathSplitOnDoubleSlash := strings.SplitN(sourceURL.Path, "//", 2) //nolint:mnd
+	pathSplitOnDoubleSlash := strings.SplitN(sourceURL.Path, "//", 2) //nolint:mnd // 2: the path and the subdirectory after "//"
 
 	if len(pathSplitOnDoubleSlash) > 1 {
 		sourceURLModifiedPath, err := parseSourceURL(sourceURL.String())

--- a/internal/tips/stack_nested_generate_test.go
+++ b/internal/tips/stack_nested_generate_test.go
@@ -50,7 +50,7 @@ func emptyStackFuncFactory() inthclparse.StackFuncFactory {
 func writeFile(t *testing.T, fsys vfs.FS, path, content string) {
 	t.Helper()
 
-	require.NoError(t, fsys.MkdirAll(filepath.Dir(path), 0o755)) //nolint:mnd
+	require.NoError(t, fsys.MkdirAll(filepath.Dir(path), 0o755))
 
 	f, err := fsys.Create(path)
 	require.NoError(t, err)

--- a/internal/tips/stack_target_test.go
+++ b/internal/tips/stack_target_test.go
@@ -97,7 +97,7 @@ func TestGiveStackTargetTip(t *testing.T) {
 
 			for _, dir := range tc.stackDirs {
 				abs := filepath.Join(workingDir, dir)
-				require.NoError(t, fs.MkdirAll(abs, 0o755)) //nolint:mnd
+				require.NoError(t, fs.MkdirAll(abs, 0o755))
 				f, err := fs.Create(filepath.Join(abs, config.DefaultStackFile))
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
@@ -105,7 +105,7 @@ func TestGiveStackTargetTip(t *testing.T) {
 
 			for _, dir := range tc.unitDirs {
 				abs := filepath.Join(workingDir, dir)
-				require.NoError(t, fs.MkdirAll(abs, 0o755)) //nolint:mnd
+				require.NoError(t, fs.MkdirAll(abs, 0o755))
 				f, err := fs.Create(filepath.Join(abs, "terragrunt.hcl"))
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
@@ -146,7 +146,7 @@ func TestGiveStackTargetTipFiresOnceAcrossCalls(t *testing.T) {
 	fs := vfs.NewMemMapFS()
 
 	abs := filepath.Join(workingDir, "envs/prod")
-	require.NoError(t, fs.MkdirAll(abs, 0o755)) //nolint:mnd
+	require.NoError(t, fs.MkdirAll(abs, 0o755))
 	f, err := fs.Create(filepath.Join(abs, config.DefaultStackFile))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
@@ -208,7 +208,7 @@ func TestGiveStackTargetTipConcurrentWithRacing(t *testing.T) {
 	fs := vfs.NewMemMapFS()
 
 	abs := filepath.Join(workingDir, "envs/prod")
-	require.NoError(t, fs.MkdirAll(abs, 0o755)) //nolint:mnd
+	require.NoError(t, fs.MkdirAll(abs, 0o755))
 	f, err := fs.Create(filepath.Join(abs, config.DefaultStackFile))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())

--- a/internal/util/datetime.go
+++ b/internal/util/datetime.go
@@ -1,4 +1,3 @@
-//nolint:gocritic
 package util
 
 import (
@@ -10,8 +9,7 @@ import (
 func ParseTimestamp(ts string) (time.Time, error) {
 	t, err := time.Parse(time.RFC3339, ts)
 	if err != nil {
-		// TODO: Remove this lint suppression
-		switch err := err.(type) { //nolint:errorlint
+		switch err := err.(type) { //nolint:errorlint,gocritic // time.Parse returns *time.ParseError directly, and the switch binds it
 		case *time.ParseError:
 			// If err is a time.ParseError then its string representation is not
 			// appropriate since it relies on details of Go's strange date format

--- a/internal/util/reflect.go
+++ b/internal/util/reflect.go
@@ -42,7 +42,7 @@ func MustWalkTerraformOutput(value any, path ...string) any {
 	for _, p := range path {
 		v := reflect.ValueOf(found)
 
-		switch reflect.TypeOf(found).Kind() { //nolint:exhaustive
+		switch reflect.TypeOf(found).Kind() { //nolint:exhaustive // the default branch handles the rest
 		case reflect.Map:
 			if !v.MapIndex(reflect.ValueOf(p)).IsValid() {
 				return nil

--- a/internal/util/reflect.go
+++ b/internal/util/reflect.go
@@ -42,7 +42,7 @@ func MustWalkTerraformOutput(value any, path ...string) any {
 	for _, p := range path {
 		v := reflect.ValueOf(found)
 
-		switch reflect.TypeOf(found).Kind() { //nolint:exhaustive // the default branch handles the rest
+		switch reflect.TypeOf(found).Kind() { //nolint:exhaustive // only the kinds a path can descend into matter; reflect.Kind has 26 members
 		case reflect.Map:
 			if !v.MapIndex(reflect.ValueOf(p)).IsValid() {
 				return nil

--- a/internal/util/shell.go
+++ b/internal/util/shell.go
@@ -66,7 +66,7 @@ type ProcessExecutionError struct {
 	DisableSummary  bool
 }
 
-func (err ProcessExecutionError) Error() string { //nolint:gocritic
+func (err ProcessExecutionError) Error() string { //nolint:gocritic // hugeParam: ProcessExecutionError is used as an error by value, not by pointer
 	commandStr := strings.TrimSpace(
 		strings.Join(append([]string{err.Command}, err.Args...), " "),
 	)
@@ -88,10 +88,10 @@ func (err ProcessExecutionError) Error() string { //nolint:gocritic
 	)
 }
 
-func (err ProcessExecutionError) ExitStatus() (int, error) { //nolint:gocritic
+func (err ProcessExecutionError) ExitStatus() (int, error) { //nolint:gocritic // hugeParam: ProcessExecutionError is used as an error by value, not by pointer
 	return GetExitCode(err.Err)
 }
 
-func (err ProcessExecutionError) Unwrap() error { //nolint:gocritic
+func (err ProcessExecutionError) Unwrap() error { //nolint:gocritic // hugeParam: ProcessExecutionError is used as an error by value, not by pointer
 	return err.Err
 }

--- a/internal/util/shell.go
+++ b/internal/util/shell.go
@@ -66,7 +66,7 @@ type ProcessExecutionError struct {
 	DisableSummary  bool
 }
 
-func (err ProcessExecutionError) Error() string { //nolint:gocritic // hugeParam: ProcessExecutionError is used as an error by value, not by pointer
+func (err *ProcessExecutionError) Error() string {
 	commandStr := strings.TrimSpace(
 		strings.Join(append([]string{err.Command}, err.Args...), " "),
 	)
@@ -88,10 +88,10 @@ func (err ProcessExecutionError) Error() string { //nolint:gocritic // hugeParam
 	)
 }
 
-func (err ProcessExecutionError) ExitStatus() (int, error) { //nolint:gocritic // hugeParam: ProcessExecutionError is used as an error by value, not by pointer
+func (err *ProcessExecutionError) ExitStatus() (int, error) {
 	return GetExitCode(err.Err)
 }
 
-func (err ProcessExecutionError) Unwrap() error { //nolint:gocritic // hugeParam: ProcessExecutionError is used as an error by value, not by pointer
+func (err *ProcessExecutionError) Unwrap() error {
 	return err.Err
 }

--- a/internal/view/diagnostic/severity.go
+++ b/internal/view/diagnostic/severity.go
@@ -16,8 +16,7 @@ const (
 type DiagnosticSeverity hcl.DiagnosticSeverity
 
 func (severity DiagnosticSeverity) String() string {
-	// TODO: Remove lint suppression
-	switch hcl.DiagnosticSeverity(severity) { //nolint:exhaustive
+	switch hcl.DiagnosticSeverity(severity) { //nolint:exhaustive // the default branch handles the rest
 	case hcl.DiagError:
 		return DiagnosticSeverityError
 	case hcl.DiagWarning:

--- a/internal/view/diagnostic/severity.go
+++ b/internal/view/diagnostic/severity.go
@@ -16,11 +16,13 @@ const (
 type DiagnosticSeverity hcl.DiagnosticSeverity
 
 func (severity DiagnosticSeverity) String() string {
-	switch hcl.DiagnosticSeverity(severity) { //nolint:exhaustive // the default branch handles the rest
+	switch hcl.DiagnosticSeverity(severity) {
 	case hcl.DiagError:
 		return DiagnosticSeverityError
 	case hcl.DiagWarning:
 		return DiagnosticSeverityWarning
+	case hcl.DiagInvalid:
+		return DiagnosticSeverityUnknown
 	default:
 		return DiagnosticSeverityUnknown
 	}

--- a/internal/view/human_render.go
+++ b/internal/view/human_render.go
@@ -23,7 +23,6 @@ const (
 	ansiReset = "\x1b[0m"
 )
 
-//nolint:gochecknoglobals
 var (
 	redStyle           = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
 	yellowStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
@@ -112,8 +111,7 @@ func (render *HumanRender) Diagnostic(diag *diagnostic.Diagnostic) (string, erro
 		leftRuleWidth                            int // in visual character cells
 	)
 
-	// TODO: Remove lint suppression
-	switch hcl.DiagnosticSeverity(diag.Severity) { //nolint:exhaustive
+	switch hcl.DiagnosticSeverity(diag.Severity) { //nolint:exhaustive // the default branch handles the rest
 	case hcl.DiagError:
 		buf.WriteString(render.styled(&boldRedStyle, "Error: "))
 		leftRuleLine = render.styled(&redStyle, "│") + " "

--- a/internal/view/human_render.go
+++ b/internal/view/human_render.go
@@ -111,7 +111,7 @@ func (render *HumanRender) Diagnostic(diag *diagnostic.Diagnostic) (string, erro
 		leftRuleWidth                            int // in visual character cells
 	)
 
-	switch hcl.DiagnosticSeverity(diag.Severity) { //nolint:exhaustive // the default branch handles the rest
+	switch hcl.DiagnosticSeverity(diag.Severity) {
 	case hcl.DiagError:
 		buf.WriteString(render.styled(&boldRedStyle, "Error: "))
 		leftRuleLine = render.styled(&redStyle, "│") + " "
@@ -124,6 +124,8 @@ func (render *HumanRender) Diagnostic(diag *diagnostic.Diagnostic) (string, erro
 		leftRuleStart = render.styled(&yellowStyle, "╷")
 		leftRuleEnd = render.styled(&yellowStyle, "╵")
 		leftRuleWidth = 2
+	case hcl.DiagInvalid:
+		fallthrough
 	default:
 		// Clear out any coloring that might be applied by Terraform's UI helper,
 		// so our result is not context-sensitive.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,7 +106,7 @@ var (
 			writer.WithMsgSeparator(logMsgSeparator),
 		)
 
-		parseOpts := make([]hclparse.Option, 0, 3) //nolint:mnd
+		parseOpts := make([]hclparse.Option, 0, 3) //nolint:mnd // capacity hint for the options appended below
 		parseOpts = append(parseOpts,
 			hclparse.WithDiagnosticsWriter(v, writer, l.Formatter().DisabledColors()),
 			hclparse.WithLogger(l),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1811,7 +1811,7 @@ func DetectDeprecatedConfigurations(
 	if DetectInputsCtyUsage(file) {
 		// Dependency inputs (dependency.foo.inputs.bar) are now blocked by default for performance.
 		// This deprecated feature causes significant performance overhead due to recursive parsing.
-		return errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
+		return errors.New(
 			"Reading inputs from dependencies is no longer supported. To acquire values from dependencies, use outputs (dependency.foo.outputs.bar) instead.",
 		)
 	}

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -1720,12 +1720,15 @@ func parseMarkGlobBoundary(pctx *ParsingContext, args []string) (string, []strin
 
 	switch {
 	case args[0] == markGlobBoundaryFlag:
-		if len(args) < 2 { //nolint:mnd // the flag and the value it takes
+		// lenFlagWithValue counts the flag and the directory it takes.
+		const lenFlagWithValue = 2
+
+		if len(args) < lenFlagWithValue {
 			return "", nil, fmt.Errorf("%s requires a directory value", markGlobBoundaryFlag)
 		}
 
 		raw = args[1]
-		args = slices.Delete(args, 0, 2) //nolint:mnd // drops the flag and its value
+		args = slices.Delete(args, 0, lenFlagWithValue)
 	case strings.HasPrefix(args[0], markGlobBoundaryFlag+"="):
 		raw = strings.TrimPrefix(args[0], markGlobBoundaryFlag+"=")
 		args = slices.Delete(args, 0, 1)

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -1320,11 +1320,12 @@ func sopsDecryptFile(
 
 	pctx.FilesRead.Add(path)
 
-	return sopsDecryptFileImpl(ctx, pctx, l, path, format, pctx.Venv.Sops)
+	return SopsDecryptFileWithDecrypter(ctx, pctx, l, path, format, pctx.Venv.Sops)
 }
 
-// sopsDecryptFileImpl contains the actual implementation of sopsDecryptFile
-func sopsDecryptFileImpl(
+// SopsDecryptFileWithDecrypter decrypts the SOPS-encrypted file at `path` with `d`,
+// caching the plaintext for the rest of the run.
+func SopsDecryptFileWithDecrypter(
 	ctx context.Context,
 	pctx *ParsingContext,
 	l log.Logger,

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -1448,8 +1448,6 @@ func getSelectedIncludeBlock(trackInclude TrackInclude, params []string) (*Inclu
 }
 
 // StartsWith Implementation of Terraform's StartsWith function
-//
-//nolint:dupl
 func StartsWith(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
 	if len(args) != stringCompParams {
 		return false, WrongNumberOfParamsError{
@@ -1463,8 +1461,6 @@ func StartsWith(ctx context.Context, pctx *ParsingContext, args []string) (bool,
 }
 
 // EndsWith Implementation of Terraform's EndsWith function
-//
-//nolint:dupl
 func EndsWith(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
 	if len(args) != stringCompParams {
 		return false, WrongNumberOfParamsError{
@@ -1510,8 +1506,6 @@ func TimeCmp(
 }
 
 // StrContains Implementation of Terraform's StrContains function
-//
-//nolint:dupl
 func StrContains(ctx context.Context, pctx *ParsingContext, args []string) (bool, error) {
 	if len(args) != stringCompParams {
 		return false, WrongNumberOfParamsError{
@@ -1726,12 +1720,12 @@ func parseMarkGlobBoundary(pctx *ParsingContext, args []string) (string, []strin
 
 	switch {
 	case args[0] == markGlobBoundaryFlag:
-		if len(args) < 2 { //nolint:mnd
+		if len(args) < 2 { //nolint:mnd // the flag and the value it takes
 			return "", nil, fmt.Errorf("%s requires a directory value", markGlobBoundaryFlag)
 		}
 
 		raw = args[1]
-		args = slices.Delete(args, 0, 2) //nolint:mnd
+		args = slices.Delete(args, 0, 2) //nolint:mnd // drops the flag and its value
 	case strings.HasPrefix(args[0], markGlobBoundaryFlag+"="):
 		raw = strings.TrimPrefix(args[0], markGlobBoundaryFlag+"=")
 		args = slices.Delete(args, 0, 1)

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -340,7 +340,7 @@ func mergeFeatureFlagConfig(
 			return nil, err
 		}
 	case DeepMergeMapOnly:
-		return nil, InvalidMergeStrategyTypeError(mergeStrategy)
+		return nil, IncludeMergeStrategyNotSupportedError(mergeStrategy)
 	default:
 		return nil, fmt.Errorf(
 			"you reached an impossible condition. "+

--- a/pkg/config/config_partial_test.go
+++ b/pkg/config/config_partial_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -1353,6 +1354,38 @@ terraform {
 		&srcErr,
 		"an unrelated source decode error must not be rebranded as a dependency reference error",
 	)
+}
+
+// TestPartialParseIncludeRejectsDeepMapOnly pins that deep_map_only, which applies to
+// dependency mock outputs rather than includes, is reported as unsupported.
+func TestPartialParseIncludeRejectsDeepMapOnly(t *testing.T) {
+	t.Parallel()
+
+	v, tmpDir := newMemTestDir(t)
+
+	require.NoError(t, vfs.WriteFile(v.FS, filepath.Join(tmpDir, "root.hcl"), []byte(`
+feature "skip_ci" {
+  default = true
+}
+`), 0644))
+
+	childPath := filepath.Join(tmpDir, "child", config.DefaultTerragruntConfigPath)
+	require.NoError(t, vfs.WriteFile(v.FS, childPath, []byte(`
+include "root" {
+  path           = "../root.hcl"
+  merge_strategy = "deep_map_only"
+}
+`), 0644))
+
+	l := logger.CreateLogger()
+	ctx, pctx := newTestParsingContext(t, v, childPath)
+	pctx = pctx.WithDecodeList(config.FeatureFlagsBlock, config.ExcludeBlock)
+
+	_, err := config.PartialParseConfigFile(ctx, pctx, l, childPath, nil)
+
+	var strategyErr config.IncludeMergeStrategyNotSupportedError
+
+	require.ErrorAs(t, err, &strategyErr)
 }
 
 // TestPartialParseFeatureFlagDefaultsFromIncludes verifies included feature defaults are available during partial parsing.

--- a/pkg/config/cty_helpers.go
+++ b/pkg/config/cty_helpers.go
@@ -1,4 +1,4 @@
-//nolint:dupl
+//nolint:dupl // the wrapStringSliceTo* helpers differ only in the cty type they return
 package config
 
 import (

--- a/pkg/config/cty_helpers_internal_test.go
+++ b/pkg/config/cty_helpers_internal_test.go
@@ -1,4 +1,4 @@
-package config //nolint:testpackage // needs access to unexported includeConfigAsCtyVal / includeBlockLabel
+package config // needs access to unexported includeConfigAsCtyVal / includeBlockLabel
 
 import (
 	"os"

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1000,7 +1000,7 @@ func getTerragruntOutputIfAppliedElseConfiguredDefault(
 			dependencyConfig.MockOutputs != nil {
 			mockMergeStrategy := dependencyConfig.getMockOutputsMergeStrategy()
 
-			switch mockMergeStrategy { // nolint:exhaustive
+			switch mockMergeStrategy { //nolint:exhaustive // the default branch handles the rest
 			case NoMerge:
 				return outputVal, nil
 			case ShallowMerge:

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1000,13 +1000,16 @@ func getTerragruntOutputIfAppliedElseConfiguredDefault(
 			dependencyConfig.MockOutputs != nil {
 			mockMergeStrategy := dependencyConfig.getMockOutputsMergeStrategy()
 
-			switch mockMergeStrategy { //nolint:exhaustive // the default branch handles the rest
+			switch mockMergeStrategy {
 			case NoMerge:
 				return outputVal, nil
 			case ShallowMerge:
 				return shallowMergeCtyMaps(*outputVal, *dependencyConfig.MockOutputs)
 			case DeepMergeMapOnly:
 				return deepMergeCtyMapsMapOnly(*dependencyConfig.MockOutputs, *outputVal)
+			case DeepMerge:
+				// Mock outputs merge maps only, so a full deep merge has no meaning here.
+				return nil, InvalidMergeStrategyTypeError(mockMergeStrategy)
 			default:
 				return nil, InvalidMergeStrategyTypeError(mockMergeStrategy)
 			}

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -73,6 +73,20 @@ func (err InvalidMergeStrategyTypeError) Error() string {
 	)
 }
 
+// IncludeMergeStrategyNotSupportedError reports a merge strategy that parses but
+// applies only to dependency mock outputs, so an include block cannot use it.
+type IncludeMergeStrategyNotSupportedError string
+
+func (err IncludeMergeStrategyNotSupportedError) Error() string {
+	return fmt.Sprintf(
+		"Include merge strategy %s is not supported for include blocks. Valid strategies are: %s, %s, %s",
+		string(err),
+		NoMerge,
+		ShallowMerge,
+		DeepMerge,
+	)
+}
+
 type DependencyDirNotFoundError struct {
 	Dir []string
 }

--- a/pkg/config/hclparse/attributes.go
+++ b/pkg/config/hclparse/attributes.go
@@ -24,7 +24,7 @@ func NewAttributes(file *File, hclAttrs hcl.Attributes) Attributes {
 func (attrs Attributes) ValidateIdentifier() error {
 	for _, attr := range attrs {
 		if err := attr.ValidateIdentifier(); err != nil {
-			return nil //nolint:nilerr // TODO: work out whether this should return the error
+			return err
 		}
 	}
 

--- a/pkg/config/hclparse/attributes.go
+++ b/pkg/config/hclparse/attributes.go
@@ -24,8 +24,7 @@ func NewAttributes(file *File, hclAttrs hcl.Attributes) Attributes {
 func (attrs Attributes) ValidateIdentifier() error {
 	for _, attr := range attrs {
 		if err := attr.ValidateIdentifier(); err != nil {
-			// TODO: Remove lint suppression
-			return nil //nolint:nilerr
+			return nil //nolint:nilerr // TODO: work out whether this should return the error
 		}
 	}
 

--- a/pkg/config/hclparse/file_test.go
+++ b/pkg/config/hclparse/file_test.go
@@ -28,6 +28,28 @@ type fooOnly struct {
 	Foo string `hcl:"foo"`
 }
 
+// jsonWithInvalidIdentifier parses cleanly: JSON keys are arbitrary strings, so a
+// name that HCL's own syntax would reject only surfaces when the attributes are read.
+const jsonWithInvalidIdentifier = `{"foo bar": "baz"}`
+
+// TestJustAttributesRejectsInvalidIdentifier pins that a JSON attribute name that
+// isn't a valid HCL identifier fails the read rather than being read as valid.
+func TestJustAttributesRejectsInvalidIdentifier(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	parser := hclparse.NewParser(hclparse.WithDiagnosticsWriter(venvtest.New(), &buf, true))
+
+	file, err := parser.ParseFromString(jsonWithInvalidIdentifier, "/virtual/test.hcl.json")
+	require.NoError(t, err)
+
+	attrs, err := file.JustAttributes()
+
+	require.Error(t, err, "an attribute name that is not a valid identifier must fail the read")
+	assert.Nil(t, attrs)
+}
+
 // TestRebindRoutesDiagnosticsThroughNewWriter checks that Decode-time diagnostics
 // flow through the rebound parser's writer rather than the parser the file was
 // originally parsed with.

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -163,7 +163,7 @@ func handleInclude(
 			return baseConfig, err
 		}
 
-		switch mergeStrategy { //nolint:exhaustive // the default branch handles the rest
+		switch mergeStrategy {
 		case NoMerge:
 			l.Debugf(
 				"%sIncluded config %s has strategy no merge: not merging config in.",
@@ -194,6 +194,8 @@ func handleInclude(
 			}
 
 			baseConfig = parsedIncludeConfig
+		case DeepMergeMapOnly:
+			return nil, InvalidMergeStrategyTypeError(mergeStrategy)
 		default:
 			return nil, fmt.Errorf(
 				"you reached an impossible condition. This is most likely a bug in terragrunt. Please open an issue at github.com/gruntwork-io/terragrunt with this error message. Code: UNKNOWN_MERGE_STRATEGY_%s",
@@ -241,7 +243,7 @@ func handleIncludeForDependency(
 			return nil, err
 		}
 
-		switch mergeStrategy { //nolint:exhaustive // the default branch handles the rest
+		switch mergeStrategy {
 		case NoMerge:
 			l.Debugf(
 				"Included config %s has strategy no merge: not merging config in for dependency.",
@@ -285,6 +287,8 @@ func handleIncludeForDependency(
 			}
 
 			baseDependencyBlock = mergedDependencyBlock
+		case DeepMergeMapOnly:
+			return nil, InvalidMergeStrategyTypeError(mergeStrategy)
 		default:
 			return nil, fmt.Errorf(
 				"you reached an impossible condition. This is most likely a bug in terragrunt. "+

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -195,7 +195,7 @@ func handleInclude(
 
 			baseConfig = parsedIncludeConfig
 		case DeepMergeMapOnly:
-			return nil, InvalidMergeStrategyTypeError(mergeStrategy)
+			return nil, IncludeMergeStrategyNotSupportedError(mergeStrategy)
 		default:
 			return nil, fmt.Errorf(
 				"you reached an impossible condition. This is most likely a bug in terragrunt. Please open an issue at github.com/gruntwork-io/terragrunt with this error message. Code: UNKNOWN_MERGE_STRATEGY_%s",
@@ -288,7 +288,7 @@ func handleIncludeForDependency(
 
 			baseDependencyBlock = mergedDependencyBlock
 		case DeepMergeMapOnly:
-			return nil, InvalidMergeStrategyTypeError(mergeStrategy)
+			return nil, IncludeMergeStrategyNotSupportedError(mergeStrategy)
 		default:
 			return nil, fmt.Errorf(
 				"you reached an impossible condition. This is most likely a bug in terragrunt. "+

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -163,8 +163,7 @@ func handleInclude(
 			return baseConfig, err
 		}
 
-		// TODO: Remove lint suppression
-		switch mergeStrategy { //nolint:exhaustive
+		switch mergeStrategy { //nolint:exhaustive // the default branch handles the rest
 		case NoMerge:
 			l.Debugf(
 				"%sIncluded config %s has strategy no merge: not merging config in.",
@@ -242,8 +241,7 @@ func handleIncludeForDependency(
 			return nil, err
 		}
 
-		// TODO: Remove lint suppression
-		switch mergeStrategy { //nolint:exhaustive
+		switch mergeStrategy { //nolint:exhaustive // the default branch handles the rest
 		case NoMerge:
 			l.Debugf(
 				"Included config %s has strategy no merge: not merging config in for dependency.",

--- a/pkg/config/sops_race_test.go
+++ b/pkg/config/sops_race_test.go
@@ -1,4 +1,4 @@
-package config //nolint:testpackage // needs access to sopsDecryptFileImpl
+package config_test
 
 import (
 	"fmt"
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/internal/vsops"
@@ -64,7 +66,7 @@ func TestSOPSDecryptConcurrencyWithRacing(t *testing.T) {
 		barrier = make(chan struct{})
 	)
 
-	ctx := WithConfigValues(t.Context())
+	ctx := config.WithConfigValues(t.Context())
 
 	for i, f := range files {
 		wg.Add(1)
@@ -79,10 +81,10 @@ func TestSOPSDecryptConcurrencyWithRacing(t *testing.T) {
 			l := logger.CreateLogger()
 			v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: token})
 
-			_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
+			_, pctx := config.NewParsingContext(ctx, l, v, config.WithStrictControls(controls.New()))
 			pctx.WorkingDir = filepath.Dir(filePath)
 
-			result, err := sopsDecryptFileImpl(ctx, pctx, l, filePath, "json", mockDecrypter)
+			result, err := config.SopsDecryptFileWithDecrypter(ctx, pctx, l, filePath, "json", mockDecrypter)
 			assert.NoError(t, err)
 			assert.Contains(t, result, `"value":"secret-from-unit-`)
 			assert.Contains(t, result, token)
@@ -127,7 +129,7 @@ func TestSOPSDecryptDistinctPathsOverlapWithRacing(t *testing.T) {
 			return os.ReadFile(path)
 		})
 
-	ctx := WithConfigValues(t.Context())
+	ctx := config.WithConfigValues(t.Context())
 
 	var wg sync.WaitGroup
 
@@ -136,10 +138,10 @@ func TestSOPSDecryptDistinctPathsOverlapWithRacing(t *testing.T) {
 			l := logger.CreateLogger()
 			v := venvtest.NewWithOSFS().WithEnv(map[string]string{})
 
-			_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
+			_, pctx := config.NewParsingContext(ctx, l, v, config.WithStrictControls(controls.New()))
 			pctx.WorkingDir = dir
 
-			result, err := sopsDecryptFileImpl(ctx, pctx, l, f, "json", blockingDecrypter)
+			result, err := config.SopsDecryptFileWithDecrypter(ctx, pctx, l, f, "json", blockingDecrypter)
 			require.NoError(t, err)
 			assert.Contains(t, result, `"value":"secret"`)
 		})
@@ -185,7 +187,7 @@ func TestSOPSDecryptDeduplicatesSamePathWithRacing(t *testing.T) {
 		barrier = make(chan struct{})
 	)
 
-	ctx := WithConfigValues(t.Context())
+	ctx := config.WithConfigValues(t.Context())
 
 	for range numGoroutines {
 		wg.Go(func() {
@@ -194,10 +196,10 @@ func TestSOPSDecryptDeduplicatesSamePathWithRacing(t *testing.T) {
 			l := logger.CreateLogger()
 			v := venvtest.NewWithOSFS().WithEnv(map[string]string{})
 
-			_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
+			_, pctx := config.NewParsingContext(ctx, l, v, config.WithStrictControls(controls.New()))
 			pctx.WorkingDir = dir
 
-			result, err := sopsDecryptFileImpl(ctx, pctx, l, secretFile, "json", countingDecrypter)
+			result, err := config.SopsDecryptFileWithDecrypter(ctx, pctx, l, secretFile, "json", countingDecrypter)
 			require.NoError(t, err)
 			assert.Contains(t, result, `"value":"shared"`)
 		})

--- a/pkg/config/sops_test.go
+++ b/pkg/config/sops_test.go
@@ -99,7 +99,7 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) {
 
 // TestSOPSDecryptLeavesProcessEnvAlone pins that a credential the run was
 // started with outlives a decrypt that carried its own value for the same name.
-func TestSOPSDecryptLeavesProcessEnvAlone(t *testing.T) { //nolint:paralleltest // t.Setenv
+func TestSOPSDecryptLeavesProcessEnvAlone(t *testing.T) { // t.Setenv bars t.Parallel
 	const authKey = "SOPS_TEST_UNTOUCHED_CRED"
 
 	t.Setenv(authKey, "real-ci-token")

--- a/pkg/config/sops_test.go
+++ b/pkg/config/sops_test.go
@@ -1,6 +1,6 @@
 //go:build sops
 
-package config //nolint:testpackage // needs access to sopsDecryptFileImpl
+package config_test
 
 import (
 	"errors"
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/internal/vsops"
@@ -70,13 +72,13 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) {
 		t.Parallel()
 
 		l := logger.CreateLogger()
-		ctx := WithConfigValues(t.Context())
+		ctx := config.WithConfigValues(t.Context())
 		v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: "fresh-token"})
 
-		_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
+		_, pctx := config.NewParsingContext(ctx, l, v, config.WithStrictControls(controls.New()))
 		pctx.WorkingDir = filepath.Dir(secretFile)
 
-		result, err := sopsDecryptFileImpl(ctx, pctx, l, secretFile, "json", authRequiringDecrypter)
+		result, err := config.SopsDecryptFileWithDecrypter(ctx, pctx, l, secretFile, "json", authRequiringDecrypter)
 		require.NoError(t, err, "decrypt must succeed with credentials from the venv")
 		assert.Contains(t, result, `"value":"secret-from-unit-01"`)
 	})
@@ -85,13 +87,13 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) {
 		t.Parallel()
 
 		l := logger.CreateLogger()
-		ctx := WithConfigValues(t.Context())
+		ctx := config.WithConfigValues(t.Context())
 		v := venvtest.NewWithOSFS().WithEnv(map[string]string{})
 
-		_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
+		_, pctx := config.NewParsingContext(ctx, l, v, config.WithStrictControls(controls.New()))
 		pctx.WorkingDir = filepath.Dir(secretFile)
 
-		_, err := sopsDecryptFileImpl(ctx, pctx, l, secretFile, "json", authRequiringDecrypter)
+		_, err := config.SopsDecryptFileWithDecrypter(ctx, pctx, l, secretFile, "json", authRequiringDecrypter)
 		require.Error(t, err,
 			"decrypt must fail without auth credentials, reproducing original issue #5515")
 	})
@@ -111,13 +113,13 @@ func TestSOPSDecryptLeavesProcessEnvAlone(t *testing.T) { // t.Setenv bars t.Par
 	})
 
 	l := logger.CreateLogger()
-	ctx := WithConfigValues(t.Context())
+	ctx := config.WithConfigValues(t.Context())
 	v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: "venv-token"})
 
-	_, pctx := NewParsingContext(ctx, l, v, WithStrictControls(controls.New()))
+	_, pctx := config.NewParsingContext(ctx, l, v, config.WithStrictControls(controls.New()))
 	pctx.WorkingDir = filepath.Dir(secretFile)
 
-	_, err := sopsDecryptFileImpl(ctx, pctx, l, secretFile, "json", d)
+	_, err := config.SopsDecryptFileWithDecrypter(ctx, pctx, l, secretFile, "json", d)
 	require.NoError(t, err)
 
 	assert.Equal(t, "real-ci-token", os.Getenv(authKey))

--- a/pkg/log/format/format.go
+++ b/pkg/log/format/format.go
@@ -18,10 +18,17 @@ const (
 	KeyValueFormatName = "key-value"
 )
 
+const (
+	// bareLevelWidth is the width of the level column in the bare format.
+	bareLevelWidth = 4
+	// prettyLevelWidth is the width of the level column in the pretty format.
+	prettyLevelWidth = 6
+)
+
 func NewBareFormatPlaceholders() Placeholders {
 	return Placeholders{
 		Level(
-			Width(4), //nolint:mnd // the bare format pads the level to four characters
+			Width(bareLevelWidth),
 			Case(UpperCase),
 		),
 		Interval(
@@ -46,7 +53,7 @@ func NewPrettyFormatPlaceholders() Placeholders {
 		),
 		PlainText(" "),
 		Level(
-			Width(6), //nolint:mnd // the level column is six characters wide
+			Width(prettyLevelWidth),
 			Case(UpperCase),
 			Color(PresetColor),
 		),

--- a/pkg/log/format/format.go
+++ b/pkg/log/format/format.go
@@ -7,8 +7,8 @@ import (
 	"slices"
 	"strings"
 
-	. "github.com/gruntwork-io/terragrunt/pkg/log/format/options"      //nolint:revive
-	. "github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders" //nolint:revive
+	. "github.com/gruntwork-io/terragrunt/pkg/log/format/options"
+	. "github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
 )
 
 const (
@@ -21,7 +21,7 @@ const (
 func NewBareFormatPlaceholders() Placeholders {
 	return Placeholders{
 		Level(
-			Width(4), //nolint:mnd
+			Width(4), //nolint:mnd // the bare format pads the level to four characters
 			Case(UpperCase),
 		),
 		Interval(
@@ -46,7 +46,7 @@ func NewPrettyFormatPlaceholders() Placeholders {
 		),
 		PlainText(" "),
 		Level(
-			Width(6), //nolint:mnd
+			Width(6), //nolint:mnd // the level column is six characters wide
 			Case(UpperCase),
 			Color(PresetColor),
 		),

--- a/pkg/log/format/options/align.go
+++ b/pkg/log/format/options/align.go
@@ -14,7 +14,7 @@ const (
 	RightAlign
 )
 
-var alignList = NewMapValue(map[AlignValue]string{ //nolint:gochecknoglobals
+var alignList = NewMapValue(map[AlignValue]string{
 	LeftAlign:   "left",
 	CenterAlign: "center",
 	RightAlign:  "right",

--- a/pkg/log/format/options/case.go
+++ b/pkg/log/format/options/case.go
@@ -17,7 +17,7 @@ const (
 	CapitalizeCase
 )
 
-var caseList = NewMapValue(map[CaseValue]string{ //nolint:gochecknoglobals
+var caseList = NewMapValue(map[CaseValue]string{
 	UpperCase:      "upper",
 	LowerCase:      "lower",
 	CapitalizeCase: "capitalize",

--- a/pkg/log/format/options/color.go
+++ b/pkg/log/format/options/color.go
@@ -44,7 +44,7 @@ const (
 )
 
 var (
-	colorList = NewColorList(map[ColorValue]string{ //nolint:gochecknoglobals
+	colorList = NewColorList(map[ColorValue]string{
 		PresetColor:   "preset",
 		GradientColor: "gradient",
 		DisableColor:  "disable",
@@ -68,7 +68,7 @@ var (
 		LightWhiteColor:   "light-white",
 	})
 
-	colorScheme = ColorScheme{ //nolint:gochecknoglobals
+	colorScheme = ColorScheme{
 		BlackColor:        "black",
 		RedColor:          "red",
 		WhiteColor:        "white",
@@ -157,7 +157,7 @@ const (
 
 // ansiBaseColors maps the historical color names accepted by this package to
 // their corresponding ANSI palette index.
-var ansiBaseColors = map[string]int{ //nolint:gochecknoglobals
+var ansiBaseColors = map[string]int{
 	"black":   ansiBlack,
 	"red":     ansiRed,
 	"green":   ansiGreen,
@@ -321,7 +321,7 @@ var (
 	// sequentially to each unique text in a rotating order
 	// https://user-images.githubusercontent.com/995050/47952855-ecb12480-df75-11e8-89d4-ac26c50e80b9.png
 	// https://www.hackitu.de/termcolor256/
-	defaultAutoColorValues = []ColorValue{ //nolint:gochecknoglobals
+	defaultAutoColorValues = []ColorValue{
 		66,
 		67,
 		95,

--- a/pkg/log/format/options/escape.go
+++ b/pkg/log/format/options/escape.go
@@ -12,7 +12,7 @@ const (
 	JSONEscape
 )
 
-var escapeList = NewMapValue(map[EscapeValue]string{ //nolint:gochecknoglobals
+var escapeList = NewMapValue(map[EscapeValue]string{
 	JSONEscape: "json",
 })
 

--- a/pkg/log/format/options/level_format.go
+++ b/pkg/log/format/options/level_format.go
@@ -9,7 +9,7 @@ const (
 	LevelFormatTiny
 )
 
-var levelFormatList = NewMapValue(map[LevelFormatValue]string{ //nolint:gochecknoglobals
+var levelFormatList = NewMapValue(map[LevelFormatValue]string{
 	LevelFormatTiny:  "tiny",
 	LevelFormatShort: "short",
 	LevelFormatFull:  "full",

--- a/pkg/log/format/options/path_format.go
+++ b/pkg/log/format/options/path_format.go
@@ -22,7 +22,7 @@ const (
 	DirectoryPath
 )
 
-var pathFormatList = NewMapValue(map[PathFormatValue]string{ //nolint:gochecknoglobals
+var pathFormatList = NewMapValue(map[PathFormatValue]string{
 	RelativePath:      "relative",
 	ShortRelativePath: "short-relative",
 	ShortPath:         "short",

--- a/pkg/log/format/options/time_format.go
+++ b/pkg/log/format/options/time_format.go
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	timeFormatList = NewTimeFormatValue(map[string]string{ //nolint:gochecknoglobals
+	timeFormatList = NewTimeFormatValue(map[string]string{
 		YearFull:       "2006",
 		Year:           "06",
 		MonthNumZero:   "01",

--- a/pkg/log/format/placeholders/placeholder.go
+++ b/pkg/log/format/placeholders/placeholder.go
@@ -91,7 +91,7 @@ func (phs Placeholders) Format(data *options.Data) (string, error) {
 //
 // e.g. "level(color=green, case=upper) some-text" returns the instance of the `level` placeholder
 // and "(color=green, case=upper) some-text" string.
-func (phs Placeholders) findPlaceholder(str string) (Placeholder, string) { //nolint:ireturn
+func (phs Placeholders) findPlaceholder(str string) (Placeholder, string) {
 	var (
 		placeholder Placeholder
 		optIndex    int
@@ -159,7 +159,7 @@ func Parse(str string) (Placeholders, error) {
 	}
 }
 
-func findPlaintextPlaceholder(str string) (Placeholder, string) { //nolint:ireturn
+func findPlaintextPlaceholder(str string) (Placeholder, string) {
 	if len(str) == 0 {
 		return nil, str
 	}

--- a/test/helpers/aws.go
+++ b/test/helpers/aws.go
@@ -12,6 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// deleteS3BucketBackoff is how long DeleteS3BucketWithRetry waits between attempts, giving
+// S3 time to settle after an eventually consistent read.
+const deleteS3BucketBackoff = 10 * time.Second
+
 // DeleteS3BucketWithRetry will attempt to delete the specified S3 bucket, retrying up to 3 times if there are errors to
 // handle eventual consistency issues.
 func DeleteS3BucketWithRetry(t *testing.T, awsRegion string, bucketName string) {
@@ -23,8 +27,12 @@ func DeleteS3BucketWithRetry(t *testing.T, awsRegion string, bucketName string) 
 			return
 		}
 
-		t.Logf("Error deleting s3 bucket %s. Sleeping for 10 seconds before retrying.", bucketName)
-		time.Sleep(10 * time.Second) //nolint:mnd // back off ten seconds between delete attempts
+		t.Logf(
+			"Error deleting s3 bucket %s. Sleeping for %s before retrying.",
+			bucketName,
+			deleteS3BucketBackoff,
+		)
+		time.Sleep(deleteS3BucketBackoff)
 	}
 
 	t.Fatalf("Max retries attempting to delete s3 bucket %s in region %s", bucketName, awsRegion)

--- a/test/helpers/aws.go
+++ b/test/helpers/aws.go
@@ -24,7 +24,7 @@ func DeleteS3BucketWithRetry(t *testing.T, awsRegion string, bucketName string) 
 		}
 
 		t.Logf("Error deleting s3 bucket %s. Sleeping for 10 seconds before retrying.", bucketName)
-		time.Sleep(10 * time.Second) //nolint:mnd
+		time.Sleep(10 * time.Second) //nolint:mnd // back off ten seconds between delete attempts
 	}
 
 	t.Fatalf("Max retries attempting to delete s3 bucket %s in region %s", bucketName, awsRegion)

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -473,7 +473,7 @@ func RunValidateAllWithIncludeAndGetIncludedModules(
 ) []string {
 	t.Helper()
 
-	cmdParts := make([]string, 0, 9+2*len(includeModulePaths)) //nolint:mnd
+	cmdParts := make([]string, 0, 9+2*len(includeModulePaths)) //nolint:mnd // capacity hint: the fixed args plus two per module path
 	cmdParts = append(cmdParts,
 		"terragrunt", "run", "--all", "validate",
 		"--non-interactive",
@@ -524,7 +524,7 @@ func RunValidateAllWithFilteredPlusDependenciesAndGetIncludedModules(
 ) []string {
 	t.Helper()
 
-	cmdParts := make([]string, 0, 9+2*len(units)) //nolint:mnd
+	cmdParts := make([]string, 0, 9+2*len(units)) //nolint:mnd // capacity hint: the fixed args plus two per unit
 	cmdParts = append(cmdParts,
 		"terragrunt", "run", "--all", "validate",
 		"--non-interactive",
@@ -749,9 +749,7 @@ func (provider *FakeProvider) createZipArchive(t *testing.T, providerDir string)
 		require.NoError(t, os.Remove(filepath.Join(providerDir, provider.filename())))
 	}()
 
-	// I wouldn't ignore this lint, but I actually don't know what
-	// the number is there for.
-	err = file.Truncate(1e7) //nolint:mnd
+	err = file.Truncate(1e7) //nolint:mnd // TODO: work out what this size is for
 	require.NoError(t, err)
 
 	err = file.Sync()
@@ -821,7 +819,7 @@ func certSetup(t *testing.T) (*tls.Config, *tls.Config) {
 			PostalCode:    []string{"94016"},
 		},
 		NotBefore: time.Now(),
-		NotAfter:  time.Now().AddDate(10, 0, 0), //nolint:mnd
+		NotAfter:  time.Now().AddDate(10, 0, 0), //nolint:mnd // the test CA is valid for ten years
 		IsCA:      true,
 		ExtKeyUsage: []x509.ExtKeyUsage{
 			x509.ExtKeyUsageClientAuth,
@@ -863,9 +861,9 @@ func certSetup(t *testing.T) (*tls.Config, *tls.Config) {
 			StreetAddress: []string{"Golden Gate Bridge"},
 			PostalCode:    []string{"94016"},
 		},
-		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}, //nolint:mnd
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}, //nolint:mnd // the loopback address
 		NotBefore:    time.Now(),
-		NotAfter:     time.Now().AddDate(10, 0, 0), //nolint:mnd
+		NotAfter:     time.Now().AddDate(10, 0, 0), //nolint:mnd // the test cert is valid for ten years
 		SubjectKeyId: []byte{1, 2, 3, 4, 6},
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -84,6 +84,9 @@ const (
 
 	caKeyBits = 4096
 
+	// certValidityYears is how long the test CA and its leaf certificate stay valid.
+	certValidityYears = 10
+
 	semverPartsLen = 3
 
 	// cleanupTimeout caps the runtime of a cleanup helper invoked
@@ -819,7 +822,7 @@ func certSetup(t *testing.T) (*tls.Config, *tls.Config) {
 			PostalCode:    []string{"94016"},
 		},
 		NotBefore: time.Now(),
-		NotAfter:  time.Now().AddDate(10, 0, 0), //nolint:mnd // the test CA is valid for ten years
+		NotAfter:  time.Now().AddDate(certValidityYears, 0, 0),
 		IsCA:      true,
 		ExtKeyUsage: []x509.ExtKeyUsage{
 			x509.ExtKeyUsageClientAuth,
@@ -861,9 +864,9 @@ func certSetup(t *testing.T) (*tls.Config, *tls.Config) {
 			StreetAddress: []string{"Golden Gate Bridge"},
 			PostalCode:    []string{"94016"},
 		},
-		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}, //nolint:mnd // the loopback address
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback},
 		NotBefore:    time.Now(),
-		NotAfter:     time.Now().AddDate(10, 0, 0), //nolint:mnd // the test cert is valid for ten years
+		NotAfter:     time.Now().AddDate(certValidityYears, 0, 0),
 		SubjectKeyId: []byte{1, 2, 3, 4, 6},
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -84,6 +84,9 @@ const (
 
 	caKeyBits = 4096
 
+	// fakeProviderBinarySize is the size of the dummy binary FakeProvider packs into its archive.
+	fakeProviderBinarySize = 1e7
+
 	// certValidityYears is how long the test CA and its leaf certificate stay valid.
 	certValidityYears = 10
 
@@ -752,7 +755,7 @@ func (provider *FakeProvider) createZipArchive(t *testing.T, providerDir string)
 		require.NoError(t, os.Remove(filepath.Join(providerDir, provider.filename())))
 	}()
 
-	err = file.Truncate(1e7) //nolint:mnd // TODO: work out what this size is for
+	err = file.Truncate(fakeProviderBinarySize)
 	require.NoError(t, err)
 
 	err = file.Sync()

--- a/test/helpers/test_helpers.go
+++ b/test/helpers/test_helpers.go
@@ -290,7 +290,7 @@ func (tl *testLogger) Write(p []byte) (n int, err error) {
 		}
 	}
 
-	//nolint:nilerr
+	//nolint:nilerr // a partial line left in the buffer isn't a write failure
 	return n, nil
 }
 

--- a/test/integration_aws_oidc_test.go
+++ b/test/integration_aws_oidc_test.go
@@ -268,8 +268,8 @@ func TestAwsReadTerragruntAuthProviderCmdWithOIDCChainedAssumeRole(t *testing.T)
 	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
 
 	defer func() {
-		os.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)         //nolint: usetesting
-		os.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey) //nolint: usetesting
+		os.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)         //nolint:usetesting // the bucket cleanup below needs the real creds back before t.Cleanup runs
+		os.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey) //nolint:usetesting // as above
 
 		helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
 	}()

--- a/test/integration_aws_test.go
+++ b/test/integration_aws_test.go
@@ -1597,7 +1597,7 @@ func TestAwsOutputAllCommandSpecificVariableIgnoreDependencyErrors(t *testing.T)
 	assert.Contains(t, stdout, "app2 output")
 }
 
-func TestAwsStackCommands(t *testing.T) { //nolint paralleltest
+func TestAwsStackCommands(t *testing.T) { //nolint:paralleltest // parallel runs trip a CircleCI bucket-policy error
 	// It seems that disabling parallel test execution helps avoid the CircleCi error: "NoSuchBucket Policy: The bucket policy does not exist."
 	// t.Parallel()
 	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
@@ -2445,7 +2445,7 @@ func TestAwsRemoteStateCodegenGeneratesBackendBlockS3(t *testing.T) {
 	)
 }
 
-func TestAwsOutputFromRemoteState(t *testing.T) { //nolint: paralleltest
+func TestAwsOutputFromRemoteState(t *testing.T) { //nolint:paralleltest // config.ClearOutputCache mutates a global these tests share
 	// NOTE: We can't run this test in parallel because there are other tests that also call `config.ClearOutputCache()`, but this function uses a global variable and sometimes it throws an unexpected error:
 	// "fixtures/output-from-remote-state/env1/app2/terragrunt.hcl:23,38-48: Unsupported attribute; This object does not have an attribute named "app3_text"."
 	// t.Parallel()
@@ -2524,7 +2524,7 @@ func TestAwsOutputFromRemoteState(t *testing.T) { //nolint: paralleltest
 	)
 }
 
-func TestAwsNoDependencyFetchOutputFromState(t *testing.T) { //nolint: paralleltest
+func TestAwsNoDependencyFetchOutputFromState(t *testing.T) { //nolint:paralleltest // config.ClearOutputCache mutates a global these tests share
 	// NOTE: We can't run this test in parallel because there are other tests that also call `config.ClearOutputCache()`, but this function uses a global variable and sometimes it throws an unexpected error:
 	// "fixtures/output-from-remote-state/env1/app2/terragrunt.hcl:23,38-48: Unsupported attribute; This object does not have an attribute named "app3_text"."
 	// t.Parallel()
@@ -2620,7 +2620,7 @@ func TestAwsNoDependencyFetchOutputFromState(t *testing.T) { //nolint: parallelt
 	)
 }
 
-func TestAwsMockOutputsFromRemoteState(t *testing.T) { //nolint: paralleltest
+func TestAwsMockOutputsFromRemoteState(t *testing.T) { //nolint:paralleltest // config.ClearOutputCache mutates a global these tests share
 	// NOTE: We can't run this test in parallel because there are other tests that also call `config.ClearOutputCache()`, but this function uses a global variable and sometimes it throws an unexpected error:
 	// "fixtures/output-from-remote-state/env1/app2/terragrunt.hcl:23,38-48: Unsupported attribute; This object does not have an attribute named "app3_text"."
 	// t.Parallel()
@@ -2744,7 +2744,7 @@ func TestAwsStackDependencyMockOutputsFromRemoteState(t *testing.T) {
 // TestAwsMockOutputsFromRemoteStateMissingBucket pins that a dependency read falls back to
 // mock_outputs when the state bucket itself doesn't exist yet (NoSuchBucket), not only when the
 // state object is missing (NoSuchKey).
-func TestAwsMockOutputsFromRemoteStateMissingBucket(t *testing.T) { //nolint: paralleltest
+func TestAwsMockOutputsFromRemoteStateMissingBucket(t *testing.T) { //nolint:paralleltest // matches the other output-from-remote-state tests, which don't run in parallel
 	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
 
 	// Never pre-created, so the dependency reads hit a missing bucket; init bootstraps it, so clean
@@ -3543,8 +3543,7 @@ func bucketEncryption(
 
 	output, err := client.GetBucketEncryption(ctx, input)
 	if err != nil {
-		// TODO: Remove this lint suppression
-		return nil, nil //nolint:nilerr
+		return nil, nil //nolint:nilerr // a bucket with no encryption config errors here; callers assert on the nil result
 	}
 
 	return output, nil

--- a/test/integration_common_test.go
+++ b/test/integration_common_test.go
@@ -169,7 +169,7 @@ func runMockRegistryWithAbsoluteModuleURL(
 
 	go func() {
 		<-ctx.Done()
-		server.Shutdown(ctx) //nolint:errcheck
+		server.Shutdown(ctx)
 	}()
 
 	return &url.URL{

--- a/test/integration_engine_test.go
+++ b/test/integration_engine_test.go
@@ -43,7 +43,7 @@ var (
 	)
 )
 
-//nolint:paralleltest
+//nolint:paralleltest // setupLocalEngine calls t.Setenv, which bars t.Parallel
 func TestEngineLocalPlan(t *testing.T) {
 	rootPath := setupLocalEngine(t)
 
@@ -61,7 +61,7 @@ func TestEngineLocalPlan(t *testing.T) {
 	assert.Contains(t, stdout, "1 to add, 0 to change, 0 to destroy.")
 }
 
-//nolint:paralleltest
+//nolint:paralleltest // setupLocalEngine calls t.Setenv, which bars t.Parallel
 func TestEngineLocalApply(t *testing.T) {
 	rootPath := setupLocalEngine(t)
 
@@ -389,7 +389,6 @@ func TestEngineTelemetry(t *testing.T) {
 	helpers.ValidateHookTraceParent(t, "hook_print_traceparent", str)
 }
 
-//nolint:paralleltest
 func TestEngineDisabledByNoEngineFlag(t *testing.T) {
 	t.Skip("no-engine OpenTofu engine integration is not reliably exercised in CI")
 	t.Setenv(envVarExperimental, "1")
@@ -420,7 +419,7 @@ func TestEngineDisabledByNoEngineFlag(t *testing.T) {
 	assert.Contains(t, stdout, "1 to add, 0 to change, 0 to destroy.")
 }
 
-//nolint:paralleltest
+//nolint:paralleltest // the engine tests each clean the fixture directory they share
 func TestEngineDisabledByNoEngineFlagWithExperiment(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, testFixtureOpenTofuEngine)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureOpenTofuEngine)
@@ -448,7 +447,6 @@ func TestEngineDisabledByNoEngineFlagWithExperiment(t *testing.T) {
 	assert.Contains(t, stdout, "1 to add, 0 to change, 0 to destroy.")
 }
 
-//nolint:paralleltest
 func TestEngineDisabledByNoEngineFlagWithRunAll(t *testing.T) {
 	t.Setenv(envVarExperimental, "1")
 

--- a/test/integration_feature_flags_test.go
+++ b/test/integration_feature_flags_test.go
@@ -126,7 +126,7 @@ func validateOutputsMap(t *testing.T, rootPath string, expected map[string]any) 
 
 	// Validate outputs against expected values
 	for key, expected := range expected {
-		assert.EqualValues(t, expected, outputs[key].Value) //nolint:testifylint
+		assert.EqualValues(t, expected, outputs[key].Value)
 	}
 }
 

--- a/test/integration_gcp_test.go
+++ b/test/integration_gcp_test.go
@@ -558,7 +558,7 @@ func TestGcpNoPrefixBucket(t *testing.T) {
 func TestGcpParallelStateInit(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-test") //nolint:usetesting
+	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-test") //nolint:usetesting // TODO: check whether t.TempDir works here
 	if err != nil {
 		require.NoError(t, err)
 	}
@@ -611,7 +611,7 @@ func createTmpTerragruntGCSConfig(
 ) string {
 	t.Helper()
 
-	tmpFolder, err := os.MkdirTemp("", "terragrunt-test") //nolint:usetesting
+	tmpFolder, err := os.MkdirTemp("", "terragrunt-test") //nolint:usetesting // TODO: check whether t.TempDir works here
 	if err != nil {
 		t.Fatalf("Failed to create temp folder due to error: %v", err)
 	}

--- a/test/integration_hcl_filter_test.go
+++ b/test/integration_hcl_filter_test.go
@@ -340,7 +340,7 @@ func TestHCLFormatFilterIntegration(t *testing.T) {
 	err = json.Unmarshal([]byte(stdout), &components)
 	require.NoError(t, err)
 
-	for _, component := range components {
+	for i, component := range components {
 		basename := "terragrunt.hcl"
 		if component.Type == "stack" {
 			basename = "terragrunt.stack.hcl"
@@ -350,7 +350,7 @@ func TestHCLFormatFilterIntegration(t *testing.T) {
 		content, readErr := os.ReadFile(filename)
 		require.NoError(t, readErr)
 
-		component.Contents = content //nolint:govet // unusedwrite: the loop exists to assert every file reads; the copy is discarded
+		components[i].Contents = content
 	}
 
 	checkCmd := "terragrunt hcl format --filter './needs-formatting/**' --check --working-dir " + rootPath

--- a/test/integration_hcl_filter_test.go
+++ b/test/integration_hcl_filter_test.go
@@ -350,7 +350,7 @@ func TestHCLFormatFilterIntegration(t *testing.T) {
 		content, readErr := os.ReadFile(filename)
 		require.NoError(t, readErr)
 
-		component.Contents = content //nolint:govet
+		component.Contents = content //nolint:govet // unusedwrite: the loop exists to assert every file reads; the copy is discarded
 	}
 
 	checkCmd := "terragrunt hcl format --filter './needs-formatting/**' --check --working-dir " + rootPath

--- a/test/integration_profile_tf_test.go
+++ b/test/integration_profile_tf_test.go
@@ -1,6 +1,5 @@
 //go:build tf
 
-//nolint:paralleltest // CPU profiling is process-global (pprof.StartCPUProfile), so this test must not run in parallel with the rest of the profiling suite.
 package test_test
 
 import (
@@ -16,6 +15,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestTFProfileCPUDoesNotPropagateToTofu runs serially: CPU profiling is
+// process-global (pprof.StartCPUProfile), so it cannot share the process with
+// the rest of the profiling suite.
 func TestTFProfileCPUDoesNotPropagateToTofu(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, testFixtureInputs)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureInputs)

--- a/test/integration_provider_cache_constraint_test.go
+++ b/test/integration_provider_cache_constraint_test.go
@@ -25,7 +25,7 @@ const (
 // module constraints instead of pinning exact versions in .terraform.lock.hcl files.
 // Reproduces and validates the fix for GitHub issue #4512.
 //
-//nolint:paralleltest,tparallel
+//nolint:paralleltest,tparallel // the subtests build on each other in one working dir
 func TestTFTerragruntProviderCacheWeakConstraint(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration_provider_cache_lockfile_readonly_test.go
+++ b/test/integration_provider_cache_lockfile_readonly_test.go
@@ -28,7 +28,7 @@ const (
 // leave the lock file alone when that flag is set, whether it arrives on the command
 // line or through `TF_CLI_ARGS_init`, so init fails exactly as it does without the cache.
 //
-//nolint:paralleltest,tparallel // the env-var subtest relies on t.Setenv.
+//nolint:paralleltest // the env-var subtest relies on t.Setenv.
 func TestTFTerragruntProviderCacheLockfileReadonly(t *testing.T) {
 	lockfileName := ".terraform.lock.hcl"
 

--- a/test/integration_rustfs_test.go
+++ b/test/integration_rustfs_test.go
@@ -22,7 +22,7 @@ const (
 	testFixtureStackDepsStackMockRustFS    = "fixtures/stacks/stack-deps-stack-mock-rustfs"
 )
 
-func TestRustFSOutputFromRemoteState(t *testing.T) { //nolint: paralleltest
+func TestRustFSOutputFromRemoteState(t *testing.T) {
 	rustfsAddr := setupRustFS(t)
 
 	// RustFS default credentials
@@ -105,7 +105,7 @@ func TestRustFSOutputFromRemoteState(t *testing.T) { //nolint: paralleltest
 // map-typed mock_outputs resolves for such a unit, and that a unit is never dropped silently from
 // the aggregated stack outputs: neither when mock_outputs_allowed_terraform_commands rules its mocks
 // out for the current command, nor when mock_outputs can't be keyed by unit name at all.
-func TestRustFSStackDependencyMockOutputs(t *testing.T) { //nolint: paralleltest
+func TestRustFSStackDependencyMockOutputs(t *testing.T) {
 	rustfsAddr := setupRustFS(t)
 
 	// RustFS default credentials

--- a/test/integration_scaffold_ssh_test.go
+++ b/test/integration_scaffold_ssh_test.go
@@ -1,4 +1,4 @@
-//nolint:paralleltest,tparallel // Every test in this file calls RequireSSH, which uses t.Setenv and therefore can't run in parallel.
+//nolint:paralleltest // Every test in this file calls RequireSSH, which uses t.Setenv and therefore can't run in parallel.
 package test_test
 
 import (

--- a/test/integration_serial_aws_test.go
+++ b/test/integration_serial_aws_test.go
@@ -76,7 +76,7 @@ func TestAwsTerragruntParallelism(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest
+//nolint:paralleltest // it swaps the process-wide AWS credentials
 func TestAwsReadTerragruntAuthProviderCmdRemoteState(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, testFixtureAuthProviderCmd)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAuthProviderCmd)
@@ -101,13 +101,12 @@ func TestAwsReadTerragruntAuthProviderCmdRemoteState(t *testing.T) {
 	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
 	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 
-	// I'm not sure why, but this test doesn't work with tenv
-	os.Setenv("AWS_ACCESS_KEY_ID", "")     //nolint: usetesting
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "") //nolint: usetesting
+	os.Setenv("AWS_ACCESS_KEY_ID", "")     //nolint:usetesting // t.Setenv doesn't work for this test, for reasons nobody has pinned down
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "") //nolint:usetesting // as above
 
 	defer func() {
-		os.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)         //nolint: usetesting
-		os.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey) //nolint: usetesting
+		os.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)         //nolint:usetesting // restores the creds the test cleared above
+		os.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey) //nolint:usetesting // as above
 	}()
 
 	credsConfig := filepath.Join(rootPath, "creds.config")

--- a/test/integration_serial_gcp_test.go
+++ b/test/integration_serial_gcp_test.go
@@ -20,9 +20,9 @@ func TestGcpCorrectlyMirrorsTerraformGCPAuth(t *testing.T) {
 	// There is no true way to properly unset env vars from the environment, but we still try
 	// to unset the CI credentials during this test.
 	defaultCreds := os.Getenv("GCLOUD_SERVICE_KEY")
-	defer os.Setenv("GCLOUD_SERVICE_KEY", defaultCreds) //nolint:usetesting
+	defer os.Setenv("GCLOUD_SERVICE_KEY", defaultCreds) //nolint:usetesting // restores the CI credential this test unsets
 
-	os.Unsetenv("GCLOUD_SERVICE_KEY") //nolint:usetesting
+	os.Unsetenv("GCLOUD_SERVICE_KEY")
 	t.Setenv("GOOGLE_CREDENTIALS", defaultCreds)
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGcsPath)

--- a/test/integration_serial_test.go
+++ b/test/integration_serial_test.go
@@ -1,4 +1,3 @@
-//nolint:paralleltest
 package test_test
 
 import (

--- a/test/integration_serial_tf_test.go
+++ b/test/integration_serial_tf_test.go
@@ -1,6 +1,6 @@
 //go:build tf
 
-//nolint:paralleltest
+//nolint:paralleltest // tests here set process env with t.Setenv, so none of them may run in parallel
 package test_test
 
 import (

--- a/test/integration_ssh_test.go
+++ b/test/integration_ssh_test.go
@@ -1,6 +1,6 @@
 //go:build tf
 
-//nolint:paralleltest,tparallel // Every test in this file calls RequireSSH, which uses t.Setenv and therefore can't run in parallel.
+//nolint:paralleltest // Every test in this file calls RequireSSH, which uses t.Setenv and therefore can't run in parallel.
 package test_test
 
 import (

--- a/test/integration_stacks_tf_test.go
+++ b/test/integration_stacks_tf_test.go
@@ -1649,9 +1649,8 @@ func TestTFStackFindInParentFolders(t *testing.T) {
 }
 
 // TestTFStackVersionConstraints verifies that version constraints are respected in stack runs.
-// This test cannot be parallelized as it changes the global version.Version.
 //
-//nolint:paralleltest
+//nolint:paralleltest // it overrides the global version.Version
 func TestTFStackVersionConstraints(t *testing.T) {
 	helpers.CleanupTerragruntFolder(t, testFixtureStackVersionConstraints)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackVersionConstraints)

--- a/test/integration_strict_test.go
+++ b/test/integration_strict_test.go
@@ -18,9 +18,9 @@ const (
 )
 
 // TestTFRootTerragruntHCLStrictMode uses globally mutated state to determine if strict mode has already
-// been triggered, so we don't run it in parallel.
+// been triggered.
 //
-//nolint:paralleltest,tparallel
+//nolint:paralleltest // strict mode is triggered through global state
 func TestTFRootTerragruntHCLStrictMode(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, testFixtureFindParentWithDeprecatedRoot)
 
@@ -79,9 +79,9 @@ func TestTFRootTerragruntHCLStrictMode(t *testing.T) {
 }
 
 // TestTFBareIncludeStrictMode uses globally mutated state to determine if strict mode has already
-// been triggered, so we don't run it in parallel.
+// been triggered.
 //
-//nolint:paralleltest,tparallel
+//nolint:paralleltest // strict mode is triggered through global state
 func TestTFBareIncludeStrictMode(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, testFixtureStrictBareInclude)
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -503,7 +503,7 @@ func TestErrorMessageIncludeInOutput(t *testing.T) {
 	assert.Contains(t, err.Error(), "Custom error from script")
 }
 
-//nolint:paralleltest
+//nolint:paralleltest // it unsets TG_TF_PATH for the whole process
 func TestTfPath(t *testing.T) {
 	// This test can't be parallelized because it explicitly unsets the TG_TF_PATH environment variable.
 	// t.Parallel()

--- a/test/integration_tf_test.go
+++ b/test/integration_tf_test.go
@@ -3756,9 +3756,7 @@ func TestTFTerragruntRemoteStateCodegenDoesNotGenerateWithSkip(t *testing.T) {
 	assert.False(t, helpers.FileIsInFolder(t, "foo.tfstate", generateTestCase))
 }
 
-// This function cannot be parallelized as it changes the global version.Version
-//
-//nolint:paralleltest
+//nolint:paralleltest // it overrides the global version.Version
 func TestTFTerragruntValidateAllWithVersionChecks(t *testing.T) {
 	tmpEnvPath := helpers.CopyEnvironment(t, "fixtures/version-check")
 
@@ -3793,11 +3791,7 @@ func TestTFTerragruntIncludeParentHclFile(t *testing.T) {
 	assert.Contains(t, stderr, "common_hcl")
 }
 
-// The tests here cannot be parallelized.
-// This is due to a race condition brought about by overriding `version.Version` in
-// runTerragruntVersionCommand
-//
-//nolint:paralleltest,funlen
+//nolint:paralleltest // runTerragruntVersionCommand overrides the global version.Version
 func TestTFTerragruntVersionConstraints(t *testing.T) {
 	testCases := []struct {
 		name                 string
@@ -3849,7 +3843,7 @@ func TestTFTerragruntVersionConstraints(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases { //nolint:paralleltest
+	for _, tc := range testCases { //nolint:paralleltest // the parent test overrides the global version.Version
 		t.Run(tc.name, func(t *testing.T) {
 			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureReadConfig)
 			rootPath := filepath.Join(tmpEnvPath, testFixtureReadConfig, "with_constraints")
@@ -4093,9 +4087,7 @@ func TestTFIamRolesLoadingFromDifferentModules(t *testing.T) {
 	assert.NotEmptyf(t, component2, "Missing role for component 2")
 }
 
-// This function cannot be parallelized as it changes the global version.Version
-//
-//nolint:paralleltest
+//nolint:paralleltest // it overrides the global version.Version
 func TestTFTerragruntVersionConstraintsPartialParse(t *testing.T) {
 	fixturePath := "fixtures/partial-parse/terragrunt-version-constraint"
 	helpers.CleanupTerragruntFolder(t, fixturePath)

--- a/test/integration_tflint_test.go
+++ b/test/integration_tflint_test.go
@@ -1,6 +1,6 @@
 //go:build tflint && !windows
 
-//nolint:paralleltest
+//nolint:paralleltest // tflint runs embedded in the test process and races when runs overlap
 package test_test
 
 import (


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds the `nolintlint` lint, which prevents blindly adding lint suppressions when the code paths failing lints are proving inconvenient to fix.

With the settings added here, lint suppression has to be done on a case-by-case basis, remain valid and explained in the comment.

As part of enabling it, there was also a long tail of work that could be done to adjust how we suppress (or don't suppress) lints.

I got carried away before I started splitting out some of the work in extra PRs.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting for invalid deprecated flag values, JSON attribute names, duplicate dependency paths, and unsupported include merge strategies.
  - File, response, and generated-output cleanup errors are now surfaced when no earlier error occurred.
  - Improved handling and reporting of process execution failures across command operations.
  - Generated files are written more safely, preserving existing files if generation fails.

- **Refactor**
  - Exposed SOPS decryption and formatting diff functionality through public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->