### PR TITLE
fix: Fixing stack dependency unit output cty access

### DIFF
--- a/docs/src/data/changelog/v1.1.5/stack-unit-outputs-expansion.mdx
+++ b/docs/src/data/changelog/v1.1.5/stack-unit-outputs-expansion.mdx
@@ -1,0 +1,23 @@
+---
+version: "v1.1.5"
+category: "experiments-updated"
+---
+
+#### Expanded units keep their own outputs when a whole stack is a dependency
+
+With the [`block-iteration`](/reference/experiments/active#block-iteration) experiment enabled, a `dependency` pointing at a directory that holds a `terragrunt.stack.hcl` collected the outputs of an expanded `unit` under the block's bare label. Every element wrote to that one label, so only the last one survived, and reading it returned another element's outputs.
+
+Each element is now reachable under its own key, matching the address `terragrunt stack output` already gives it:
+
+```hcl
+dependency "networking" {
+  config_path = "../live"
+}
+
+inputs = {
+  web_id = dependency.networking.outputs.aurora["web"].id
+  api_id = dependency.networking.outputs.aurora["api"].id
+}
+```
+
+A unit that declares no `expansion` is still read as `dependency.networking.outputs.vpc.id`.

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1134,8 +1134,13 @@ func getTerragruntOutput(
 	return &convertedOutput, isEmpty, err
 }
 
-// collectStackUnitOutputs aggregates per-unit outputs keyed by unit name for dependency.<stack>.outputs.<unit>.<key> resolution.
-func collectStackUnitOutputs(
+// CollectStackUnitOutputs aggregates per-unit outputs keyed by unit name for dependency.<stack>.outputs.<unit>.<key> resolution.
+//
+// Every element of an expanded unit carries its block's label, so keying by name alone would
+// keep only the last one, each element having read a different generated directory. An expanded
+// unit nests its elements under their iteration key instead, reaching one as
+// dependency.<stack>.outputs.<unit>["<key>"], the address `terragrunt stack output` gives it.
+func CollectStackUnitOutputs(
 	ctx context.Context,
 	pctx *ParsingContext,
 	l log.Logger,
@@ -1144,6 +1149,22 @@ func collectStackUnitOutputs(
 	dependencyConfig *Dependency,
 ) (map[string]cty.Value, error) {
 	unitOutputs := make(map[string]cty.Value)
+	instances := map[string]map[string]cty.Value{}
+
+	record := func(unit *Unit, value cty.Value) {
+		key, expanded := unit.InstanceKey()
+		if !expanded {
+			unitOutputs[unit.Name] = value
+
+			return
+		}
+
+		if instances[unit.Name] == nil {
+			instances[unit.Name] = map[string]cty.Value{}
+		}
+
+		instances[unit.Name][key] = value
+	}
 
 	for _, unit := range units {
 		if !unit.IsEnabled() {
@@ -1172,7 +1193,7 @@ func collectStackUnitOutputs(
 			}
 
 			if ok {
-				unitOutputs[unit.Name] = mock
+				record(unit, mock)
 				continue
 			}
 
@@ -1199,8 +1220,12 @@ func collectStackUnitOutputs(
 				return nil, fmt.Errorf("stack unit %s output convert failed: %w", unit.Name, err)
 			}
 
-			unitOutputs[unit.Name] = convertedOutput
+			record(unit, convertedOutput)
 		}
+	}
+
+	for name, byKey := range instances {
+		unitOutputs[name] = cty.ObjectVal(byKey)
 	}
 
 	return unitOutputs, nil
@@ -1281,7 +1306,7 @@ func tryGetStackOutput(
 		return nil, true, fmt.Errorf("failed to parse stack config %s: %w", stackFilePath, err)
 	}
 
-	unitOutputs, err := collectStackUnitOutputs(
+	unitOutputs, err := CollectStackUnitOutputs(
 		ctx,
 		pctx,
 		l,

--- a/pkg/config/stack_unit_outputs_test.go
+++ b/pkg/config/stack_unit_outputs_test.go
@@ -1,0 +1,116 @@
+package config_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/gruntwork-io/terragrunt/internal/cache"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+)
+
+const stackUnitOutputsRoot = "/live"
+
+// expandedUnit builds a unit as the expanding decoder hands it over: the block's label with
+// the element's key alongside it.
+func expandedUnit(name, key, path string) *config.Unit {
+	return &config.Unit{
+		Name: name,
+		Path: path,
+		Expansion: &hclparse.ExpansionBlock{
+			EachKey: new(key),
+		},
+	}
+}
+
+// TestCollectStackUnitOutputsNestsExpandedElements pins that every element of an expanded unit
+// survives collection. The elements share their block's label, so keying by name alone kept
+// only the last one, handing another element's outputs to whatever read the label.
+func TestCollectStackUnitOutputsNestsExpandedElements(t *testing.T) {
+	t.Parallel()
+
+	outputs := map[string]string{
+		"aurora/web": `{"role":{"value":"web","type":"string"}}`,
+		"aurora/api": `{"role":{"value":"api","type":"string"}}`,
+		"vpc":        `{"role":{"value":"vpc","type":"string"}}`,
+	}
+
+	files := map[string]string{}
+	for unitPath := range outputs {
+		files[filepath.Join(config.StackDir, unitPath, config.DefaultTerragruntConfigPath)] = ""
+	}
+
+	v := venvtest.New().WithFS(venvtest.NewFS(t, stackUnitOutputsRoot, files))
+
+	l := logger.CreateLogger()
+	ctx, pctx := newTestParsingContext(t, v, filepath.Join(stackUnitOutputsRoot, "terragrunt.hcl"))
+
+	// The caches the fetch path reads live on the context, and only WithConfigValues puts
+	// them there. Without it every lookup below builds a throwaway cache and misses.
+	ctx = config.WithConfigValues(ctx)
+
+	// Priming the fetch cache is what keeps this off a real tofu binary: the venv's exec is
+	// fail-closed, so a cache miss would surface as an error rather than a shell-out.
+	jsonCache := cache.ContextCache[[]byte](ctx, config.JSONOutputCacheContextKey)
+
+	// ContextCache hands back a detached instance when the key is absent, so dropping the call
+	// above would leave every Put below invisible to the fetch path and quietly send this test
+	// looking for a real tofu binary. Two lookups agreeing on one pointer prove it is installed.
+	require.Same(
+		t,
+		jsonCache,
+		cache.ContextCache[[]byte](ctx, config.JSONOutputCacheContextKey),
+		"the output cache is not on the context, so priming it below would do nothing",
+	)
+
+	for unitPath, out := range outputs {
+		jsonCache.Put(ctx, filepath.Join(
+			stackUnitOutputsRoot, config.StackDir, unitPath, config.DefaultTerragruntConfigPath,
+		), []byte(out))
+	}
+
+	collected, err := config.CollectStackUnitOutputs(
+		ctx,
+		pctx,
+		l,
+		stackUnitOutputsRoot,
+		[]*config.Unit{
+			expandedUnit("aurora", "web", "aurora/web"),
+			expandedUnit("aurora", "api", "aurora/api"),
+			{Name: "vpc", Path: "vpc"},
+		},
+		&config.Dependency{},
+	)
+	require.NoError(t, err)
+
+	role := func(v cty.Value) string { return v.GetAttr("role").AsString() }
+
+	require.Contains(t, collected, "aurora")
+
+	aurora := collected["aurora"]
+
+	// Asserted before reading an element, so a collapse reports the shape it collapsed to
+	// rather than panicking on a missing attribute.
+	for _, key := range []string{"web", "api"} {
+		require.Truef(
+			t,
+			aurora.Type().HasAttribute(key),
+			"aurora holds no %q element, collected as %s",
+			key,
+			aurora.Type().FriendlyName(),
+		)
+	}
+
+	assert.Equal(t, "web", role(aurora.GetAttr("web")))
+	assert.Equal(t, "api", role(aurora.GetAttr("api")))
+
+	// A unit with no expansion keeps the flat address it always had.
+	require.Contains(t, collected, "vpc")
+	assert.Equal(t, "vpc", role(collected["vpc"]))
+}


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes how unit outputs are accessed from stack dependencies when `expansion` is used.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded stack dependencies now preserve each unit’s outputs under its own iteration key, enabling access such as `aurora["web"]` and `aurora["api"]`.
  * Non-expanded units remain accessible through direct output paths, such as `outputs.vpc.id`.

* **Documentation**
  * Added changelog documentation describing the updated stack output access patterns.

* **Tests**
  * Added coverage for multiple expanded units sharing the same block name and for unexpanded unit outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->