### PR TITLE
chore: Adding test coverage for filters with block iteration

### DIFF
--- a/internal/discovery/phase_worktree.go
+++ b/internal/discovery/phase_worktree.go
@@ -247,13 +247,7 @@ func (p *WorktreePhase) discoverInWorktree(
 		WithDiscoveryContext(discoveryContext).
 		WithNumWorkers(p.numWorkers)
 
-	if discovery.suppressParseErrors {
-		subDiscovery = subDiscovery.WithSuppressParseErrors()
-	}
-
-	if len(discovery.parserOptions) > 0 {
-		subDiscovery = subDiscovery.WithParserOptions(discovery.parserOptions)
-	}
+	subDiscovery = subDiscovery.withParseSettingsFrom(discovery)
 
 	components, err := subDiscovery.Discover(ctx, l, v, input.Opts)
 	if err != nil {
@@ -261,6 +255,21 @@ func (p *WorktreePhase) discoverInWorktree(
 	}
 
 	return components, nil
+}
+
+// withParseSettingsFrom carries a parent discovery's parse settings onto a worktree
+// sub-discovery. A sub-discovery that parses more strictly than the parent turns a parse
+// error the parent would tolerate into an aborted worktree phase.
+func (d *Discovery) withParseSettingsFrom(parent *Discovery) *Discovery {
+	if parent.suppressParseErrors {
+		d = d.WithSuppressParseErrors()
+	}
+
+	if len(parent.parserOptions) > 0 {
+		d = d.WithParserOptions(parent.parserOptions)
+	}
+
+	return d
 }
 
 // deletedReadingComponentsToFilters discovers, in the from worktree, the units that read files
@@ -450,7 +459,8 @@ func (p *WorktreePhase) walkChangedStack(
 		fromDiscovery := NewDiscovery(fromStack.Path()).
 			WithDiscoveryContext(fromDiscoveryContext).
 			WithFilters(parentFilters).
-			WithNumWorkers(p.numWorkers)
+			WithNumWorkers(p.numWorkers).
+			withParseSettingsFrom(discovery)
 
 		var fromDiscoveryErr error
 
@@ -478,7 +488,8 @@ func (p *WorktreePhase) walkChangedStack(
 		toDiscovery := NewDiscovery(toStack.Path()).
 			WithDiscoveryContext(toDiscoveryContext).
 			WithFilters(parentFilters).
-			WithNumWorkers(p.numWorkers)
+			WithNumWorkers(p.numWorkers).
+			withParseSettingsFrom(discovery)
 
 		var toDiscoveryErr error
 

--- a/internal/discovery/phase_worktree_expansion_integration_test.go
+++ b/internal/discovery/phase_worktree_expansion_integration_test.go
@@ -1,0 +1,525 @@
+package discovery_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/worktrees"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// expansionCatalogUnit is the source every expanded unit in these tests is generated from.
+// Instances differ only by the terragrunt.values.hcl written alongside them, so their
+// directory hashes differ.
+const expansionCatalogUnit = `inputs = {
+  role = values.role
+}
+`
+
+// setupExpansionRepo creates a Git repository holding a unit catalog. The stacks
+// documentation recommends gitignoring the generated tree, so these repositories do.
+func setupExpansionRepo(t *testing.T) (string, *git.GitRunner) {
+	t.Helper()
+
+	tmpDir, runner := setupGitRepo(t)
+
+	writeExpansionFile(t, filepath.Join(tmpDir, ".gitignore"), ".terragrunt-stack\n")
+	writeExpansionFile(
+		t,
+		filepath.Join(tmpDir, "catalog", "units", "app", "terragrunt.hcl"),
+		expansionCatalogUnit,
+	)
+
+	return tmpDir, runner
+}
+
+func writeExpansionFile(t *testing.T, path, contents string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+}
+
+// parseErrorPolicy selects how a discovery treats a configuration that fails to parse.
+// find and list suppress those errors. run does not.
+type parseErrorPolicy int
+
+const (
+	failOnParseErrors parseErrorPolicy = iota
+	suppressParseErrors
+)
+
+// discoverExpansionChanges generates stacks into the worktrees for [HEAD~1...HEAD] and runs
+// discovery over them. Any extra filters join the Git expression in the same union a repeated
+// --filter would build.
+func discoverExpansionChanges(
+	t *testing.T,
+	tmpDir string,
+	cmd string,
+	extraFilters filter.Filters,
+	policy parseErrorPolicy,
+) (component.Components, worktrees.WorktreePair) {
+	t.Helper()
+
+	l := logger.CreateLogger()
+	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
+
+	w, err := worktrees.NewWorktrees(
+		t.Context(),
+		l,
+		venvtest.NewOSWithEmptyEnv(),
+		worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions},
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS()))
+	})
+
+	filters := make(filter.Filters, 0, len(gitExpressions)+len(extraFilters))
+	for _, gitExpr := range gitExpressions {
+		filters = append(filters, filter.NewFilter(gitExpr, gitExpr.String()))
+	}
+
+	filters = append(filters, extraFilters...)
+
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
+	opts.WorkingDir = tmpDir
+	opts.RootWorkingDir = tmpDir
+	opts.Filters = filters
+	opts.Experiments = experiment.NewExperiments()
+	require.NoError(t, opts.Experiments.EnableExperiment(experiment.FilterFlag))
+	require.NoError(t, opts.Experiments.EnableExperiment(experiment.BlockIteration))
+
+	require.NoError(
+		t,
+		generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w),
+	)
+
+	d := discovery.NewDiscovery(tmpDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir, Cmd: cmd}).
+		WithWorktrees(w).
+		WithFilters(filters)
+
+	if policy == suppressParseErrors {
+		d = d.WithSuppressParseErrors()
+	}
+
+	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	require.NoError(t, err)
+
+	pair, ok := w.WorktreePairs["[HEAD~1...HEAD]"]
+	require.True(t, ok)
+
+	return components, pair
+}
+
+func requireComponent(
+	t *testing.T,
+	components component.Components,
+	path string,
+) component.Component {
+	t.Helper()
+
+	for _, c := range components {
+		if c.Path() == path {
+			return c
+		}
+	}
+
+	require.Failf(t, "component not discovered", "%s not among %v", path, components.Paths())
+
+	return nil
+}
+
+func assertDestroyIntent(t *testing.T, c component.Component, ref string) {
+	t.Helper()
+
+	dc := c.DiscoveryContext()
+	require.NotNil(t, dc)
+	assert.Equal(t, ref, dc.Ref)
+	assert.Contains(t, dc.Args, "-destroy")
+}
+
+func assertApplyIntent(t *testing.T, c component.Component, ref string) {
+	t.Helper()
+
+	dc := c.DiscoveryContext()
+	require.NotNil(t, dc)
+	assert.Equal(t, ref, dc.Ref)
+	assert.NotContains(t, dc.Args, "-destroy")
+}
+
+// forEachStack renders a stack file expanding one unit per element of the set.
+func forEachStack(elements string) string {
+	return `unit "shard" {
+  expansion {
+    for_each = toset(` + elements + `)
+  }
+
+  source = "${get_repo_root()}/catalog/units/app"
+  path   = "shard/${each.key}"
+
+  values = {
+    role = each.key
+  }
+}
+`
+}
+
+// TestWorktreePhase_Integration_ExpansionForEachShrinks pins the orphan cleanup path the
+// stacks documentation points users at. An instance dropped from a for_each is discovered in
+// the from worktree and carries the run intent that destroys its state.
+func TestWorktreePhase_Integration_ExpansionForEachShrinks(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupExpansionRepo(t)
+	stackFile := filepath.Join(tmpDir, "live", "terragrunt.stack.hcl")
+
+	writeExpansionFile(t, stackFile, forEachStack(`["web", "api"]`))
+	commitChanges(t, runner, "Expand shard over web and api")
+
+	writeExpansionFile(t, stackFile, forEachStack(`["web"]`))
+	commitChanges(t, runner, "Drop the api shard")
+
+	components, pair := discoverExpansionChanges(t, tmpDir, "apply", nil, failOnParseErrors)
+
+	orphan := requireComponent(
+		t,
+		components,
+		filepath.Join(pair.FromWorktree.Path, "live", ".terragrunt-stack", "shard", "api"),
+	)
+	assertDestroyIntent(t, orphan, "HEAD~1")
+
+	assert.NotContains(
+		t,
+		components.Paths(),
+		filepath.Join(pair.ToWorktree.Path, "live", ".terragrunt-stack", "shard", "web"),
+		"the surviving instance is unchanged between refs, so it stays out of the run",
+	)
+}
+
+// TestWorktreePhase_Integration_ExpansionForEachGrows pins a growing for_each. The new
+// instance is discovered in the to worktree and runs the command as typed.
+func TestWorktreePhase_Integration_ExpansionForEachGrows(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupExpansionRepo(t)
+	stackFile := filepath.Join(tmpDir, "live", "terragrunt.stack.hcl")
+
+	writeExpansionFile(t, stackFile, forEachStack(`["web"]`))
+	commitChanges(t, runner, "Expand shard over web")
+
+	writeExpansionFile(t, stackFile, forEachStack(`["web", "api"]`))
+	commitChanges(t, runner, "Add the api shard")
+
+	components, pair := discoverExpansionChanges(t, tmpDir, "apply", nil, failOnParseErrors)
+
+	added := requireComponent(
+		t,
+		components,
+		filepath.Join(pair.ToWorktree.Path, "live", ".terragrunt-stack", "shard", "api"),
+	)
+	assertApplyIntent(t, added, "HEAD")
+
+	assert.NotContains(
+		t,
+		components.Paths(),
+		filepath.Join(pair.FromWorktree.Path, "live", ".terragrunt-stack", "shard", "api"),
+	)
+}
+
+// TestWorktreePhase_Integration_ExpansionCountShrinks pins how a count expansion behaves when
+// its iteration set loses an element. Instances are addressed by index, so dropping anything
+// but the last element shifts every later instance onto the values of its successor. The
+// shifted directories still pair up and are reported as changed. Only the trailing index is
+// left unpaired, as the orphan.
+func TestWorktreePhase_Integration_ExpansionCountShrinks(t *testing.T) {
+	t.Parallel()
+
+	countStack := func(elements string) string {
+		return `locals {
+  shards = ` + elements + `
+}
+
+unit "shard" {
+  expansion {
+    count = length(local.shards)
+  }
+
+  source = "${get_repo_root()}/catalog/units/app"
+  path   = "shard/${count.index}"
+
+  values = {
+    role = local.shards[count.index]
+  }
+}
+`
+	}
+
+	testCases := []struct {
+		name             string
+		to               string
+		expectedChanged  []string
+		expectedOrphaned []string
+	}{
+		{
+			name:             "trailing element dropped",
+			to:               `["alpha", "bravo"]`,
+			expectedChanged:  nil,
+			expectedOrphaned: []string{"2"},
+		},
+		{
+			name:             "middle element dropped",
+			to:               `["alpha", "charlie"]`,
+			expectedChanged:  []string{"1"},
+			expectedOrphaned: []string{"2"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir, runner := setupExpansionRepo(t)
+			stackFile := filepath.Join(tmpDir, "live", "terragrunt.stack.hcl")
+
+			writeExpansionFile(t, stackFile, countStack(`["alpha", "bravo", "charlie"]`))
+			commitChanges(t, runner, "Expand shard over three elements")
+
+			writeExpansionFile(t, stackFile, countStack(tc.to))
+			commitChanges(t, runner, "Shrink the shard expansion")
+
+			components, pair := discoverExpansionChanges(t, tmpDir, "apply", nil, failOnParseErrors)
+
+			expected := make([]string, 0, len(tc.expectedChanged)+len(tc.expectedOrphaned)+1)
+			expected = append(expected, filepath.Join(pair.ToWorktree.Path, "live"))
+
+			for _, index := range tc.expectedChanged {
+				changed := filepath.Join(
+					pair.ToWorktree.Path, "live", ".terragrunt-stack", "shard", index,
+				)
+				assertApplyIntent(t, requireComponent(t, components, changed), "HEAD")
+				expected = append(expected, changed)
+			}
+
+			for _, index := range tc.expectedOrphaned {
+				orphan := filepath.Join(
+					pair.FromWorktree.Path, "live", ".terragrunt-stack", "shard", index,
+				)
+				assertDestroyIntent(t, requireComponent(t, components, orphan), "HEAD~1")
+				expected = append(expected, orphan)
+			}
+
+			assert.ElementsMatch(t, expected, components.Paths())
+		})
+	}
+}
+
+// TestWorktreePhase_Integration_ExpansionUnitDisabled pins how a Git filter reads
+// enabled = false. The address is meant to survive the toggle, but the generated directory
+// does not, so the unit turns up only on the from side and is scheduled for destruction.
+func TestWorktreePhase_Integration_ExpansionUnitDisabled(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupExpansionRepo(t)
+	stackFile := filepath.Join(tmpDir, "live", "terragrunt.stack.hcl")
+
+	enabledStack := func(enabled string) string {
+		return `unit "legacy" {
+  enabled = ` + enabled + `
+
+  source = "${get_repo_root()}/catalog/units/app"
+  path   = "legacy"
+
+  values = {
+    role = "legacy"
+  }
+}
+`
+	}
+
+	writeExpansionFile(t, stackFile, enabledStack("true"))
+	commitChanges(t, runner, "Add the legacy unit")
+
+	writeExpansionFile(t, stackFile, enabledStack("false"))
+	commitChanges(t, runner, "Disable the legacy unit")
+
+	components, pair := discoverExpansionChanges(t, tmpDir, "apply", nil, failOnParseErrors)
+
+	disabled := requireComponent(
+		t,
+		components,
+		filepath.Join(pair.FromWorktree.Path, "live", ".terragrunt-stack", "legacy"),
+	)
+	assertDestroyIntent(t, disabled, "HEAD~1")
+}
+
+// TestWorktreePhase_Integration_ExpansionStackDisabled pins that disabling a stack block
+// takes the units nested underneath it along. The generated stack directory and the units it
+// generated in turn all come back from the from side, each scheduled for destruction.
+func TestWorktreePhase_Integration_ExpansionStackDisabled(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupExpansionRepo(t)
+
+	writeExpansionFile(
+		t,
+		filepath.Join(tmpDir, "catalog", "stacks", "team", "terragrunt.stack.hcl"),
+		`unit "member" {
+  source = "${get_repo_root()}/catalog/units/app"
+  path   = "member"
+
+  values = {
+    role = "member"
+  }
+}
+`,
+	)
+
+	stackFile := filepath.Join(tmpDir, "live", "terragrunt.stack.hcl")
+
+	enabledStack := func(enabled string) string {
+		return `stack "team" {
+  enabled = ` + enabled + `
+
+  source = "${get_repo_root()}/catalog/stacks/team"
+  path   = "team"
+}
+`
+	}
+
+	writeExpansionFile(t, stackFile, enabledStack("true"))
+	commitChanges(t, runner, "Add the team stack")
+
+	writeExpansionFile(t, stackFile, enabledStack("false"))
+	commitChanges(t, runner, "Disable the team stack")
+
+	components, pair := discoverExpansionChanges(t, tmpDir, "apply", nil, failOnParseErrors)
+
+	generated := filepath.Join(pair.FromWorktree.Path, "live", ".terragrunt-stack", "team")
+	assertDestroyIntent(t, requireComponent(t, components, generated), "HEAD~1")
+	assertDestroyIntent(
+		t,
+		requireComponent(t, components, filepath.Join(generated, ".terragrunt-stack", "member")),
+		"HEAD~1",
+	)
+}
+
+// TestWorktreePhase_Integration_ExpansionReadingAffectedOrphan pins the second route to an
+// orphan. The stack file is untouched, but the file it reads to build its iteration set
+// changed, which is enough for reading-affected detection to walk the stack.
+func TestWorktreePhase_Integration_ExpansionReadingAffectedOrphan(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupExpansionRepo(t)
+	shardsFile := filepath.Join(tmpDir, "shards.hcl")
+
+	writeExpansionFile(
+		t,
+		filepath.Join(tmpDir, "live", "terragrunt.stack.hcl"),
+		`locals {
+  shards = read_terragrunt_config("${get_repo_root()}/shards.hcl").locals.shards
+}
+
+unit "shard" {
+  expansion {
+    for_each = toset(local.shards)
+  }
+
+  source = "${get_repo_root()}/catalog/units/app"
+  path   = "shard/${each.key}"
+
+  values = {
+    role = each.key
+  }
+}
+`,
+	)
+
+	writeExpansionFile(t, shardsFile, `locals {
+  shards = ["web", "api"]
+}
+`)
+	commitChanges(t, runner, "Expand shard over the shards file")
+
+	writeExpansionFile(t, shardsFile, `locals {
+  shards = ["web"]
+}
+`)
+	commitChanges(t, runner, "Drop the api shard from the shards file")
+
+	components, pair := discoverExpansionChanges(t, tmpDir, "apply", nil, failOnParseErrors)
+
+	orphan := requireComponent(
+		t,
+		components,
+		filepath.Join(pair.FromWorktree.Path, "live", ".terragrunt-stack", "shard", "api"),
+	)
+	assertDestroyIntent(t, orphan, "HEAD~1")
+}
+
+// TestWorktreePhase_Integration_ExpansionParseErrorsSuppressedInChangedStack covers a unit
+// inside a changed stack whose configuration does not parse. Walking the stack runs a
+// discovery per side, and those have to tolerate parse errors exactly as the parent does. A
+// stricter sub-discovery fails the whole worktree phase, and a command that suppresses parse
+// errors swallows that failure, so the orphan never reaches the user.
+func TestWorktreePhase_Integration_ExpansionParseErrorsSuppressedInChangedStack(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupExpansionRepo(t)
+
+	writeExpansionFile(
+		t,
+		filepath.Join(tmpDir, "catalog", "units", "malformed", "terragrunt.hcl"),
+		"inputs = {\n",
+	)
+
+	stackFile := filepath.Join(tmpDir, "live", "terragrunt.stack.hcl")
+	stackWithMalformedUnit := func(elements string) string {
+		return forEachStack(elements) + `
+unit "malformed" {
+  source = "${get_repo_root()}/catalog/units/malformed"
+  path   = "malformed"
+}
+`
+	}
+
+	writeExpansionFile(t, stackFile, stackWithMalformedUnit(`["web", "api"]`))
+	commitChanges(t, runner, "Expand shard over web and api")
+
+	writeExpansionFile(t, stackFile, stackWithMalformedUnit(`["web"]`))
+	commitChanges(t, runner, "Drop the api shard")
+
+	// A negated attribute filter subtracts from the Git expression's union rather than
+	// replacing it, and matching on source forces discovery to parse every candidate. That is
+	// what brings the malformed unit into the walk.
+	sourceExpr, err := filter.NewAttributeExpression(filter.AttributeSource, "**/never-matches")
+	require.NoError(t, err)
+
+	negated := filter.NewPrefixExpression("!", sourceExpr)
+	extraFilters := filter.Filters{filter.NewFilter(negated, negated.String())}
+
+	components, pair := discoverExpansionChanges(t, tmpDir, "", extraFilters, suppressParseErrors)
+
+	orphan := requireComponent(
+		t,
+		components,
+		filepath.Join(pair.FromWorktree.Path, "live", ".terragrunt-stack", "shard", "api"),
+	)
+	assert.Equal(t, "HEAD~1", orphan.DiscoveryContext().Ref)
+}

--- a/test/integration_stack_expansion_filter_test.go
+++ b/test/integration_stack_expansion_filter_test.go
@@ -1,0 +1,455 @@
+package test_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// expansionFilterCatalogUnit is the source every expanded unit in these tests is generated
+// from. Instances differ only by the terragrunt.values.hcl written alongside them.
+const expansionFilterCatalogUnit = `inputs = {
+  role = values.role
+}
+`
+
+// setupExpansionFilterRepo creates a Git repository holding a unit catalog. The stacks
+// documentation recommends gitignoring the generated tree, so these repositories do.
+func setupExpansionFilterRepo(t *testing.T) (string, *git.GitRunner) {
+	t.Helper()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+	runner := helpers.InitTestGitRunner(t, tmpDir)
+
+	writeExpansionFilterFile(t, filepath.Join(tmpDir, ".gitignore"), ".terragrunt-stack\n")
+	writeExpansionFilterFile(
+		t,
+		filepath.Join(tmpDir, "catalog", "units", "app", "terragrunt.hcl"),
+		expansionFilterCatalogUnit,
+	)
+
+	return tmpDir, runner
+}
+
+func writeExpansionFilterFile(t *testing.T, path, contents string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+}
+
+func commitExpansionFilterChanges(t *testing.T, runner *git.GitRunner, message string) {
+	t.Helper()
+
+	require.NoError(t, runner.Add(t.Context(), "."))
+	require.NoError(t, runner.Commit(t.Context(), message))
+}
+
+// expansionFilterStack renders a stack file expanding one unit per element of the set.
+func expansionFilterStack(elements string) string {
+	return `unit "shard" {
+  expansion {
+    for_each = toset(` + elements + `)
+  }
+
+  source = "${get_repo_root()}/catalog/units/app"
+  path   = "shard/${each.key}"
+
+  values = {
+    role = each.key
+  }
+}
+`
+}
+
+// runExpansionFilterFind runs `terragrunt find` with the block-iteration experiment enabled
+// and returns the selected paths.
+func runExpansionFilterFind(t *testing.T, tmpDir, args string) []string {
+	t.Helper()
+
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt find --no-color --experiment block-iteration --working-dir "+tmpDir+" "+args,
+	)
+	require.NoError(t, err, "stderr: %s", stderr)
+
+	trimmed := strings.TrimSpace(stdout)
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "\n")
+}
+
+// generateExpansionFilterStacks runs `terragrunt stack generate` over tmpDir and returns the
+// generated unit directories, relative to tmpDir.
+func generateExpansionFilterStacks(t *testing.T, tmpDir, args string) []string {
+	t.Helper()
+
+	_, stderr, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt stack generate --no-color --experiment block-iteration --working-dir "+tmpDir+" "+args,
+	)
+	require.NoError(t, err, "stderr: %s", stderr)
+
+	var generated []string
+
+	require.NoError(t, filepath.WalkDir(tmpDir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if entry.Name() != "terragrunt.hcl" {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(tmpDir, filepath.Dir(path))
+		if relErr != nil {
+			return relErr
+		}
+
+		if strings.Contains(rel, ".terragrunt-stack") {
+			generated = append(generated, filepath.ToSlash(rel))
+		}
+
+		return nil
+	}))
+
+	return generated
+}
+
+// TestStackExpansionGitFilterSelectsRemovedInstance pins the orphan cleanup workflow end to
+// end. An instance dropped from a for_each is selected alongside its stack, whether the diff
+// is spelled out as a Git expression or reached through --filter-affected.
+func TestStackExpansionGitFilterSelectsRemovedInstance(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupExpansionFilterRepo(t)
+	stackFile := filepath.Join(tmpDir, "live", "terragrunt.stack.hcl")
+
+	writeExpansionFilterFile(t, stackFile, expansionFilterStack(`["web", "api"]`))
+	commitExpansionFilterChanges(t, runner, "Expand shard over web and api")
+
+	// --filter-affected compares against main, so the initial state has to live there before
+	// the change lands on a branch of its own.
+	if branch, err := runner.Config(t.Context(), "init.defaultBranch"); err != nil ||
+		branch != "main" {
+		require.NoError(t, runner.Checkout(t.Context(), "main", true))
+	}
+
+	require.NoError(t, runner.Checkout(t.Context(), "shrink-expansion", true))
+
+	writeExpansionFilterFile(t, stackFile, expansionFilterStack(`["web"]`))
+	commitExpansionFilterChanges(t, runner, "Drop the api shard")
+
+	expected := []string{"live", "live/.terragrunt-stack/shard/api"}
+
+	for _, tc := range []struct {
+		name string
+		args string
+	}{
+		{name: "git expression", args: "--filter '[main...HEAD]'"},
+		{name: "filter-affected", args: "--filter-affected"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.ElementsMatch(t, expected, runExpansionFilterFind(t, tmpDir, tc.args))
+		})
+	}
+}
+
+// TestStackExpansionGitFilterNeedsTheStackFileInTheDiff pins the limit of orphan discovery.
+// An iteration set driven from outside the repository shrinks without touching the stack file
+// or anything it reads. The diff then gives Terragrunt nothing to compare, and the instance
+// that disappeared never shows up, even though its directory is still on disk.
+func TestStackExpansionGitFilterNeedsTheStackFileInTheDiff(t *testing.T) {
+	// t.Setenv rules out t.Parallel: the iteration set is driven from the environment.
+	tmpDir, runner := setupExpansionFilterRepo(t)
+
+	writeExpansionFilterFile(
+		t,
+		filepath.Join(tmpDir, "live", "terragrunt.stack.hcl"),
+		expansionFilterStack(`compact(split(",", get_env("TEST_EXPANSION_SHARDS", "web,api")))`),
+	)
+	commitExpansionFilterChanges(t, runner, "Expand shard over the environment")
+
+	helpers.RunTerragrunt(
+		t,
+		"terragrunt stack generate --experiment block-iteration --working-dir "+tmpDir,
+	)
+
+	writeExpansionFilterFile(
+		t,
+		filepath.Join(tmpDir, "catalog", "units", "app", "terragrunt.hcl"),
+		expansionFilterCatalogUnit+"\n# Touched\n",
+	)
+	commitExpansionFilterChanges(t, runner, "Touch the catalog unit")
+
+	t.Setenv("TEST_EXPANSION_SHARDS", "web")
+
+	require.DirExists(t, filepath.Join(tmpDir, "live", ".terragrunt-stack", "shard", "api"))
+
+	assert.ElementsMatch(
+		t,
+		[]string{"catalog/units/app"},
+		runExpansionFilterFind(t, tmpDir, "--filter '[HEAD~1...HEAD]'"),
+	)
+}
+
+// TestStackExpansionFilterRestrictedToStacksNarrowsGeneration pins which filters narrow the
+// set of stacks Terragrunt generates. Generation stays permissive until a filter names stacks.
+// A filter aimed at a generated unit path leaves every stack generated, and only a
+// stack-restricted filter cuts the set down.
+func TestStackExpansionFilterRestrictedToStacksNarrowsGeneration(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		args      string
+		generated []string
+	}{
+		{
+			name: "no filter",
+			generated: []string{
+				"live/.terragrunt-stack/shard/api",
+				"live/.terragrunt-stack/shard/web",
+				"other/.terragrunt-stack/shard/solo",
+			},
+		},
+		{
+			name: "path filter naming a generated unit",
+			args: "--filter './live/.terragrunt-stack/shard/web'",
+			generated: []string{
+				"live/.terragrunt-stack/shard/api",
+				"live/.terragrunt-stack/shard/web",
+				"other/.terragrunt-stack/shard/solo",
+			},
+		},
+		{
+			name: "path filter restricted to stacks",
+			args: "--filter './live | type=stack'",
+			generated: []string{
+				"live/.terragrunt-stack/shard/api",
+				"live/.terragrunt-stack/shard/web",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir, runner := setupExpansionFilterRepo(t)
+
+			writeExpansionFilterFile(
+				t,
+				filepath.Join(tmpDir, "live", "terragrunt.stack.hcl"),
+				expansionFilterStack(`["web", "api"]`),
+			)
+			writeExpansionFilterFile(
+				t,
+				filepath.Join(tmpDir, "other", "terragrunt.stack.hcl"),
+				expansionFilterStack(`["solo"]`),
+			)
+			commitExpansionFilterChanges(t, runner, "Add two expanding stacks")
+
+			assert.ElementsMatch(
+				t,
+				tc.generated,
+				generateExpansionFilterStacks(t, tmpDir, tc.args),
+			)
+		})
+	}
+}
+
+// TestStackExpansionFilterSelectsGeneratedInstancePath pins how a single expanded instance is
+// selected. The keyed address Terragrunt logs is a display string, and the bracket that opens
+// it is the Git expression delimiter in filter syntax, so it cannot be written as a filter
+// term at all. Users select an instance by the directory its path attribute produced.
+func TestStackExpansionFilterSelectsGeneratedInstancePath(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupExpansionFilterRepo(t)
+
+	writeExpansionFilterFile(
+		t,
+		filepath.Join(tmpDir, "live", "terragrunt.stack.hcl"),
+		expansionFilterStack(`["web", "api"]`),
+	)
+	commitExpansionFilterChanges(t, runner, "Expand shard over web and api")
+
+	helpers.RunTerragrunt(
+		t,
+		"terragrunt stack generate --experiment block-iteration --working-dir "+tmpDir,
+	)
+
+	assert.ElementsMatch(
+		t,
+		[]string{"live/.terragrunt-stack/shard/web"},
+		runExpansionFilterFind(t, tmpDir, "--filter './live/.terragrunt-stack/shard/web'"),
+	)
+
+	assert.ElementsMatch(
+		t,
+		[]string{"live/.terragrunt-stack/shard/web"},
+		runExpansionFilterFind(t, tmpDir, "--filter 'name=web'"),
+	)
+
+	// The CLI renders a filter parse failure as a diagnostic rather than passing the typed
+	// error through, so the parser is asked directly for what the run rejects.
+	_, err := filter.Parse(`shard["web"]`)
+
+	var parseErr filter.ParseError
+	require.ErrorAs(t, err, &parseErr)
+
+	_, _, err = helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt find --no-color --experiment block-iteration --working-dir "+tmpDir+
+			` --filter 'shard["web"]'`,
+	)
+	require.Error(t, err)
+}
+
+// TestStackExpansionSelectionIgnoresStaleGeneratedDirectory pins how a Git-filtered run
+// treats a generated directory the current stack file no longer produces. Regeneration leaves
+// it in place, so the working directory keeps offering a unit no ref generates. The worktrees
+// are clean checkouts and decide the selection, so once the shrink falls outside the diff the
+// leftover directory contributes nothing.
+func TestStackExpansionSelectionIgnoresStaleGeneratedDirectory(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupExpansionFilterRepo(t)
+	stackFile := filepath.Join(tmpDir, "live", "terragrunt.stack.hcl")
+
+	writeExpansionFilterFile(t, stackFile, expansionFilterStack(`["web", "api"]`))
+	commitExpansionFilterChanges(t, runner, "Expand shard over web and api")
+
+	helpers.RunTerragrunt(
+		t,
+		"terragrunt stack generate --experiment block-iteration --working-dir "+tmpDir,
+	)
+
+	writeExpansionFilterFile(t, stackFile, expansionFilterStack(`["web"]`))
+	commitExpansionFilterChanges(t, runner, "Drop the api shard")
+
+	helpers.RunTerragrunt(
+		t,
+		"terragrunt stack generate --experiment block-iteration --working-dir "+tmpDir,
+	)
+
+	assert.DirExists(
+		t,
+		filepath.Join(tmpDir, "live", ".terragrunt-stack", "shard", "api"),
+		"regeneration leaves the dropped instance's directory behind",
+	)
+
+	assert.ElementsMatch(
+		t,
+		[]string{"live", "live/.terragrunt-stack/shard/api"},
+		runExpansionFilterFind(t, tmpDir, "--filter '[HEAD~1...HEAD]'"),
+	)
+
+	writeExpansionFilterFile(
+		t,
+		filepath.Join(tmpDir, "catalog", "units", "app", "terragrunt.hcl"),
+		expansionFilterCatalogUnit+"\n# Touched\n",
+	)
+	commitExpansionFilterChanges(t, runner, "Touch the catalog unit")
+
+	assert.ElementsMatch(
+		t,
+		[]string{"catalog/units/app"},
+		runExpansionFilterFind(t, tmpDir, "--filter '[HEAD~1...HEAD]'"),
+	)
+}
+
+// TestStackExpansionGitFilterRejectsDestroy pins the command a user has to reach for when an
+// expansion shrinks. Terragrunt schedules the destroy itself, off an apply against the older
+// ref, and rejects a destroy the user asks for outright.
+func TestStackExpansionGitFilterRejectsDestroy(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupExpansionFilterRepo(t)
+	stackFile := filepath.Join(tmpDir, "live", "terragrunt.stack.hcl")
+
+	writeExpansionFilterFile(t, stackFile, expansionFilterStack(`["web", "api"]`))
+	commitExpansionFilterChanges(t, runner, "Expand shard over web and api")
+
+	writeExpansionFilterFile(t, stackFile, expansionFilterStack(`["web"]`))
+	commitExpansionFilterChanges(t, runner, "Drop the api shard")
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt run --all destroy --experiment block-iteration --non-interactive"+
+			" --working-dir "+tmpDir+" --filter '[HEAD~1...HEAD]'",
+	)
+
+	var commandErr discovery.GitFilterCommandError
+	require.ErrorAs(t, err, &commandErr)
+	assert.Equal(t, "destroy", commandErr.Cmd)
+}
+
+// TestStackExpansionGitFilterNarrowedBySelectingFilter pins what happens when a Git filter is
+// paired with a filter that selects. Filters union, and a generated unit the Git filter
+// surfaces has to survive every selecting filter in that union. Narrowing a cleanup run to one
+// stack therefore drops the orphans it was meant to cover, and naming a generated unit path
+// drops everything, because that path lives in the worktrees rather than in the working
+// directory the filter resolves against.
+func TestStackExpansionGitFilterNarrowedBySelectingFilter(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, runner := setupExpansionFilterRepo(t)
+	liveStack := filepath.Join(tmpDir, "live", "terragrunt.stack.hcl")
+	otherStack := filepath.Join(tmpDir, "other", "terragrunt.stack.hcl")
+
+	writeExpansionFilterFile(t, liveStack, expansionFilterStack(`["web", "api"]`))
+	writeExpansionFilterFile(t, otherStack, expansionFilterStack(`["red", "blue"]`))
+	commitExpansionFilterChanges(t, runner, "Expand two stacks")
+
+	writeExpansionFilterFile(t, liveStack, expansionFilterStack(`["web"]`))
+	writeExpansionFilterFile(t, otherStack, expansionFilterStack(`["red"]`))
+	commitExpansionFilterChanges(t, runner, "Shrink both expansions")
+
+	assert.ElementsMatch(
+		t,
+		[]string{
+			"live",
+			"other",
+			"live/.terragrunt-stack/shard/api",
+			"other/.terragrunt-stack/shard/blue",
+		},
+		runExpansionFilterFind(t, tmpDir, "--filter '[HEAD~1...HEAD]'"),
+	)
+
+	restricted := runExpansionFilterFind(
+		t,
+		tmpDir,
+		"--filter '[HEAD~1...HEAD]' --filter './live | type=stack'",
+	)
+	assert.Contains(t, restricted, "live")
+	assert.NotContains(t, restricted, "other")
+	assert.NotContains(t, restricted, "live/.terragrunt-stack/shard/api")
+
+	assert.Empty(t, runExpansionFilterFind(
+		t,
+		tmpDir,
+		"--filter '[HEAD~1...HEAD]' --filter './live/.terragrunt-stack/shard/api'",
+	))
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds coverage for filters combined with block iteration.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Worktree discovery now consistently honors the parent discovery’s parsing settings.
  * Parse errors that are configured to be tolerated no longer unexpectedly stop worktree discovery.
  * Improved reliability when identifying changed, added, and orphaned stack expansion instances.

* **Tests**
  * Added integration coverage for stack expansion changes, filtering, disabled units, orphaned instances, and suppressed parse errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->