### PR TITLE
perf: Use `git cat-file --batch` instead of a `git cat-file` call per blob

### DIFF
--- a/docs/src/data/changelog/v1.1.5/cas-source-ingestion.mdx
+++ b/docs/src/data/changelog/v1.1.5/cas-source-ingestion.mdx
@@ -1,0 +1,22 @@
+---
+version: "v1.1.5"
+category: "performance-improvements"
+---
+
+#### Faster first-time source downloads
+
+The first time Terragrunt stores a repository in the [Content Addressable Store (CAS)](/features/caching/cas), it copies the content of every file out of the clone. It used to launch a separate `git` process for each one, and on repositories with many files those launches dominated the time.
+
+Terragrunt now reads a repository's content through a single long-lived `git` process, and stores several files at a time.
+
+In [benchmarks](https://github.com/gruntwork-io/terragrunt/blob/main/internal/cas/cold_ingest_benchmark_test.go) on an Apple M3 Max:
+
+| files | before | after | change |
+| --- | --- | --- | --- |
+| 200 | 2.16s | 0.38s | -83% |
+| 1,000 | 10.41s | 0.74s | -93% |
+| 3,000 | 34.25s | 1.69s | -95% |
+
+The saving grows with the number of files.
+
+This applies when the CAS does not already hold the content, such as the first use of a new module version or a run against an empty store. Downloads that the CAS can already serve skipped this work before and are unchanged.

--- a/internal/cas/benchmark_test.go
+++ b/internal/cas/benchmark_test.go
@@ -170,7 +170,7 @@ func BenchmarkGitOperations(b *testing.B) {
 		}
 	})
 
-	b.Run("cat-file", func(b *testing.B) {
+	b.Run("cat-file --batch", func(b *testing.B) {
 		tree, err := g.LsTreeRecursive(ctx, "HEAD")
 		require.NoError(b, err)
 		require.NotEmpty(b, tree.Entries(), "no entries in tree")
@@ -185,10 +185,17 @@ func BenchmarkGitOperations(b *testing.B) {
 		defer os.Remove(tmpFile)
 		defer tmp.Close()
 
+		batch, err := g.StartCatFileBatch(ctx)
+		require.NoError(b, err)
+
+		// Not b.Cleanup. The benchmark's context is already canceled by the
+		// time cleanups run, and Close reports that as a failure.
+		defer func() { require.NoError(b, batch.Close()) }()
+
 		b.ResetTimer()
 
 		for b.Loop() {
-			err := g.CatFile(ctx, hash, tmp)
+			err := batch.ReadBlob(hash, tmp)
 			require.NoError(b, err)
 		}
 	})

--- a/internal/cas/blob_ingest_test.go
+++ b/internal/cas/blob_ingest_test.go
@@ -1,0 +1,211 @@
+package cas_test
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+)
+
+const (
+	coldIngestFileCount = 300
+
+	// coldIngestLargeSize is past every buffer between git and the store so
+	// at least one blob spans several reads.
+	coldIngestLargeSize = 300 * 1024
+
+	missingBlobID = "0000000000000000000000000000000000000000"
+)
+
+// TestCAS_ColdIngestBlobsMatchGit ingests a repository of a few hundred
+// files through one cat-file batch and checks that every blob lands in the
+// store under git's own object id with exactly the content committed.
+func TestCAS_ColdIngestBlobsMatchGit(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	l := logger.CreateLogger()
+	v := venvtest.NewOSWithEmptyEnv()
+
+	files := coldIngestFixture()
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFiles(ctx, files, "cold ingest fixture"))
+
+	repoURL, err := srv.Start(ctx)
+	require.NoError(t, err)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+	targetPath := filepath.Join(tempDir, "repo")
+
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	require.NoError(t, c.Clone(ctx, l, v, repoURL, cas.WithDir(targetPath), cas.WithDepth(-1)))
+
+	for path, want := range files {
+		linked, err := os.ReadFile(filepath.Join(targetPath, filepath.FromSlash(path)))
+		require.NoError(t, err, path)
+		assert.Equal(t, want, linked, "materialized %s", path)
+
+		oid := gitBlobID(want)
+
+		stored, err := os.ReadFile(filepath.Join(c.BlobStore().Path(), oid[:2], oid))
+		require.NoError(t, err, "blob %s for %s", oid, path)
+		assert.Equal(t, want, stored, "stored blob for %s", path)
+	}
+}
+
+// TestCAS_EnsureBlobClosesTempHandleOnReadFailure pins that a failed read
+// leaves neither an open handle nor a temp file behind. An unclosed handle
+// would live until its finalizer runs, and on Windows it would also block
+// the temp file's removal.
+func TestCAS_EnsureBlobClosesTempHandleOnReadFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile(ctx, "a.txt", []byte("a\n"), "seed"))
+
+	repoURL, err := srv.Start(ctx)
+	require.NoError(t, err)
+
+	runner, err := git.NewGitRunner(venvtest.NewOSWithEmptyEnv())
+	require.NoError(t, err)
+
+	runner = runner.WithWorkDir(helpers.TmpDirWOSymlinks(t))
+	require.NoError(t, runner.Clone(ctx, repoURL, true, 1, "main"))
+
+	batch, err := runner.StartCatFileBatch(ctx)
+	require.NoError(t, err)
+
+	// Not t.Cleanup. The test's context is already canceled by the time
+	// cleanups run, and Close reports that as a failure.
+	defer func() { require.NoError(t, batch.Close()) }()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
+	require.NoError(t, err)
+
+	fsys := &handleTrackingFS{FS: vfs.NewOSFS()}
+	v := venvtest.NewOSWithEmptyEnv().WithFS(fsys)
+
+	err = c.EnsureBlob(v, batch, missingBlobID, cas.StoredFilePerms)
+	require.ErrorIs(t, err, git.ErrCatFileMissing)
+
+	require.Len(t, fsys.created, 1, "one temp handle expected")
+
+	tmp := fsys.created[0]
+	assert.True(t, tmp.closed.Load(), "temp handle left open after a failed read")
+	assert.NoFileExists(t, tmp.Name())
+}
+
+// handleTrackingFS records every file Create hands out so a test can
+// assert the caller closed it. Locks pass through to the wrapped
+// filesystem, since the store takes one before it writes.
+type handleTrackingFS struct {
+	vfs.FS
+	created []*trackedHandle
+}
+
+func (fsys *handleTrackingFS) Create(name string) (vfs.File, error) {
+	f, err := fsys.FS.Create(name)
+	if err != nil {
+		return nil, err
+	}
+
+	tracked := &trackedHandle{File: f}
+	fsys.created = append(fsys.created, tracked)
+
+	return tracked, nil
+}
+
+func (fsys *handleTrackingFS) Lock(name string) (vfs.Unlocker, error) {
+	return vfs.Lock(fsys.FS, name)
+}
+
+func (fsys *handleTrackingFS) TryLock(name string) (vfs.Unlocker, bool, error) {
+	return vfs.TryLock(fsys.FS, name)
+}
+
+// trackedHandle flags itself closed so handleTrackingFS can report a
+// handle its caller dropped.
+type trackedHandle struct {
+	vfs.File
+	closed atomic.Bool
+}
+
+func (f *trackedHandle) Close() error {
+	f.closed.Store(true)
+
+	return f.File.Close()
+}
+
+// coldIngestFixture builds the file map for the cold-ingest test. It is
+// mostly distinct text files, plus binary content with NUL bytes and
+// embedded newlines, empty files, duplicates that dedupe to one blob, and
+// one file larger than any buffer on the read path.
+func coldIngestFixture() map[string][]byte {
+	files := make(map[string][]byte, coldIngestFileCount)
+
+	for i := range coldIngestFileCount {
+		path := fmt.Sprintf("dir%02d/file%03d", i%10, i)
+
+		switch {
+		case i%50 == 0:
+			files[path+".empty"] = []byte{}
+		case i%7 == 0:
+			files[path+".bin"] = binaryContent(i)
+		case i%11 == 0:
+			files[path+".dup"] = []byte("shared content\n")
+		default:
+			files[path+".txt"] = []byte("file " + strconv.Itoa(i) + "\nline two\n")
+		}
+	}
+
+	large := make([]byte, coldIngestLargeSize)
+	for i := range large {
+		large[i] = byte(i*13 + i/257)
+	}
+
+	files["large.bin"] = large
+
+	return files
+}
+
+// binaryContent returns content with NUL bytes and newlines placed so the
+// response framing cannot rely on either being absent.
+func binaryContent(seed int) []byte {
+	content := make([]byte, 0, 64)
+	content = append(content, 0, '\n', byte(seed), 0xff, '\n', '\n', 0)
+	content = append(content, []byte(strconv.Itoa(seed))...)
+	content = append(content, 0, '\n')
+
+	return content
+}
+
+// gitBlobID computes the SHA-1 object id git assigns to a blob with content.
+func gitBlobID(content []byte) string {
+	h := sha1.New()
+	fmt.Fprintf(h, "blob %d\x00", len(content))
+	h.Write(content)
+
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -16,6 +16,8 @@ import (
 
 	"errors"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
@@ -271,6 +273,72 @@ func (c *CAS) Clone(
 		Fetch:    c.gitFetcher(url, &opts),
 		Attrs:    map[string]any{"branch": opts.Branch},
 	})
+}
+
+// EnsureBlob stores the blob named by hash unless the store already has
+// it, streaming its content straight from batch into the store's temp
+// file instead of going through [Content.Store]. The stored blob takes the
+// git tree mode with the write bits cleared, so the default-link path can
+// hardlink it without changing whether it is executable.
+func (c *CAS) EnsureBlob(
+	v *venv.Venv,
+	batch *git.CatFileBatch,
+	hash string,
+	gitPerm os.FileMode,
+) (err error) {
+	v.RequireGOOS()
+
+	needsWrite, lock, err := c.blobStore.EnsureWithWait(v, hash)
+	if err != nil {
+		return err
+	}
+
+	if !needsWrite {
+		return nil
+	}
+
+	defer func() {
+		if unlockErr := lock.Unlock(); unlockErr != nil {
+			err = errors.Join(err, unlockErr)
+		}
+	}()
+
+	content := NewContent(c.blobStore)
+
+	tmpHandle, err := content.GetTmpHandle(v, hash)
+	if err != nil {
+		return err
+	}
+
+	tmpPath := tmpHandle.Name()
+
+	defer func() {
+		if _, statErr := v.FS.Stat(tmpPath); statErr == nil {
+			err = errors.Join(err, v.FS.Remove(tmpPath))
+		}
+	}()
+
+	if err = streamBlob(v, batch, hash, tmpHandle); err != nil {
+		return err
+	}
+
+	if err = v.FS.Rename(tmpPath, content.getPath(hash)); err != nil {
+		return err
+	}
+
+	// Symlink entries (git mode 120000) have no permission bits, but the blob
+	// stores the link target string and must stay readable so linkTree can
+	// resolve the symlink at materialization time.
+	storedPerm := gitPerm.Perm() &^ WriteBitMask
+	if storedPerm == 0 {
+		storedPerm = StoredFilePerms
+	}
+
+	if err = v.FS.Chmod(content.getPath(hash), storedPerm); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // gitFetcher returns a SourceFetcher that ingests through the git-native
@@ -685,14 +753,74 @@ func (c *CAS) storeTreeRecursive(
 
 // storeBlobs stores blobs in the CAS. Gitlink entries (type "commit")
 // name objects that live in another repository entirely, so only blob
-// entries are written; submodule contents arrive via
-// [CAS.storeSubmodules].
+// entries are written. Submodule contents arrive via
+// [CAS.storeSubmodules]. Every blob the store lacks is read through a
+// `git cat-file --batch` process, started only when there is something to
+// read.
+//
+// The pending blobs are split across [vfs.FSWorkers] shards, which
+// overlaps the store's own writes. Shards never outnumber the blobs they
+// serve, so a small tree still starts a single git process.
 func (c *CAS) storeBlobs(
 	ctx context.Context,
 	v *venv.Venv,
 	runner *git.GitRunner,
 	entries []git.TreeEntry,
 ) error {
+	pending := c.blobsNeedingWrite(v, entries)
+	if len(pending) == 0 {
+		return nil
+	}
+
+	shards := min(vfs.FSWorkers, len(pending))
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(shards)
+
+	for shard := range shards {
+		g.Go(func() error {
+			return c.storeBlobShard(ctx, v, runner, pending, shard, shards)
+		})
+	}
+
+	return g.Wait()
+}
+
+// storeBlobShard stores the pending blobs at every index congruent to
+// shard modulo shards. A batch answers requests in order on one pair of
+// pipes, so it serves a single goroutine. Each shard therefore starts and
+// closes its own.
+func (c *CAS) storeBlobShard(
+	ctx context.Context,
+	v *venv.Venv,
+	runner *git.GitRunner,
+	pending []git.TreeEntry,
+	shard int,
+	shards int,
+) (err error) {
+	batch, err := runner.StartCatFileBatch(ctx)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err = errors.Join(err, batch.Close())
+	}()
+
+	for i := shard; i < len(pending); i += shards {
+		entry := pending[i]
+		if err := c.EnsureBlob(v, batch, entry.Hash, gitFilePerm(entry.Mode)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// blobsNeedingWrite filters entries down to the blobs the store lacks.
+func (c *CAS) blobsNeedingWrite(v *venv.Venv, entries []git.TreeEntry) []git.TreeEntry {
+	var pending []git.TreeEntry
+
 	for _, entry := range entries {
 		if entry.Type != git.EntryTypeBlob {
 			continue
@@ -702,12 +830,10 @@ func (c *CAS) storeBlobs(
 			continue
 		}
 
-		if err := c.ensureBlob(ctx, v, runner, entry.Hash, gitFilePerm(entry.Mode)); err != nil {
-			return err
-		}
+		pending = append(pending, entry)
 	}
 
-	return nil
+	return pending
 }
 
 // storeSubmodules ingests the repositories behind gitlink entries so the
@@ -784,86 +910,25 @@ func submoduleURLs(
 	return nil, nil
 }
 
-// ensureBlob ensures that a blob exists in the CAS.
-// It doesn't use the standard content.Store method because
-// we want to take advantage of the ability to write to the
-// entry using `git cat-file`. gitPerm is the git tree mode for
-// this blob; the stored blob is chmodded to gitPerm with the
-// write bits cleared so the default-link path can hardlink the
-// blob directly without altering its executable-ness.
-//
-// err is a named return so the deferred unlock and tempfile cleanup
-// can errors.Join their failures into what the caller actually sees;
-// otherwise the assignments target a local variable that has no
-// connection to the function's return slot.
-func (c *CAS) ensureBlob(
-	ctx context.Context,
+// streamBlob reads the blob named by hash from batch into tmpHandle and
+// closes the handle whatever the outcome. The caller removes or renames
+// the file next, and Windows refuses both while a handle is open.
+func streamBlob(
 	v *venv.Venv,
-	runner *git.GitRunner,
+	batch *git.CatFileBatch,
 	hash string,
-	gitPerm os.FileMode,
+	tmpHandle vfs.File,
 ) (err error) {
-	v.RequireGOOS()
-
-	needsWrite, lock, err := c.blobStore.EnsureWithWait(v, hash)
-	if err != nil {
-		return err
-	}
-
-	if !needsWrite {
-		return nil
-	}
-
 	defer func() {
-		if unlockErr := lock.Unlock(); unlockErr != nil {
-			err = errors.Join(err, unlockErr)
-		}
+		err = errors.Join(err, tmpHandle.Close())
 	}()
 
-	content := NewContent(c.blobStore)
-
-	tmpHandle, err := content.GetTmpHandle(v, hash)
-	if err != nil {
-		return err
-	}
-
-	tmpPath := tmpHandle.Name()
-
-	defer func() {
-		if _, statErr := v.FS.Stat(tmpPath); statErr == nil {
-			err = errors.Join(err, v.FS.Remove(tmpPath))
-		}
-	}()
-
-	err = runner.CatFile(ctx, hash, tmpHandle)
-	if err != nil {
+	if err := batch.ReadBlob(hash, tmpHandle); err != nil {
 		return err
 	}
 
 	if v.Platform.GOOS == WindowsOS {
-		if err = tmpHandle.Sync(); err != nil {
-			return err
-		}
-	}
-
-	if err = tmpHandle.Close(); err != nil {
-		return err
-	}
-
-	if err = v.FS.Rename(tmpPath, content.getPath(hash)); err != nil {
-		return err
-	}
-
-	// Symlink entries (git mode 120000) have no permission bits, but the blob
-	// stores the link target string and must stay readable so linkTree can
-	// resolve the symlink at materialization time.
-	storedPerm := gitPerm.Perm() &^ WriteBitMask
-	if storedPerm == 0 {
-		storedPerm = StoredFilePerms
-	}
-
-	if err = v.FS.Chmod(content.getPath(hash), storedPerm); err != nil {
-		return err
+		return tmpHandle.Sync()
 	}
 
 	return nil

--- a/internal/cas/cold_ingest_benchmark_test.go
+++ b/internal/cas/cold_ingest_benchmark_test.go
@@ -1,0 +1,112 @@
+package cas_test
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+)
+
+const (
+	// coldIngestMinSize is the smallest a fixture file gets. With
+	// [coldIngestSizeSpread] it puts every file in the 64..512 byte band,
+	// where the per-blob overhead outweighs the copy itself.
+	coldIngestMinSize = 64
+
+	// coldIngestSizeSpread is how far above [coldIngestMinSize] a fixture
+	// file's size may reach.
+	coldIngestSizeSpread = 449
+
+	// coldIngestSeed keeps the fixture identical across runs and trees so
+	// benchstat compares the same repository.
+	coldIngestSeed = 0x7a11
+
+	coldIngestTopDirs = 17
+	coldIngestSubDirs = 13
+
+	// coldIngestAlphabet is the printable content of every fixture file.
+	coldIngestAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789 \n"
+)
+
+// BenchmarkColdIngest clones repositories of increasing size into a fresh
+// store on every iteration, so each blob takes the cold path from git into
+// the store. The timed region includes the fetch and the tree listing.
+// Only the store and target directories are created outside it.
+func BenchmarkColdIngest(b *testing.B) {
+	l := logger.CreateLogger()
+	v := venvtest.NewOSWithEmptyEnv()
+
+	for _, fileCount := range []int{200, 1000, 3000} {
+		b.Run("files="+strconv.Itoa(fileCount), func(b *testing.B) {
+			repoURL := startColdIngestServer(b, fileCount)
+			tempDir := b.TempDir()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; b.Loop(); i++ {
+				b.StopTimer()
+
+				storePath := filepath.Join(tempDir, "store", strconv.Itoa(i))
+				targetPath := filepath.Join(tempDir, "repo", strconv.Itoa(i))
+
+				c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
+				require.NoError(b, err)
+
+				b.StartTimer()
+
+				require.NoError(b, c.Clone(b.Context(), l, v, repoURL, cas.WithDir(targetPath),
+					cas.WithDepth(-1)))
+			}
+		})
+	}
+}
+
+// startColdIngestServer serves a repository whose single commit has
+// fileCount distinct small files spread across nested directories.
+func startColdIngestServer(b *testing.B, fileCount int) string {
+	b.Helper()
+
+	srv, err := git.NewServer()
+	require.NoError(b, err)
+
+	b.Cleanup(func() { require.NoError(b, srv.Close()) })
+
+	require.NoError(b, srv.CommitFiles(b.Context(), coldIngestBenchFixture(fileCount), "cold ingest bench fixture"))
+
+	url, err := srv.Start(b.Context())
+	require.NoError(b, err)
+
+	return url
+}
+
+// coldIngestBenchFixture builds fileCount files of deterministic content.
+// Every file embeds its own index so no two dedupe to the same blob.
+func coldIngestBenchFixture(fileCount int) map[string][]byte {
+	rng := rand.New(rand.NewPCG(coldIngestSeed, coldIngestSeed))
+	files := make(map[string][]byte, fileCount)
+
+	for i := range fileCount {
+		path := fmt.Sprintf("d%02d/s%02d/file%05d.txt", i%coldIngestTopDirs, (i/coldIngestTopDirs)%coldIngestSubDirs, i)
+
+		size := coldIngestMinSize + rng.IntN(coldIngestSizeSpread)
+		content := make([]byte, 0, size)
+		content = append(content, []byte("file "+strconv.Itoa(i)+"\n")...)
+
+		for len(content) < size {
+			content = append(content, coldIngestAlphabet[rng.IntN(len(coldIngestAlphabet))])
+		}
+
+		files[path] = content
+	}
+
+	return files
+}

--- a/internal/git/catfile_batch.go
+++ b/internal/git/catfile_batch.go
@@ -1,0 +1,352 @@
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+)
+
+const (
+	// catFileBatchHeaderLimit bounds one `git cat-file --batch` header line.
+	// A SHA-256 object id, a type name, and a decimal size fit well inside
+	// it. A longer line means the stream has drifted from the request.
+	catFileBatchHeaderLimit = 256
+
+	// catFileBatchHeaderFields is the field count of the header for an
+	// object git found: <oid> SP <type> SP <size>.
+	catFileBatchHeaderFields = 3
+
+	// catFileBatchNoObjectFields is the field count of the reply for a name
+	// git could not serve an object for: <name> SP <reason>.
+	catFileBatchNoObjectFields = 2
+
+	// catFileBatchWaitDelay bounds how long Wait blocks on a git process
+	// that outlives its canceled context, before exec kills it outright.
+	catFileBatchWaitDelay = 5 * time.Second
+
+	catFileBatchOp = "git_cat_file_batch"
+
+	// catFileBatchMissing is the reason git reports for a name it knows no
+	// object by.
+	catFileBatchMissing = "missing"
+
+	// catFileBatchAmbiguous is the reason git reports for a name that
+	// abbreviates more than one object.
+	catFileBatchAmbiguous = "ambiguous"
+)
+
+// CatFileBatch is a long-lived `git cat-file --batch` process that serves
+// many object reads without forking git for each one. Object names go to
+// the process one per line, and answers come back on stdout in the same
+// order.
+//
+// A batch serves one goroutine at a time. [CatFileBatch.ReadBlob] treats a
+// request and its response as one unit on the shared pipes, so concurrent
+// calls would interleave frames.
+//
+// Callers must call [CatFileBatch.Close] exactly once, whatever the outcome
+// of the reads, so the process is reaped.
+type CatFileBatch struct {
+	// ctx is the context the process was started under. Canceling it kills
+	// git, and the death arrives here as an ordinary EOF. Reads and Close
+	// consult ctx so that a canceled session is not read as a clean one.
+	ctx context.Context
+
+	// cmd is the running git process, reaped by Close.
+	cmd vexec.Cmd
+
+	// stdin is where object names go, one per line. Closing it asks git to
+	// exit, so only Close does that.
+	stdin *os.File
+
+	// stdoutR is the read end of git's stdout. Close needs the descriptor
+	// itself, which a bufio.Reader cannot give it.
+	stdoutR *os.File
+
+	// stdout is where every response is read. One buffer fill can cover a
+	// header line and a small object together, and bytes already pulled in
+	// cannot be reached through stdoutR.
+	stdout *bufio.Reader
+
+	// stderr collects what git says about a request it could not serve. A
+	// failed read and a non-zero exit both report it.
+	stderr *bytes.Buffer
+}
+
+// StartCatFileBatch spawns `git cat-file --batch` against the configured
+// working-directory repository. The process lives until
+// [CatFileBatch.Close]. Canceling ctx kills it and fails any read in flight
+// with an error wrapping ctx's error.
+func (g *GitRunner) StartCatFileBatch(ctx context.Context) (*CatFileBatch, error) {
+	if err := g.RequiresWorkDir(); err != nil {
+		return nil, err
+	}
+
+	// These are OS pipes because exec hands an *os.File straight to the
+	// child. Anything else gets a copier goroutine that Wait joins before
+	// returning. The stdin copier would block in Read on this side once git
+	// exits, with nothing left to release it, and Close would hang.
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		return nil, commandError(err, "")
+	}
+
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		return nil, commandError(errors.Join(err, stdinR.Close(), stdinW.Close()), "")
+	}
+
+	stderr := &bytes.Buffer{}
+
+	cmd := g.prepareCommand(ctx, "cat-file", "--batch")
+	cmd.SetStdin(stdinR)
+	cmd.SetStdout(stdoutW)
+	cmd.SetStderr(stderr)
+	cmd.SetWaitDelay(catFileBatchWaitDelay)
+
+	startErr := cmd.Start()
+
+	// The child has its own copies of the ends it was handed. Closing ours
+	// makes git's exit arrive here as EOF on stdout and EPIPE on stdin.
+	childEndsErr := errors.Join(stdinR.Close(), stdoutW.Close())
+
+	if startErr != nil {
+		err := errors.Join(startErr, childEndsErr, stdinW.Close(), stdoutR.Close())
+
+		return nil, commandError(err, stderr.String())
+	}
+
+	b := &CatFileBatch{
+		ctx:     ctx,
+		cmd:     cmd,
+		stdin:   stdinW,
+		stdoutR: stdoutR,
+		stdout:  bufio.NewReader(stdoutR),
+		stderr:  stderr,
+	}
+
+	if childEndsErr != nil {
+		return nil, errors.Join(childEndsErr, b.Close())
+	}
+
+	return b, nil
+}
+
+// ReadBlob streams the content of the blob named by hash to w. It reports:
+//
+//   - [ErrCatFileMissing], for a name git does not know.
+//   - [ErrCatFileAmbiguous], for an abbreviated name matching several
+//     objects.
+//   - [ErrCatFileNotBlob], for an object that is not a blob.
+//   - w's own error, when w fails partway through the object.
+//   - [ErrCatFileFraming], for a response that breaks git's framing or
+//     names another object.
+//   - [ErrCatFileShortRead], for a stream that ends early because git died
+//     or ctx was canceled.
+//
+// The first four leave the batch usable. Whatever content the response
+// includes is consumed before the error comes back, so the stream stays in
+// step for the next request. The last two leave the batch out of step, and
+// it should be closed.
+func (b *CatFileBatch) ReadBlob(hash string, w io.Writer) error {
+	if _, err := io.WriteString(b.stdin, hash+"\n"); err != nil {
+		return b.failure(hash, errors.Join(ErrCatFileShortRead, err))
+	}
+
+	objType, size, err := b.readHeader(hash)
+	if err != nil {
+		return b.failure(hash, err)
+	}
+
+	dst := w
+	if objType != EntryTypeBlob {
+		dst = io.Discard
+	}
+
+	if err := b.readContent(dst, size); err != nil {
+		return b.failure(hash, err)
+	}
+
+	if objType != EntryTypeBlob {
+		return b.failure(hash, ErrCatFileNotBlob)
+	}
+
+	// Cancellation races the kill signal. git may have flushed the whole
+	// object before it died, but the process is gone either way, so the
+	// read has to be reported as failed.
+	if err := b.ctx.Err(); err != nil {
+		return b.failure(hash, err)
+	}
+
+	return nil
+}
+
+// Close ends the session and reaps the process. Callers must call it
+// exactly once.
+//
+// A non-zero exit comes back as a [*WrappedError] with git's stderr as
+// context. A canceled ctx is reported the same way even when git managed to
+// exit cleanly first, since the session it was given is over.
+func (b *CatFileBatch) Close() error {
+	// git exits once its stdin reaches EOF.
+	err := b.stdin.Close()
+
+	// A frame left half-read by a failed ReadBlob is still queued in the
+	// pipe. Draining it cannot hang, since git is already on its way out,
+	// and the copy ends when the pipe closes.
+	if _, drainErr := io.Copy(io.Discard, b.stdoutR); drainErr != nil {
+		err = errors.Join(err, drainErr)
+	}
+
+	err = errors.Join(err, b.cmd.Wait(), b.stdoutR.Close(), b.ctx.Err())
+	if err == nil {
+		return nil
+	}
+
+	return commandError(err, b.stderr.String())
+}
+
+// readHeader parses the header line of the next response into the object's
+// type and size. git frames a response as that header line, the object
+// content, and a trailing newline. A header naming any object other than
+// hash is refused as [ErrCatFileFraming].
+func (b *CatFileBatch) readHeader(hash string) (objType string, size int64, err error) {
+	line, err := b.readHeaderLine()
+	if err != nil {
+		return "", 0, err
+	}
+
+	fields := strings.Fields(line)
+
+	// git answers with the name it resolved, so a header naming anything else
+	// belongs to another request and the stream has drifted. An abbreviation
+	// resolves to the full object id, which still starts with what was sent.
+	if len(fields) == 0 || !strings.HasPrefix(fields[0], hash) {
+		return "", 0, framingError(line)
+	}
+
+	// Neither reply includes content, so returning here leaves the stream in
+	// step for the next request.
+	if len(fields) == catFileBatchNoObjectFields {
+		switch fields[1] {
+		case catFileBatchMissing:
+			return "", 0, ErrCatFileMissing
+		case catFileBatchAmbiguous:
+			return "", 0, ErrCatFileAmbiguous
+		}
+	}
+
+	if len(fields) != catFileBatchHeaderFields {
+		return "", 0, framingError(line)
+	}
+
+	size, err = strconv.ParseInt(fields[2], 10, 64)
+	if err != nil || size < 0 {
+		return "", 0, framingError(line)
+	}
+
+	return fields[1], size, nil
+}
+
+// readHeaderLine reads up to the newline ending a header, refusing lines
+// longer than [catFileBatchHeaderLimit].
+func (b *CatFileBatch) readHeaderLine() (string, error) {
+	line, err := b.stdout.ReadSlice('\n')
+	if err != nil {
+		// A whole buffer with no newline in it is already past the limit.
+		if errors.Is(err, bufio.ErrBufferFull) {
+			return "", framingError(string(line[:min(len(line), catFileBatchHeaderLimit)]))
+		}
+
+		return "", errors.Join(ErrCatFileShortRead, err)
+	}
+
+	// ReadSlice stops at the buffer rather than at the limit, so an overlong
+	// header is read further than it is accepted. Both outcomes end the
+	// batch, so only the threshold has to be exact.
+	if len(line) > catFileBatchHeaderLimit {
+		return "", framingError(string(line[:catFileBatchHeaderLimit]))
+	}
+
+	return string(line[:len(line)-1]), nil
+}
+
+// readContent copies exactly size bytes of object content to dst, then
+// finishes the frame.
+func (b *CatFileBatch) readContent(dst io.Writer, size int64) error {
+	frame := &io.LimitedReader{R: b.stdout, N: size}
+
+	if _, err := io.Copy(dst, frame); err != nil {
+		// Finishing the frame is right whether dst or the pipe failed. A
+		// dead pipe fails again and marks the batch out of step. A failed
+		// dst leaves the stream intact for the next request.
+		return errors.Join(err, b.finishFrame(frame))
+	}
+
+	return b.finishFrame(frame)
+}
+
+// finishFrame discards whatever remains of the frame, then consumes the
+// newline git prints after every object. What remains comes from the
+// limited reader, not from the count io.Copy reports. A dst that fails
+// partway through a write has consumed bytes from the stream that never
+// reached it.
+func (b *CatFileBatch) finishFrame(frame *io.LimitedReader) error {
+	if _, err := io.Copy(io.Discard, frame); err != nil {
+		return errors.Join(ErrCatFileShortRead, err)
+	}
+
+	if frame.N > 0 {
+		return errors.Join(ErrCatFileShortRead, io.ErrUnexpectedEOF)
+	}
+
+	c, err := b.stdout.ReadByte()
+	if err != nil {
+		return errors.Join(ErrCatFileShortRead, err)
+	}
+
+	if c != '\n' {
+		return framingError("object content not followed by a newline")
+	}
+
+	return nil
+}
+
+// failure wraps a ReadBlob error for hash, adding the context's error when
+// cancellation cut the stream short.
+func (b *CatFileBatch) failure(hash string, err error) error {
+	if ctxErr := b.ctx.Err(); ctxErr != nil && !errors.Is(err, ctxErr) {
+		err = errors.Join(ctxErr, err)
+	}
+
+	return &WrappedError{
+		Op:      catFileBatchOp,
+		Context: hash,
+		Err:     err,
+	}
+}
+
+// commandError reports a failure to run or finish the process, with
+// whatever git wrote to stderr as context.
+func commandError(err error, stderr string) error {
+	return &WrappedError{
+		Op:      catFileBatchOp,
+		Context: stderr,
+		Err:     errors.Join(ErrCommandSpawn, err),
+	}
+}
+
+// framingError quotes the offending line so control bytes from a corrupt
+// stream cannot reach a terminal unescaped.
+func framingError(line string) error {
+	return fmt.Errorf("%w: %q", ErrCatFileFraming, line)
+}

--- a/internal/git/catfile_batch_exec_test.go
+++ b/internal/git/catfile_batch_exec_test.go
@@ -1,0 +1,438 @@
+//go:build exec && !windows
+
+package git_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// batchLargeBlobSize is well past the bufio buffer and the io.Copy chunk
+	// so a read that is interrupted mid-object still has content in flight.
+	batchLargeBlobSize = 1 << 20
+
+	// batchPromptness bounds how long a read or close may take after the
+	// context is canceled. Past that, the test calls it hung.
+	batchPromptness = 30 * time.Second
+
+	missingObjectID = "0000000000000000000000000000000000000000"
+
+	// ambiguousPrefixLen is git's shortest accepted abbreviation, and the
+	// length a caller passing a truncated name would send.
+	ambiguousPrefixLen = 4
+
+	// ambiguousSearchBound is one past the number of distinct prefixes of
+	// ambiguousPrefixLen hex digits. Searching that many distinct blobs
+	// therefore hits a collision, by the pigeonhole principle.
+	ambiguousSearchBound = 1<<(4*ambiguousPrefixLen) + 1
+)
+
+// errSinkFailed is the error the failing writers below report, so a test
+// can tell it apart from anything the batch itself produces.
+var errSinkFailed = errors.New("sink failed")
+
+// batchFixture is a bare clone of a repository whose blobs are known by
+// path, plus the hash of its head commit and an abbreviated object name
+// that two of its blobs share.
+type batchFixture struct {
+	files           map[string][]byte
+	hashes          map[string]string
+	dir             string
+	commitHash      string
+	ambiguousPrefix string
+}
+
+func TestExecCatFileBatch_ReadBlob(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fx := newBatchFixture(t)
+
+	batch, err := batchRunner(t, fx.dir).StartCatFileBatch(ctx)
+	require.NoError(t, err)
+
+	for path, want := range fx.files {
+		var got bytes.Buffer
+
+		require.NoError(t, batch.ReadBlob(fx.hashes[path], &got), path)
+		assert.Equal(t, want, got.Bytes(), path)
+	}
+
+	require.NoError(t, batch.Close())
+}
+
+func TestExecCatFileBatch_MissingObject(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fx := newBatchFixture(t)
+
+	batch, err := batchRunner(t, fx.dir).StartCatFileBatch(ctx)
+	require.NoError(t, err)
+
+	err = batch.ReadBlob(missingObjectID, &bytes.Buffer{})
+	require.ErrorIs(t, err, git.ErrCatFileMissing)
+
+	var wrappedErr *git.WrappedError
+
+	require.ErrorAs(t, err, &wrappedErr)
+	assert.Equal(t, missingObjectID, wrappedErr.Context)
+
+	var got bytes.Buffer
+
+	require.NoError(t, batch.ReadBlob(fx.hashes["text.txt"], &got))
+	assert.Equal(t, fx.files["text.txt"], got.Bytes())
+
+	require.NoError(t, batch.Close())
+}
+
+func TestExecCatFileBatch_AmbiguousName(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fx := newBatchFixture(t)
+
+	batch, err := batchRunner(t, fx.dir).StartCatFileBatch(ctx)
+	require.NoError(t, err)
+
+	var got bytes.Buffer
+
+	err = batch.ReadBlob(fx.ambiguousPrefix, &got)
+	require.ErrorIs(t, err, git.ErrCatFileAmbiguous)
+	require.NotErrorIs(t, err, git.ErrCatFileFraming)
+	assert.Empty(t, got.Bytes())
+
+	require.NoError(t, batch.ReadBlob(fx.hashes["text.txt"], &got))
+	assert.Equal(t, fx.files["text.txt"], got.Bytes())
+
+	require.NoError(t, batch.Close())
+}
+
+// TestExecCatFileBatch_ResponseNamesAnotherObject pins that a response for
+// an object the caller did not ask for is refused instead of being handed
+// back as the answer. A newline inside the request smuggles a second object
+// name past ReadBlob, so git answers twice and the first answer names only
+// part of what was sent.
+func TestExecCatFileBatch_ResponseNamesAnotherObject(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fx := newBatchFixture(t)
+
+	batch, err := batchRunner(t, fx.dir).StartCatFileBatch(ctx)
+	require.NoError(t, err)
+
+	var got bytes.Buffer
+
+	smuggled := fx.hashes["text.txt"] + "\n" + fx.hashes["binary.bin"]
+
+	err = batch.ReadBlob(smuggled, &got)
+	require.ErrorIs(t, err, git.ErrCatFileFraming)
+	assert.Empty(t, got.Bytes(), "content for another object must not reach the writer")
+
+	require.NoError(t, batch.Close())
+}
+
+func TestExecCatFileBatch_NotBlob(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fx := newBatchFixture(t)
+
+	batch, err := batchRunner(t, fx.dir).StartCatFileBatch(ctx)
+	require.NoError(t, err)
+
+	var got bytes.Buffer
+
+	err = batch.ReadBlob(fx.commitHash, &got)
+	require.ErrorIs(t, err, git.ErrCatFileNotBlob)
+	assert.Empty(t, got.Bytes(), "commit content must not reach the writer")
+
+	require.NoError(t, batch.ReadBlob(fx.hashes["binary.bin"], &got))
+	assert.Equal(t, fx.files["binary.bin"], got.Bytes())
+
+	require.NoError(t, batch.Close())
+}
+
+func TestExecCatFileBatch_CloseReportsExit(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// Not a repository: git prints a fatal error and exits 128.
+	batch, err := batchRunner(t, helpers.TmpDirWOSymlinks(t)).StartCatFileBatch(ctx)
+	require.NoError(t, err)
+
+	err = batch.ReadBlob(missingObjectID, &bytes.Buffer{})
+	require.ErrorIs(t, err, git.ErrCatFileShortRead)
+
+	err = batch.Close()
+	require.ErrorIs(t, err, git.ErrCommandSpawn)
+
+	var wrappedErr *git.WrappedError
+
+	require.ErrorAs(t, err, &wrappedErr)
+	assert.Equal(t, 128, vexec.ExitCode(wrappedErr.Err))
+	assert.NotEmpty(t, wrappedErr.Context, "stderr should carry git's diagnostic")
+}
+
+func TestExecCatFileBatch_WriterFailure(t *testing.T) {
+	t.Parallel()
+
+	fx := newBatchFixture(t)
+
+	testCases := []struct {
+		sink    io.Writer
+		wantErr error
+		name    string
+	}{
+		{
+			name:    "write error",
+			sink:    failOnWrite{},
+			wantErr: errSinkFailed,
+		},
+		{
+			name:    "short write",
+			sink:    shortWrite{},
+			wantErr: io.ErrShortWrite,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+
+			batch, err := batchRunner(t, fx.dir).StartCatFileBatch(ctx)
+			require.NoError(t, err)
+
+			// The large blob guarantees the failure lands with most of the
+			// object still queued in the pipe. The next read would otherwise
+			// parse those bytes as its header.
+			err = batch.ReadBlob(fx.hashes["large.bin"], tc.sink)
+			require.ErrorIs(t, err, tc.wantErr)
+			require.NotErrorIs(t, err, git.ErrCatFileShortRead)
+			require.NotErrorIs(t, err, git.ErrCatFileFraming)
+
+			var got bytes.Buffer
+
+			require.NoError(t, batch.ReadBlob(fx.hashes["text.txt"], &got))
+			assert.Equal(t, fx.files["text.txt"], got.Bytes())
+
+			require.NoError(t, batch.Close())
+		})
+	}
+}
+
+func TestExecCatFileBatch_Cancel(t *testing.T) {
+	t.Parallel()
+
+	fx := newBatchFixture(t)
+
+	t.Run("canceled before read", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+
+		batch, err := batchRunner(t, fx.dir).StartCatFileBatch(ctx)
+		require.NoError(t, err)
+
+		cancel()
+
+		err = awaitPromptly(t, func() error {
+			return batch.ReadBlob(fx.hashes["text.txt"], &bytes.Buffer{})
+		})
+		require.ErrorIs(t, err, context.Canceled)
+
+		err = awaitPromptly(t, batch.Close)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("canceled during read", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+
+		batch, err := batchRunner(t, fx.dir).StartCatFileBatch(ctx)
+		require.NoError(t, err)
+
+		// Whether the kill lands before git has flushed the rest of the
+		// object is up to the scheduler. Only the outcome is pinned. The
+		// read fails even when every byte arrived.
+		err = awaitPromptly(t, func() error {
+			return batch.ReadBlob(fx.hashes["large.bin"], &cancelOnWrite{cancel: cancel})
+		})
+		require.ErrorIs(t, err, context.Canceled)
+
+		err = awaitPromptly(t, batch.Close)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// cancelOnWrite cancels the context on its first write, while the rest of
+// the object is still queued behind it, and then keeps accepting data.
+type cancelOnWrite struct {
+	cancel context.CancelFunc
+}
+
+func (w *cancelOnWrite) Write(p []byte) (int, error) {
+	w.cancel()
+
+	return len(p), nil
+}
+
+// failOnWrite refuses every write with errSinkFailed.
+type failOnWrite struct{}
+
+func (failOnWrite) Write([]byte) (int, error) {
+	return 0, errSinkFailed
+}
+
+// shortWrite accepts half of every write and reports no error, which
+// io.Copy turns into [io.ErrShortWrite].
+type shortWrite struct{}
+
+func (shortWrite) Write(p []byte) (int, error) {
+	return len(p) / 2, nil
+}
+
+// awaitPromptly runs fn on its own goroutine and fails the test if it has
+// not returned within batchPromptness.
+func awaitPromptly(t *testing.T, fn func() error) error {
+	t.Helper()
+
+	done := make(chan error, 1)
+
+	go func() { done <- fn() }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(batchPromptness):
+		t.Fatal("call did not return after the context was canceled")
+
+		return nil
+	}
+}
+
+// batchRunner returns a runner bound to dir.
+func batchRunner(t *testing.T, dir string) *git.GitRunner {
+	t.Helper()
+
+	runner, err := git.NewGitRunner(venv.OSVenv())
+	require.NoError(t, err)
+
+	return runner.WithWorkDir(dir)
+}
+
+// newBatchFixture commits blobs that stress the response framing (embedded
+// newlines and NUL bytes, an empty blob, one larger than any buffer on the
+// path, two whose object ids share a prefix) and clones them into a bare
+// repository.
+func newBatchFixture(t *testing.T) *batchFixture {
+	t.Helper()
+
+	ctx := t.Context()
+
+	large := make([]byte, batchLargeBlobSize)
+	for i := range large {
+		large[i] = byte(i*7 + i/251)
+	}
+
+	first, second, prefix := ambiguousBlobPair()
+
+	files := map[string][]byte{
+		"text.txt":    []byte("hello\nworld\n"),
+		"binary.bin":  []byte("\x00\n\x01\xff\n\n\x00end\n\x00"),
+		"empty":       {},
+		"large.bin":   large,
+		"no-newline":  []byte(strings.Repeat("x", 100)),
+		"ambiguous/a": first,
+		"ambiguous/b": second,
+	}
+
+	srv, err := git.NewServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+
+	require.NoError(t, srv.CommitFiles(ctx, files, "batch fixture"))
+
+	commitHash, err := srv.Head(ctx)
+	require.NoError(t, err)
+
+	url, err := srv.Start(ctx)
+	require.NoError(t, err)
+
+	dir := helpers.TmpDirWOSymlinks(t)
+	runner := batchRunner(t, dir)
+
+	require.NoError(t, runner.Clone(ctx, url, true, 1, "main"))
+
+	tree, err := runner.LsTreeRecursive(ctx, commitHash)
+	require.NoError(t, err)
+
+	hashes := make(map[string]string, len(files))
+	for _, entry := range tree.Entries() {
+		hashes[entry.Path] = entry.Hash
+	}
+
+	require.Len(t, hashes, len(files))
+
+	// The pair comes from hashing locally, and git's own ids confirm it.
+	require.Equal(t, prefix, hashes["ambiguous/a"][:ambiguousPrefixLen])
+	require.Equal(t, prefix, hashes["ambiguous/b"][:ambiguousPrefixLen])
+
+	return &batchFixture{
+		files:           files,
+		hashes:          hashes,
+		dir:             dir,
+		commitHash:      commitHash,
+		ambiguousPrefix: prefix,
+	}
+}
+
+// ambiguousBlobPair returns two blob contents whose git object ids share
+// their first ambiguousPrefixLen hex digits, plus that prefix. The search
+// is deterministic, so every run commits the same pair.
+func ambiguousBlobPair() (first, second []byte, prefix string) {
+	seen := make(map[string][]byte, ambiguousSearchBound)
+
+	for i := range ambiguousSearchBound {
+		content := fmt.Appendf(nil, "ambiguous %d\n", i)
+		prefix := gitBlobID(content)[:ambiguousPrefixLen]
+
+		if earlier, ok := seen[prefix]; ok {
+			return earlier, content, prefix
+		}
+
+		seen[prefix] = content
+	}
+
+	panic("pigeonhole bound exhausted without a prefix collision")
+}
+
+// gitBlobID computes the SHA-1 object id git assigns to a blob with content.
+func gitBlobID(content []byte) string {
+	h := sha1.New()
+	fmt.Fprintf(h, "blob %d\x00", len(content))
+	h.Write(content)
+
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/git/errors.go
+++ b/internal/git/errors.go
@@ -57,4 +57,20 @@ var (
 	ErrReadTree            = errors.New("failed to read tree")
 	ErrNoWorkDir           = errors.New("working directory not set")
 	ErrUnknownRevision     = errors.New("unknown revision")
+
+	// ErrCatFileMissing reports that `git cat-file --batch` knows no object by
+	// the requested name.
+	ErrCatFileMissing = errors.New("object not found")
+	// ErrCatFileAmbiguous reports that the requested name abbreviates more
+	// than one object known to `git cat-file --batch`.
+	ErrCatFileAmbiguous = errors.New("object name is ambiguous")
+	// ErrCatFileNotBlob reports that the requested object exists but is not a
+	// blob.
+	ErrCatFileNotBlob = errors.New("object is not a blob")
+	// ErrCatFileFraming reports a `git cat-file --batch` response that does not
+	// follow the framing git-cat-file(1) documents.
+	ErrCatFileFraming = errors.New("malformed git cat-file --batch response")
+	// ErrCatFileShortRead reports a `git cat-file --batch` stream that ended
+	// before the requested object was delivered in full.
+	ErrCatFileShortRead = errors.New("git cat-file --batch ended before delivering the object")
 )

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -474,31 +473,6 @@ func (g *GitRunner) LsTreeRecursive(ctx context.Context, ref string) (*Tree, err
 	}
 
 	return tree, nil
-}
-
-// CatFile writes the contents of a git object
-// to a given writer.
-func (g *GitRunner) CatFile(ctx context.Context, hash string, w io.Writer) error {
-	if err := g.RequiresWorkDir(); err != nil {
-		return err
-	}
-
-	var stderr bytes.Buffer
-
-	cmd := g.prepareCommand(ctx, "cat-file", "-p", hash)
-
-	cmd.SetStdout(w)
-	cmd.SetStderr(&stderr)
-
-	if err := cmd.Run(); err != nil {
-		return &WrappedError{
-			Op:      "git_cat_file",
-			Context: stderr.String(),
-			Err:     errors.Join(ErrCommandSpawn, err),
-		}
-	}
-
-	return nil
 }
 
 // CreateDetachedWorktree creates a new detached worktree for a given reference

--- a/internal/git/git_commands_test.go
+++ b/internal/git/git_commands_test.go
@@ -1,7 +1,6 @@
 package git_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -308,37 +307,15 @@ func TestGitRunner_RevParseCommit(t *testing.T) {
 	}
 }
 
-func TestGitRunner_CatFile(t *testing.T) {
+func TestGitRunner_StartCatFileBatch(t *testing.T) {
 	t.Parallel()
-
-	t.Run("writes object", func(t *testing.T) {
-		t.Parallel()
-
-		runner := newMemRunner(t, staticResult(vexec.Result{
-			Stdout: []byte("content"),
-		})).WithWorkDir("/repo")
-
-		var output bytes.Buffer
-
-		require.NoError(t, runner.CatFile(t.Context(), headHash, &output))
-		assert.Equal(t, "content", output.String())
-	})
-
-	t.Run("command failure", func(t *testing.T) {
-		t.Parallel()
-
-		runner := newMemRunner(t, staticResult(vexec.Result{ExitCode: 128})).WithWorkDir("/repo")
-
-		err := runner.CatFile(t.Context(), headHash, &bytes.Buffer{})
-		require.ErrorIs(t, err, git.ErrCommandSpawn)
-	})
 
 	t.Run("missing workdir", func(t *testing.T) {
 		t.Parallel()
 
 		runner := newMemRunner(t, staticResult(vexec.Result{}))
 
-		err := runner.CatFile(t.Context(), headHash, &bytes.Buffer{})
+		_, err := runner.StartCatFileBatch(t.Context())
 		require.ErrorIs(t, err, git.ErrNoWorkDir)
 	})
 }

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -67,6 +67,18 @@ type ContextLocker interface {
 	LockContext(ctx context.Context, name string) (Unlocker, error)
 }
 
+// FSWorkers bounds how many goroutines may run filesystem metadata
+// operations at once.
+//
+// Measurement on APFS (the default for macOS) puts the ceiling at four
+// before performance starts to degrade. Until we have more granular
+// concurrency controls than `--parallelism`, we should use this as the
+// ceiling for filesystem workers.
+//
+// Callers that fan out over per-file work should cap their errgroup here
+// rather than at GOMAXPROCS.
+const FSWorkers = 4
+
 const maxSymlinkEvaluations = 255
 
 // NewOSFS returns a filesystem backed by the real operating system filesystem.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Storing blobs in the CAS required a `git cat-file` process per blob, which is generally low overhead because Git is well optimized, but the process management overhead can add up at scale.

Blobs now stream out of long-lived `git cat-file --batch` processes feeding in blobs that need writing on stdin and persisting the blobs out of stdout.

In my micro-benchmarking on an Apple M3 Max, I saw the following performance benefits to this adjustment:

| files | before | after | change |
| --- | --- | --- | --- |
| 200 | 2.16s | 0.38s | -83% |
| 1,000 | 10.41s | 0.74s | -93% |
| 3,000 | 34.25s | 1.69s | -95% |

While benchmarking, I noticed that running shards of `git cat-file --batch` with 4 workers tended to be the sweet spot for the worker count on APFS. With more extensive benchmarking, we might want to tune the worker count differently on Linux and Windows, but this seems like a good floor for now. We might also be able to offer users more granular control over the worker count here if we have concurrency controls more granular than `--parallelism`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Faster first-time ingestion of Git repositories into the content store, with reported improvements of 83–95% for repositories containing 200–3,000 files.
  * Cached content download performance is unchanged.

* **Reliability**
  * Improved handling of missing, invalid, incomplete, and interrupted Git object reads.

* **Documentation**
  * Added a changelog entry describing cold-ingestion performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->