### PR TITLE
chore: Improving expansion diagnostics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
 	github.com/ProtonMail/go-crypto v1.4.1
+	github.com/agext/levenshtein v1.2.3
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/aws/aws-sdk-go-v2 v1.43.8
@@ -133,7 +134,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1655,7 +1655,7 @@ func ParseConfig(
 		return nil, err
 	}
 
-	if err := ValidateBlockIterationExperiment(pctx.Experiments, file); err != nil {
+	if err := ValidateBlockIteration(pctx.Experiments, file); err != nil {
 		return nil, err
 	}
 

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -617,7 +617,7 @@ func PartialParseConfig(
 		return nil, err
 	}
 
-	if err := ValidateBlockIterationExperiment(pctx.Experiments, file); err != nil {
+	if err := ValidateBlockIteration(pctx.Experiments, file); err != nil {
 		return nil, err
 	}
 

--- a/pkg/config/enabled_test.go
+++ b/pkg/config/enabled_test.go
@@ -248,10 +248,10 @@ func TestUnitAndStackDecodeEnabled(t *testing.T) {
 	assert.True(t, *stackCfg.Stacks[0].Enabled)
 }
 
-// TestValidateBlockIterationExperimentGatesEnabled pins which block types reject a bare
+// TestValidateBlockIterationGatesEnabled pins which block types reject a bare
 // enabled attribute while the experiment is off. The dependency row expects no error,
 // since that block has always accepted enabled.
-func TestValidateBlockIterationExperimentGatesEnabled(t *testing.T) {
+func TestValidateBlockIterationGatesEnabled(t *testing.T) {
 	t.Parallel()
 
 	skipInExperimentMode(t)
@@ -316,7 +316,7 @@ unit "app" {
 
 			file := parseHCLString(t, tc.cfg, tc.configPath)
 
-			err := config.ValidateBlockIterationExperiment(experiment.NewExperiments(), file)
+			err := config.ValidateBlockIteration(experiment.NewExperiments(), file)
 
 			if !tc.wantErr {
 				require.NoError(t, err)

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 )
 
 // Custom error types
@@ -618,6 +619,30 @@ func (err ExpansionRequiresExperimentError) Error() string {
 		err.ConfigPath,
 		experiment.BlockIteration,
 		experiment.BlockIteration,
+	)
+}
+
+// MisspelledExpansionBlockError is returned when a dependency, unit, or stack block nests a
+// block whose name is a near miss of expansion.
+type MisspelledExpansionBlockError struct {
+	ConfigPath string
+	BlockType  string
+	BlockLabel string
+	BlockName  string
+}
+
+func (err MisspelledExpansionBlockError) Error() string {
+	block := err.BlockType
+	if err.BlockLabel != "" {
+		block = fmt.Sprintf("%s %q", err.BlockType, err.BlockLabel)
+	}
+
+	return fmt.Sprintf(
+		"the %s block in %s declares a %q block, which Terragrunt does not recognize; did you mean %q?",
+		block,
+		err.ConfigPath,
+		err.BlockName,
+		hclparse.ExpansionBlockName,
 	)
 }
 

--- a/pkg/config/expansion.go
+++ b/pkg/config/expansion.go
@@ -2,8 +2,11 @@ package config
 
 import (
 	"slices"
+	"strings"
 
+	"github.com/agext/levenshtein"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
@@ -32,28 +35,44 @@ var blockIterationSyntaxSchema = &hcl.BodySchema{
 	Blocks:     []hcl.BlockHeaderSchema{{Type: hclparse.ExpansionBlockName}},
 }
 
-// ValidateBlockIterationExperiment rejects block-iteration syntax while the experiment is
-// off: an expansion block on a dependency, unit, or stack, and a bare enabled attribute on
-// a unit or stack.
+// maxExpansionTypoDistance is how far a nested block name may sit from expansion and still
+// read as a misspelling of it. Two edits cover a dropped, doubled, or swapped letter. The
+// only other block a unit or stack nests, autoinclude, sits well outside that.
+const maxExpansionTypoDistance = 2
+
+// ValidateBlockIteration rejects block-iteration syntax that Terragrunt would otherwise run
+// without complaint: syntax the block-iteration experiment gates while the experiment is
+// off, and a misspelling of the expansion block name.
 //
 // This reads the raw body rather than the decoded config because unit and stack blocks
-// decode through an `hcl:",remain"` field, which absorbs an unrecognized expansion block
-// or attribute instead of rejecting it. Without this pass a user who writes expansion or
-// enabled without the experiment watches the block silently do nothing.
-func ValidateBlockIterationExperiment(experiments experiment.Experiments, file *hclparse.File) error {
-	if experiments.Evaluate(experiment.BlockIteration) {
-		return nil
-	}
-
+// decode through an `hcl:",remain"` field, which absorbs an unrecognized block or attribute
+// instead of rejecting it. Without this pass a user who writes expansion without the
+// experiment, or writes expanson with it, watches the block silently do nothing.
+func ValidateBlockIteration(experiments experiment.Experiments, file *hclparse.File) error {
 	// Diagnostics are dropped throughout this pass: a body malformed enough to produce them
 	// fails the decode that follows with a message pointing at the real problem, and this
 	// gate has nothing to add to it.
 	content, _, _ := file.Body.PartialContent(blockIterationCandidateSchema)
 
+	iterationEnabled := experiments.Evaluate(experiment.BlockIteration)
+
 	for _, block := range content.Blocks {
 		label := ""
 		if len(block.Labels) > 0 {
 			label = block.Labels[0]
+		}
+
+		if name := misspelledExpansionBlock(block); name != "" {
+			return MisspelledExpansionBlockError{
+				ConfigPath: file.ConfigPath,
+				BlockType:  block.Type,
+				BlockLabel: label,
+				BlockName:  name,
+			}
+		}
+
+		if iterationEnabled {
+			continue
 		}
 
 		inner, _, _ := block.Body.PartialContent(blockIterationSyntaxSchema)
@@ -80,4 +99,34 @@ func ValidateBlockIterationExperiment(experiments experiment.Experiments, file *
 	}
 
 	return nil
+}
+
+// misspelledExpansionBlock returns the name of the first block nested inside block that sits
+// close enough to expansion to read as a typo of it, and the empty string when none does. A
+// name differing only in case counts, since the decoder matches block names exactly.
+//
+// Only native HCL syntax is read. A JSON body draws no line between a nested block and an
+// attribute, so it offers no block name to compare.
+func misspelledExpansionBlock(block *hcl.Block) string {
+	body, ok := block.Body.(*hclsyntax.Body)
+	if !ok {
+		return ""
+	}
+
+	for _, nested := range body.Blocks {
+		if nested.Type == hclparse.ExpansionBlockName {
+			continue
+		}
+
+		distance := levenshtein.Distance(
+			strings.ToLower(nested.Type),
+			hclparse.ExpansionBlockName,
+			nil,
+		)
+		if distance <= maxExpansionTypoDistance {
+			return nested.Type
+		}
+	}
+
+	return ""
 }

--- a/pkg/config/expansion_test.go
+++ b/pkg/config/expansion_test.go
@@ -71,9 +71,9 @@ const unitWithExpansionJSON = `{
   }
 }`
 
-// TestValidateBlockIterationExperimentGatesExpansion pins which block types reject an
+// TestValidateBlockIterationGatesExpansion pins which block types reject an
 // expansion block while the experiment is off, and that the error names the offending block.
-func TestValidateBlockIterationExperimentGatesExpansion(t *testing.T) {
+func TestValidateBlockIterationGatesExpansion(t *testing.T) {
 	t.Parallel()
 
 	skipInExperimentMode(t)
@@ -160,7 +160,7 @@ generate "backend" {
 
 			file := parseHCLString(t, tc.cfg, tc.configPath)
 
-			err := config.ValidateBlockIterationExperiment(experiment.NewExperiments(), file)
+			err := config.ValidateBlockIteration(experiment.NewExperiments(), file)
 
 			if !tc.wantErr {
 				require.NoError(t, err)
@@ -176,9 +176,9 @@ generate "backend" {
 	}
 }
 
-// TestValidateBlockIterationExperimentGateClearsWhenOn pins that turning the experiment on
+// TestValidateBlockIterationGateClearsWhenOn pins that turning the experiment on
 // clears the gate for both expansion blocks and bare enabled attributes.
-func TestValidateBlockIterationExperimentGateClearsWhenOn(t *testing.T) {
+func TestValidateBlockIterationGateClearsWhenOn(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -222,7 +222,7 @@ func TestValidateBlockIterationExperimentGateClearsWhenOn(t *testing.T) {
 
 			require.NoError(
 				t,
-				config.ValidateBlockIterationExperiment(
+				config.ValidateBlockIteration(
 					experiments,
 					parseHCLString(t, tc.cfg, tc.configPath),
 				),
@@ -1269,6 +1269,237 @@ inputs = {
 		"first_region": "region-r0",
 		"last_region":  "region-r39",
 	}, cfg.Inputs)
+}
+
+// TestValidateBlockIterationRejectsMisspelledExpansion pins that a nested block name close
+// enough to expansion to be a typo of it is reported. A unit or stack block decodes through
+// an `hcl:",remain"` field, which would otherwise absorb the block and leave the component a
+// single static instance.
+func TestValidateBlockIterationRejectsMisspelledExpansion(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		configPath    string
+		cfg           string
+		wantBlockType string
+		wantLabel     string
+		wantBlockName string
+	}{
+		{
+			name:       "unit with a dropped letter",
+			configPath: config.DefaultStackFile,
+			cfg: `
+unit "app" {
+  expanson {
+    count = 2
+  }
+
+  source = "./modules/app"
+  path   = "app"
+}
+`,
+			wantBlockType: "unit",
+			wantLabel:     "app",
+			wantBlockName: "expanson",
+		},
+		{
+			name:       "stack with a swapped letter",
+			configPath: config.DefaultStackFile,
+			cfg: `
+stack "team" {
+  expantion {
+    count = 2
+  }
+
+  source = "./stacks/team"
+  path   = "team"
+}
+`,
+			wantBlockType: "stack",
+			wantLabel:     "team",
+			wantBlockName: "expantion",
+		},
+		{
+			name:       "unit with a capitalized block name",
+			configPath: config.DefaultStackFile,
+			cfg: `
+unit "app" {
+  Expansion {
+    count = 2
+  }
+
+  source = "./modules/app"
+  path   = "app"
+}
+`,
+			wantBlockType: "unit",
+			wantLabel:     "app",
+			wantBlockName: "Expansion",
+		},
+		{
+			name:       "dependency with a dropped letter",
+			configPath: config.DefaultTerragruntConfigPath,
+			cfg: `
+dependency "aurora" {
+  expanson {
+    count = 2
+  }
+
+  config_path = "../aurora"
+}
+`,
+			wantBlockType: "dependency",
+			wantLabel:     "aurora",
+			wantBlockName: "expanson",
+		},
+		{
+			name:       "unit spelling expansion correctly",
+			configPath: config.DefaultStackFile,
+			cfg:        unitWithExpansionHCL,
+		},
+		{
+			name:       "unit with an autoinclude block",
+			configPath: config.DefaultStackFile,
+			cfg: `
+unit "app" {
+  autoinclude {
+    inputs = {
+      env = "test"
+    }
+  }
+
+  source = "./modules/app"
+  path   = "app"
+}
+`,
+		},
+		{
+			name:       "json body, which names no blocks to compare",
+			configPath: jsonConfigPath,
+			cfg:        `{"dependency": {"aurora": {"expanson": {"count": 2}, "config_path": "../aurora"}}}`,
+		},
+	}
+
+	experiments := experiment.NewExperiments()
+	require.NoError(t, experiments.EnableExperiment(experiment.BlockIteration))
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			file := parseHCLString(t, tc.cfg, tc.configPath)
+
+			err := config.ValidateBlockIteration(experiments, file)
+
+			if tc.wantBlockName == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			var typed config.MisspelledExpansionBlockError
+			require.ErrorAs(t, err, &typed)
+			assert.Equal(t, tc.wantBlockType, typed.BlockType)
+			assert.Equal(t, tc.wantLabel, typed.BlockLabel)
+			assert.Equal(t, tc.wantBlockName, typed.BlockName)
+			assert.Equal(t, tc.configPath, typed.ConfigPath)
+		})
+	}
+}
+
+// TestValidateBlockIterationRejectsMisspelledExpansionWithTheExperimentOff pins that the
+// misspelling is caught whether or not the experiment is on. A config the experiment gate
+// would reject anyway is still worth spelling correctly.
+func TestValidateBlockIterationRejectsMisspelledExpansionWithTheExperimentOff(t *testing.T) {
+	t.Parallel()
+
+	skipInExperimentMode(t)
+
+	file := parseHCLString(t, `
+unit "app" {
+  expanson {
+    count = 2
+  }
+
+  source = "./modules/app"
+  path   = "app"
+}
+`, config.DefaultStackFile)
+
+	err := config.ValidateBlockIteration(experiment.NewExperiments(), file)
+
+	var typed config.MisspelledExpansionBlockError
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, "expanson", typed.BlockName)
+}
+
+// TestReadStackConfigStringRejectsMisspelledExpansion proves the misspelling check is wired
+// into the stack parse, not just callable on its own. Without it the unit below generates a
+// single static instance.
+func TestReadStackConfigStringRejectsMisspelledExpansion(t *testing.T) {
+	t.Parallel()
+
+	err := parseStackErr(t, `
+unit "app" {
+  expanson {
+    for_each = toset(["web", "api"])
+  }
+
+  source = "./modules/app"
+  path   = "app/${each.key}"
+}
+`)
+
+	var typed config.MisspelledExpansionBlockError
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, "unit", typed.BlockType)
+	assert.Equal(t, "expanson", typed.BlockName)
+}
+
+// TestPartialParseKeepsParsingPastABrokenExpansion covers the best-effort parsing find and
+// list depend on. With a handler that forgives diagnostics, a dependency whose elements
+// cannot decode is dropped, and the rest of the config still parses.
+func TestPartialParseKeepsParsingPastABrokenExpansion(t *testing.T) {
+	t.Parallel()
+
+	ctx, pctx := newExpansionParsingContext(t, venvtest.New(), config.DefaultTerragruntConfigPath)
+
+	forgiving := hclparse.WithDiagnosticsHandler(
+		func(_ *hcl.File, _ hcl.Diagnostics) (hcl.Diagnostics, error) {
+			return nil, nil
+		},
+	)
+
+	pctx = pctx.
+		WithDecodeList(config.DependencyBlock).
+		WithParseOption(append(pctx.ParserOptions, forgiving))
+
+	cfg, err := config.PartialParseConfigString(
+		ctx,
+		pctx,
+		logger.CreateLogger(),
+		config.DefaultTerragruntConfigPath,
+		`
+dependency "broken" {
+  expansion {
+    count = 2
+  }
+
+  config_path = "../broken-${count.index}"
+  bogus       = "nope"
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+`,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, cfg.TerragruntDependencies, 1)
+
+	assert.Equal(t, "vpc", cfg.TerragruntDependencies[0].Name)
 }
 
 func parseDependencyString(tb testing.TB, cfg string) (*config.TerragruntConfig, error) {

--- a/pkg/config/hclparse/expansion.go
+++ b/pkg/config/hclparse/expansion.go
@@ -308,9 +308,9 @@ func ExpandBlock(
 	}
 
 	if expansion == nil {
-		instance, err := decodeInstance(block, outType, ctx)
-		if err != nil {
-			return nil, err
+		instance, diags := decodeInstance(block, outType, ctx)
+		if diags.HasErrors() {
+			return nil, diags
 		}
 
 		return []Instance{{Value: instance}}, nil
@@ -414,7 +414,7 @@ func expandCount(
 		}
 	}
 
-	instances := make([]Instance, 0, total)
+	decoder := newElementDecoder(total)
 
 	for index := range total {
 		child := ctx.NewChild()
@@ -424,18 +424,10 @@ func expandCount(
 			}),
 		}
 
-		value, err := decodeInstance(block, outType, child)
-		if err != nil {
-			return nil, err
-		}
-
-		instances = append(instances, Instance{
-			Value:      value,
-			CountIndex: new(index),
-		})
+		decoder.decode(block, outType, child, InstanceKey{CountIndex: new(index)})
 	}
 
-	return instances, nil
+	return decoder.result()
 }
 
 func expandForEach(
@@ -475,7 +467,7 @@ func expandForEach(
 		}
 	}
 
-	instances := make([]Instance, 0, size)
+	decoder := newElementDecoder(size)
 
 	for it := collection.ElementIterator(); it.Next(); {
 		elementKey, elementValue := it.Element()
@@ -493,18 +485,10 @@ func expandForEach(
 			}),
 		}
 
-		value, err := decodeInstance(block, outType, child)
-		if err != nil {
-			return nil, err
-		}
-
-		instances = append(instances, Instance{
-			Value:   value,
-			EachKey: new(key),
-		})
+		decoder.decode(block, outType, child, InstanceKey{EachKey: new(key)})
 	}
 
-	return instances, nil
+	return decoder.result()
 }
 
 // requireConcrete rejects expansion values that cannot be iterated, converted, or
@@ -543,9 +527,83 @@ func expansionKey(key cty.Value, subject *hcl.Range) (string, error) {
 	}
 }
 
+// elementDecoder decodes a block once per expansion element. A failing element does not stop
+// the decode, since a mistake that only one element's each.value reaches would otherwise go
+// unreported. The decoder drops any diagnostic an earlier element already produced, so one
+// mistake in the body is reported once however many elements the block expands into.
+type elementDecoder struct {
+	reported  map[diagnosticID]struct{}
+	instances []Instance
+	diags     hcl.Diagnostics
+}
+
+// diagnosticID is the part of a diagnostic that decides whether two elements hit the same
+// problem. The expression and eval context a diagnostic also carries differ per element even
+// when the message does not.
+type diagnosticID struct {
+	summary  string
+	detail   string
+	subject  hcl.Range
+	severity hcl.DiagnosticSeverity
+}
+
+func newElementDecoder(elements int) *elementDecoder {
+	return &elementDecoder{
+		reported:  make(map[diagnosticID]struct{}),
+		instances: make([]Instance, 0, elements),
+	}
+}
+
+func (dec *elementDecoder) decode(
+	block *hcl.Block,
+	outType reflect.Type,
+	ctx *hcl.EvalContext,
+	key InstanceKey,
+) {
+	value, diags := decodeInstance(block, outType, ctx)
+	if !diags.HasErrors() {
+		dec.instances = append(dec.instances, Instance{Value: value, InstanceKey: key})
+
+		return
+	}
+
+	for _, diag := range diags {
+		id := diagnosticID{
+			summary:  diag.Summary,
+			detail:   diag.Detail,
+			severity: diag.Severity,
+		}
+		if diag.Subject != nil {
+			id.subject = *diag.Subject
+		}
+
+		if _, reported := dec.reported[id]; reported {
+			continue
+		}
+
+		dec.reported[id] = struct{}{}
+		dec.diags = append(dec.diags, diag)
+	}
+}
+
+// result returns the decoded instances, or every distinct diagnostic the elements produced.
+// An expansion that failed for any element yields no instances, so a caller never addresses
+// a set with holes in it.
+func (dec *elementDecoder) result() ([]Instance, error) {
+	if dec.diags.HasErrors() {
+		return nil, dec.diags
+	}
+
+	return dec.instances, nil
+}
+
 // decodeInstance decodes the whole block body, expansion sub-block included, into a
 // fresh value of outType.
-func decodeInstance(block *hcl.Block, outType reflect.Type, ctx *hcl.EvalContext) (any, error) {
+func decodeInstance(
+	block *hcl.Block,
+	outType reflect.Type,
+	ctx *hcl.EvalContext,
+) (any, hcl.Diagnostics) {
 	instance := reflect.New(outType.Elem())
 
 	if diags := gohcl.DecodeBody(block.Body, ctx, instance.Interface()); diags.HasErrors() {

--- a/pkg/config/hclparse/expansion_test.go
+++ b/pkg/config/hclparse/expansion_test.go
@@ -821,3 +821,121 @@ func keysOf(instances []hclparse.Instance) []string {
 
 	return keys
 }
+
+// TestExpandBlocksReportsOneDiagnosticPerMistake pins that a mistake in the body of an
+// expanded block is reported once, not once per element. The block below expands to five
+// instances, every one of which fails to decode the same way.
+func TestExpandBlocksReportsOneDiagnosticPerMistake(t *testing.T) {
+	t.Parallel()
+
+	_, err := expandDependencies(t, `
+dependency "a" {
+  expansion {
+    count = 5
+  }
+
+  path  = "../x"
+  bogus = "nope"
+}
+`, nil)
+
+	var diags hcl.Diagnostics
+	require.ErrorAs(t, err, &diags)
+	assert.Len(t, diags, 1)
+}
+
+// TestExpandBlocksDecodesPastAFailingElement pins that expansion decodes every element even
+// after one has failed, so a mistake only one element's each.value reaches is still
+// reported. Both elements below fail, each in its own way.
+func TestExpandBlocksDecodesPastAFailingElement(t *testing.T) {
+	t.Parallel()
+
+	const cfg = `
+dependency "a" {
+  expansion {
+    for_each = local.shapes
+  }
+
+  path = "../${each.value.name}"
+}
+`
+
+	shapes := func(elements map[string]cty.Value) *hcl.EvalContext {
+		return &hcl.EvalContext{
+			Variables: map[string]cty.Value{
+				"local": cty.ObjectVal(map[string]cty.Value{
+					"shapes": cty.ObjectVal(elements),
+				}),
+			},
+		}
+	}
+
+	// Objects sort their keys, so "b" is decoded first.
+	noName := cty.ObjectVal(map[string]cty.Value{"other": cty.StringVal("x")})
+	notAnObject := cty.StringVal("plain")
+
+	_, err := expandDependencies(t, cfg, shapes(map[string]cty.Value{"b": noName}))
+
+	var first hcl.Diagnostics
+	require.ErrorAs(t, err, &first)
+
+	_, err = expandDependencies(t, cfg, shapes(map[string]cty.Value{
+		"b": noName,
+		"c": notAnObject,
+	}))
+
+	var both hcl.Diagnostics
+	require.ErrorAs(t, err, &both)
+
+	assert.Greater(t, len(both), len(first))
+}
+
+// TestExpandBlocksKeepsParsingPastABrokenExpansion covers the best-effort parsing find, list
+// and the LSP depend on. A block whose elements cannot decode is dropped when the handler
+// forgives its diagnostics, and the rest of the file still comes back.
+func TestExpandBlocksKeepsParsingPastABrokenExpansion(t *testing.T) {
+	t.Parallel()
+
+	parser := hclparse.NewParser(
+		hclparse.WithDiagnosticsHandler(
+			func(_ *hcl.File, _ hcl.Diagnostics) (hcl.Diagnostics, error) {
+				return nil, nil
+			},
+		),
+	)
+
+	file, err := parser.ParseFromString(`
+dependency "broken" {
+  expansion {
+    count = 2
+  }
+
+  path  = "../${count.index}"
+  bogus = "nope"
+}
+
+dependency "vpc" {
+  path = "../vpc"
+}
+`, "terragrunt.hcl")
+	require.NoError(t, err)
+
+	instances, err := file.ExpandBlocks("dependency", new(testBlock), nil)
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+
+	assert.Equal(t, "vpc", instances[0].Value.(*testBlock).Name)
+}
+
+func expandDependencies(
+	tb testing.TB,
+	cfg string,
+	ctx *hcl.EvalContext,
+) ([]hclparse.Instance, error) {
+	tb.Helper()
+
+	file, err := hclparse.NewParser().ParseFromString(cfg, "terragrunt.hcl")
+	require.NoError(tb, err)
+
+	return file.ExpandBlocks("dependency", new(testBlock), ctx)
+}

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -1212,7 +1212,7 @@ func ParseStackConfig(
 		parser = parser.WithValues(values)
 	}
 
-	if err := ValidateBlockIterationExperiment(parser.Experiments, file); err != nil {
+	if err := ValidateBlockIteration(parser.Experiments, file); err != nil {
 		return nil, err
 	}
 
@@ -1709,7 +1709,7 @@ func processStackConfigIncludes(
 			return fmt.Errorf("failed to read include %q: %w", inc.Name, err)
 		}
 
-		if err := ValidateBlockIterationExperiment(experiments, incFile); err != nil {
+		if err := ValidateBlockIteration(experiments, incFile); err != nil {
 			return err
 		}
 
@@ -1812,7 +1812,7 @@ func mergeStackAutoIncludeFile(
 		return *typed
 	}
 
-	if err := ValidateBlockIterationExperiment(experiments, incFile); err != nil {
+	if err := ValidateBlockIteration(experiments, incFile); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Improves diagnostics for block iteration errors.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration files now detect likely misspellings of `expansion` blocks and report the correct block name.
  * Validation applies consistently, including when the related experiment is disabled.
  * Configuration parsing now reports expansion errors more clearly and avoids repeating identical diagnostics.
  * Parsing continues to identify additional issues after an invalid expansion element, while forgiving handlers can proceed with the remaining valid configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->