### PR TITLE
feat: allow to override root span `internal` kind

### DIFF
--- a/docs/src/content/docs/06-troubleshooting/02-open-telemetry.mdx
+++ b/docs/src/content/docs/06-troubleshooting/02-open-telemetry.mdx
@@ -33,6 +33,9 @@ Tracing configuration:
 - `TG_TELEMETRY_TRACE_EXPORTER_HTTP_ENDPOINT` - in case of `http` exporter, this is the endpoint to which traces will be sent.
 - `TG_TELEMETRY_TRACE_EXPORTER_INSECURE_ENDPOINT` - if set to true, the exporter will not validate the server's certificate, helpful for local traces collection.
 - `TRACEPARENT` - if set, the value will be used as a parent trace context, format `TRACEPARENT=00-<hex_trace_id>-<hex_span_id>-<trace_flags>`, example: `TRACEPARENT=00-xxx-yyy-01`
+- `TG_TELEMETRY_TRACE_ROOT_SPAN_KIND` - span kind of the root command span. Defaults to `internal`, which is what the OpenTelemetry specification prescribes for the local root span of a CLI process. Supported values are `internal`, `server`, `consumer`, `producer` and `client`; an unrecognized value falls back to `internal`.
+
+  Set this to `server` if your APM backend only builds a service-level transaction (throughput, response time, error rate) from entry spans whose kind is `server` or `consumer`. New Relic, Datadog and Elastic all use that heuristic, so without it a Terragrunt run produces spans but no transaction. The alternative is an OpenTelemetry Collector `transform` processor rewriting the kind, which needs a collector in the export path.
 
 Metrics configuration:
 

--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
 	"github.com/hashicorp/go-version"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Command category names.
@@ -206,7 +207,7 @@ func WrapWithTelemetry(
 			}
 
 			return nil
-		})
+		}, trace.WithSpanKind(opts.Telemetry.RootSpanKind()))
 	}
 }
 

--- a/internal/cli/flags/global/flags.go
+++ b/internal/cli/flags/global/flags.go
@@ -56,6 +56,7 @@ const (
 	TelemetryTraceExporterFlagName                  = "telemetry-trace-exporter"
 	TelemetryTraceExporterInsecureEndpointFlagName  = "telemetry-trace-exporter-insecure-endpoint"
 	TelemetryTraceExporterHTTPEndpointFlagName      = "telemetry-trace-exporter-http-endpoint"
+	TelemetryTraceRootSpanKindFlagName              = "telemetry-trace-root-span-kind"
 	TraceparentFlagName                             = "traceparent"
 	TelemetryMetricExporterFlagName                 = "telemetry-metric-exporter"
 	TelemetryMetricExporterInsecureEndpointFlagName = "telemetry-metric-exporter-insecure-endpoint"
@@ -393,6 +394,11 @@ func NewTelemetryFlags(opts *options.TerragruntOptions, prefix flags.Prefix) cli
 				opts.StrictControls,
 			),
 		),
+
+		flags.NewFlag(&clihelper.GenericFlag[string]{
+			EnvVars:     tgPrefix.EnvVars(TelemetryTraceRootSpanKindFlagName),
+			Destination: &opts.Telemetry.TraceRootSpanKind,
+		}),
 
 		flags.NewFlag(&clihelper.GenericFlag[string]{
 			EnvVars:     flags.Prefix{}.EnvVars(TraceparentFlagName),

--- a/internal/telemetry/opts.go
+++ b/internal/telemetry/opts.go
@@ -1,5 +1,11 @@
 package telemetry
 
+import (
+	"strings"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
 // Options are Telemetry options.
 type Options struct {
 	// TraceExporter is the type of trace exporter to be used.
@@ -8,6 +14,17 @@ type Options struct {
 	TraceExporterHTTPEndpoint string
 	// TraceParent is used as a parent trace context.
 	TraceParent string
+	// TraceRootSpanKind overrides the OpenTelemetry span kind of the root command
+	// span. Empty (the default) leaves it as "internal", which is what the
+	// OpenTelemetry specification prescribes for the local root span of a CLI
+	// process.
+	//
+	// Several APM backends (New Relic, Datadog, Elastic) only derive a
+	// service-level transaction - throughput, response time, error rate - from
+	// entry spans whose kind is "server" or "consumer". Setting this to "server"
+	// makes each Terragrunt run show up as such a transaction without needing an
+	// OpenTelemetry Collector in the export path to rewrite it.
+	TraceRootSpanKind string
 	// MetricExporter is the type of metrics exporter.
 	MetricExporter string
 	// LogsExporter is the type of logs exporter to be used.
@@ -21,4 +38,26 @@ type Options struct {
 	// LogsExporterInsecureEndpoint is useful for local logs collection.
 	// If set to true, the exporter will not validate the server's certificate.
 	LogsExporterInsecureEndpoint bool
+}
+
+// RootSpanKind resolves TraceRootSpanKind to an OpenTelemetry span kind.
+// Unset, unrecognized and nil-receiver cases all yield [trace.SpanKindInternal],
+// so a bad value degrades to the default behavior rather than failing a run.
+func (opts *Options) RootSpanKind() trace.SpanKind {
+	if opts == nil {
+		return trace.SpanKindInternal
+	}
+
+	switch strings.ToLower(strings.TrimSpace(opts.TraceRootSpanKind)) {
+	case "server":
+		return trace.SpanKindServer
+	case "consumer":
+		return trace.SpanKindConsumer
+	case "producer":
+		return trace.SpanKindProducer
+	case "client":
+		return trace.SpanKindClient
+	default:
+		return trace.SpanKindInternal
+	}
 }

--- a/internal/telemetry/otel_update_test.go
+++ b/internal/telemetry/otel_update_test.go
@@ -223,3 +223,97 @@ func TestNewTelemeterNoExporters(t *testing.T) {
 	assert.True(t, called)
 	require.NoError(t, tlm.Shutdown(t.Context()))
 }
+
+func TestOptionsRootSpanKind(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		opts     *telemetry.Options
+		name     string
+		expected trace.SpanKind
+	}{
+		{name: "nil receiver", opts: nil, expected: trace.SpanKindInternal},
+		{name: "unset", opts: &telemetry.Options{}, expected: trace.SpanKindInternal},
+		{
+			name:     "server",
+			opts:     &telemetry.Options{TraceRootSpanKind: "server"},
+			expected: trace.SpanKindServer,
+		},
+		{
+			name:     "case and space insensitive",
+			opts:     &telemetry.Options{TraceRootSpanKind: "  SERVER "},
+			expected: trace.SpanKindServer,
+		},
+		{
+			name:     "consumer",
+			opts:     &telemetry.Options{TraceRootSpanKind: "consumer"},
+			expected: trace.SpanKindConsumer,
+		},
+		{
+			name:     "unrecognized value degrades to internal",
+			opts:     &telemetry.Options{TraceRootSpanKind: "garbage"},
+			expected: trace.SpanKindInternal,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, tc.opts.RootSpanKind())
+		})
+	}
+}
+
+func TestCollectHonorsSpanKind(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
+	opts.Telemetry.TraceExporter = consoleExporter
+
+	tlm, err := telemetry.NewTelemeter(
+		t.Context(), nil, "terragrunt", "v0.0.0-test", &buf, opts.Telemetry, false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, tlm)
+
+	require.NoError(t, tlm.Collect(
+		t.Context(), nil, "entry_span", nil,
+		func(_ context.Context, _ log.Logger) error { return nil },
+		trace.WithSpanKind(trace.SpanKindServer),
+	))
+	require.NoError(t, tlm.Shutdown(t.Context()))
+
+	// SpanKindServer serializes as 2 in the console exporter's JSON.
+	assert.Contains(t, buf.String(), `"SpanKind":2`)
+}
+
+func TestCollectSetsErrorStatusOnFailure(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
+	opts.Telemetry.TraceExporter = consoleExporter
+
+	tlm, err := telemetry.NewTelemeter(
+		t.Context(), nil, "terragrunt", "v0.0.0-test", &buf, opts.Telemetry, false,
+	)
+	require.NoError(t, err)
+
+	errSentinel := errors.New("intentional failure")
+
+	gotErr := tlm.Collect(
+		t.Context(), nil, "failing_span", nil,
+		func(_ context.Context, _ log.Logger) error { return errSentinel },
+	)
+	require.ErrorIs(t, gotErr, errSentinel)
+	require.NoError(t, tlm.Shutdown(t.Context()))
+
+	// Backends derive an errored transaction from the span status, not from the
+	// recorded exception event, so both must be present.
+	assert.Contains(t, buf.String(), `"Code":"Error"`)
+	assert.Contains(t, buf.String(), errSentinel.Error())
+}

--- a/internal/telemetry/telemeter.go
+++ b/internal/telemetry/telemeter.go
@@ -8,6 +8,7 @@ import (
 	"runtime/debug"
 
 	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type Telemeter struct {
@@ -106,9 +107,13 @@ func (tlm *Telemeter) Shutdown(ctx context.Context) error {
 // OpenTelemetry log bridge derives trace and span IDs from the logger's context,
 // so records correlate with their span only when the logger carries it. Pass
 // childL onward to any code whose logs should resolve to this span.
+//
+// Any spanOpts are forwarded to span creation. Callers that need a non-default
+// span kind pass trace.WithSpanKind(...) here.
 func (tlm *Telemeter) Collect(
 	ctx context.Context, l log.Logger, name string, attrs map[string]any,
 	fn func(childCtx context.Context, childL log.Logger) error,
+	spanOpts ...trace.SpanStartOption,
 ) error {
 	if tlm == nil {
 		// This should not happen in normal operation. Log a stack trace to help
@@ -136,7 +141,7 @@ func (tlm *Telemeter) Collect(
 
 			return fn(ctx, childL)
 		})
-	})
+	}, spanOpts...)
 }
 
 // WithoutLogger adapts a logger-less callback to [Telemeter.Collect]'s

--- a/internal/telemetry/tracer.go
+++ b/internal/telemetry/tracer.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -197,16 +198,19 @@ func NewTraceExporter(
 	}
 }
 
-// Trace collects traces for method execution.
+// Trace collects traces for method execution. Any spanOpts are forwarded to the
+// underlying tracer's Start call, so callers can set the span kind, extra
+// attributes or links without reaching for the OpenTelemetry SDK directly.
 func (tracer *Tracer) Trace(
 	ctx context.Context, name string, attrs map[string]any, fn func(childCtx context.Context) error,
+	spanOpts ...trace.SpanStartOption,
 ) error {
 	if tracer == nil || tracer.spanExporter == nil ||
 		tracer.provider == nil { // invoke function without tracing
 		return fn(ctx)
 	}
 
-	ctx, span := tracer.openSpan(ctx, name, attrs)
+	ctx, span := tracer.openSpan(ctx, name, attrs, spanOpts...)
 
 	if span == nil {
 		if tracer.l != nil {
@@ -223,8 +227,11 @@ func (tracer *Tracer) Trace(
 	defer span.End()
 
 	if err := fn(ctx); err != nil {
-		// record error in span
+		// Record both the exception event and the span status: backends derive an
+		// errored transaction from the status, not from the event.
 		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+
 		return err
 	}
 
@@ -236,6 +243,7 @@ func (tracer *Tracer) openSpan(
 	ctx context.Context,
 	name string,
 	attrs map[string]any,
+	spanOpts ...trace.SpanStartOption,
 ) (context.Context, trace.Span) {
 	if tracer.provider == nil {
 		return ctx, nil
@@ -261,7 +269,7 @@ func (tracer *Tracer) openSpan(
 	// a useful lint, though. We should consider removing the suppression
 	// and fixing the lint.
 
-	ctx, span := tracer.Start(ctx, name) // nolint:spancheck
+	ctx, span := tracer.Start(ctx, name, spanOpts...) // nolint:spancheck
 	// convert attrs map to span.SetAttributes
 	span.SetAttributes(mapToAttributes(attrs)...)
 


### PR DESCRIPTION
## Description

Terragrunt emits every span with the default `internal` kind. `Collect` → `Trace` → `openSpan` is a closed pipe, and `openSpan` calls `tracer.Start(ctx, name)` with no `SpanStartOption` at all, so no caller can influence span creation.

APM backends that build a service-level transaction from an entry span key off `span.kind = server OR span.kind = consumer` — New Relic, Datadog and Elastic all use that heuristic. With every span `internal`, a Terragrunt run produces a trace but no transaction, so it has no throughput, response time, or error rate in the APM view.

This PR:

* threads `...trace.SpanStartOption` through `Collect` → `Trace` → `openSpan` → `Start`
* applies it to the root command span via a new env var, `TG_TELEMETRY_TRACE_ROOT_SPAN_KIND`
* calls `span.SetStatus(codes.Error, ...)` next to the existing `span.RecordError`

The variadic tail keeps all existing call sites compiling unchanged, and also makes `WithAttributes`, `WithLinks` and `WithTimestamp` reachable for future use.

### Why an opt-in env var rather than hardcoding `server`

`server` on a CLI root span is a deviation from the OpenTelemetry specification: `SERVER` means an inbound synchronous remote request, and OTel's `cicd.*` / `process.*` semantic conventions deliberately define no span kind. The default therefore stays `internal` and nobody's existing traces change shape.

There is a partial argument for `server` in CI, which is why the option exists at all: Terragrunt already accepts `TRACEPARENT` and marks the grafted parent `Remote: true`, so in a pipeline the root span genuinely begins work that crossed a process boundary.

An unrecognized value degrades to `internal` rather than failing the run.

The alternative to a Go-side change is an OpenTelemetry Collector `transform` processor rewriting `span.kind`, which requires a collector in the export path. That is not available to users exporting straight from ephemeral CI runners to a vendor OTLP endpoint.

### Span status on error

`span.RecordError` records an exception event but leaves the span status `Unset`. Backends derive an errored transaction from the status, not from the event, so failed Terragrunt runs previously reported a 0% error rate even where spans were being collected.

## TODOs

- [x] Update the OpenTelemetry docs page
- [x] Unit tests for `Options.RootSpanKind`, span-kind plumbing, and error status
- [ ] Confirm the flag name and the opt-in-vs-hardcode call with maintainers

## Release Notes (draft)

Added `TG_TELEMETRY_TRACE_ROOT_SPAN_KIND` to set the OpenTelemetry span kind of the root command span, so APM backends that require a `server` or `consumer` entry span can build a service transaction from a Terragrunt run. Spans now also carry an error status when the traced operation fails.
