### PR TITLE
fix: Export dependency inputs as TF_VAR_ on the init fast path

### DIFF
--- a/docs/src/data/changelog/v1.1.5/dependency-output-inputs-as-variables.mdx
+++ b/docs/src/data/changelog/v1.1.5/dependency-output-inputs-as-variables.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### Dependency outputs resolve when the dependency encrypts its state with a variable
+
+OpenTofu resolves the `encryption` block before it reads state, so a key provider argument written as `var.something` needs a value even for `tofu output`. Terragrunt passes `inputs` as `TF_VAR_*` variables when it runs a unit, but the dependency optimization skipped that step when reading outputs from a dependency that was already initialized. The dependent unit failed on the variable that had no value, and `disable_dependency_optimization = true` on the dependency's `remote_state` block was the only workaround.
+
+That optimization now exports the dependency's own `inputs`, so these units resolve with it left on. A variable already set in the environment still wins, as it does on a normal run.
+
+The optimization reads `inputs` without resolving dependency outputs. A dependency that takes its key from another unit's output still needs `disable_dependency_optimization = true`.

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"slices"
 
+	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
 	"github.com/gruntwork-io/terragrunt/internal/remotestate"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -39,6 +40,7 @@ const (
 	ExcludeBlock
 	ErrorsBlock
 	TerraformExtraArgs
+	InputsBlock
 )
 
 // terragruntIncludeMultiple is a struct that can be used to only decode the include block with labels.
@@ -63,6 +65,12 @@ type terragruntFeatureFlags struct {
 type terragruntErrors struct {
 	Errors *ErrorsConfig `hcl:"errors,block"`
 	Remain hcl.Body      `hcl:",remain"`
+}
+
+// terragruntInputs is a struct that can be used to only decode the inputs attribute.
+type terragruntInputs struct {
+	Inputs *cty.Value `hcl:"inputs,attr"`
+	Remain hcl.Body   `hcl:",remain"`
 }
 
 // terragruntTerraform is a struct that can be used to only decode the terraform block.
@@ -578,12 +586,11 @@ func TerragruntConfigFromPartialConfig(
 //   - FeatureFlagsBlock: Parses the `feature` block in the config
 //   - EngineBlock: Parses the `engine` block in the config
 //   - ExcludeBlock : Parses the `exclude` block in the config
+//   - InputsBlock: Parses the `inputs` attribute in the config
 //
 // Note that the following blocks are always decoded:
 // - locals
 // - include
-// Note also that the following blocks are never decoded in a partial parse:
-// - inputs
 func PartialParseConfigString(
 	ctx context.Context,
 	pctx *ParsingContext,
@@ -859,6 +866,23 @@ func PartialParseConfig(
 				output.Errors.Merge(decoded.Errors)
 			} else {
 				output.Errors = decoded.Errors
+			}
+
+		case InputsBlock:
+			decoded := terragruntInputs{}
+
+			err := file.Decode(&decoded, evalParsingContext)
+			if err != nil {
+				return nil, err
+			}
+
+			if decoded.Inputs != nil {
+				inputs, err := ctyhelper.ParseCtyValueToMap(*decoded.Inputs)
+				if err != nil {
+					return nil, err
+				}
+
+				output.Inputs = inputs
 			}
 
 		default:

--- a/pkg/config/config_partial_test.go
+++ b/pkg/config/config_partial_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1489,4 +1490,48 @@ exclude {
 			assert.Equal(t, tc.expected, terragruntConfig.Exclude.If)
 		})
 	}
+}
+
+// TestPartialParseInputsBlock pins that a partial parse limited to [config.InputsBlock] resolves
+// locals inside the `inputs` attribute and decodes nothing else.
+func TestPartialParseInputsBlock(t *testing.T) {
+	t.Parallel()
+
+	cfg := `
+locals {
+  passphrase = "not-a-real-passphrase"
+}
+
+remote_state {
+  backend = "local"
+  config  = {}
+}
+
+inputs = {
+  passphrase = local.passphrase
+  replicas   = 3
+}
+`
+
+	l := logger.CreateLogger()
+
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), config.DefaultTerragruntConfigPath)
+	pctx = pctx.WithDecodeList(config.InputsBlock)
+
+	terragruntConfig, err := config.PartialParseConfigString(
+		ctx,
+		pctx,
+		l,
+		config.DefaultTerragruntConfigPath,
+		cfg,
+		nil,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		map[string]any{"passphrase": "not-a-real-passphrase", "replicas": json.Number("3")},
+		terragruntConfig.Inputs,
+	)
+	assert.Nil(t, terragruntConfig.RemoteState)
 }

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1992,6 +1992,10 @@ func getTerragruntOutputJSONFromInitFolder(
 		),
 	)
 
+	if err := setDependencyInputsAsEnvVars(ctx, pctx, l, terraformWorkingDir); err != nil {
+		return nil, err
+	}
+
 	bareCtx := tf.ContextWithTerraformCommandHook(ctx, nil)
 
 	// Discard streamed stdout; the JSON is read from the returned CmdOutput.
@@ -2023,6 +2027,44 @@ func getTerragruntOutputJSONFromInitFolder(
 	)
 
 	return jsonBytes, nil
+}
+
+// setDependencyInputsAsEnvVars exports a dependency's own `inputs` as TF_VAR_* entries, the way a
+// full run of that unit does. OpenTofu resolves the `encryption` block before it reads state, so a
+// key provider argument written as `var.something` has no other source for its value under a bare
+// `tofu output`.
+func setDependencyInputsAsEnvVars(
+	ctx context.Context,
+	pctx *ParsingContext,
+	l log.Logger,
+	modulePath string,
+) error {
+	inputsTGConfig, err := PartialParseConfigFile(
+		ctx,
+		pctx.WithDecodeList(InputsBlock).WithDiagnosticsSuppressed(l),
+		l,
+		pctx.TerragruntConfigPath,
+		nil,
+	)
+	if err != nil {
+		// Exporting inputs is best effort. An `inputs` attribute that reads another unit's outputs
+		// would need a second round of dependency output resolution, the cost this fast path avoids.
+		l.Debugf(
+			"Could not parse inputs from target config %s: %v",
+			pctx.TerragruntConfigPath,
+			err,
+		)
+
+		return nil
+	}
+
+	return run.SetTerragruntInputsAsEnvVars(
+		l,
+		pctx.Venv.FS,
+		pctx.Venv.Env,
+		modulePath,
+		inputsTGConfig.ToRunConfig(l, pctx.Venv.FS),
+	)
 }
 
 // getTerragruntOutputJSONFromRemoteState will retrieve the outputs directly by using just the remote state block. This

--- a/pkg/config/dependency_fast_path_test.go
+++ b/pkg/config/dependency_fast_path_test.go
@@ -1,0 +1,133 @@
+package config_test
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf"
+	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDependencyOutputFromInitFolderExportsInputsAsEnvVars pins that the fast path for an
+// already-init-ed dependency sets a TF_VAR_ entry for each of that dependency's inputs.
+func TestDependencyOutputFromInitFolderExportsInputsAsEnvVars(t *testing.T) {
+	t.Parallel()
+
+	outputEnv := runDependencyOutputFastPath(t, `
+inputs = {
+  passphrase = "not-a-real-passphrase"
+}
+`)
+
+	assert.Contains(t, outputEnv, "TF_VAR_passphrase=not-a-real-passphrase")
+}
+
+// TestDependencyOutputFromInitFolderSkipsUnresolvableInputs pins that the fast path exports no
+// TF_VAR_* entries when it cannot evaluate the dependency's `inputs`. Unknown values decode as
+// empty strings, so exporting only the resolvable subset would give `tofu output` a wrong value
+// for the rest.
+func TestDependencyOutputFromInitFolderSkipsUnresolvableInputs(t *testing.T) {
+	t.Parallel()
+
+	outputEnv := runDependencyOutputFastPath(t, `
+dependency "vault" {
+  config_path = "../vault"
+}
+
+inputs = {
+  static     = "yes"
+  passphrase = dependency.vault.outputs.secret
+}
+`)
+
+	for _, entry := range outputEnv {
+		assert.False(
+			t,
+			strings.HasPrefix(entry, "TF_VAR_"),
+			"unresolvable inputs must export no variables, got %s",
+			entry,
+		)
+	}
+}
+
+// runDependencyOutputFastPath parses a unit that reads an output of a dependency whose config
+// includes the given body, and requires that output to resolve. The dependency is already init-ed,
+// so the fast path fires, and the returned slice is the environment its `tofu output` ran with.
+func runDependencyOutputFastPath(t *testing.T, depConfigBody string) []string {
+	t.Helper()
+
+	l := logger.CreateLogger()
+	v := venvtest.NewWithOSFS()
+
+	rootDir := t.TempDir()
+	appDir := filepath.Join(rootDir, "app")
+	depDir := filepath.Join(rootDir, "dep")
+
+	require.NoError(t, v.FS.MkdirAll(appDir, 0755))
+	require.NoError(t, v.FS.MkdirAll(depDir, 0755))
+
+	appConfigPath := filepath.Join(appDir, config.DefaultTerragruntConfigPath)
+	require.NoError(t, vfs.WriteFile(v.FS, appConfigPath, []byte(`
+dependency "dep" {
+  config_path = "../dep"
+}
+
+inputs = {
+  from_dep = dependency.dep.outputs.foo
+}
+`), 0644))
+
+	depConfigPath := filepath.Join(depDir, config.DefaultTerragruntConfigPath)
+	require.NoError(t, vfs.WriteFile(v.FS, depConfigPath, []byte(`
+remote_state {
+  backend = "local"
+
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite"
+  }
+
+  config = {
+    path = "terraform.tfstate"
+  }
+}
+`+depConfigBody), 0644))
+
+	var outputEnv []string
+
+	v = v.WithHandler(func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		if !slices.Contains(inv.Args, tf.CommandNameOutput) {
+			return vexec.Result{}
+		}
+
+		outputEnv = slices.Clone(inv.Env)
+
+		return vexec.Result{Stdout: []byte(`{"foo":{"value":"bar","type":"string"}}`)}
+	})
+
+	// The fast path fires only once the dependency's source has been init-ed, which Terragrunt
+	// detects by the .terraform directory in the cache dir that source resolves to.
+	_, depDownloadDir := util.DefaultWorkingAndDownloadDirs(depConfigPath)
+
+	depSource, err := tf.NewSource(l, v.FS, ".", depDownloadDir, depDir, false)
+	require.NoError(t, err)
+	require.NoError(t, v.FS.MkdirAll(filepath.Join(depSource.WorkingDir, ".terraform"), 0755))
+
+	ctx, pctx := newTestParsingContext(t, v, appConfigPath)
+
+	cfg, err := config.ParseConfigFile(ctx, pctx, l, appConfigPath, nil)
+	require.NoError(t, err)
+	require.Equal(t, "bar", cfg.Inputs["from_dep"])
+
+	return outputEnv
+}

--- a/pkg/config/telemetry.go
+++ b/pkg/config/telemetry.go
@@ -122,6 +122,8 @@ func partialDecodeSectionName(section PartialDecodeSectionType) string {
 		return "exclude"
 	case ErrorsBlock:
 		return "errors"
+	case InputsBlock:
+		return "inputs"
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
