### PR TITLE
chore: Setting up per-run env and version to increase test parallelization

### DIFF
--- a/internal/strict/view/plaintext/render.go
+++ b/internal/strict/view/plaintext/render.go
@@ -34,21 +34,23 @@ var subTemplates = func() *template.Template {
 }()
 
 // tabFlusher is the minimal subset of *tabwriter.Writer that formatOutput uses.
-// It exists so tests can swap newTabFlusher for a stub whose Flush() returns
-// a controlled error.
+// It exists so a test can give a Render a stub whose Flush() returns a
+// controlled error.
 type tabFlusher interface {
 	io.Writer
 	Flush() error
 }
 
-var newTabFlusher = func(w io.Writer) tabFlusher {
-	return tabwriter.NewWriter(w, tabMinWidth, tabWidth, tabPadding, ' ', 0)
+type Render struct {
+	newTabFlusher func(w io.Writer) tabFlusher
 }
 
-type Render struct{}
-
 func NewRender() *Render {
-	return &Render{}
+	return &Render{
+		newTabFlusher: func(w io.Writer) tabFlusher {
+			return tabwriter.NewWriter(w, tabMinWidth, tabWidth, tabPadding, ' ', 0)
+		},
+	}
 }
 
 // List implements [view.Render].
@@ -80,7 +82,7 @@ func (render *Render) buildTemplate(templ string, customFuncs map[string]any) *t
 
 func (render *Render) formatOutput(t *template.Template, data any) (string, error) {
 	out := new(bytes.Buffer)
-	tabOut := newTabFlusher(out)
+	tabOut := render.newTabFlusher(out)
 
 	if err := t.ExecuteTemplate(tabOut, "template", data); err != nil {
 		return "", fmt.Errorf("failed to execute template: %w", err)

--- a/internal/strict/view/plaintext/render_internal_test.go
+++ b/internal/strict/view/plaintext/render_internal_test.go
@@ -49,22 +49,16 @@ type failingFlusher struct {
 
 func (f *failingFlusher) Flush() error { return f.err }
 
-// This test must run serially because it swaps the package-level newTabFlusher
-// seam to force a Flush failure path. Other tests read that variable
-// concurrently when running with t.Parallel().
-//
-//nolint:paralleltest // mutates package-level newTabFlusher.
 func TestRenderFormatOutputFlushError(t *testing.T) {
+	t.Parallel()
+
 	sentinel := errors.New("flush boom")
-	original := newTabFlusher
 
-	t.Cleanup(func() { newTabFlusher = original })
-
-	newTabFlusher = func(w io.Writer) tabFlusher {
+	r := NewRender()
+	r.newTabFlusher = func(w io.Writer) tabFlusher {
 		return &failingFlusher{Writer: w, err: sentinel}
 	}
 
-	r := NewRender()
 	_, err := r.List(strict.Controls{})
 	require.ErrorIs(t, err, sentinel)
 }

--- a/test/helpers/package.go
+++ b/test/helpers/package.go
@@ -1161,13 +1161,52 @@ func RemoveFolder(t *testing.T, path string) {
 	}
 }
 
+// envCtxKey keys the environment a run should see, so a test can adjust it
+// without touching the process and can therefore still run in parallel.
+type envCtxKey struct{}
+
+// RunEnv returns the environment a Terragrunt run would start with, for a test
+// to adjust and hand back through [ContextWithEnv].
+func RunEnv(t *testing.T) map[string]string {
+	t.Helper()
+
+	return venv.ParseEnviron(os.Environ())
+}
+
+// ContextWithEnv returns a context that runs started with the helpers in this
+// package resolve their environment against, in place of the process environment.
+func ContextWithEnv(ctx context.Context, env map[string]string) context.Context {
+	return context.WithValue(ctx, envCtxKey{}, env)
+}
+
+// envFromContext returns the environment stored by [ContextWithEnv], or nil.
+func envFromContext(ctx context.Context) map[string]string {
+	env, _ := ctx.Value(envCtxKey{}).(map[string]string)
+
+	return env
+}
+
 func RunTerragruntCommandWithContext(
 	t *testing.T,
 	ctx context.Context,
 	command string,
 	writer,
 	errwriter io.Writer,
-	extraArgs ...string,
+) error {
+	t.Helper()
+
+	return runTerragruntCommand(t, ctx, version.GetVersion(), command, writer, errwriter)
+}
+
+// runTerragruntCommand runs command through an app reporting itself as ver, so a
+// test can pin the Terragrunt version a run sees without touching the process.
+func runTerragruntCommand(
+	t *testing.T,
+	ctx context.Context,
+	ver string,
+	command string,
+	writer,
+	errwriter io.Writer,
 ) error {
 	t.Helper()
 
@@ -1207,6 +1246,10 @@ func RunTerragruntCommandWithContext(
 	opts := options.NewTerragruntOptions(vexec.NewOSExec())
 
 	v := venv.OSVenv()
+	if env := envFromContext(ctx); env != nil {
+		v = v.WithEnv(env)
+	}
+
 	v.Writers = &writerpkg.Writers{Writer: syncWriter, ErrWriter: syncErrWriter}
 
 	l := log.New(
@@ -1216,6 +1259,7 @@ func RunTerragruntCommandWithContext(
 	)
 
 	app := cli.NewApp(l, opts, v)
+	app.Version = ver
 
 	ctx = log.ContextWithLogger(ctx, l)
 
@@ -1233,6 +1277,8 @@ func RunTerragruntCommand(
 	return RunTerragruntCommandWithContext(t, t.Context(), command, writer, errwriter)
 }
 
+// RunTerragruntVersionCommand runs command against an app that reports itself as
+// ver, which is what version constraints in the config are checked against.
 func RunTerragruntVersionCommand(
 	t *testing.T,
 	ver string,
@@ -1242,9 +1288,7 @@ func RunTerragruntVersionCommand(
 ) error {
 	t.Helper()
 
-	version.Version = ver
-
-	return RunTerragruntCommand(t, command, writer, errwriter)
+	return runTerragruntCommand(t, t.Context(), ver, command, writer, errwriter)
 }
 
 func RunTerragrunt(t *testing.T, command string) {

--- a/test/integration_cas_rustfs_test.go
+++ b/test/integration_cas_rustfs_test.go
@@ -33,8 +33,10 @@ import (
 // against an in-Docker RustFS instance: a second CASGetter request for
 // the same object skips the download when HeadObject reports the same
 // version metadata.
-func TestCAS_S3_RustFS_ProbeAvoidsRedownload(t *testing.T) { //nolint: paralleltest // setupRustFSForCAS calls t.Setenv, which bars t.Parallel.
-	endpoint := setupRustFSForCAS(t)
+func TestCAS_S3_RustFS_ProbeAvoidsRedownload(t *testing.T) {
+	t.Parallel()
+
+	endpoint, env := setupRustFSForCAS(t)
 
 	bucket := "cas-test-" + strings.ToLower(helpers.UniqueID())
 	key := "modules/example.tar.gz"
@@ -52,7 +54,7 @@ func TestCAS_S3_RustFS_ProbeAvoidsRedownload(t *testing.T) { //nolint: parallelt
 	c, err := tgcas.New(venvtest.NewWithOSFS(), tgcas.WithStorePath(storePath))
 	require.NoError(t, err)
 
-	v := venv.OSVenv()
+	v := venv.OSVenv().WithEnv(env)
 
 	resolvers := tggetter.DefaultSourceResolvers(v)
 	resolvers[tggetter.SchemeS3] = newRustFSS3Resolver(t, endpoint)
@@ -91,10 +93,10 @@ func TestCAS_S3_RustFS_ProbeAvoidsRedownload(t *testing.T) { //nolint: parallelt
 	require.FileExists(t, filepath.Join(second, "main.tf"))
 }
 
-// setupRustFSForCAS spins up the same RustFS container the existing
-// integration tests use and exports the AWS_* env vars the SDK config
-// chain reads.
-func setupRustFSForCAS(t *testing.T) string {
+// setupRustFSForCAS spins up the same RustFS container the existing integration
+// tests use, and returns its address alongside the environment the SDK config
+// chain reads its credentials from.
+func setupRustFSForCAS(t *testing.T) (string, map[string]string) {
 	t.Helper()
 
 	_, addr := helpers.RunContainer(
@@ -105,11 +107,12 @@ func setupRustFSForCAS(t *testing.T) string {
 		testcontainers.WithWaitStrategy(wait.ForLog("Starting:")),
 	)
 
-	t.Setenv("AWS_ACCESS_KEY_ID", "rustfsadmin")
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "rustfsadmin")
-	t.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	env := helpers.RunEnv(t)
+	env["AWS_ACCESS_KEY_ID"] = "rustfsadmin"
+	env["AWS_SECRET_ACCESS_KEY"] = "rustfsadmin"
+	env["AWS_DEFAULT_REGION"] = "us-east-1"
 
-	return addr
+	return addr, env
 }
 
 func newRustFSClient(t *testing.T, endpoint string) *s3.Client {
@@ -214,8 +217,10 @@ func rustfsSourceURL(t *testing.T, endpoint, bucket, key string) string {
 // The single-object test above resolves to ModeFile and never reaches
 // S3Getter.Get, so this is what covers the paginated listing and the
 // key-to-path mapping.
-func TestS3PrefixDownloadReproducesLayout(t *testing.T) { //nolint: paralleltest // setupRustFSForCAS calls t.Setenv, which bars t.Parallel.
-	endpoint := setupRustFSForCAS(t)
+func TestS3PrefixDownloadReproducesLayout(t *testing.T) {
+	t.Parallel()
+
+	endpoint, env := setupRustFSForCAS(t)
 
 	bucket := "prefix-test-" + strings.ToLower(helpers.UniqueID())
 	prefix := "modules/vpc"
@@ -238,7 +243,7 @@ func TestS3PrefixDownloadReproducesLayout(t *testing.T) { //nolint: paralleltest
 	// must stay out of the download.
 	uploadRustFSObject(t, s3Client, bucket, prefix+"-sibling.tf", []byte("# excluded"))
 
-	v := venv.OSVenv()
+	v := venv.OSVenv().WithEnv(env)
 	dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "module")
 
 	_, err := tggetter.NewClient(logger.CreateLogger(), v).Get(t.Context(), &tggetter.Request{

--- a/test/integration_provider_cache_lockfile_readonly_test.go
+++ b/test/integration_provider_cache_lockfile_readonly_test.go
@@ -27,12 +27,14 @@ const (
 // dependency check and silently defeated `-lockfile=readonly`. The cache must now
 // leave the lock file alone when that flag is set, whether it arrives on the command
 // line or through `TF_CLI_ARGS_init`, so init fails exactly as it does without the cache.
-//
-//nolint:paralleltest // the env-var subtest relies on t.Setenv.
 func TestTFTerragruntProviderCacheLockfileReadonly(t *testing.T) {
+	t.Parallel()
+
 	lockfileName := ".terraform.lock.hcl"
 
 	t.Run("cache writes lock file without readonly", func(t *testing.T) {
+		t.Parallel()
+
 		appPath := copyProviderCacheLockfileReadonlyFixture(t)
 		providerCacheDir := helpers.TmpDirWOSymlinks(t)
 
@@ -47,6 +49,8 @@ func TestTFTerragruntProviderCacheLockfileReadonly(t *testing.T) {
 	})
 
 	t.Run("readonly via flag is enforced", func(t *testing.T) {
+		t.Parallel()
+
 		appPath := copyProviderCacheLockfileReadonlyFixture(t)
 		providerCacheDir := helpers.TmpDirWOSymlinks(t)
 
@@ -64,6 +68,8 @@ func TestTFTerragruntProviderCacheLockfileReadonly(t *testing.T) {
 	})
 
 	t.Run("readonly is logged at debug level", func(t *testing.T) {
+		t.Parallel()
+
 		appPath := copyProviderCacheLockfileReadonlyFixture(t)
 		providerCacheDir := helpers.TmpDirWOSymlinks(t)
 
@@ -79,15 +85,15 @@ func TestTFTerragruntProviderCacheLockfileReadonly(t *testing.T) {
 	})
 
 	t.Run("readonly via TF_CLI_ARGS_init is enforced", func(t *testing.T) {
-		t.Setenv(
-			tf.EnvNameTFCLIArgsInit,
-			fmt.Sprintf("%s=%s", tf.FlagNameLockfile, tf.LockfileModeReadonly),
-		)
+		t.Parallel()
+
+		env := helpers.RunEnv(t)
+		env[tf.EnvNameTFCLIArgsInit] = fmt.Sprintf("%s=%s", tf.FlagNameLockfile, tf.LockfileModeReadonly)
 
 		appPath := copyProviderCacheLockfileReadonlyFixture(t)
 		providerCacheDir := helpers.TmpDirWOSymlinks(t)
 
-		_, _, err := helpers.RunTerragruntCommandWithOutput(t, fmt.Sprintf(
+		_, _, err := helpers.RunTerragruntCommandWithOutputWithContext(t, helpers.ContextWithEnv(t.Context(), env), fmt.Sprintf(
 			"terragrunt run --provider-cache --provider-cache-dir %s --non-interactive --working-dir %s -- init",
 			providerCacheDir,
 			appPath,

--- a/test/integration_stacks_tf_test.go
+++ b/test/integration_stacks_tf_test.go
@@ -1649,9 +1649,9 @@ func TestTFStackFindInParentFolders(t *testing.T) {
 }
 
 // TestTFStackVersionConstraints verifies that version constraints are respected in stack runs.
-//
-//nolint:paralleltest // it overrides the global version.Version
 func TestTFStackVersionConstraints(t *testing.T) {
+	t.Parallel()
+
 	helpers.CleanupTerragruntFolder(t, testFixtureStackVersionConstraints)
 	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureStackVersionConstraints)
 	rootPath := filepath.Join(tmpEnvPath, testFixtureStackVersionConstraints, "live")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -503,10 +503,8 @@ func TestErrorMessageIncludeInOutput(t *testing.T) {
 	assert.Contains(t, err.Error(), "Custom error from script")
 }
 
-//nolint:paralleltest // it unsets TG_TF_PATH for the whole process
 func TestTfPath(t *testing.T) {
-	// This test can't be parallelized because it explicitly unsets the TG_TF_PATH environment variable.
-	// t.Parallel()
+	t.Parallel()
 
 	// Test that the terragrunt run version command correctly identifies and uses
 	// the terraform_binary path configuration if present
@@ -516,16 +514,14 @@ func TestTfPath(t *testing.T) {
 	workingDir, err := filepath.EvalSymlinks(workingDir)
 	require.NoError(t, err)
 
-	// If TG_TF_PATH is not set, we'll use the default tofu binary,
-	// we'll explicitly set the value so that the test can pass.
-	if tfPath := os.Getenv("TG_TF_PATH"); tfPath != "" {
-		// Unset after using t.Setenv so that it'll be reset after the test.
-		t.Setenv("TG_TF_PATH", "")
-		os.Unsetenv("TG_TF_PATH")
-	}
+	// The run has to fall through to the terraform_binary the config names, so it
+	// starts without the TG_TF_PATH the suite may be running under.
+	env := helpers.RunEnv(t)
+	delete(env, "TG_TF_PATH")
 
-	_, stderr, err := helpers.RunTerragruntCommandWithOutput(
+	_, stderr, err := helpers.RunTerragruntCommandWithOutputWithContext(
 		t,
+		helpers.ContextWithEnv(t.Context(), env),
 		"terragrunt run version --working-dir "+workingDir,
 	)
 	require.NoError(t, err)

--- a/test/integration_tf_test.go
+++ b/test/integration_tf_test.go
@@ -3756,8 +3756,9 @@ func TestTFTerragruntRemoteStateCodegenDoesNotGenerateWithSkip(t *testing.T) {
 	assert.False(t, helpers.FileIsInFolder(t, "foo.tfstate", generateTestCase))
 }
 
-//nolint:paralleltest // it overrides the global version.Version
 func TestTFTerragruntValidateAllWithVersionChecks(t *testing.T) {
+	t.Parallel()
+
 	tmpEnvPath := helpers.CopyEnvironment(t, "fixtures/version-check")
 
 	stdout := bytes.Buffer{}
@@ -3791,8 +3792,9 @@ func TestTFTerragruntIncludeParentHclFile(t *testing.T) {
 	assert.Contains(t, stderr, "common_hcl")
 }
 
-//nolint:paralleltest // runTerragruntVersionCommand overrides the global version.Version
 func TestTFTerragruntVersionConstraints(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name                 string
 		terragruntVersion    string
@@ -3843,8 +3845,10 @@ func TestTFTerragruntVersionConstraints(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases { //nolint:paralleltest // the parent test overrides the global version.Version
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			tmpEnvPath := helpers.CopyEnvironment(t, testFixtureReadConfig)
 			rootPath := filepath.Join(tmpEnvPath, testFixtureReadConfig, "with_constraints")
 
@@ -4087,8 +4091,9 @@ func TestTFIamRolesLoadingFromDifferentModules(t *testing.T) {
 	assert.NotEmptyf(t, component2, "Missing role for component 2")
 }
 
-//nolint:paralleltest // it overrides the global version.Version
 func TestTFTerragruntVersionConstraintsPartialParse(t *testing.T) {
+	t.Parallel()
+
 	fixturePath := "fixtures/partial-parse/terragrunt-version-constraint"
 	helpers.CleanupTerragruntFolder(t, fixturePath)
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Un-serializes some testing that was previously required to remain serialized because it mutated global state by moving that logic to venv, etc.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test isolation by applying environment variables per test instead of changing shared process-wide settings.
  - Enabled parallel execution for additional integration and regression tests.
  - Added coverage for renderer-specific flush-error behavior.
  - Preserved credential and configuration discovery during parallel integration test runs.
- **Refactor**
  - Improved test command helpers to accept explicit versions and environment overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->