### PR TITLE
fix: propagate context from parent process to child one

### DIFF
--- a/internal/telemetry/context.go
+++ b/internal/telemetry/context.go
@@ -2,9 +2,8 @@ package telemetry
 
 import (
 	"context"
-	"fmt"
 
-	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 type contextKey byte
@@ -12,6 +11,7 @@ type contextKey byte
 const (
 	telemeterContextKey contextKey = iota
 	TraceParentEnv                 = "TRACEPARENT"
+	traceParentHeader              = "traceparent"
 )
 
 // ContextWithTelemeter returns a new context with the provided Telemeter attached.
@@ -31,27 +31,22 @@ func TelemeterFromContext(ctx context.Context) *Telemeter {
 	return new(Telemeter)
 }
 
-// TraceParentFromContext returns the W3C traceparent header value from
-// the context's span, or an error if not available.
+// TraceParentFromContext returns the W3C traceparent header value of the current
+// span, so that a child process joins this trace as its child. Falls back to the
+// remote parent this process inherited when there is no current span, and to an
+// empty string when there is neither.
 func TraceParentFromContext(ctx context.Context, telemetry *Options) string {
-	span := trace.SpanFromContext(ctx)
-	spanContext := span.SpanContext()
+	carrier := propagation.MapCarrier{}
 
-	if !spanContext.IsValid() {
-		return ""
+	propagation.TraceContext{}.Inject(ctx, carrier)
+
+	if traceParent := carrier.Get(traceParentHeader); traceParent != "" {
+		return traceParent
 	}
 
-	if telemetry != nil && len(telemetry.TraceParent) > 0 {
+	if telemetry != nil {
 		return telemetry.TraceParent
 	}
 
-	traceID := spanContext.TraceID().String()
-	spanID := spanContext.SpanID().String()
-	flags := "00"
-
-	if spanContext.TraceFlags().IsSampled() {
-		flags = "01"
-	}
-
-	return fmt.Sprintf("00-%s-%s-%s", traceID, spanID, flags)
+	return ""
 }

--- a/internal/telemetry/context_test.go
+++ b/internal/telemetry/context_test.go
@@ -1,0 +1,89 @@
+package telemetry_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	remoteTraceID     = "b2ff1f9c0d4a4e8fa9a1c3e5d7b9f1a3"
+	remoteSpanID      = "0e6f631d793c718a"
+	remoteTraceParent = "00-" + remoteTraceID + "-" + remoteSpanID + "-01"
+
+	currentTraceID     = "aa11bb22cc33dd44ee55ff6677889900"
+	currentSpanID      = "43aad9a8f32c6dea"
+	currentTraceParent = "00-" + currentTraceID + "-" + currentSpanID + "-01"
+)
+
+// ctxWithSpanContext returns a context carrying a valid span context with the
+// given trace ID, span ID and trace flags.
+func ctxWithSpanContext(
+	t *testing.T, traceIDHex, spanIDHex string, traceFlags trace.TraceFlags,
+) context.Context {
+	t.Helper()
+
+	traceID, err := trace.TraceIDFromHex(traceIDHex)
+	require.NoError(t, err)
+
+	spanID, err := trace.SpanIDFromHex(spanIDHex)
+	require.NoError(t, err)
+
+	return trace.ContextWithSpanContext(t.Context(), trace.NewSpanContext(
+		trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: traceFlags,
+		},
+	))
+}
+
+func TestTraceParentFromContextPrefersCurrentSpan(t *testing.T) {
+	t.Parallel()
+
+	// The remote parent belongs to the root span alone. Handing it to a child
+	// process would make every span in the run a sibling of the root.
+	got := telemetry.TraceParentFromContext(
+		ctxWithSpanContext(t, currentTraceID, currentSpanID, trace.FlagsSampled),
+		&telemetry.Options{TraceParent: remoteTraceParent},
+	)
+	assert.Equal(t, currentTraceParent, got)
+}
+
+func TestTraceParentFromContextWithoutOptions(t *testing.T) {
+	t.Parallel()
+
+	got := telemetry.TraceParentFromContext(
+		ctxWithSpanContext(t, currentTraceID, currentSpanID, trace.FlagsSampled), nil,
+	)
+	assert.Equal(t, currentTraceParent, got)
+}
+
+func TestTraceParentFromContextFallsBackToRemoteParent(t *testing.T) {
+	t.Parallel()
+
+	got := telemetry.TraceParentFromContext(
+		t.Context(), &telemetry.Options{TraceParent: remoteTraceParent},
+	)
+	assert.Equal(t, remoteTraceParent, got)
+}
+
+func TestTraceParentFromContextEmpty(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, telemetry.TraceParentFromContext(t.Context(), nil))
+	assert.Empty(t, telemetry.TraceParentFromContext(t.Context(), &telemetry.Options{}))
+}
+
+func TestTraceParentFromContextUnsampled(t *testing.T) {
+	t.Parallel()
+
+	got := telemetry.TraceParentFromContext(
+		ctxWithSpanContext(t, currentTraceID, currentSpanID, 0), nil,
+	)
+	assert.Equal(t, "00-"+currentTraceID+"-"+currentSpanID+"-00", got)
+}

--- a/internal/telemetry/tracer.go
+++ b/internal/telemetry/tracer.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"runtime/debug"
-	"strconv"
-	"strings"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 
@@ -15,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
@@ -27,8 +26,6 @@ const (
 	otlpHTTPTraceExporterType traceExporterType = "otlpHttp"
 	otlpGrpcTraceExporterType traceExporterType = "otlpGrpc"
 	httpTraceExporterType     traceExporterType = "http"
-
-	traceParentParts = 4
 )
 
 type traceExporterType string
@@ -63,6 +60,11 @@ func NewTracer(
 
 	otel.SetTracerProvider(provider)
 
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
 	var (
 		parentTraceID    *trace.TraceID
 		parentSpanID     *trace.SpanID
@@ -70,33 +72,19 @@ func NewTracer(
 	)
 
 	if opts.TraceParent != "" {
-		// parse trace parent values
-		parts := strings.Split(opts.TraceParent, "-")
-		if len(parts) != traceParentParts {
+		parentCtx := propagation.TraceContext{}.Extract(
+			ctx,
+			propagation.MapCarrier{traceParentHeader: opts.TraceParent},
+		)
+
+		parentSpanContext := trace.SpanContextFromContext(parentCtx)
+		if !parentSpanContext.IsValid() {
 			return nil, fmt.Errorf("invalid TRACEPARENT value %s", opts.TraceParent)
 		}
 
-		_, traceIDHex, spanIDHex, traceFlagsStr := parts[0], parts[1], parts[2], parts[3]
-
-		parsedFlag, err := strconv.Atoi(traceFlagsStr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid trace flags: %w", err)
-		}
-
-		traceFlags := trace.FlagsSampled
-		if parsedFlag == 0 {
-			traceFlags = 0
-		}
-
-		traceID, err := trace.TraceIDFromHex(traceIDHex)
-		if err != nil {
-			return nil, err
-		}
-
-		spanID, err := trace.SpanIDFromHex(spanIDHex)
-		if err != nil {
-			return nil, err
-		}
+		traceID := parentSpanContext.TraceID()
+		spanID := parentSpanContext.SpanID()
+		traceFlags := parentSpanContext.TraceFlags()
 
 		parentTraceID = &traceID
 		parentSpanID = &spanID

--- a/internal/telemetry/tracer_test.go
+++ b/internal/telemetry/tracer_test.go
@@ -1,7 +1,9 @@
 package telemetry_test
 
 import (
+	"context"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
@@ -9,9 +11,12 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestNewTraceExporter(t *testing.T) {
@@ -86,4 +91,119 @@ func TestNewTraceExporter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewTracerExtractsTraceParent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		traceParent   string
+		expectError   bool
+		expectSampled bool
+	}{
+		{
+			name:          "sampled",
+			traceParent:   "00-" + remoteTraceID + "-" + remoteSpanID + "-01",
+			expectSampled: true,
+		},
+		{
+			name:        "unsampled",
+			traceParent: "00-" + remoteTraceID + "-" + remoteSpanID + "-00",
+		},
+		{
+			// Only bit 0 of trace-flags is the sampled flag. Bit 1 is the random
+			// trace ID flag and says nothing about sampling.
+			name:        "random flag without the sampled flag",
+			traceParent: "00-" + remoteTraceID + "-" + remoteSpanID + "-02",
+		},
+		{
+			name:          "random and sampled flags",
+			traceParent:   "00-" + remoteTraceID + "-" + remoteSpanID + "-03",
+			expectSampled: true,
+		},
+		{
+			// Version 00 reserves the remaining trace-flags bits.
+			name:        "reserved trace-flags bits",
+			traceParent: "00-" + remoteTraceID + "-" + remoteSpanID + "-ff",
+			expectError: true,
+		},
+		{
+			name:        "not a traceparent",
+			traceParent: "garbage",
+			expectError: true,
+		},
+		{
+			name:        "missing trace-flags field",
+			traceParent: "00-" + remoteTraceID + "-" + remoteSpanID,
+			expectError: true,
+		},
+		{
+			name:        "all-zero trace ID and parent ID",
+			traceParent: "00-" + strings.Repeat("0", 32) + "-" + strings.Repeat("0", 16) + "-01",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
+			opts.Telemetry.TraceExporter = "console"
+			opts.Telemetry.TraceParent = tt.traceParent
+
+			tracer, err := telemetry.NewTracer(
+				t.Context(), nil, "terragrunt", "v0.0.0-test", io.Discard, opts.Telemetry,
+			)
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, tracer)
+
+			// The remote parent is grafted onto the first span started on a context
+			// that carries none.
+			var got trace.SpanContext
+
+			require.NoError(t, tracer.Trace(
+				t.Context(), "root", nil,
+				func(childCtx context.Context) error {
+					got = trace.SpanContextFromContext(childCtx)
+					return nil
+				},
+			))
+
+			assert.Equal(t, remoteTraceID, got.TraceID().String())
+			assert.Equal(t, tt.expectSampled, got.TraceFlags().IsSampled())
+		})
+	}
+}
+
+func TestNewTracerRegistersGlobalPropagator(t *testing.T) {
+	t.Parallel()
+
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
+	opts.Telemetry.TraceExporter = "console"
+
+	tracer, err := telemetry.NewTracer(
+		t.Context(), nil, "terragrunt", "v0.0.0-test", io.Discard, opts.Telemetry,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, tracer)
+
+	// The global default propagator is a no-op, which leaves instrumented clients
+	// injecting no traceparent at all.
+	ctx, span := tracer.Start(t.Context(), "outbound")
+	t.Cleanup(func() { span.End() })
+
+	carrier := propagation.MapCarrier{}
+	otel.GetTextMapPropagator().Inject(ctx, carrier)
+
+	assert.Contains(
+		t, carrier.Get("traceparent"), span.SpanContext().TraceID().String(),
+	)
 }


### PR DESCRIPTION
## Description

Three defects in W3C trace context handling, each of which splits or flattens a Terragrunt run's trace.

### 1. Child processes inherited the wrong parent ID

`TraceParentFromContext` returned `Options.TraceParent` verbatim whenever it was set, ignoring the current span:

```go
if telemetry != nil && len(telemetry.TraceParent) > 0 {
    return telemetry.TraceParent
}
```

`Options.TraceParent` holds the traceparent *this* process inherited, and `Tracer.openSpan` already grafts it onto the root span as a remote parent. Returning it again from this function put that remote parent ID into the `TRACEPARENT` handed to every child process, so every subprocess span became a sibling of the root span instead of a child of the span that launched it.

Reproduced with a `before_hook` that echoes `$TRACEPARENT`:

* no inherited traceparent → the hook sees the parent ID of the `run_sh` span (correct)
* `TRACEPARENT` set → the hook sees the inherited parent ID, not `run_sh`

The current span now takes precedence, with `Options.TraceParent` kept as the fallback for call sites that have no span in flight — telemetry disabled, or code running outside any `Collect` — where the inherited value at least keeps the child on the same trace. The trace ID is unchanged either way; only the parent ID becomes the actual caller.

The value is now produced by `propagation.TraceContext{}.Inject` rather than assembled with `fmt.Sprintf`, which drops the hard-coded version and trace-flags formatting and makes this the mirror of the extract in `NewTracer`.

> [!NOTE]
> `internal/getter/oci_auth.go` already passes `nil` options to opt out of the old behavior, which reads as a workaround for this bug.

### 2. No global text map propagator was registered

`otel.SetTextMapPropagator` was called nowhere, leaving OpenTelemetry's no-op default in place. Instrumented outbound clients — `otelhttp` and `otelgrpc`, reached through the cloud SDKs — injected no traceparent header, so each remote span started its own trace. In-process parentage was unaffected; only cross-process continuation was.

Now registers a composite `TraceContext` and `Baggage` propagator, and only when a trace exporter is configured, since `NewTracer` returns early otherwise.

### 3. trace-flags was parsed as a decimal number

The hand-rolled parse ran `strconv.Atoi` over the trace-flags field and treated any non-zero result as sampled. Only bit 0 is the sampled flag, so `02` — the random trace ID flag with the sampled flag clear — was reported as sampled.

Replaced with `propagation.TraceContext{}.Extract`, which validates the version, the trace ID, the parent ID and the trace-flags field per the specification.

> [!IMPORTANT]
> This is stricter than before. A value that `Atoi` happened to tolerate, such as trace-flags with the version-00 reserved bits set (`-ff`), is now rejected with `invalid TRACEPARENT value`. That matches the specification, but it is a behavior change.

## TODOs

- [x] Unit tests for `TraceParentFromContext`: current span precedence, fallback, and the sampled flag
- [x] Unit tests for traceparent extraction, covering the trace-flags cases and reserved-bit rejection
- [x] Unit test asserting the global propagator injects a traceparent header
- [ ] Consider a span-tree assertion helper for the integration suite — nothing there checks parentage today, which is why this class of regression is invisible
- [ ] File the upstream `getsops/sops` request for a context-aware decrypt path

## Release Notes (draft)

Fixed W3C trace context propagation so that child processes Terragrunt launches inherit the current span as their parent rather than the traceparent the run itself inherited, which previously flattened the span tree whenever `TRACEPARENT` was set. Registered a trace context propagator so instrumented outbound clients continue the run's trace, and fixed sampled flag parsing of an inherited traceparent.
