### PR TITLE
fix(gcs): read dependency outputs from state with external_account creds

### DIFF
--- a/docs/src/data/changelog/v1.1.5/gcs-workload-identity-federation.mdx
+++ b/docs/src/data/changelog/v1.1.5/gcs-workload-identity-federation.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### Direct GCS state reads work with Workload Identity Federation
+
+With the [`dependency-fetch-output-from-state`](/reference/experiments/active#dependency-fetch-output-from-state) experiment enabled, a GCS backend authenticated through Workload Identity Federation still ran `tofu output` or `terraform output` for every dependency, so the experiment made no difference.
+
+It affected any credentials file of type `external_account`, which is what [`google-github-actions/auth`](https://github.com/google-github-actions/auth) writes and points `GOOGLE_APPLICATION_CREDENTIALS` at. Terragrunt read only `service_account` and `authorized_user` files directly.
+
+Terragrunt now reads `external_account` credentials directly, including the service-account impersonation chain that `google-github-actions/auth` adds when you name a service account. Direct reads apply when the `credential_source` is a `url` or an absolute `file` path. Every other source still uses the normal output method: an `executable` source would run with Terragrunt's environment instead of the unit's, an AWS source would authenticate with Terragrunt's AWS credentials, and a relative `file` path would resolve against Terragrunt's working directory instead of the unit's. The `impersonate_service_account` backend setting is unrelated and still uses the normal output method.

--- a/docs/src/data/changelog/v1.1.5/gcs-workload-identity-federation.mdx
+++ b/docs/src/data/changelog/v1.1.5/gcs-workload-identity-federation.mdx
@@ -9,4 +9,15 @@ With the [`dependency-fetch-output-from-state`](/reference/experiments/active#de
 
 It affected any credentials file of type `external_account`, which is what [`google-github-actions/auth`](https://github.com/google-github-actions/auth) writes and points `GOOGLE_APPLICATION_CREDENTIALS` at. Terragrunt read only `service_account` and `authorized_user` files directly.
 
-Terragrunt now reads `external_account` credentials directly, including the service-account impersonation chain that `google-github-actions/auth` adds when you name a service account. Direct reads apply when the `credential_source` is a `url` or an absolute `file` path. Every other source still uses the normal output method: an `executable` source would run with Terragrunt's environment instead of the unit's, an AWS source would authenticate with Terragrunt's AWS credentials, and a relative `file` path would resolve against Terragrunt's working directory instead of the unit's. The `impersonate_service_account` backend setting is unrelated and still uses the normal output method.
+Terragrunt now reads `external_account` credentials files directly, including the service-account impersonation that `google-github-actions/auth` configures when you give it a service account. A direct read requires the file's `credential_source` to be one of:
+
+- `url`
+- `file` with an absolute path
+
+Any other `credential_source` keeps the previous behavior, and the dependency still runs `tofu output` or `terraform output`. Reading those directly would use Terragrunt's own process rather than the unit's environment to resolve the identity:
+
+- `executable` would run the command with Terragrunt's environment.
+- AWS (an `environment_id` such as `aws1`) would use Terragrunt's AWS credentials.
+- `file` with a relative path would resolve against Terragrunt's working directory.
+
+The `impersonate_service_account` backend setting is a separate feature and is not affected. Backends that set it still run `tofu output` or `terraform output`.

--- a/docs/src/data/experiments/dependency-fetch-output-from-state.mdx
+++ b/docs/src/data/experiments/dependency-fetch-output-from-state.mdx
@@ -15,7 +15,9 @@ By default, Terragrunt retrieves dependency outputs by running `tofu output` or 
 
 Azure state protected with `customer_provided_key`, and Azure configurations that rely on native-only authentication, `metadata_host`, or `timeout_seconds`, also use the normal method.
 
-GCS configurations that rely on backend-only credential environment variables, inline credentials or relative credential-file paths, service-account impersonation, custom storage endpoints, custom universe domains, or competing credential sources with different precedence also use the normal method. This preserves the native backend's authentication and endpoint behavior.
+GCS configurations that rely on backend-only credential environment variables, inline credentials or relative credential-file paths, the `impersonate_service_account` setting, custom storage endpoints, custom universe domains, or competing credential sources with different precedence also use the normal method. This preserves the native backend's authentication and endpoint behavior.
+
+Terragrunt reads `service_account`, `authorized_user`, and `external_account` (Workload Identity Federation) credential files directly. An `external_account` file is read directly only when its `credential_source` is a `url` or an absolute `file` path. Every other source uses the normal method. An `executable` source would run with Terragrunt's environment rather than the unit's, an AWS source would authenticate with Terragrunt's AWS credentials, and a relative `file` path would resolve against Terragrunt's working directory rather than the unit's.
 
 **Known Limitations:**
 

--- a/docs/src/data/experiments/dependency-fetch-output-from-state.mdx
+++ b/docs/src/data/experiments/dependency-fetch-output-from-state.mdx
@@ -17,7 +17,13 @@ Azure state protected with `customer_provided_key`, and Azure configurations tha
 
 GCS configurations that rely on backend-only credential environment variables, inline credentials or relative credential-file paths, the `impersonate_service_account` setting, custom storage endpoints, custom universe domains, or competing credential sources with different precedence also use the normal method. This preserves the native backend's authentication and endpoint behavior.
 
-Terragrunt reads `service_account`, `authorized_user`, and `external_account` (Workload Identity Federation) credential files directly. An `external_account` file is read directly only when its `credential_source` is a `url` or an absolute `file` path. Every other source uses the normal method. An `executable` source would run with Terragrunt's environment rather than the unit's, an AWS source would authenticate with Terragrunt's AWS credentials, and a relative `file` path would resolve against Terragrunt's working directory rather than the unit's.
+The `credentials` backend setting is a local path to a Google Cloud credentials file in JSON format. `GOOGLE_APPLICATION_CREDENTIALS` points to the same kind of file. Neither is the same thing as `access_token`, which is a temporary OAuth 2.0 access token used as-is rather than a file.
+
+Terragrunt reads credentials files of type `service_account`, `authorized_user`, and `external_account` (Workload Identity Federation) directly. An `external_account` file is read directly only when its `credential_source` is a `url` or a `file` with an absolute path. Any other source uses the normal method, because a direct read would resolve it with Terragrunt's own environment and working directory rather than the unit's:
+
+- `executable` would run the command with Terragrunt's environment.
+- AWS (an `environment_id` such as `aws1`) would use Terragrunt's AWS credentials.
+- `file` with a relative path would resolve against Terragrunt's working directory.
 
 **Known Limitations:**
 

--- a/pkg/config/dependency_internal_test.go
+++ b/pkg/config/dependency_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -308,4 +309,106 @@ func TestApplyExtraArgsEnvVarsForOutput(t *testing.T) {
 			assert.Equal(t, tc.want, pctx.Venv.Env)
 		})
 	}
+}
+
+// TestGCSCredentialFileDirectStateReadSupported covers every credential file shape the gate decides on, including the external_account sources of issue #6810.
+func TestGCSCredentialFileDirectStateReadSupported(t *testing.T) {
+	t.Parallel()
+
+	const credentialPath = "/config/credentials.json"
+
+	testCases := []struct {
+		name     string
+		contents string
+		want     bool
+	}{
+		{name: "service account", contents: `{"type":"service_account"}`, want: true},
+		{name: "authorized user", contents: `{"type":"authorized_user"}`, want: true},
+		{
+			name:     "external account with a file source",
+			contents: `{"type":"external_account","credential_source":{"file":"/var/run/token"}}`,
+			want:     true,
+		},
+		{
+			name:     "external account with a relative file source",
+			contents: `{"type":"external_account","credential_source":{"file":"token.json"}}`,
+		},
+		{
+			name:     "external account with a tilde file source",
+			contents: `{"type":"external_account","credential_source":{"file":"~/token"}}`,
+		},
+		{
+			name:     "external account with a kubernetes token file and format",
+			contents: `{"type":"external_account","credential_source":{"file":"/var/run/service-account/token","format":{"type":"text"}}}`,
+			want:     true,
+		},
+		{
+			name:     "external account with a url source and headers",
+			contents: `{"type":"external_account","credential_source":{"url":"https://sts.example.com/token","headers":{"Authorization":"Bearer x"},"format":{"type":"json","subject_token_field_name":"value"}}}`,
+			want:     true,
+		},
+		{
+			name:     "external account with a url source",
+			contents: `{"type":"external_account","credential_source":{"url":"https://sts.example.com/token"}}`,
+			want:     true,
+		},
+		{
+			name:     "external account with an aws source",
+			contents: `{"type":"external_account","credential_source":{"environment_id":"aws1","region_url":"http://169.254.169.254/latest/meta-data/placement/availability-zone","url":"http://169.254.169.254/latest/meta-data/iam/security-credentials","regional_cred_verification_url":"https://sts.{region}.amazonaws.com"}}`,
+		},
+		{
+			name:     "external account with a certificate source",
+			contents: `{"type":"external_account","credential_source":{"certificate":{"use_default_certificate_config":true}}}`,
+		},
+		{
+			name:     "external account with an executable alongside a url",
+			contents: `{"type":"external_account","credential_source":{"url":"https://sts.example.com/token","executable":{"command":"/usr/bin/token"}}}`,
+		},
+		{
+			name:     "external account with an executable source",
+			contents: `{"type":"external_account","credential_source":{"executable":{"command":"/usr/bin/token"}}}`,
+		},
+		{
+			name:     "external account with no source",
+			contents: `{"type":"external_account"}`,
+		},
+		{
+			name:     "external account with an unrecognized source",
+			contents: `{"type":"external_account","credential_source":{"future":"kind"}}`,
+		},
+		{
+			name:     "external account with a null credential source",
+			contents: `{"type":"external_account","credential_source":null}`,
+		},
+		{name: "external account authorized user", contents: `{"type":"external_account_authorized_user"}`},
+		{name: "impersonated service account", contents: `{"type":"impersonated_service_account"}`},
+		{name: "missing type", contents: `{}`},
+		{name: "empty object", contents: `{"type":""}`},
+		{name: "malformed json", contents: `{"type":`},
+		{name: "trailing content", contents: `{"type":"service_account"}{"extra":true}`},
+		{name: "not an object", contents: `"service_account"`},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := venvtest.New()
+			require.NoError(t, vfs.WriteFile(v.FS, credentialPath, []byte(testCase.contents), 0o600))
+
+			pctx := &ParsingContext{Venv: v}
+
+			assert.Equal(t, testCase.want, gcsCredentialFileDirectStateReadSupported(pctx, credentialPath))
+		})
+	}
+}
+
+// TestGCSCredentialFileDirectStateReadSupportedMissingFile pins that an unreadable credential file falls back instead of reading state as the wrong identity.
+func TestGCSCredentialFileDirectStateReadSupportedMissingFile(t *testing.T) {
+	t.Parallel()
+
+	pctx := &ParsingContext{Venv: venvtest.New()}
+
+	assert.True(t, gcsCredentialFileDirectStateReadSupported(pctx, ""), "an unset credential path is not a divergence")
+	assert.False(t, gcsCredentialFileDirectStateReadSupported(pctx, "/config/absent.json"))
 }

--- a/pkg/config/dependency_state_eligibility_test.go
+++ b/pkg/config/dependency_state_eligibility_test.go
@@ -98,7 +98,7 @@ func TestDependencyStateEligibilityRoutesSafely(t *testing.T) {
 			backendConfig: eligibilityConfig(gcsConfig, map[string]string{"credentials": `"credentials.json"`}),
 		},
 		{
-			name:          "GCS external account credential file falls back",
+			name:          "GCS external account credential file without a credential source falls back",
 			backend:       "gcs",
 			backendConfig: eligibilityConfig(gcsConfig, map[string]string{"credentials": `"/credentials/external.json"`}),
 			files:         map[string]string{"/credentials/external.json": `{"type":"external_account"}`},

--- a/pkg/config/dependency_state_gcs.go
+++ b/pkg/config/dependency_state_gcs.go
@@ -21,6 +21,22 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
+// Credential file types the GCS backend resolves through the Google SDK.
+const (
+	gcsCredentialTypeServiceAccount  = "service_account"
+	gcsCredentialTypeAuthorizedUser  = "authorized_user"
+	gcsCredentialTypeExternalAccount = "external_account"
+)
+
+// gcsExternalAccountSource is the subject-token source of an external_account credentials file.
+type gcsExternalAccountSource struct {
+	EnvironmentID string          `json:"environment_id"`
+	File          string          `json:"file"`
+	URL           string          `json:"url"`
+	Certificate   json.RawMessage `json:"certificate"`
+	Executable    json.RawMessage `json:"executable"`
+}
+
 // gcsStringConfigKeys names the backend settings a direct read consumes as strings.
 var gcsStringConfigKeys = []string{
 	"access_token",
@@ -139,9 +155,7 @@ func gcsEncryptionKeyDirectStateReadSupported(value string) bool {
 	return filepath.IsAbs(value) && !strings.HasPrefix(value, "~")
 }
 
-// gcsCredentialFileDirectStateReadSupported retains credential files whose
-// authentication does not launch or configure an external subject-token
-// provider from the Terragrunt process environment.
+// gcsCredentialFileDirectStateReadSupported retains credential files the direct reader resolves the same way the native backend does.
 func gcsCredentialFileDirectStateReadSupported(pctx *ParsingContext, filename string) bool {
 	if filename == "" {
 		return true
@@ -153,7 +167,8 @@ func gcsCredentialFileDirectStateReadSupported(pctx *ParsingContext, filename st
 	}
 
 	var metadata struct {
-		Type string `json:"type"`
+		Type             string                   `json:"type"`
+		CredentialSource gcsExternalAccountSource `json:"credential_source"`
 	}
 
 	decoder := json.NewDecoder(file)
@@ -170,7 +185,14 @@ func gcsCredentialFileDirectStateReadSupported(pctx *ParsingContext, filename st
 		return false
 	}
 
-	return metadata.Type == "service_account" || metadata.Type == "authorized_user"
+	switch metadata.Type {
+	case gcsCredentialTypeServiceAccount, gcsCredentialTypeAuthorizedUser:
+		return true
+	case gcsCredentialTypeExternalAccount:
+		return metadata.CredentialSource.supported()
+	default:
+		return false
+	}
 }
 
 func gcsBackendConfigKeyKnown(key string) bool {
@@ -476,4 +498,21 @@ func gcsCredentialPrecedenceSupported(env map[string]string, settings gcsDirectS
 	}
 
 	return settings.credentials == "" || applicationCredentials == ""
+}
+
+// supported mirrors the SDK's subject-provider selection order and keeps only the sources that resolve to the same identity the native backend uses: an absolute file path, or a URL.
+func (source *gcsExternalAccountSource) supported() bool {
+	if len(source.Certificate) > 0 {
+		return false
+	}
+
+	if strings.HasPrefix(source.EnvironmentID, "aws") || len(source.Executable) > 0 {
+		return false
+	}
+
+	if source.File != "" {
+		return filepath.IsAbs(source.File)
+	}
+
+	return source.URL != ""
 }

--- a/pkg/config/dependency_state_gcs_credential_test.go
+++ b/pkg/config/dependency_state_gcs_credential_test.go
@@ -7,8 +7,12 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -75,6 +79,102 @@ func TestDependencyStateEligibilityStreamsGCSCredentialFile(t *testing.T) {
 		assert.Equal(t, int32(1), fsys.credentialOpens.Load())
 		assert.Equal(t, int32(1), fsys.closes.Load())
 	})
+}
+
+// TestDependencyStateEligibilityAcceptsExternalAccountCredentials covers issue #6810: a Workload Identity Federation credentials file must keep direct state reads enabled.
+func TestDependencyStateEligibilityAcceptsExternalAccountCredentials(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		source         string
+		viaEnvironment bool
+		withTokenFile  bool
+		wantDirect     bool
+	}{
+		{
+			name:           "credentials exported through GOOGLE_APPLICATION_CREDENTIALS remain direct",
+			withTokenFile:  true,
+			viaEnvironment: true,
+			wantDirect:     true,
+		},
+		{
+			name:          "file sourced subject token remains direct",
+			withTokenFile: true,
+			wantDirect:    true,
+		},
+		{
+			name:       "url sourced subject token remains direct",
+			source:     `{"url":"https://sts.example.com/subject-token"}`,
+			wantDirect: true,
+		},
+		{
+			// An AWS source reads its credentials from the process environment.
+			name:   "aws sourced subject token falls back",
+			source: `{"environment_id":"aws1"}`,
+		},
+		{
+			// An executable source would run with the Terragrunt process environment.
+			name:   "executable sourced subject token falls back",
+			source: `{"executable":{"command":"/usr/bin/get-token","timeout_millis":5000}}`,
+		},
+		{
+			name:   "executable alongside a file source still falls back",
+			source: `{"file":"/credentials/subject-token","executable":{"command":"/usr/bin/get-token"}}`,
+		},
+		{
+			name:   "empty credential source falls back",
+			source: `{}`,
+		},
+		{
+			name:   "unrecognized credential source falls back",
+			source: `{"future_source":{"kind":"unknown"}}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			source := testCase.source
+			if testCase.withTokenFile {
+				source = fmt.Sprintf(`{"file":%q}`, writeSubjectTokenFile(t))
+			}
+
+			cfg, recorder := parseGCSExternalAccountFixture(t, externalAccountCredentials(source), testCase.viaEnvironment)
+
+			if !testCase.wantDirect {
+				assert.Equal(t, "from-native-output", cfg.Inputs["result"])
+				assert.Empty(t, recorder.requestPaths(), "a rejected credential must not reach the network")
+				assertEligibilityOutputInvocation(t, recorder.invocations())
+
+				return
+			}
+
+			assert.Equal(t, "from-direct", cfg.Inputs["result"])
+			assert.Contains(t, recorder.requestPaths(), gcsStatePath)
+			assert.Empty(t, recorder.invocations(), "a direct read must not run the native output command")
+
+			paths := strings.Join(recorder.requestPaths(), " ")
+			assert.Contains(t, paths, "sts.googleapis.com", "the subject token must be exchanged")
+			assert.Contains(t, paths, "iamcredentials.googleapis.com", "the impersonation chain must be followed")
+		})
+	}
+}
+
+// TestDependencyStateEligibilityExternalAccountCredentialIOFailure pins that a credential file whose close fails keeps the unit on the native output path.
+func TestDependencyStateEligibilityExternalAccountCredentialIOFailure(t *testing.T) {
+	t.Parallel()
+
+	cfg, recorder, fsys := parseGCSCredentialEligibilityFixture(
+		t,
+		externalAccountCredentials(`{"file":"/var/run/subject-token"}`),
+		errGCSCredentialClose,
+	)
+
+	assert.Equal(t, "from-native-output", cfg.Inputs["result"])
+	assert.Empty(t, recorder.requestPaths())
+	assert.Equal(t, int32(1), fsys.closes.Load())
 }
 
 func parseGCSCredentialEligibilityFixture(
@@ -183,4 +283,77 @@ func (file *gcsCredentialStreamFile) Close() error {
 	file.fsys.closes.Add(1)
 
 	return errors.Join(file.File.Close(), file.fsys.closeErr)
+}
+
+// externalAccountCredentials builds the credentials file google-github-actions/auth writes, including the impersonation chain it adds for a named service account.
+func externalAccountCredentials(credentialSource string) string {
+	return `{"type":"external_account",` +
+		`"audience":"//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/g",` +
+		`"subject_token_type":"urn:ietf:params:oauth:token-type:jwt",` +
+		`"token_url":"https://sts.googleapis.com/v1/token",` +
+		`"service_account_impersonation_url":"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/gh@p.iam.gserviceaccount.com:generateAccessToken",` +
+		`"credential_source":` + credentialSource + `}`
+}
+
+// writeSubjectTokenFile uses the real filesystem because the Google SDK opens the subject-token path itself rather than through the unit's vfs.
+func writeSubjectTokenFile(t *testing.T) string {
+	t.Helper()
+
+	tokenPath := filepath.Join(t.TempDir(), "subject-token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte("subject-token-value"), 0o600))
+
+	return tokenPath
+}
+
+func parseGCSExternalAccountFixture(
+	t *testing.T,
+	credentials string,
+	viaEnvironment bool,
+) (*config.TerragruntConfig, *dependencyStateRecorder) {
+	t.Helper()
+
+	recorder := newDependencyStateRecorder(t, http.StatusOK, terraformState("from-direct"))
+	recorder.respond = func(req *http.Request) *http.Response {
+		switch req.URL.Host {
+		case "sts.googleapis.com", "oauth2.googleapis.com", "sts.example.com":
+			return vhttp.Respond(
+				http.StatusOK,
+				[]byte(`{"access_token":"federated-token","token_type":"Bearer","expires_in":3600,"issued_token_type":"urn:ietf:params:oauth:token-type:access_token"}`),
+				nil,
+			)
+		case "iamcredentials.googleapis.com":
+			return vhttp.Respond(
+				http.StatusOK,
+				[]byte(`{"accessToken":"impersonated-token","expireTime":"2099-01-01T00:00:00Z"}`),
+				nil,
+			)
+		case "storage.googleapis.com":
+			return vhttp.Respond(http.StatusOK, terraformState("from-direct"), nil)
+		default:
+			t.Errorf("unexpected request to %s", req.URL.Host)
+
+			return vhttp.Respond(http.StatusInternalServerError, nil, nil)
+		}
+	}
+
+	testCase := dependencyStateEligibilityTestCase{
+		backend: "gcs",
+		backendConfig: eligibilityConfig(
+			eligibilityGCSConfig(),
+			map[string]string{"credentials": strconv.Quote(gcsCredentialPath)},
+			"access_token",
+		),
+		files: map[string]string{gcsCredentialPath: credentials},
+	}
+
+	// The reporter's setup exports the credentials file instead of naming it in the backend block.
+	if viaEnvironment {
+		testCase.backendConfig = eligibilityConfig(eligibilityGCSConfig(), nil, "access_token", "credentials")
+		testCase.env = map[string]string{"GOOGLE_APPLICATION_CREDENTIALS": gcsCredentialPath}
+	}
+
+	cfg, err := parseDependencyStateEligibilityFixture(t, recorder, &testCase)
+	require.NoError(t, err)
+
+	return cfg, recorder
 }


### PR DESCRIPTION


<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

- Accept external_account credential files for direct GCS state reads
- Restrict eligibility to absolute file and url subject-token sources
- Cover the GOOGLE_APPLICATION_CREDENTIALS delivery path end to end
- Document supported credential types in the experiment page and changelog

Fixes #6810.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Cloud Storage state access for Workload Identity Federation credentials sourced from URLs or absolute file paths.
  * Support includes service-account impersonation chains while preserving fallback behavior for unsupported credential sources, such as AWS and executable providers.
  * Credential files that cannot be read continue to use the standard output path.

* **Documentation**
  * Clarified credential-file, access-token, credential-source, and fallback behavior for Google Cloud Storage backends.
  * Added a changelog entry describing the Workload Identity Federation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->