### PR TITLE
chore: Adding explicit capacity hints

### DIFF
--- a/internal/awshelper/config.go
+++ b/internal/awshelper/config.go
@@ -215,7 +215,7 @@ func (b *AWSConfigBuilder) BuildS3Client(
 		return s3.NewFromConfig(cfg), nil
 	}
 
-	customFN := make([]func(*s3.Options), 0, 2) //nolint:mnd // at most two S3 option overrides are appended below
+	var customFN []func(*s3.Options)
 
 	if b.sessionConfig.CustomS3Endpoint != "" {
 		customFN = append(customFN, func(o *s3.Options) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,6 +61,10 @@ const (
 
 	logMsgSeparator = "\n"
 
+	// defaultParserOptionCount is what DefaultParserOptions can return: the
+	// diagnostics writer, the logger, and the bare-include file update.
+	defaultParserOptionCount = 3
+
 	DefaultEngineType                   = "rpc"
 	MetadataTerraform                   = "terraform"
 	MetadataTerraformBinary             = "terraform_binary"
@@ -106,7 +110,7 @@ var (
 			writer.WithMsgSeparator(logMsgSeparator),
 		)
 
-		parseOpts := make([]hclparse.Option, 0, 3) //nolint:mnd // capacity hint for the options appended below
+		parseOpts := make([]hclparse.Option, 0, defaultParserOptionCount)
 		parseOpts = append(parseOpts,
 			hclparse.WithDiagnosticsWriter(v, writer, l.Formatter().DisabledColors()),
 			hclparse.WithLogger(l),

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -84,6 +84,9 @@ const (
 
 	caKeyBits = 4096
 
+	// argsPerModulePath is the flag and value each module path adds to a command line.
+	argsPerModulePath = 2
+
 	// fakeProviderBinarySize is the size of the dummy binary FakeProvider packs into its archive.
 	fakeProviderBinarySize = 1e7
 
@@ -479,13 +482,15 @@ func RunValidateAllWithIncludeAndGetIncludedModules(
 ) []string {
 	t.Helper()
 
-	cmdParts := make([]string, 0, 9+2*len(includeModulePaths)) //nolint:mnd // capacity hint: the fixed args plus two per module path
-	cmdParts = append(cmdParts,
+	fixedArgs := []string{
 		"terragrunt", "run", "--all", "validate",
 		"--non-interactive",
 		"--log-level", "debug",
 		"--working-dir", rootModulePath,
-	)
+	}
+
+	cmdParts := make([]string, 0, len(fixedArgs)+argsPerModulePath*len(includeModulePaths))
+	cmdParts = append(cmdParts, fixedArgs...)
 
 	for _, module := range includeModulePaths {
 		cmdParts = append(cmdParts, "--queue-include-dir", module)
@@ -530,13 +535,15 @@ func RunValidateAllWithFilteredPlusDependenciesAndGetIncludedModules(
 ) []string {
 	t.Helper()
 
-	cmdParts := make([]string, 0, 9+2*len(units)) //nolint:mnd // capacity hint: the fixed args plus two per unit
-	cmdParts = append(cmdParts,
+	fixedArgs := []string{
 		"terragrunt", "run", "--all", "validate",
 		"--non-interactive",
 		"--log-level", "debug",
 		"--working-dir", workDir,
-	)
+	}
+
+	cmdParts := make([]string, 0, len(fixedArgs)+argsPerModulePath*len(units))
+	cmdParts = append(cmdParts, fixedArgs...)
 
 	for _, unit := range units {
 		cmdParts = append(cmdParts, "--filter", fmt.Sprintf("'{%s}...'", unit))


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Replaces some magic numbers with explicit capacity hints.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal configuration and storage handling while preserving existing application behavior.
  * Centralized capacity calculations to improve maintainability without changing user-facing functionality.
  * Updated configuration validation flow with no intended change to validation results.

* **Tests**
  * Refined command construction helpers and standardized argument sizing while preserving generated command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->