### PR TITLE
feat: add unit relative path span attribute

### DIFF
--- a/internal/component/component_test.go
+++ b/internal/component/component_test.go
@@ -1,6 +1,7 @@
 package component_test
 
 import (
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -271,4 +272,52 @@ func TestUnitGuardConfigParseWithRacing(t *testing.T) {
 
 	assert.Equal(t, int32(1), parses.Load(), "config should be parsed exactly once")
 	assert.NotNil(t, unit.Config(), "config should be populated after parsing")
+}
+
+func TestUnitDisplayPath(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		workingDir string
+		unitPath   string
+		expected   string
+	}{
+		{
+			name:       "nested unit is relative to the working dir",
+			workingDir: filepath.Join(string(filepath.Separator), "repo"),
+			unitPath: filepath.Join(
+				string(filepath.Separator), "repo",
+				"walmart-b2b", "test", "infra", "cloudarmor",
+			),
+			expected: filepath.Join("walmart-b2b", "test", "infra", "cloudarmor"),
+		},
+		{
+			name:       "no ./ prefix is added",
+			workingDir: filepath.Join(string(filepath.Separator), "base"),
+			unitPath:   filepath.Join(string(filepath.Separator), "base", "child"),
+			expected:   "child",
+		},
+		{
+			name:       "empty working dir falls back to the absolute path",
+			workingDir: "",
+			unitPath:   filepath.Join(string(filepath.Separator), "base", "child"),
+			expected:   filepath.Join(string(filepath.Separator), "base", "child"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			unit := component.NewUnit(tc.unitPath)
+			if tc.workingDir != "" {
+				unit = unit.WithDiscoveryContext(&component.DiscoveryContext{
+					WorkingDir: tc.workingDir,
+				})
+			}
+
+			assert.Equal(t, tc.expected, unit.DisplayPath())
+		})
+	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -464,10 +464,15 @@ func (rnr *Runner) Run(
 
 		unitPath := u.Path()
 		unitName := filepath.Base(unitPath)
+		// DisplayPath is the working-dir-relative path shown in log prefixes. It is
+		// emitted alongside the absolute unit_path because telemetry backends
+		// truncate long string attributes, hiding the part that identifies the unit.
+		unitPathRelative := u.DisplayPath()
 
 		return telemetry.TelemeterFromContext(ctx).
 			Collect(ctx, unitLogger, "runner_pool_task", map[string]any{
 				"unit_path":              unitPath,
+				"unit_path_relative":     unitPathRelative,
 				"unit_name":              unitName,
 				"terraform_command":      unitOpts.TerraformCommand,
 				"terraform_cli_args":     unitOpts.TerraformCliArgs,
@@ -519,6 +524,7 @@ func (rnr *Runner) Run(
 				err = telemetry.TelemeterFromContext(childCtx).
 					Collect(childCtx, unitLogger, "unit_read_config", map[string]any{
 						"unit_path":              unitPath,
+						"unit_path_relative":     unitPathRelative,
 						"unit_name":              unitName,
 						"terragrunt_config_path": unitOpts.TerragruntConfigPath,
 					}, func(readCtx context.Context, unitLogger log.Logger) error {
@@ -554,9 +560,10 @@ func (rnr *Runner) Run(
 
 				err = telemetry.TelemeterFromContext(childCtx).
 					Collect(childCtx, unitLogger, "unit_run", map[string]any{
-						"unit_path":         unitPath,
-						"unit_name":         unitName,
-						"terraform_command": unitOpts.TerraformCommand,
+						"unit_path":          unitPath,
+						"unit_path_relative": unitPathRelative,
+						"unit_name":          unitName,
+						"terraform_command":  unitOpts.TerraformCommand,
 					}, func(runCtx context.Context, unitLogger log.Logger) error {
 						return unitRunner.Run(
 							runCtx,


### PR DESCRIPTION
## Description

Unit spans emit `unit_path` as an absolute filesystem path. In CI that path is long and mostly noise:

```
/home/runner/_work/dice-environments/dice-environments/infra-live-repo/walmart-b2b/test/infra/cloudarmor
```

Telemetry backends truncate long string attributes in list views, so the part that actually identifies the unit — the tail — is the part that gets hidden. Finding out which unit a span belongs to costs an extra click.

This PR emits `unit_path_relative` alongside it, reusing `(*component.Unit).DisplayPath()` — the same working-dir-relative path Terragrunt already shows in log prefixes:

```
walmart-b2b/test/infra/cloudarmor
```

`unit_path` keeps the absolute value, so existing queries and dashboards are unaffected. The name sorts adjacent to `unit_path` in an alphabetical attribute list, which is the point of the change.

Applies to the `runner_pool_task`, `unit_read_config` and `unit_run` spans. All three read the same `unitPath` variable, so one new variable covers every site.

### Deliberately unchanged

The `stack_generate_unit` and `unit_output` spans also set a `unit_path` attribute, but theirs comes from the HCL `path` attribute of a `unit` block, which `resolveDestPath` already requires to be relative. Those spans emit short values like `app1` today.

### Notes on the base directory

`DisplayPath()` is relative to `DiscoveryContext.WorkingDir`, i.e. the Terragrunt working directory. That is the base that produces the value above; the git repo root would retain an `infra-live-repo/` prefix, since the Actions checkout directory sits above it.

`DisplayPath()` is called unconditionally rather than gated on `LogShowAbsPaths`. The logger gates it because a prefix has to pick one path or the other; telemetry emits both attributes, so the relative one should always be present. When the discovery context is missing it falls back to the absolute path, so the attribute is degraded but never empty.

## TODOs

- [x] Table test for `DisplayPath()`, first case being the reported path — it had no direct unit test, and this change promotes it to a telemetry contract

## Release Notes (draft)

Added a `unit_path_relative` span attribute carrying the unit path relative to the working directory, matching what log prefixes show. The existing absolute `unit_path` attribute is unchanged.
