### PR TITLE
fix: Check duplicate dependency config path

### DIFF
--- a/docs/src/data/changelog/v1.1.5/duplicate-dependency-config-paths.mdx
+++ b/docs/src/data/changelog/v1.1.5/duplicate-dependency-config-paths.mdx
@@ -1,0 +1,24 @@
+---
+version: "v1.1.5"
+category: "new-features"
+---
+
+#### `duplicate-dependency-labels` also catches a shared `config_path`
+
+Two `dependency` blocks with different labels can point at the same `config_path`. Both parse, so the same unit is declared twice, and the two blocks drift apart as soon as one gains a `mock_outputs` or `skip_outputs` the other lacks:
+
+```hcl
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+dependency "network" {
+  config_path = "../vpc"
+}
+```
+
+Terragrunt now warns when it finds this, alongside the existing warning for two blocks sharing a label. With the [`duplicate-dependency-labels`](/reference/strict-controls/active#duplicate-dependency-labels) strict control enabled, the warning becomes an error naming both addresses and the path they share:
+
+```text
+/path/to/terragrunt.hcl: dependencies vpc and network both point at ../vpc; declare that dependency once and reference it under one name
+```

--- a/docs/src/data/strict-controls/duplicate-dependency-labels.mdx
+++ b/docs/src/data/strict-controls/duplicate-dependency-labels.mdx
@@ -4,7 +4,7 @@ status: active
 since: "1.1.4"
 ---
 
-Throw an error when two `dependency` blocks in one configuration claim the same address.
+Throw an error when two `dependency` blocks in one configuration address the same dependency, by sharing a label or a `config_path`.
 
 ### `duplicate-dependency-labels` - Reason
 
@@ -32,5 +32,23 @@ Terragrunt warns about this by default. Enabling the control turns it into an er
 ```
 
 Give each block a label of its own. A configuration that was relying on the shadowing to pick the last block should keep only that block.
+
+Two blocks with different labels can also point at one `config_path`. Both are reachable, so the same unit is declared twice, and the two blocks drift apart as soon as one gains a `mock_outputs` or `skip_outputs` the other lacks:
+
+```hcl
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+dependency "network" {
+  config_path = "../vpc"
+}
+```
+
+That is warned about by default too. Under the control it is an error naming both addresses and the path they share:
+
+```text
+/path/to/terragrunt.hcl: dependencies vpc and network both point at ../vpc; declare that dependency once and reference it under one name
+```
 
 Blocks are compared by the address they resolve to rather than by label alone, so the elements of a block expanded with the [`block-iteration`](/reference/experiments/active#block-iteration) experiment, which all carry the label the block was written with, remain valid.

--- a/internal/strict/controls/controls.go
+++ b/internal/strict/controls/controls.go
@@ -96,7 +96,7 @@ const (
 	OptionalHooks = "optional-hooks"
 
 	// DuplicateDependencyLabels is the control that prevents two `dependency` blocks in one
-	// configuration from claiming the same address.
+	// configuration from addressing the same dependency, by label or by config_path.
 	DuplicateDependencyLabels = "duplicate-dependency-labels"
 )
 
@@ -240,11 +240,11 @@ func New() strict.Controls {
 
 		&Control{
 			Name:        DuplicateDependencyLabels,
-			Description: "Prevents two `dependency` blocks in one configuration from claiming the same address.",
+			Description: "Prevents two `dependency` blocks in one configuration from addressing the same dependency, whether by sharing a label or a `config_path`.",
 			Error: errors.New( //nolint:staticcheck // user-facing message intentionally written as full sentences
-				"Two `dependency` blocks address the same dependency. Give each block a label of its own.",
+				"Two `dependency` blocks address the same dependency, by sharing a label or a `config_path`. Declare each dependency once.",
 			),
-			Warning: "Two `dependency` blocks address the same dependency, so only the last of them can be referenced and the rest are unreachable. Give each block a label of its own. In a future version of Terragrunt, this will result in an error.",
+			Warning: "Two `dependency` blocks address the same dependency, by sharing a label or a `config_path`. Only the last block with a given label can be referenced, and two blocks for one `config_path` declare the same unit twice. Declare each dependency once. In a future version of Terragrunt, this will result in an error.",
 		},
 
 		&Control{

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -325,12 +325,14 @@ func decodeDependencyBlocks(
 }
 
 // validateUniqueDependencies reports two dependency blocks in one config that address the
-// same dependency. HCL allows the repeated label, and nothing downstream reports it: the
-// dependency map is keyed by address, so the last block silently wins and the ones before
-// it become unreachable.
+// same dependency, either by resolving to the same address or by pointing at the same
+// config_path. HCL allows both, and nothing downstream reports either. The dependency map is
+// keyed by address, so a repeated address means the last block silently wins. A repeated
+// config_path declares one unit twice, and the two blocks drift apart as soon as one gains
+// a mock_outputs or skip_outputs the other lacks.
 //
 // Whether that is an error or a warning is left to the duplicate-dependency-labels strict
-// control, since configs carrying a shadowed block have always run.
+// control, since configs with either duplicate have always run.
 func validateUniqueDependencies(
 	ctx context.Context,
 	pctx *ParsingContext,
@@ -338,18 +340,40 @@ func validateUniqueDependencies(
 	configPath string,
 	deps Dependencies,
 ) error {
-	address, found := duplicateDependencyAddress(deps)
-	if !found {
-		return nil
+	if address, found := duplicateDependencyAddress(deps); found {
+		return evaluateDuplicateDependency(ctx, pctx, l, DuplicateDependencyError{
+			ConfigPath: configPath,
+			Address:    address,
+		})
 	}
 
+	if dup, found := duplicateDependencyConfigPath(configPath, deps); found {
+		return evaluateDuplicateDependency(ctx, pctx, l, DuplicateDependencyConfigPathError{
+			ConfigPath:     configPath,
+			DependencyPath: dup.path,
+			FirstAddress:   dup.first,
+			SecondAddress:  dup.second,
+		})
+	}
+
+	return nil
+}
+
+// evaluateDuplicateDependency returns strictErr when the duplicate-dependency-labels control
+// is enabled, and otherwise lets the control log its warning.
+func evaluateDuplicateDependency(
+	ctx context.Context,
+	pctx *ParsingContext,
+	l log.Logger,
+	strictErr error,
+) error {
 	control := pctx.StrictControls.Find(controls.DuplicateDependencyLabels)
 	if control == nil {
 		return errors.New("failed to find control " + controls.DuplicateDependencyLabels)
 	}
 
 	if control.GetEnabled() {
-		return DuplicateDependencyError{ConfigPath: configPath, Address: address}
+		return strictErr
 	}
 
 	return control.Evaluate(log.ContextWithLogger(ctx, l))
@@ -372,6 +396,50 @@ func duplicateDependencyAddress(deps Dependencies) (string, bool) {
 	}
 
 	return "", false
+}
+
+// sharedDependencyPath names the two dependency addresses that point at one config_path.
+type sharedDependencyPath struct {
+	path   string
+	first  string
+	second string
+}
+
+// duplicateDependencyConfigPath returns the first config_path that two enabled dependency
+// blocks both point at. Paths are resolved against the config's directory before comparing,
+// so two spellings of one directory count as the same path. A disabled dependency reads
+// nothing and so collides with nothing, and a config_path that is not yet a known string
+// is skipped.
+func duplicateDependencyConfigPath(configPath string, deps Dependencies) (sharedDependencyPath, bool) {
+	seen := make(map[string]string, len(deps))
+
+	for i := range deps {
+		dep := &deps[i]
+
+		if !dep.isEnabled() || !dep.ConfigPath.IsWhollyKnown() || dep.ConfigPath.IsNull() ||
+			!dep.ConfigPath.Type().Equals(cty.String) {
+			continue
+		}
+
+		path := dep.ConfigPath.AsString()
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(filepath.Dir(configPath), path)
+		}
+
+		path = filepath.Clean(path)
+
+		if first, duplicate := seen[path]; duplicate {
+			return sharedDependencyPath{
+				path:   dep.ConfigPath.AsString(),
+				first:  first,
+				second: dep.mergeKey(),
+			}, true
+		}
+
+		seen[path] = dep.mergeKey()
+	}
+
+	return sharedDependencyPath{}, false
 }
 
 // Decode the dependency blocks from the file, and then retrieve all the outputs from the remote state. Then encode the

--- a/pkg/config/dependency_test.go
+++ b/pkg/config/dependency_test.go
@@ -462,3 +462,100 @@ dependency "foo" {
 	require.ErrorAs(t, err, &typed)
 	assert.Equal(t, "foo[a]", typed.Address)
 }
+
+const duplicateDependencyConfigPaths = `
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+dependency "network" {
+  config_path = "../vpc"
+}
+`
+
+// TestDuplicateDependencyConfigPathsWarnByDefault pins that two blocks pointing at one
+// config_path still parse, since such configs have always run.
+func TestDuplicateDependencyConfigPathsWarnByDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyString(t, duplicateDependencyConfigPaths)
+
+	require.NoError(t, err)
+	assert.Len(t, cfg.TerragruntDependencies, 2)
+}
+
+// TestDuplicateDependencyConfigPathsRejectedWhenStrict pins that the strict control turns a
+// shared config_path into a parse failure naming both addresses and the path.
+func TestDuplicateDependencyConfigPathsRejectedWhenStrict(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseDependencyStringStrict(t, duplicateDependencyConfigPaths)
+
+	var typed config.DuplicateDependencyConfigPathError
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, "vpc", typed.FirstAddress)
+	assert.Equal(t, "network", typed.SecondAddress)
+	assert.Equal(t, "../vpc", typed.DependencyPath)
+	assert.Equal(t, config.DefaultTerragruntConfigPath, typed.ConfigPath)
+}
+
+// TestDuplicateDependencyConfigPathsCompareResolvedPaths pins that two spellings of one
+// directory are read as the same config_path.
+func TestDuplicateDependencyConfigPathsCompareResolvedPaths(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseDependencyStringStrict(t, `
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+dependency "network" {
+  config_path = "./../vpc/"
+}
+`)
+
+	var typed config.DuplicateDependencyConfigPathError
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, "./../vpc/", typed.DependencyPath)
+}
+
+// TestDuplicateDependencyConfigPathsIgnoreDisabled pins that a disabled block does not
+// collide, since it reads nothing.
+func TestDuplicateDependencyConfigPathsIgnoreDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseDependencyStringStrict(t, `
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+dependency "network" {
+  config_path = "../vpc"
+  enabled     = false
+}
+`)
+
+	require.NoError(t, err)
+	assert.Len(t, cfg.TerragruntDependencies, 2)
+}
+
+// TestExpandedDependencyConfigPathCollisionRejectedWhenStrict pins that the elements of one
+// expanded block collide when their config_path does not vary with the key.
+func TestExpandedDependencyConfigPathCollisionRejectedWhenStrict(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseDependencyStringStrict(t, `
+dependency "vpc" {
+  expansion {
+    for_each = toset(["a", "b"])
+  }
+
+  config_path = "../vpc"
+}
+`)
+
+	var typed config.DuplicateDependencyConfigPathError
+	require.ErrorAs(t, err, &typed)
+	assert.Equal(t, "vpc[a]", typed.FirstAddress)
+	assert.Equal(t, "vpc[b]", typed.SecondAddress)
+}

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -418,6 +418,25 @@ func (err DuplicateDependencyError) Error() string {
 	)
 }
 
+// DuplicateDependencyConfigPathError is returned when two dependency blocks in one config
+// point at the same config_path under different addresses.
+type DuplicateDependencyConfigPathError struct {
+	ConfigPath     string
+	DependencyPath string
+	FirstAddress   string
+	SecondAddress  string
+}
+
+func (err DuplicateDependencyConfigPathError) Error() string {
+	return fmt.Sprintf(
+		"%s: dependencies %s and %s both point at %s; declare that dependency once and reference it under one name",
+		err.ConfigPath,
+		err.FirstAddress,
+		err.SecondAddress,
+		err.DependencyPath,
+	)
+}
+
 type TerragruntOutputListEncodingError struct {
 	Err   error
 	Paths []string


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds a warning when users use duplicate dependency paths. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Duplicate dependency detection now warns when differently labeled dependency blocks resolve to the same configuration path.
  - With the `duplicate-dependency-labels` strict control enabled, these warnings become errors identifying both dependency addresses and the shared path.
  - Path normalization ensures equivalent path spellings are detected consistently.
  - Disabled dependency blocks are excluded from duplicate detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->