### PR TITLE
fix: populate run report cause for units that fail before tofu/terraform runs

### DIFF
--- a/internal/runner/controller.go
+++ b/internal/runner/controller.go
@@ -28,6 +28,7 @@ type Controller struct {
 	runner      UnitRunnerFunc
 	readyCh     chan struct{}
 	unitsMap    map[string]*component.Unit
+	unitErrs    *xsync.Map[string, error]
 	concurrency int
 }
 
@@ -52,12 +53,21 @@ func WithMaxConcurrency(concurrency int) ControllerOption {
 	}
 }
 
+// UnitErr returns the error recorded for the unit at path during [Controller.Run],
+// or nil if the unit did not run or succeeded. It must not be called while Run
+// is still executing.
+func (dr *Controller) UnitErr(path string) error {
+	err, _ := dr.unitErrs.Load(path)
+	return err
+}
+
 // NewController creates a new Controller with the given options and a pre-built queue, which must not be nil.
 func NewController(q *queue.Queue, units []*component.Unit, opts ...ControllerOption) *Controller {
 	dr := &Controller{
 		q:           q,
 		readyCh:     make(chan struct{}, 1), // buffered to avoid blocking
 		concurrency: options.DefaultParallelism,
+		unitErrs:    xsync.NewMap[string, error](),
 	}
 	unitsMap := make(map[string]*component.Unit)
 
@@ -85,10 +95,15 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 			"ignore_dependency_order": dr.q.IgnoreDependencyOrder,
 		}, func(childCtx context.Context, l log.Logger) error {
 			var (
-				wg      sync.WaitGroup
-				sem     = make(chan struct{}, dr.concurrency)
-				results = xsync.NewMap[string, error]()
+				wg  sync.WaitGroup
+				sem = make(chan struct{}, dr.concurrency)
 			)
+
+			// Fresh map per execution, kept on the controller after Run returns:
+			// the report sweep must read only this execution's errors, never
+			// stale ones from a prior Run on the same controller.
+			results := xsync.NewMap[string, error]()
+			dr.unitErrs = results
 
 			if dr.runner == nil {
 				return ErrRunnerNotSet

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -691,6 +691,15 @@ func (rnr *Runner) Run(
 							report.WithReason(report.ReasonAncestorError),
 							report.WithCauseAncestorExit(failedAncestor),
 						}
+					} else if run.Cause == nil {
+						// Units that fail before OpenTofu/Terraform runs (config parsing,
+						// dependency output resolution) never reach the unit runner's EndRun,
+						// which is where the cause is normally recorded. Recover the error
+						// the controller captured for this unit so the report carries the
+						// failure text instead of an empty cause.
+						if unitErr := controller.UnitErr(entry.Component.Path()); unitErr != nil {
+							endOpts = append(endOpts, report.WithCauseRunError(unitErr.Error()))
+						}
 					}
 
 					if endErr := r.EndRun(l, run.Path, endOpts...); endErr != nil {

--- a/test/integration_report_test.go
+++ b/test/integration_report_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,6 +35,42 @@ func TestTerragruntReportDisableSummary(t *testing.T) {
 
 	// Verify the report output does not contain the summary
 	assert.NotContains(t, stdout, "Run Summary")
+}
+
+// TestTerragruntReportRunErrorCause verifies that a unit that fails before
+// OpenTofu/Terraform runs still carries the failure text as its report cause.
+//
+// Only chain-b is put on the queue: its dependency chain-a is neither in the
+// queue (so there is no failed ancestor to blame) nor applied (so resolving its
+// outputs fails during config evaluation, before OpenTofu/Terraform runs).
+func TestTerragruntReportRunErrorCause(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureReportPath)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureReportPath)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureReportPath)
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt run --all --non-interactive --working-dir "+rootPath+
+			" --queue-strict-include --queue-include-dir chain-b"+
+			" --report-file "+helpers.ReportFile+" -- apply",
+	)
+	require.Error(t, err)
+
+	reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
+	assert.FileExists(t, reportFilePath)
+
+	runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
+	require.NoError(t, err)
+
+	run := runs.FindByName("chain-b")
+	require.NotNil(t, run)
+	assert.Equal(t, "failed", run.Result)
+	require.NotNil(t, run.Reason)
+	assert.Equal(t, "run error", *run.Reason)
+	require.NotNil(t, run.Cause, "config evaluation failure must populate the run cause")
+	assert.Contains(t, *run.Cause, "detected no outputs")
 }
 
 // lineType represents the type of line we're processing


### PR DESCRIPTION
## Description

Run report entries for units that fail **before** OpenTofu/Terraform runs — config evaluation errors, dependency output resolution failures — carry an empty `Cause`, while units failing inside OpenTofu/Terraform carry the full error text. The report tells you *that* a unit failed with a "run error", but not *why*, so a consumer (e.g. shipping the report to an observability platform) cannot distinguish "dependency X was not resolved" from any other configuration error.

Root cause: such units never reach the unit runner's `EndRun` call (`internal/runner/unit_runner.go`), where the cause is normally recorded from the run error. The post-run sweep in `internal/runner/runner.go` writes their report rows knowing only the queue entry status; the actual error lives in the controller's per-unit results map, which was local to `Controller.Run` and discarded with it.

This PR keeps that per-unit error map on the `Controller` and exposes it via `UnitErr`, then lets the sweep recover the captured error for failed entries that have no ancestor cause and no cause recorded yet.

Behavior is preserved for every other path:

* units that ran keep the cause set by the unit runner — the sweep only fills a `nil` cause
* `early exit` runs keep the failed ancestor's name as their cause
* `retry succeeded` / `error ignored` / `excluded` runs are untouched
* succeeded runs are untouched

Before (unit failing on dependency output resolution):

```json
{
  "Name": "chain-b",
  "Result": "failed",
  "Reason": "run error"
}
```

After:

```json
{
  "Name": "chain-b",
  "Result": "failed",
  "Reason": "run error",
  "Cause": "error occurred:\n\n* resolving dependency \"chain_a\" outputs: .../chain-a/terragrunt.hcl is a dependency of .../chain-b/terragrunt.hcl but detected no outputs. Either the target module has not been applied yet, or the module has no outputs."
}
```

The integration test reuses the existing `fixtures/report` fixtures: putting only `chain-b` on the queue (`--queue-strict-include --queue-include-dir chain-b`) makes resolving `chain-a`'s outputs fail during config evaluation, with no failed ancestor in the queue to blame. The test fails on `main` with `Cause = nil` and passes with this change.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [ ] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failure reports now include the underlying error message when a unit fails during configuration evaluation or dependency output resolution.
  * Improved run results for pre-execution failures by reporting the specific cause instead of leaving it blank.
  * Ensured reported errors reflect the latest execution rather than stale errors from a previous run.

* **Tests**
  * Added coverage verifying that configuration-related failures include their error details in generated reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->