### PR TITLE
chore: Fixing cloud credentials test env semantics

### DIFF
--- a/test/integration_aws_oidc_test.go
+++ b/test/integration_aws_oidc_test.go
@@ -242,37 +242,33 @@ func TestAwsReadTerragruntAuthProviderCmdWithOIDCChainedAssumeRole(t *testing.T)
 	targetRole := os.Getenv("AWS_TEST_OIDC_CHAIN_TARGET_ROLE_ARN")
 	require.NotEmpty(t, targetRole)
 
-	// These tests need to be run without the static key + secret
-	// used by most AWS tests here. Capture them first so the deferred
-	// bucket cleanup can use them: neither chain role can delete the
-	// bucket on its own (the source role has no S3 permissions and the
-	// target role is only reachable through the source role).
-	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
-	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
-
-	t.Setenv("AWS_ACCESS_KEY_ID", "")
-	os.Unsetenv("AWS_ACCESS_KEY_ID")
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
-	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
-
-	t.Setenv("OIDC_TOKEN", token)
-
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAuthProviderCmd)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureAuthProviderCmd, "remote-state-assume-role")
 	helpers.CleanupTerraformFolder(t, rootPath)
 	mockAuthCmd := filepath.Join(rootPath, "mock-auth-cmd.sh")
+
+	// The script reads OIDC_TOKEN and exits non-zero without it, so it has to be
+	// set before the script is validated below.
+	t.Setenv("OIDC_TOKEN", token)
 
 	helpers.ValidateAuthProviderScript(t, rootPath, mockAuthCmd)
 
 	tmpTerragruntConfigFile := filepath.Join(rootPath, "terragrunt.hcl")
 	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
 
-	defer func() {
-		os.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)         //nolint:usetesting // the bucket cleanup below needs the real creds back before t.Cleanup runs
-		os.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey) //nolint:usetesting // as above
-
+	// Registered before the credentials are cleared, so it runs after they are put
+	// back: neither chain role can delete the bucket on its own, since the source
+	// role has no S3 permissions and the target role is only reachable through it.
+	t.Cleanup(func() {
 		helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
-	}()
+	})
+
+	// The run has to reach AWS through the OIDC chain rather than the static key
+	// and secret most AWS tests here run with.
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
 
 	helpers.CopyAndFillMapPlaceholders(
 		t,

--- a/test/integration_gcp_test.go
+++ b/test/integration_gcp_test.go
@@ -558,10 +558,7 @@ func TestGcpNoPrefixBucket(t *testing.T) {
 func TestGcpParallelStateInit(t *testing.T) {
 	t.Parallel()
 
-	tmpEnvPath, err := os.MkdirTemp("", "terragrunt-test") //nolint:usetesting // TODO: check whether t.TempDir works here
-	if err != nil {
-		require.NoError(t, err)
-	}
+	tmpEnvPath := helpers.TmpDirWOSymlinks(t)
 
 	for i := range 20 {
 		err := util.CopyFolderContents(
@@ -592,7 +589,7 @@ func TestGcpParallelStateInit(t *testing.T) {
 		gcsBucketName,
 		"root.hcl",
 	)
-	err = vfs.CopyFile(vfs.NewOSFS(), tmpTerragruntGCSConfigPath, tmpTerragruntConfigFile)
+	err := vfs.CopyFile(vfs.NewOSFS(), tmpTerragruntGCSConfigPath, tmpTerragruntConfigFile)
 	require.NoError(t, err)
 
 	helpers.RunTerragrunt(
@@ -611,10 +608,7 @@ func createTmpTerragruntGCSConfig(
 ) string {
 	t.Helper()
 
-	tmpFolder, err := os.MkdirTemp("", "terragrunt-test") //nolint:usetesting // TODO: check whether t.TempDir works here
-	if err != nil {
-		t.Fatalf("Failed to create temp folder due to error: %v", err)
-	}
+	tmpFolder := helpers.TmpDirWOSymlinks(t)
 
 	tmpTerragruntConfigFile := filepath.Join(tmpFolder, configFileName)
 	originalTerragruntConfigPath := filepath.Join(templatesPath, configFileName)

--- a/test/integration_serial_aws_test.go
+++ b/test/integration_serial_aws_test.go
@@ -76,7 +76,6 @@ func TestAwsTerragruntParallelism(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // it swaps the process-wide AWS credentials
 func TestAwsReadTerragruntAuthProviderCmdRemoteState(t *testing.T) {
 	helpers.CleanupTerraformFolder(t, testFixtureAuthProviderCmd)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureAuthProviderCmd)
@@ -86,7 +85,11 @@ func TestAwsReadTerragruntAuthProviderCmdRemoteState(t *testing.T) {
 	helpers.ValidateAuthProviderScript(t, rootPath, mockAuthCmd)
 
 	s3BucketName := "terragrunt-test-bucket-" + strings.ToLower(helpers.UniqueID())
-	defer helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
+
+	// Registered before the credentials are cleared, so it runs after they are put back.
+	t.Cleanup(func() {
+		helpers.DeleteS3Bucket(t, helpers.TerraformRemoteStateS3Region, s3BucketName)
+	})
 
 	rootTerragruntConfigPath := filepath.Join(rootPath, config.DefaultTerragruntConfigPath)
 	helpers.CopyTerragruntConfigAndFillPlaceholders(
@@ -101,13 +104,13 @@ func TestAwsReadTerragruntAuthProviderCmdRemoteState(t *testing.T) {
 	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
 	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 
-	os.Setenv("AWS_ACCESS_KEY_ID", "")     //nolint:usetesting // t.Setenv doesn't work for this test, for reasons nobody has pinned down
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "") //nolint:usetesting // as above
-
-	defer func() {
-		os.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)         //nolint:usetesting // restores the creds the test cleared above
-		os.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey) //nolint:usetesting // as above
-	}()
+	// The run has to reach AWS through the auth provider command rather than the
+	// static key and secret. The SDK reads an empty variable as a credential, so
+	// each one is taken out of the environment; t.Setenv puts it back at the end.
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
 
 	credsConfig := filepath.Join(rootPath, "creds.config")
 
@@ -136,7 +139,9 @@ func TestAwsReadTerragruntAuthProviderCmdCredsForDependency(t *testing.T) {
 	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 
 	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
 
 	dependencyCredsConfig := filepath.Join(rootPath, "dependency", "creds.config")
 	helpers.CopyAndFillMapPlaceholders(

--- a/test/integration_serial_gcp_test.go
+++ b/test/integration_serial_gcp_test.go
@@ -16,13 +16,14 @@ import (
 )
 
 func TestGcpCorrectlyMirrorsTerraformGCPAuth(t *testing.T) {
-	// We need to ensure Terragrunt works correctly when GOOGLE_CREDENTIALS are specified.
-	// There is no true way to properly unset env vars from the environment, but we still try
-	// to unset the CI credentials during this test.
+	// Terragrunt has to work when only GOOGLE_CREDENTIALS is set, so the CI credential
+	// is taken out of the environment for this test. t.Setenv registers the restore,
+	// and the Unsetenv that follows takes the variable out rather than blanking it.
 	defaultCreds := os.Getenv("GCLOUD_SERVICE_KEY")
-	defer os.Setenv("GCLOUD_SERVICE_KEY", defaultCreds) //nolint:usetesting // restores the CI credential this test unsets
 
+	t.Setenv("GCLOUD_SERVICE_KEY", "")
 	os.Unsetenv("GCLOUD_SERVICE_KEY")
+
 	t.Setenv("GOOGLE_CREDENTIALS", defaultCreds)
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureGcsPath)

--- a/test/integration_tf_test.go
+++ b/test/integration_tf_test.go
@@ -4338,7 +4338,9 @@ func TestTFExplainingMissingCredentials(t *testing.T) {
 	// no parallel because we need to set env vars
 	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/tmp/not-existing-creds-46521694")
 	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
 
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureInitError)
 	initTestCase := filepath.Join(tmpEnvPath, testFixtureInitError)


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Updates the way we handle env vars in tests related to cloud credentials using `t.Setenv` and `os.Unsetenv` consistently. While handling this, there were some places where we were able to also drop usage of `t.Setenv` and instead set the `env` in `venv` instead. This unlocked some additional parallelization in tests.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved AWS and GCP integration test isolation by reliably clearing and restoring credential environment variables.
  - Ensured cloud resource cleanup runs safely before credentials are restored.
  - Added symlink-safe temporary directory handling for GCP tests.
  - Strengthened missing-credentials coverage by explicitly removing AWS credentials during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->