### PR TITLE
perf: Using singleflight cached CAS probe

### DIFF
--- a/docs/src/content/docs/03-features/07-caching/04-cas/02-git.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/02-git.mdx
@@ -43,6 +43,19 @@ Two special cases bypass or extend the probe:
 - **Pinned commit SHA already cached.** If you pin to a full commit SHA and that commit is already in the local store, Terragrunt answers from the store and skips `ls-remote` entirely, so the resolution stays offline. This is especially useful if you plan to use Terragrunt in an air-gapped environment.
 - **Commit SHA.** `ls-remote` only lists named refs. If it returns no match (you supplied a commit SHA directly), Terragrunt defers resolution to the fetch step, which canonicalizes the ref with `git rev-parse` against the local store after a full-history fetch.
 
+<Since version="1.1.5">
+
+**Shared probes and reads.** Units in one run that resolve the same URL and ref at the same time share a single `ls-remote`, and units that need the same commit share a single read of it into the store. The first unit to ask does the work and the others wait for its answer. A unit that starts after that answer has arrived probes again unless a recorded answer covers it (see the probe cache below), so a `run --all` over hundreds of units that point at one branch costs one probe for each group of units that start together, and at most one fetch. A unit that is cancelled while waiting stops waiting; the shared work carries on for the units still depending on it.
+
+**The probe cache.** With the [`offline-cas`](/reference/experiments/active#offline-cas) experiment enabled, each `ls-remote` answer is recorded under `probes/` in the store, keyed by URL and ref. [Recorded probes](/features/caching/cas#recorded-probes) covers the rules every source follows and the flags that change them; two things are specific to Git:
+
+- A **semantic version tag** (`v1.2.3` or `1.2.3`, with an optional pre-release or build suffix) is the pinned case, trusted for 24 hours. Only a tag qualifies. `ls-remote` lists a branch of a given name ahead of the tag, so a branch named like a version resolves as a branch and keeps being probed.
+- Under [`--cas-offline`](/reference/cli/commands/run#cas-offline), a pinned commit SHA is looked up in the local bare repository before the recorded answers are consulted, so a commit already fetched resolves without either.
+
+Entries are filed under the repository with credentials stripped, so a token rotated between runs still finds the answer recorded for the repository it addresses.
+
+</Since>
+
 ## Cache key & deduplication
 
 The cache key for the root tree is the commit hash itself, content-addressed by Git's native scheme. Both SHA-1 and SHA-256 repositories are supported, with the algorithm detected per repository. Because the commit hash is content-addressed, the same commit reached through two repositories or two refs resolves to the same stored tree, and identical file blobs are shared across every repository that contains them.
@@ -63,6 +76,12 @@ Git is unique among the getters in that a cache miss is not always all-or-nothin
 
 When the commit hash is already keyed in the store, Terragrunt reads the tree and hard links its blobs into the target without fetching again from the remote. For a pinned commit SHA that is already cached, even the ref-resolution step stays offline.
 
+<Since version="1.1.5">
+
+With the [`offline-cas`](/reference/experiments/active#offline-cas) experiment enabled, a semantic version tag probed within the last 24 hours also skips the remote, since its recorded answer is served instead of a fresh `ls-remote`. See [Recorded probes](/features/caching/cas#recorded-probes) for which sources are cached and for how long.
+
+</Since>
+
 ## Submodules
 
 A submodule is recorded in the parent repository as a pointer to a commit in another repository. During a fetch, Terragrunt reads the submodule URL from `.gitmodules`, fetches the pinned commit from that URL into the same central store layout, and materializes the submodule contents in place. Nested submodules are handled the same way, and relative URLs (such as `../sibling.git`) are resolved against the parent repository URL.
@@ -73,4 +92,4 @@ A committed submodule path with no `.gitmodules` entry (typically an accidentall
 
 ## Fallback behavior
 
-Concurrent units that target the same remote URL share one Git fetch instead of cloning in parallel. If that shared fetch through the central repository hangs or fails, Terragrunt logs a warning and falls back to a plain clone in a temporary directory. If the host cannot hard link from the store (for example across a filesystem boundary), Terragrunt copies the content instead.
+Units in one run that need the same commit share one read of it into the store; the rest wait for the first to finish. Separate Terragrunt processes coordinate through a per-URL lock on the central repository: a process that takes the lock after another has already fetched the commit finds it present and does not fetch it again. If the central repository cannot be used, because the lock is held for more than five minutes or the fetch fails, Terragrunt logs a warning and falls back to a plain clone in a temporary directory. With `--cas-offline`, a commit the store lacks is an error and no clone is attempted. If the host cannot hard link from the store (for example across a filesystem boundary), Terragrunt copies the content instead.

--- a/docs/src/content/docs/03-features/07-caching/04-cas/index.mdx
+++ b/docs/src/content/docs/03-features/07-caching/04-cas/index.mdx
@@ -32,6 +32,12 @@ You can disable the CAS at any time using the `--no-cas` flag. This flag is avai
 
 The same commands accept the `--cas-clone-depth` flag, which controls the `git clone --depth` value the CAS uses when cloning a Git source (default `1`; `-1` clones the full history).
 
+<Since version="1.1.5">
+
+They accept three more flags, gated behind the [`offline-cas`](/reference/experiments/active#offline-cas) experiment: `--cas-offline` resolves every source from the local store without contacting a remote, `--cas-refresh` asks every remote again instead of trusting a recorded probe, and `--cas-probe-ttl` sets how long a recorded probe of a source that can change upstream is trusted. See [Recorded probes](#recorded-probes) for how recorded answers are used.
+
+</Since>
+
 ## Supported sources
 
 The CAS sits in front of every getter Terragrunt uses to fetch a source. Each getter resolves a source through a **cheap probe**: a low-cost remote request that yields a cache key without downloading the full payload (e.g. for Git this is `git ls-remote`). When the probe key is already present in the store, Terragrunt links the cached content to a target directory and skips the download entirely. Getters with no cheap probe always download (or, for local paths, copy) and then key the result by the content hash of what they fetched.
@@ -51,6 +57,27 @@ Each getter has a dedicated page describing its exact mechanics:
 | [Local paths](/features/caching/cas/local) | None; always copies | Content-addressed on the copied tree |
 
 Regardless of the probe, every getter shares the same back half: download (or copy) the source, hash its files into the store as content-addressed blobs, record a tree describing their layout, and hard link the result into the target directory. Identical files therefore occupy disk space once no matter which getter fetched them or how many configurations use them.
+
+
+## Recorded probes
+
+<Since version="1.1.5">
+
+Units in one run that resolve the same source at the same time share a single probe, and the answer the first one gets is the answer they all use.
+
+Recording those answers for later runs is gated behind the [`offline-cas`](/reference/experiments/active#offline-cas) experiment. With it enabled, every probe answer is written under `probes/` in the store, keyed by the source URL, so a later run can resolve a source without asking its remote again. Whether a recorded answer is served in place of a fresh probe depends on whether the source can change upstream:
+
+- **Pinned sources are trusted for 24 hours.** A source is pinned when its URL names a specific revision that a publisher does not reissue: a Git semantic version tag, an S3 object version, an OCI manifest digest, an exact registry module version, or a full Mercurial changeset node.
+- **Everything else is probed on every run.** A push or an upload is seen immediately. That covers Git branches and `HEAD`, HTTP endpoints, GCS objects, OCI tags, and Mercurial branch names. [`--cas-probe-ttl`](/reference/cli/commands/run#cas-probe-ttl) trusts these answers for a chosen duration, for example `--cas-probe-ttl 10m` for a batch of runs that need not each pay for a probe.
+
+Two flags change how the recorded answers are used:
+
+- [`--cas-offline`](/reference/cli/commands/run#cas-offline) never contacts a remote. Every source is resolved from its recorded answer, however old, and linked from the store. A source with no recorded answer, or whose content is not in the store, fails with an error naming it rather than being fetched. Run once without the flag to fill the store first.
+- [`--cas-refresh`](/reference/cli/commands/run#cas-refresh) ignores the recorded answers and asks every remote again, then records what it learns. Use it when a version tag has been moved and the cache still remembers the previous revision.
+
+The two flags cannot be combined, and both need the experiment. A source with no cheap probe, such as an SMB share or a local path, has no answer to record and is fetched on every run, `--cas-offline` included. Recorded answers that have expired stay on disk until the store is deleted.
+
+</Since>
 
 ## Usage
 
@@ -189,10 +216,14 @@ The CAS store is organized into namespaced directories:
     - 1a2b3c4d5e6f7890/
       - repo/
       - lock
+  - probes/ (recorded probe answers, one file per source)
+    - sha256/
+      - 1a2b3c4d5e6f7890/
+        - 0d6e4079e36703eb.json
 
 </FileTree>
 
-The `blobs/` directory stores all file content, identified by hash. Blobs are purely content-addressed, so the same file content always maps to the same hash regardless of origin. The `trees/` directory stores the tree structures that describe the layout of files in a fetched source, whether that source is a Git ref, an object store download, or a local directory. The `synth/trees/` directory stores synthetic tree structures created during CAS-backed stack generation when `update_source_with_cas` is used. These synthetic trees use a deterministic hash based on the source reference and path. The `git/` directory holds one bare Git repository per remote URL, keyed by a hash of the URL, so cache misses for Git sources can fetch only the new objects instead of re-cloning the repository. Non-Git getters do not use `git/`; they download into a temporary directory and ingest the result.
+The `blobs/` directory stores all file content, identified by hash. Blobs are purely content-addressed, so the same file content always maps to the same hash regardless of origin. The `trees/` directory stores the tree structures that describe the layout of files in a fetched source, whether that source is a Git ref, an object store download, or a local directory. The `synth/trees/` directory stores synthetic tree structures created during CAS-backed stack generation when `update_source_with_cas` is used. These synthetic trees use a deterministic hash based on the source reference and path. The `git/` directory holds one bare Git repository per remote URL, keyed by a hash of the URL, so cache misses for Git sources can fetch only the new objects instead of re-cloning the repository. Non-Git getters do not use `git/`; they download into a temporary directory and ingest the result. The `probes/` directory holds the answer to each probe, one file per source, so a later run can resolve a source without querying its remote again. Entries sit under the hash algorithm that named them, so a later algorithm gets its own subtree instead of colliding with what is already there. [Recorded probes](#recorded-probes) covers when a recorded answer is served and when a fresh query is made.
 
 Each content object within a namespace is stored at `{hash[:2]}/{hash}`, where the first two characters create a partition directory to avoid degraded file system performance from large flat directories.
 
@@ -220,7 +251,7 @@ When the content is not already in the CAS:
 3. **Fetch the source.** Terragrunt downloads (or, for local paths, copies) the source into a temporary location.
 
    <Aside type="note" title="Git sources">
-   Terragrunt fetches into a persisted bare repository kept per remote URL under `git/`. Branch and tag refs use a shallow fetch; a bare commit SHA uses a full-history fetch so it can be resolved locally. Subsequent misses against the same URL reuse the repository and transfer only new objects, and concurrent units targeting the same URL share a single fetch instead of cloning in parallel.
+   Terragrunt fetches into a persisted bare repository kept per remote URL under `git/`. Branch and tag refs use a shallow fetch; a bare commit SHA uses a full-history fetch so it can be resolved locally. Subsequent misses against the same URL reuse the repository and transfer only new objects, and concurrent units targeting the same URL share a single fetch instead of cloning in parallel, coordinated by a per-URL lock that works across processes.
    </Aside>
 
 4. **Ingest into the store.** Each file is hashed and stored as a content-addressed blob addressed by its hash, and a tree file describing the layout in the filesystem under its own cache key.

--- a/docs/src/data/changelog/v1.1.5/cas-shared-probes.mdx
+++ b/docs/src/data/changelog/v1.1.5/cas-shared-probes.mdx
@@ -1,0 +1,35 @@
+---
+version: "v1.1.5"
+category: "performance-improvements"
+---
+
+#### Fewer remote probes for sources shared across units
+
+`run --all` asked the remote what a source resolved to once per unit, so a hundred units sharing one module made a hundred requests. Each of them then read the same commit out of the store for itself.
+
+Units that resolve the same source at the same time now share one probe, and units that need the same Git commit share the work of reading it into the [CAS](/features/caching/cas).
+
+Measured over 100 units pointing at one Git module, counting the Git commands a run spawns:
+
+| 100 units, one shared module | Before | After |
+| --- | --- | --- |
+| First run: `git ls-remote` | 100 | 1 |
+| First run: reading the commit into the store | 202 | 4 |
+| First run: Git commands in total | 304 | 7 |
+| Later run, source on a branch | 100 | 1 |
+| Later run, source on a version tag | 100 | 0 |
+
+The last row needs the `offline-cas` experiment described below; the rest apply to every run. Against a local Git server the first run went from roughly 5 seconds to 0.3, and a later run from 1 second to 0.1. A real remote makes each avoided `ls-remote` worth more, since it costs a network round trip rather than a local process.
+
+The new `offline-cas` experiment goes a step further and has the CAS record each probe answer in the store, so a later run can skip the request. How long it trusts an answer depends on the source:
+
+- A source pinned to a specific revision keeps its answer for 24 hours: a semantic version tag, an S3 object version, an OCI manifest digest, an exact registry module version, or a full Mercurial changeset node.
+- A source that can change upstream, such as a Git branch or an OCI tag, gets a fresh probe on every run, so a push or an upload shows up immediately.
+
+The experiment also unlocks three flags that change how the recorded answers are used:
+
+- `--cas-offline` never contacts a remote. Sources come from the local store and the recorded answers, and anything missing is an error rather than a fetch.
+- `--cas-refresh` ignores the recorded answers for one run and asks every remote again.
+- `--cas-probe-ttl` trusts a changeable source's answer for a duration you choose, such as `10m`.
+
+See [Recorded probes](/features/caching/cas#recorded-probes) and the [`offline-cas` experiment](/reference/experiments/active#offline-cas).

--- a/docs/src/data/changelog/v1.1.5/offline-cas.mdx
+++ b/docs/src/data/changelog/v1.1.5/offline-cas.mdx
@@ -1,0 +1,18 @@
+---
+version: "v1.1.5"
+category: "experiments-added"
+---
+
+#### `offline-cas` gates the CAS probe cache
+
+The `offline-cas` experiment has been added as the gate for the probe cache the [CAS](/features/caching/cas) keeps, in which it records what each source resolved to so a later run can skip asking the remote.
+
+Enabling the experiment turns the cache on and unlocks three flags that change how its answers are used: `--cas-offline`, `--cas-refresh`, and `--cas-probe-ttl`. Setting one of them without the experiment returns an error naming the flag.
+
+```bash
+terragrunt run --experiment offline-cas --all --cas-offline -- plan
+```
+
+Without the experiment nothing is recorded or served, and every run probes every source, as before.
+
+See the [experiment documentation](/reference/experiments/active#offline-cas) for what each flag does and what has to land before it stabilizes.

--- a/docs/src/data/commands/catalog.mdx
+++ b/docs/src/data/commands/catalog.mdx
@@ -22,6 +22,9 @@ flags:
   - catalog-no-hooks
   - no-cas
   - cas-clone-depth
+  - cas-offline
+  - cas-refresh
+  - cas-probe-ttl
 ---
 
 ```bash

--- a/docs/src/data/commands/run.mdx
+++ b/docs/src/data/commands/run.mdx
@@ -83,6 +83,9 @@ flags:
   - version-manager-file-name
   - no-cas
   - cas-clone-depth
+  - cas-offline
+  - cas-refresh
+  - cas-probe-ttl
 ---
 
 import { Aside } from '@astrojs/starlight/components';

--- a/docs/src/data/commands/stack/generate.mdx
+++ b/docs/src/data/commands/stack/generate.mdx
@@ -15,6 +15,9 @@ flags:
   - stack-generate-filter
   - no-cas
   - cas-clone-depth
+  - cas-offline
+  - cas-refresh
+  - cas-probe-ttl
 ---
 
 import FileTree from "@components/vendored/starlight/FileTree.astro";

--- a/docs/src/data/commands/stack/run.mdx
+++ b/docs/src/data/commands/stack/run.mdx
@@ -24,6 +24,9 @@ flags:
   - no-stack-generate
   - no-cas
   - cas-clone-depth
+  - cas-offline
+  - cas-refresh
+  - cas-probe-ttl
 ---
 
 import { Aside } from '@astrojs/starlight/components';

--- a/docs/src/data/experiments/offline-cas.mdx
+++ b/docs/src/data/experiments/offline-cas.mdx
@@ -1,0 +1,46 @@
+---
+name: offline-cas
+since: "1.1.5"
+---
+
+Control over the probe cache the [CAS](/features/caching/cas) keeps, including resolving a run without contacting any remote.
+
+### `offline-cas` - What it does
+
+This experiment turns on the probe cache. The CAS records the answer to each cheap probe it makes, for every source it probes, so a later run can learn what a source resolves to without querying the remote again. An answer for a source pinned to a specific revision is served for 24 hours; anything that can change upstream is probed again on every run.
+
+Three flags come with it and change how the recorded answers are used:
+
+- [`--cas-offline`](/reference/cli/commands/run#cas-offline) never contacts a remote. Every source is answered from its recorded probe, however old, and linked from the local store. A source with no recorded answer, or whose content the store lacks, fails with an error naming it instead of being fetched.
+- [`--cas-refresh`](/reference/cli/commands/run#cas-refresh) ignores the recorded answers for one run and asks every remote again, then records what it learns. Use it when a version tag has moved and the 24 hour window for pinned sources has not passed.
+- [`--cas-probe-ttl`](/reference/cli/commands/run#cas-probe-ttl) trusts a recorded probe of a source that can change upstream for a chosen duration, such as `10m`, rather than probing it on every run.
+
+```bash
+terragrunt run --experiment offline-cas --all --cas-offline -- plan
+```
+
+The flags are available on the same commands as `--no-cas`. `--cas-offline` and `--cas-refresh` cannot be combined. A source with no cheap probe, such as an SMB share, has no answer to record and is fetched on every run. With the experiment off, nothing is recorded or served and every run probes every source.
+
+### `offline-cas` - How to enable it
+
+```bash
+# Via CLI flag
+terragrunt run --experiment offline-cas --all --cas-probe-ttl 10m -- plan
+
+# Via environment variable
+export TG_EXPERIMENT=offline-cas
+terragrunt run --all --cas-probe-ttl 10m -- plan
+```
+
+Setting one of the three flags without the experiment returns an error naming the flag.
+
+### `offline-cas` - Criteria for stabilization
+
+To transition the `offline-cas` feature to a stable release, the following must be addressed, at a minimum:
+
+- [ ] Confirm an offline run reports every unresolvable source in one pass, rather than failing on the first one.
+- [ ] Decide whether the sources with no cheap probe (SMB shares) should be resolvable offline, or whether failing on them is right.
+- [ ] Decide whether a warm store should be reachable without a prior online run, such as through a store that can be built and shipped to an air-gapped host.
+- [ ] Decide whether the 24 hour window for pinned sources belongs under `--cas-probe-ttl` or stays separate.
+- [ ] Decide how the store is pruned, covering recorded answers and the much larger content beside them, so a long-lived store does not keep growing on sources that are gone. Marking an answer as used when it is served, so that age since last use drives eviction rather than age since recording, is the likely mechanism.
+- [ ] Community feedback from air-gapped and high-unit-count runs on whether the three flags cover their needs.

--- a/docs/src/data/flags/cas-offline.mdx
+++ b/docs/src/data/flags/cas-offline.mdx
@@ -1,0 +1,26 @@
+---
+name: cas-offline
+description: When using CAS, never contact a remote; resolve every source from the local store and fail on anything missing.
+type: bool
+env:
+  - TG_CAS_OFFLINE
+since: "v1.1.5"
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Experimental">
+This flag is gated behind the [`offline-cas`](/reference/experiments/active#offline-cas) experiment. Enable it with `--experiment=offline-cas` or `TG_EXPERIMENT=offline-cas`; otherwise setting `--cas-offline` returns an error.
+</Aside>
+
+Forbids the CAS from contacting any remote. Each source is resolved locally instead: a source pinned to a specific revision that the store already holds is looked up there, and everything else is answered from the most recent probe the [probe cache](/features/caching/cas#recorded-probes) recorded for it, however old that result is. The content is then linked from the store as usual.
+
+A source with no recorded answer, or whose content is not in the store, fails with an error naming it instead of being fetched. Run once without this flag to populate the store, then rerun with it.
+
+Any other CAS failure on a source, such as a store file that cannot be read, also fails the run. Without this flag Terragrunt falls back to the standard downloader, which fetches from the remote.
+
+```bash
+terragrunt run --all --cas-offline -- plan
+```
+
+Every source the CAS resolves through a cheap probe is covered: Git, HTTP and HTTPS, S3, GCS, OCI, the OpenTofu/Terraform registry, and Mercurial. A source with no cheap probe, such as an SMB share, has nothing recorded and is still fetched. Local paths are copied as usual. The flag has no effect when the CAS is disabled with `--no-cas`, and it cannot be combined with `--cas-refresh`.

--- a/docs/src/data/flags/cas-probe-ttl.mdx
+++ b/docs/src/data/flags/cas-probe-ttl.mdx
@@ -1,0 +1,25 @@
+---
+name: cas-probe-ttl
+description: When using CAS, trust a recorded probe of a source that can change upstream for this long before asking the remote again.
+defaultVal: "0"
+type: string
+env:
+  - TG_CAS_PROBE_TTL
+since: "v1.1.5"
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Experimental">
+This flag is gated behind the [`offline-cas`](/reference/experiments/active#offline-cas) experiment. Enable it with `--experiment=offline-cas` or `TG_EXPERIMENT=offline-cas`; otherwise setting `--cas-probe-ttl` returns an error.
+</Aside>
+
+Sets how long the CAS serves a recorded probe of a source that can change upstream in place of a fresh one. That covers a Git branch or `HEAD`, a Git tag that is not a semantic version, an HTTP endpoint, a GCS object, an OCI tag, and a Mercurial branch name. The value is a duration such as `30s`, `10m`, or `1h`. Negative values are rejected.
+
+The default of `0` probes these sources on every run, so a push or an upload followed by a run sees the new revision. Raise it when a burst of runs against the same sources should not each pay for a probe, accepting that a change made inside the window is not seen until it passes.
+
+```bash
+terragrunt run --all --cas-probe-ttl 10m -- plan
+```
+
+A source pinned to a specific revision is trusted for 24 hours regardless of this flag; see [Recorded probes](/features/caching/cas#recorded-probes) for which sources count as pinned. Use `--cas-refresh` to bypass every recorded result for one run.

--- a/docs/src/data/flags/cas-refresh.mdx
+++ b/docs/src/data/flags/cas-refresh.mdx
@@ -1,0 +1,24 @@
+---
+name: cas-refresh
+description: When using CAS, ignore recorded probe results and ask every remote again.
+type: bool
+env:
+  - TG_CAS_REFRESH
+since: "v1.1.5"
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Experimental">
+This flag is gated behind the [`offline-cas`](/reference/experiments/active#offline-cas) experiment. Enable it with `--experiment=offline-cas` or `TG_EXPERIMENT=offline-cas`; otherwise setting `--cas-refresh` returns an error.
+</Aside>
+
+Skips the [probe cache](/features/caching/cas#recorded-probes) for this run, so every source is resolved with a fresh probe. Units that resolve the same source at the same time still share one probe; a unit that starts later asks the remote again. The fresh results are recorded for later runs.
+
+A source pinned to a specific revision, such as a semantic version tag or an S3 object version, is trusted for 24 hours by default, so a tag that has been moved keeps resolving to its previous revision until that window passes. This flag picks up the new one right away.
+
+```bash
+terragrunt run --all --cas-refresh -- plan
+```
+
+The flag has no effect when the CAS is disabled with `--no-cas`, and it cannot be combined with `--cas-offline`.

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/agext/levenshtein v1.2.3
 	github.com/alecthomas/chroma/v2 v2.27.0
@@ -131,7 +132,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.57.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.57.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect

--- a/internal/cas/benchmark_test.go
+++ b/internal/cas/benchmark_test.go
@@ -1,6 +1,7 @@
 package cas_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,10 +11,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
@@ -70,6 +73,99 @@ func BenchmarkClone(b *testing.B) {
 				cas.WithDepth(-1)))
 		}
 	})
+}
+
+// BenchmarkConcurrentClone measures the `run --all` shape: many units,
+// each with its own CAS over one shared store, cloning the same branch of
+// one source at the same time. "warm tree" pre-populates the store so only
+// the probe sits on the hot path; "cold store" starts each iteration from
+// an empty store so the ingest does too.
+func BenchmarkConcurrentClone(b *testing.B) {
+	repoURL := startBenchServer(b)
+
+	l := logger.CreateLogger()
+
+	v := venvtest.NewOSWithEmptyEnv()
+
+	callerCounts := []int{8, 32, 128}
+
+	b.Run("warm tree", func(b *testing.B) {
+		for _, callers := range callerCounts {
+			b.Run(strconv.Itoa(callers)+" callers", func(b *testing.B) {
+				tempDir := b.TempDir()
+				storePath := filepath.Join(tempDir, "store")
+
+				require.NoError(b, cloneConcurrently(b.Context(), l, v, storePath, repoURL,
+					filepath.Join(tempDir, "warm"), 1))
+
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for i := 0; b.Loop(); i++ {
+					b.StopTimer()
+
+					targetRoot := filepath.Join(tempDir, "repo", strconv.Itoa(i))
+
+					b.StartTimer()
+
+					require.NoError(b, cloneConcurrently(b.Context(), l, v, storePath, repoURL,
+						targetRoot, callers))
+				}
+			})
+		}
+	})
+
+	b.Run("cold store", func(b *testing.B) {
+		for _, callers := range callerCounts {
+			b.Run(strconv.Itoa(callers)+" callers", func(b *testing.B) {
+				tempDir := b.TempDir()
+
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for i := 0; b.Loop(); i++ {
+					b.StopTimer()
+
+					storePath := filepath.Join(tempDir, "store", strconv.Itoa(i))
+					targetRoot := filepath.Join(tempDir, "repo", strconv.Itoa(i))
+
+					b.StartTimer()
+
+					require.NoError(b, cloneConcurrently(b.Context(), l, v, storePath, repoURL,
+						targetRoot, callers))
+				}
+			})
+		}
+	})
+}
+
+// cloneConcurrently runs callers clones of main at once, each through a CAS
+// of its own over storePath and into its own directory under targetRoot,
+// and returns the first error any of them hit.
+func cloneConcurrently(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+	storePath, repoURL, targetRoot string,
+	callers int,
+) error {
+	g, ctx := errgroup.WithContext(ctx)
+
+	for i := range callers {
+		g.Go(func() error {
+			c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
+			if err != nil {
+				return err
+			}
+
+			return c.Clone(ctx, l, v, repoURL,
+				cas.WithDir(filepath.Join(targetRoot, strconv.Itoa(i))),
+				cas.WithBranch("main"),
+				cas.WithDepth(-1))
+		})
+	}
+
+	return g.Wait()
 }
 
 func BenchmarkContent(b *testing.B) {

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"errors"
 
@@ -96,12 +97,16 @@ func WithMutable(mutable bool) CloneOption {
 
 // CAS clones a git repository using content-addressable storage.
 type CAS struct {
-	blobStore  *Store
-	treeStore  *Store
-	synthStore *Store
-	gitStore   *GitStore
-	storePath  string
-	cloneDepth int
+	blobStore         *Store
+	treeStore         *Store
+	synthStore        *Store
+	gitStore          *GitStore
+	probeCache        *ProbeCache
+	storePath         string
+	cloneDepth        int
+	probeTTL          time.Duration
+	probeMode         ProbeMode
+	probeCacheEnabled bool
 }
 
 // WithStorePath specifies a custom path for the content store.
@@ -120,6 +125,57 @@ func WithStorePath(path string) Option {
 func WithCloneDepth(depth int) Option {
 	return func(c *CAS) {
 		c.cloneDepth = depth
+	}
+}
+
+// WithProbeCache records every probe answer in the store and serves one
+// back while it is fresh, so a later process can resolve a source without
+// asking its remote again. Without it nothing is written to or read from
+// `probes/` and every process probes every source, which is what a run
+// gets until the offline-cas experiment is enabled.
+//
+// [WithProbeTTL] sets how long an answer for a source that can change
+// upstream is served; a pinned source keeps [DefaultImmutableProbeTTL]
+// regardless. [WithOffline] and [WithProbeRefresh] act on this cache and
+// enable it themselves, having nothing to do without one.
+func WithProbeCache() Option {
+	return func(c *CAS) {
+		c.probeCacheEnabled = true
+	}
+}
+
+// WithOffline forbids every call to a remote. Probes answer from the local
+// git store and the persisted probe cache regardless of TTL, and content
+// the store lacks fails with [OfflineMissError] instead of being fetched.
+// A source with no cheap probe, such as an SMB share, has no answer to
+// serve and is still fetched.
+// Passing this together with [WithProbeRefresh] is a caller bug that the
+// CLI rejects at flag validation; here the later option wins.
+func WithOffline() Option {
+	return func(c *CAS) {
+		c.probeMode = ProbeModeOffline
+		c.probeCacheEnabled = true
+	}
+}
+
+// WithProbeRefresh ignores the persisted probe cache for this process, so
+// every probe reaches the network unless it joins one already in flight.
+// Answers are still recorded for later runs.
+func WithProbeRefresh() Option {
+	return func(c *CAS) {
+		c.probeMode = ProbeModeRefresh
+		c.probeCacheEnabled = true
+	}
+}
+
+// WithProbeTTL sets how long a persisted probe of a source that can change
+// upstream is served without asking the remote again. Zero, the default,
+// re-probes in every process so a push followed by a run sees the new
+// revision. A pinned source keeps [DefaultImmutableProbeTTL] regardless.
+// Has no effect without [WithProbeCache].
+func WithProbeTTL(ttl time.Duration) Option {
+	return func(c *CAS) {
+		c.probeTTL = ttl
 	}
 }
 
@@ -144,6 +200,7 @@ func New(v *venv.Venv, opts ...Option) (*CAS, error) {
 	c.treeStore = NewStore(filepath.Join(c.storePath, "trees"))
 	c.synthStore = NewStore(filepath.Join(c.storePath, "synth", "trees"))
 	c.gitStore = NewGitStore(filepath.Join(c.storePath, "git"))
+	c.probeCache = NewProbeCache(filepath.Join(c.storePath, probeCacheDirName))
 
 	return c, nil
 }
@@ -190,16 +247,41 @@ func (c *CAS) ensureStorePaths(v *venv.Venv) error {
 type GitResolver struct {
 	// Venv supplies the executor Probe derives its git runner from. Required.
 	Venv *venv.Venv
-	// Store enables an offline fast path: a full-length SHA in
+	// Logger receives probe-cache diagnostics. Required when Cache is set.
+	Logger log.Logger
+	// Store enables an offline fast path: a commit-form
 	// [GitResolver.Branch] is checked against the local store before
-	// reaching ls-remote. When nil, every Probe runs ls-remote.
+	// reaching ls-remote, in the shapes [GitResolver.storeProbe]
+	// accepts. When nil, every Probe runs ls-remote.
 	Store *GitStore
+	// Cache persists ls-remote answers across processes. When nil no
+	// answer is recorded or served; the in-process flight still applies.
+	Cache *ProbeCache
 	// Branch is the ref to query. Empty means HEAD.
 	Branch string
+	// MutableTTL is how long a persisted probe for a branch, HEAD, or a
+	// tag that is not a version is served without ls-remote. Zero means
+	// every process re-probes. See [ProbeTTL].
+	MutableTTL time.Duration
+	// Mode selects between the network and the persisted cache.
+	Mode ProbeMode
+}
+
+// probeResult is what one probe flight delivers to every caller that
+// joined it.
+type probeResult struct {
+	key    string
+	origin probeOrigin
 }
 
 // Scheme returns "git".
 func (r *GitResolver) Scheme() string { return "git" }
+
+// Pinned always reports false. Git decides immutability after probing,
+// from the ref ls-remote matched rather than the ref that was asked for
+// (see [GitResolver.recordProbe]), so it has no pre-probe answer to give.
+// Nothing consults it: [CAS.Clone] asks for [ProbeCachedByResolver].
+func (r *GitResolver) Pinned(_ string) bool { return false }
 
 // Probe returns the commit SHA for r.Branch (HEAD when empty). The
 // returned SHA is the cache key verbatim and doubles as the git
@@ -208,34 +290,171 @@ func (r *GitResolver) Scheme() string { return "git" }
 // `git ls-remote` is authoritative; ls-remote misses (the caller
 // supplied a commit-form ref directly) surface as
 // [ErrNoVersionMetadata] so the fetcher canonicalizes via rev-parse.
-// When [GitResolver.Store] is set, a full-length SHA in r.Branch
-// short-circuits ls-remote on a local cache hit.
+// When [GitResolver.Store] is set, a commit r.Branch names that the
+// store already holds short-circuits ls-remote (see
+// [GitResolver.storeProbe]). Concurrent probes of the same (URL, ref)
+// anywhere in the process share one ls-remote, and a persisted answer
+// within its TTL (see [ProbeTTL]) skips ls-remote entirely.
 func (r *GitResolver) Probe(ctx context.Context, rawURL string) (string, error) {
-	if r.Store != nil && looksLikeFullSHA(r.Branch) {
-		if hash, ok := r.Store.ProbeCachedCommit(ctx, r.Venv, rawURL, r.Branch); ok {
-			return hash, nil
-		}
+	if hash, ok := r.storeProbe(ctx, rawURL); ok {
+		recordProbeOrigin(ctx, probeOriginGitStore)
+
+		return hash, nil
+	}
+
+	res, err := flights.probe.do(ctx, r.flightKey(rawURL), func(ctx context.Context) (probeResult, error) {
+		return r.probeUncoalesced(ctx, rawURL)
+	})
+	if err != nil {
+		return "", err
+	}
+
+	recordProbeOrigin(ctx, res.origin)
+
+	return res.key, nil
+}
+
+// storeProbe answers from the local bare repository when it already
+// holds the commit r.Branch names.
+//
+// Online only a full-length SHA is offered to the store, so a hex-named
+// branch keeps tracking its remote tip instead of freezing at the first
+// commit its name prefixed. Offline there is no tip to track and the
+// only other outcome is [OfflineMissError], so an abbreviated SHA is
+// offered too; [GitStore.ProbeCachedCommit] rejects a name that resolved
+// through ref lookup on its own.
+func (r *GitResolver) storeProbe(ctx context.Context, rawURL string) (string, bool) {
+	if r.Store == nil {
+		return "", false
+	}
+
+	if !looksLikeFullSHA(r.Branch) && r.Mode != ProbeModeOffline {
+		return "", false
+	}
+
+	return r.Store.ProbeCachedCommit(ctx, r.Venv, rawURL, r.Branch)
+}
+
+// flightKey identifies the probe of rawURL for r.Branch within the
+// process. See [probeFlightKey] for how the key is built.
+func (r *GitResolver) flightKey(rawURL string) string {
+	root := ""
+	if r.Cache != nil {
+		root = r.Cache.RootPath()
+	}
+
+	return probeFlightKey(root, rawURL, r.Branch)
+}
+
+// probeFlightKey identifies the probe of url for ref within the process.
+// It carries the cache root because the flight records its answer there,
+// and probes over different stores must each record their own. The URL is
+// redacted so the flights line up with the partition
+// [ProbeCache.EntryPath] records under: two units reaching one source
+// through different credentials share an answer here for the same reason
+// they share the persisted one.
+func probeFlightKey(cacheRoot, url, ref string) string {
+	return cacheRoot + "\x00" + RedactURL(url) + "\x00" + ref
+}
+
+// probeUncoalesced answers one probe from the persisted cache or, when
+// the mode allows it, from ls-remote, recording a fresh network answer
+// for later processes.
+func (r *GitResolver) probeUncoalesced(ctx context.Context, rawURL string) (probeResult, error) {
+	if entry, ok := r.cachedProbe(rawURL); ok {
+		return probeResult{key: entry.Key, origin: probeOriginProbeCache}, nil
+	}
+
+	if r.Mode == ProbeModeOffline {
+		return probeResult{}, &OfflineMissError{Source: RedactURL(rawURL), Ref: probeRefName(r.Branch)}
 	}
 
 	runner, err := git.NewGitRunner(r.Venv)
 	if err != nil {
-		return "", err
+		return probeResult{}, err
 	}
 
 	results, err := runner.LsRemote(ctx, rawURL, r.Branch)
 	if err != nil {
 		if errors.Is(err, git.ErrNoMatchingReference) {
-			return "", ErrNoVersionMetadata
+			return probeResult{}, ErrNoVersionMetadata
 		}
 
-		return "", err
+		return probeResult{}, err
 	}
 
 	if len(results) == 0 {
-		return "", ErrNoVersionMetadata
+		return probeResult{}, ErrNoVersionMetadata
 	}
 
-	return results[0].Hash, nil
+	r.recordProbe(rawURL, results[0])
+
+	return probeResult{key: results[0].Hash, origin: probeOriginLsRemote}, nil
+}
+
+// cachedProbe returns the persisted answer for rawURL when the mode and
+// TTL allow serving it.
+func (r *GitResolver) cachedProbe(rawURL string) (ProbeEntry, bool) {
+	if r.Cache == nil || r.Mode == ProbeModeRefresh {
+		return ProbeEntry{}, false
+	}
+
+	entry, ok := r.Cache.Lookup(r.Venv.FS, rawURL, r.Branch)
+	if !ok || !looksLikeFullSHA(entry.Key) {
+		return ProbeEntry{}, false
+	}
+
+	if r.Mode == ProbeModeOffline {
+		return entry, true
+	}
+
+	ttl := ProbeTTL(&entry, r.MutableTTL)
+	if ttl <= 0 || time.Since(entry.ProbedAt) >= ttl {
+		return ProbeEntry{}, false
+	}
+
+	return entry, true
+}
+
+// recordProbe persists a network answer. A failed write costs only the
+// next process a probe, so it is logged rather than failing a probe that
+// already succeeded.
+func (r *GitResolver) recordProbe(rawURL string, res git.LsRemoteResult) {
+	if r.Cache == nil {
+		return
+	}
+
+	// Immutability follows the ref ls-remote matched, not the name asked
+	// for: a branch named v1.2.3 shadows a tag of that name in ls-remote's
+	// output and must keep re-probing like any other branch.
+	entry := ProbeEntry{
+		ProbedAt:  time.Now(),
+		Key:       res.Hash,
+		Immutable: IsSemverTag(res.Ref),
+	}
+
+	if err := r.Cache.Store(r.Venv.FS, rawURL, r.Branch, &entry); err != nil {
+		r.Logger.Debugf("cas: probe cache write for %s failed: %v", RedactURL(rawURL), err)
+	}
+}
+
+// newGitResolver builds the [GitResolver] for branch with this CAS's
+// stores, probe cache, and mode.
+func (c *CAS) newGitResolver(l log.Logger, v *venv.Venv, branch string) *GitResolver {
+	cache := c.probeCache
+	if !c.probeCacheEnabled {
+		cache = nil
+	}
+
+	return &GitResolver{
+		Venv:       v,
+		Logger:     l,
+		Store:      c.gitStore,
+		Cache:      cache,
+		Branch:     branch,
+		MutableTTL: c.probeTTL,
+		Mode:       c.probeMode,
+	}
 }
 
 // Clone fetches url into the target directory through the CAS, using a
@@ -267,11 +486,12 @@ func (c *CAS) Clone(
 	clonedOpts.Dir = c.prepareTargetDirectory(opts.Dir, url)
 
 	return c.FetchSource(ctx, l, v, &clonedOpts, SourceRequest{
-		Scheme:   "git",
-		URL:      url,
-		Resolver: &GitResolver{Venv: v, Store: c.gitStore, Branch: opts.Branch},
-		Fetch:    c.gitFetcher(url, &opts),
-		Attrs:    map[string]any{"branch": opts.Branch},
+		Scheme:       "git",
+		URL:          url,
+		Resolver:     c.newGitResolver(l, v, opts.Branch),
+		Fetch:        c.gitFetcher(url, &opts),
+		Attrs:        map[string]any{"branch": opts.Branch},
+		ProbeCaching: ProbeCachedByResolver,
 	})
 }
 
@@ -359,10 +579,49 @@ func (c *CAS) gitFetcher(url string, opts *CloneOptions) SourceFetcher {
 	}
 }
 
-// populateTreeFromRef dispatches by ref kind, short-circuiting on a
-// cached [symbolicRef] and otherwise calling the kind-specific
-// populate. Returns the canonical commit hash.
+// populateTreeFromRef returns the canonical commit hash for ref, ingesting
+// its tree when the store lacks it. Concurrent ingests of the same ref
+// anywhere in the process share one flight; the flight runs with the
+// first caller's logger, venv, and clone options, and later callers only
+// wait for its tree.
 func (c *CAS) populateTreeFromRef(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+	opts *CloneOptions,
+	ref resolvedRef,
+) (string, error) {
+	if hash := ref.knownHash(); hash != "" && !c.treeStore.NeedsWrite(v, hash) {
+		return hash, nil
+	}
+
+	if c.probeMode == ProbeModeOffline {
+		url, requested := ref.origin()
+
+		return "", &OfflineMissError{Source: RedactURL(url), Ref: probeRefName(requested)}
+	}
+
+	return flights.ingest.do(ctx, c.ingestFlightKey(ref), func(ctx context.Context) (string, error) {
+		return c.ingestRef(ctx, l, v, opts, ref)
+	})
+}
+
+// ingestFlightKey identifies the tree an ingest writes into this store:
+// the commit hash when it is already known, otherwise the (URL, ref) pair
+// that will resolve to it.
+func (c *CAS) ingestFlightKey(ref resolvedRef) string {
+	if hash := ref.knownHash(); hash != "" {
+		return c.storePath + "\x00commit\x00" + hash
+	}
+
+	url, requested := ref.origin()
+
+	return c.storePath + "\x00ref\x00" + url + "\x00" + requested
+}
+
+// ingestRef dispatches by ref kind to the populate that fills the store.
+// Returns the canonical commit hash.
+func (c *CAS) ingestRef(
 	ctx context.Context,
 	l log.Logger,
 	v *venv.Venv,
@@ -371,10 +630,6 @@ func (c *CAS) populateTreeFromRef(
 ) (string, error) {
 	switch ref := ref.(type) {
 	case *symbolicRef:
-		if !c.treeStore.NeedsWrite(v, ref.Hash) {
-			return ref.Hash, nil
-		}
-
 		if err := c.populateTreeFromSymbolicRef(ctx, l, v, opts, ref); err != nil {
 			return "", err
 		}
@@ -382,10 +637,6 @@ func (c *CAS) populateTreeFromRef(
 		return ref.Hash, nil
 
 	case *commitRef:
-		if ref.Hash != "" && !c.treeStore.NeedsWrite(v, ref.Hash) {
-			return ref.Hash, nil
-		}
-
 		return c.populateTreeFromCommitRef(ctx, l, v, opts, ref)
 
 	default:
@@ -575,6 +826,11 @@ func (c *CAS) prepareTargetDirectory(dir, url string) string {
 // otherwise.
 type resolvedRef interface {
 	CommitHash() string
+	// knownHash returns the canonical commit hash when resolution already
+	// produced one, and "" when only a fetch can produce it.
+	knownHash() string
+	// origin returns the remote URL and the ref the caller asked for.
+	origin() (url, ref string)
 }
 
 // symbolicRef carries an ls-remote-resolved branch, tag, or HEAD.
@@ -586,6 +842,10 @@ type symbolicRef struct {
 
 // CommitHash returns the canonical commit hash ls-remote resolved.
 func (r *symbolicRef) CommitHash() string { return r.Hash }
+
+func (r *symbolicRef) knownHash() string { return r.Hash }
+
+func (r *symbolicRef) origin() (string, string) { return r.URL, r.Branch }
 
 // commitRef carries a ref ls-remote did not canonicalize. The central git
 // store resolves it later via rev-parse and a full-history fetch on a
@@ -607,27 +867,33 @@ type commitRef struct {
 // git store happened to have the commit cached.
 func (r *commitRef) CommitHash() string { return r.RawRef }
 
+func (r *commitRef) knownHash() string { return r.Hash }
+
+func (r *commitRef) origin() (string, string) { return r.URL, r.RawRef }
+
 // resolveReference resolves branch into a [resolvedRef] via [GitResolver].
 //
 // Full-length SHAs (40 or 64 hex chars) are checked against the local git
-// store first so previously-cloned commits resolve offline; abbreviated
-// SHAs skip the probe to avoid mistaking a hex-named branch tip for the
-// SHA prefix and freezing the branch at its first-fetched tip (see
-// [looksLikeFullSHA]).
+// store first so previously-cloned commits resolve offline; online an
+// abbreviated SHA skips that check to avoid mistaking a hex-named branch
+// tip for the SHA prefix and freezing the branch at its first-fetched tip
+// (see [looksLikeFullSHA]). Offline there is no moving tip to track and
+// the alternative is a failed run, so the store answers an abbreviated
+// SHA too, still as a [commitRef] so the stack key stays the ref the user
+// wrote.
 func (c *CAS) resolveReference(
 	ctx context.Context,
+	l log.Logger,
 	v *venv.Venv,
 	url, branch string,
 ) (resolvedRef, error) {
-	if looksLikeFullSHA(branch) {
+	if looksLikeFullSHA(branch) || c.probeMode == ProbeModeOffline {
 		if hash, ok := c.gitStore.ProbeCachedCommit(ctx, v, url, branch); ok {
 			return &commitRef{URL: url, RawRef: branch, Hash: hash}, nil
 		}
 	}
 
-	r := &GitResolver{Venv: v, Store: c.gitStore, Branch: branch}
-
-	key, err := r.Probe(ctx, url)
+	key, err := c.newGitResolver(l, v, branch).Probe(ctx, url)
 	if err != nil {
 		if errors.Is(err, ErrNoVersionMetadata) {
 			return &commitRef{URL: url, RawRef: branch}, nil

--- a/internal/cas/cas_test.go
+++ b/internal/cas/cas_test.go
@@ -101,7 +101,7 @@ func TestCAS_FallbackWhenGitStoreFails(t *testing.T) {
 	gitStoreRoot := filepath.Join(storePath, "git")
 	require.NoError(t, os.MkdirAll(gitStoreRoot, 0o755))
 
-	entry := cas.EntryPathForURL(gitStoreRoot, repoURL)
+	entry := cas.EntryPathForURL(gitStoreRoot, repoURL, cas.HashSHA256)
 	require.NoError(t, os.WriteFile(entry, []byte("not a directory"), 0o644))
 
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))

--- a/internal/cas/clone_flight_test.go
+++ b/internal/cas/clone_flight_test.go
@@ -1,0 +1,388 @@
+package cas_test
+
+import (
+	"context"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+)
+
+// newRecordedVenv returns an OS-backed bundle whose git invocations are
+// counted by the returned recorder. A nil gate leaves ls-remote ungated.
+func newRecordedVenv(gate chan struct{}) (*venv.Venv, *gitExecRecorder) {
+	rec := newGitExecRecorder(vexec.NewOSExec(), gate)
+
+	return venvtest.NewOSWithEmptyEnv().WithExec(rec), rec
+}
+
+// newStoreCAS constructs a CAS over storePath with opts, the way each unit
+// of a `run --all` constructs its own. The persisted probe cache is on, as
+// it is for a run with the offline-cas experiment enabled. It returns the
+// construction error rather than asserting so goroutines can call it too.
+func newStoreCAS(storePath string, opts ...cas.Option) (*cas.CAS, error) {
+	base := make([]cas.Option, 0, len(opts)+2)
+	base = append(base, cas.WithStorePath(storePath), cas.WithProbeCache())
+
+	return cas.New(venvtest.NewWithOSFS(), append(base, opts...)...)
+}
+
+// cloneInto runs one Clone of branch into dst through a CAS built over
+// storePath, the unit of work every goroutine in these tests performs.
+func cloneInto(
+	ctx context.Context,
+	v *venv.Venv,
+	storePath, repoURL, branch, dst string,
+	opts ...cas.Option,
+) error {
+	c, err := newStoreCAS(storePath, opts...)
+	if err != nil {
+		return err
+	}
+
+	return c.Clone(ctx, logger.CreateLogger(), v, repoURL,
+		cas.WithDir(dst),
+		cas.WithBranch(branch),
+		cas.WithDepth(-1))
+}
+
+// TestCASClone_ConcurrentInstancesShareProbeAndIngestWithRacing pins the
+// `run --all` shape end to end: 32 CAS instances over one store cloning
+// the same branch at once cost one ls-remote and one ingest between them.
+// The first ls-remote is held until every goroutine has been started so
+// the others join its flight rather than racing it, and the mutable-ref
+// TTL covers any goroutine the scheduler still manages to hold back past
+// the flight's completion, so the count is exact rather than probable.
+func TestCASClone_ConcurrentInstancesShareProbeAndIngestWithRacing(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startTestServer(t)
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+
+	gate := make(chan struct{})
+	v, rec := newRecordedVenv(gate)
+
+	const callers = 32
+
+	errs := make([]error, callers)
+
+	var started, wg sync.WaitGroup
+
+	started.Add(callers)
+
+	for i := range callers {
+		wg.Go(func() {
+			started.Done()
+
+			errs[i] = cloneInto(t.Context(), v, storePath, repoURL, "main",
+				filepath.Join(tempDir, "dst-"+strconv.Itoa(i)),
+				cas.WithProbeTTL(time.Hour))
+		})
+	}
+
+	started.Wait()
+	close(gate)
+	wg.Wait()
+
+	for i := range callers {
+		require.NoError(t, errs[i], "caller %d", i)
+		assert.FileExists(t, filepath.Join(tempDir, "dst-"+strconv.Itoa(i), "main.tf"), "caller %d", i)
+	}
+
+	assert.Equal(t, 1, rec.count("ls-remote"), "every caller must share one probe")
+	assert.Equal(t, 1, rec.count("fetch"), "every caller must share one fetch into the git store")
+	assert.Equal(t, 1, rec.count("ls-tree"), "every caller must share one tree ingest")
+}
+
+// TestCASClone_LeaderCancellationFollowersStillSucceedWithRacing pins that
+// the caller whose context started a probe flight can go away without
+// taking the flight with it: the followers still get their clone. The
+// first ls-remote is held open so the leader can be cancelled mid-flight.
+func TestCASClone_LeaderCancellationFollowersStillSucceedWithRacing(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startTestServer(t)
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+
+	gate := make(chan struct{})
+	v, rec := newRecordedVenv(gate)
+
+	leaderCtx, cancelLeader := context.WithCancel(t.Context())
+	defer cancelLeader()
+
+	leaderErr := make(chan error, 1)
+
+	go func() {
+		leaderErr <- cloneInto(leaderCtx, v, storePath, repoURL, "main", filepath.Join(tempDir, "leader"))
+	}()
+
+	<-rec.firstLsRemote
+
+	const followers = 3
+
+	errs := make([]error, followers)
+
+	var wg sync.WaitGroup
+
+	for i := range followers {
+		wg.Go(func() {
+			errs[i] = cloneInto(t.Context(), v, storePath, repoURL, "main",
+				filepath.Join(tempDir, "follower-"+strconv.Itoa(i)))
+		})
+	}
+
+	cancelLeader()
+	require.ErrorIs(t, <-leaderErr, context.Canceled)
+
+	close(gate)
+	wg.Wait()
+
+	for i := range followers {
+		require.NoError(t, errs[i], "follower %d", i)
+		assert.FileExists(t, filepath.Join(tempDir, "follower-"+strconv.Itoa(i), "main.tf"), "follower %d", i)
+	}
+}
+
+// TestCASClone_SemverTagProbePersistsAcrossInstancesUntilTTL pins the
+// persisted probe end to end: a second CAS over the same store clones a
+// semver tag without ls-remote, until [cas.DefaultImmutableProbeTTL] has
+// passed. The clones run inside a synctest bubble so the TTL is stepped
+// over with no real wait, against the synthetic clock the probe cache
+// reads. The server starts outside the bubble, and the clock only moves
+// between clones: a goroutine waiting on a running git process is not
+// durably blocked, so the bubble would not advance while one is in
+// flight.
+func TestCASClone_SemverTagProbePersistsAcrossInstancesUntilTTL(t *testing.T) {
+	t.Parallel()
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile(t.Context(), "main.tf", []byte("# tagged"), "init"))
+	require.NoError(t, srv.Tag(t.Context(), "v1.0.0"))
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+	v, rec := newRecordedVenv(nil)
+
+	synctest.Test(t, func(t *testing.T) {
+		for i, dst := range []string{"first", "second"} {
+			require.NoError(t, cloneInto(t.Context(), v, storePath, repoURL, "v1.0.0", filepath.Join(tempDir, dst)))
+			assert.Equal(t, 1, rec.count("ls-remote"), "clone %d", i)
+		}
+
+		synctest.Sleep(cas.DefaultImmutableProbeTTL + time.Minute)
+
+		require.NoError(t, cloneInto(t.Context(), v, storePath, repoURL, "v1.0.0", filepath.Join(tempDir, "third")))
+		assert.Equal(t, 2, rec.count("ls-remote"), "an expired entry must be re-probed")
+		assert.FileExists(t, filepath.Join(tempDir, "third", "main.tf"))
+	})
+}
+
+// TestCASClone_OfflineServesCachedSourceWithoutNetwork pins the offline
+// happy path: once a branch has been cloned, a later offline clone of it
+// is answered entirely from the persisted probe and the tree store. The
+// server is shut down first so any network attempt would fail loudly.
+func TestCASClone_OfflineServesCachedSourceWithoutNetwork(t *testing.T) {
+	t.Parallel()
+
+	srv := newEmptyTestServer(t)
+	require.NoError(t, srv.CommitFile(t.Context(), "main.tf", []byte("# offline"), "init"))
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+
+	online, _ := newRecordedVenv(nil)
+	require.NoError(t, cloneInto(t.Context(), online, storePath, repoURL, "main", filepath.Join(tempDir, "online")))
+
+	require.NoError(t, srv.Close())
+
+	v, rec := newRecordedVenv(nil)
+	dst := filepath.Join(tempDir, "offline")
+
+	require.NoError(t, cloneInto(t.Context(), v, storePath, repoURL, "main", dst, cas.WithOffline()))
+
+	assert.FileExists(t, filepath.Join(dst, "main.tf"))
+	assert.Equal(t, 0, rec.count("ls-remote"))
+	assert.Equal(t, 0, rec.count("fetch"))
+	assert.Equal(t, 0, rec.count("clone"))
+}
+
+// TestCASClone_OfflinePinnedSHAServedFromGitStore pins that a full commit
+// SHA already fetched into the central git store resolves offline through
+// the local rev-parse path rather than the probe cache.
+func TestCASClone_OfflinePinnedSHAServedFromGitStore(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startTestServer(t)
+	headHash := resolveHead(t, repoURL)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+
+	online, _ := newRecordedVenv(nil)
+	require.NoError(t, cloneInto(t.Context(), online, storePath, repoURL, headHash, filepath.Join(tempDir, "online")))
+
+	v, rec := newRecordedVenv(nil)
+	dst := filepath.Join(tempDir, "offline")
+
+	require.NoError(t, cloneInto(t.Context(), v, storePath, repoURL, headHash, dst, cas.WithOffline()))
+
+	assert.FileExists(t, filepath.Join(dst, "main.tf"))
+	assert.Equal(t, 0, rec.count("ls-remote"))
+	assert.Equal(t, 0, rec.count("fetch"))
+	assert.Equal(t, 0, rec.count("clone"))
+}
+
+// TestCASClone_OfflineAbbreviatedSHAServedFromGitStore pins the ref shape
+// ls-remote can never name: an abbreviated commit SHA is never recorded in
+// the probe cache, so offline it has only the local rev-parse to resolve
+// it. A run that populated the store must therefore be enough to serve the
+// same pin offline, as the flag documentation promises.
+func TestCASClone_OfflineAbbreviatedSHAServedFromGitStore(t *testing.T) {
+	t.Parallel()
+
+	const abbrevLen = 12
+
+	repoURL := startTestServer(t)
+	abbrev := resolveHead(t, repoURL)[:abbrevLen]
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+
+	online, _ := newRecordedVenv(nil)
+	require.NoError(t, cloneInto(t.Context(), online, storePath, repoURL, abbrev, filepath.Join(tempDir, "online")))
+
+	v, rec := newRecordedVenv(nil)
+	dst := filepath.Join(tempDir, "offline")
+
+	require.NoError(t, cloneInto(t.Context(), v, storePath, repoURL, abbrev, dst, cas.WithOffline()))
+
+	assert.FileExists(t, filepath.Join(dst, "main.tf"))
+	assert.Equal(t, 0, rec.count("ls-remote"))
+	assert.Equal(t, 0, rec.count("fetch"))
+	assert.Equal(t, 0, rec.count("clone"))
+}
+
+// TestCASClone_OfflineMissFailsWithoutFallbackClone pins the offline miss:
+// a source the store has never seen fails with the typed error, and none
+// of ls-remote, fetch, or the temporary-clone fallback runs.
+func TestCASClone_OfflineMissFailsWithoutFallbackClone(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startTestServer(t)
+	tempDir := helpers.TmpDirWOSymlinks(t)
+
+	v, rec := newRecordedVenv(nil)
+
+	err := cloneInto(t.Context(), v, filepath.Join(tempDir, "store"), repoURL, "main",
+		filepath.Join(tempDir, "dst"), cas.WithOffline())
+	require.ErrorIs(t, err, cas.ErrCASOffline)
+
+	var miss *cas.OfflineMissError
+
+	require.ErrorAs(t, err, &miss)
+	assert.Equal(t, repoURL, miss.Source)
+	assert.Equal(t, "main", miss.Ref)
+
+	assert.Equal(t, 0, rec.count("ls-remote"))
+	assert.Equal(t, 0, rec.count("fetch"))
+	assert.Equal(t, 0, rec.count("clone"))
+}
+
+// TestCASClone_OfflineProbeHitWithMissingTreeFails pins the fetch-side
+// guard: a persisted probe can answer offline, but when the tree it names
+// is gone from the store the clone fails with the typed error instead of
+// fetching or falling back to a temporary clone.
+func TestCASClone_OfflineProbeHitWithMissingTreeFails(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startTestServer(t)
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+
+	online, _ := newRecordedVenv(nil)
+	require.NoError(t, cloneInto(t.Context(), online, storePath, repoURL, "main", filepath.Join(tempDir, "online")))
+
+	c, err := newStoreCAS(storePath)
+	require.NoError(t, err)
+	require.NoError(t, online.FS.RemoveAll(c.TreeStore().Path()))
+
+	v, rec := newRecordedVenv(nil)
+
+	err = cloneInto(t.Context(), v, storePath, repoURL, "main", filepath.Join(tempDir, "offline"), cas.WithOffline())
+	require.ErrorIs(t, err, cas.ErrCASOffline)
+
+	assert.Equal(t, 0, rec.count("ls-remote"))
+	assert.Equal(t, 0, rec.count("fetch"))
+	assert.Equal(t, 0, rec.count("clone"))
+}
+
+// TestCASClone_OfflineMissRedactsCredentials pins that neither offline
+// miss, the probe-side one against an empty store nor the fetch-side one
+// behind a persisted probe whose tree is gone, carries the token a source
+// URL embeds anywhere in its error chain. The chain is rendered as a whole
+// because that rendering is what the fallback warning logs.
+func TestCASClone_OfflineMissRedactsCredentials(t *testing.T) {
+	t.Parallel()
+
+	const token = "secret-token"
+
+	repoURL := startTestServer(t)
+
+	u, err := url.Parse(repoURL)
+	require.NoError(t, err)
+
+	u.User = url.UserPassword("oauth2", token)
+	credURL := u.String()
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	storePath := filepath.Join(tempDir, "store")
+
+	v, rec := newRecordedVenv(nil)
+
+	probeMiss := cloneInto(t.Context(), v, storePath, credURL, "main",
+		filepath.Join(tempDir, "probe-miss"), cas.WithOffline())
+	require.ErrorIs(t, probeMiss, cas.ErrCASOffline)
+	assert.NotContains(t, probeMiss.Error(), token, "the probe-side miss must not render the token")
+
+	online, _ := newRecordedVenv(nil)
+	require.NoError(t, cloneInto(t.Context(), online, storePath, credURL, "main", filepath.Join(tempDir, "online")))
+
+	c, err := newStoreCAS(storePath)
+	require.NoError(t, err)
+	require.NoError(t, online.FS.RemoveAll(c.TreeStore().Path()))
+
+	fetchMiss := cloneInto(t.Context(), v, storePath, credURL, "main",
+		filepath.Join(tempDir, "fetch-miss"), cas.WithOffline())
+	require.ErrorIs(t, fetchMiss, cas.ErrCASOffline)
+	assert.NotContains(t, fetchMiss.Error(), token, "the fetch-side miss must not render the token")
+
+	var miss *cas.OfflineMissError
+
+	require.ErrorAs(t, fetchMiss, &miss)
+	assert.Equal(t, repoURL, miss.Source)
+
+	assert.Equal(t, 0, rec.count("ls-remote"))
+	assert.Equal(t, 0, rec.count("fetch"))
+	assert.Equal(t, 0, rec.count("clone"))
+}

--- a/internal/cas/commitref_test.go
+++ b/internal/cas/commitref_test.go
@@ -77,7 +77,7 @@ func TestCASCloneByCommitRef(t *testing.T) {
 		)
 
 		// Drop the test server: a cached clone must not need it.
-		repoEntry := cas.EntryPathForURL(filepath.Join(storePath, "git"), repoURL)
+		repoEntry := cas.EntryPathForURL(filepath.Join(storePath, "git"), repoURL, cas.HashSHA256)
 		_, err = os.Stat(filepath.Join(repoEntry, "repo"))
 		require.NoError(t, err)
 
@@ -554,7 +554,7 @@ func TestCAS_CommitRefFallbackWhenGitStoreFails(t *testing.T) {
 	gitStoreRoot := filepath.Join(storePath, "git")
 	require.NoError(t, os.MkdirAll(gitStoreRoot, 0o755))
 
-	blocker := cas.EntryPathForURL(gitStoreRoot, repoURL)
+	blocker := cas.EntryPathForURL(gitStoreRoot, repoURL, cas.HashSHA256)
 	require.NoError(t, os.WriteFile(blocker, []byte("not a directory"), 0o644))
 
 	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))

--- a/internal/cas/errors.go
+++ b/internal/cas/errors.go
@@ -79,7 +79,33 @@ var (
 	ErrGitStoreFSNotOS      = errors.New("git store requires an OS-backed filesystem")
 	ErrFallbackCloneDir     = errors.New("failed to create fallback clone directory")
 	ErrFetchClosureRequired = errors.New("fetch closure is required")
+	ErrCASOffline           = errors.New("cas offline")
 )
+
+// OfflineMissError reports that --cas-offline forbade the network call
+// that would have filled a gap in the local store. It unwraps to
+// [ErrCASOffline].
+type OfflineMissError struct {
+	// Source is the source URL with any credentials removed.
+	Source string
+	// Ref is the branch, tag, or commit requested. Empty for a source that
+	// is not addressed by ref, such as an object in a bucket, whose URL
+	// already names everything that was asked for.
+	Ref string
+}
+
+func (e *OfflineMissError) Error() string {
+	const gap = " is not in the local CAS store and --cas-offline forbids fetching it; " +
+		"run once without --cas-offline to populate the store, or drop the flag"
+
+	if e.Ref == "" {
+		return e.Source + gap
+	}
+
+	return e.Source + " at " + e.Ref + gap
+}
+
+func (e *OfflineMissError) Unwrap() error { return ErrCASOffline }
 
 // UpdateSourceWithCASRequiresCASError is returned when a block sets
 // update_source_with_cas = true but CAS is unavailable, either because the

--- a/internal/cas/execrecorder_test.go
+++ b/internal/cas/execrecorder_test.go
@@ -1,0 +1,160 @@
+package cas_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+)
+
+// stubHash is the commit hash lsRemoteStub reports.
+const stubHash = "0123456789abcdef0123456789abcdef01234567"
+
+// lsRemoteStub answers `git ls-remote` from memory, counting calls and,
+// when gate is set, holding each call until gate closes or the command's
+// context ends (or gate alone when ignoreCancel is set, standing in for a
+// git that has stopped listening). Every other git subcommand is answered
+// with empty output.
+//
+// The answer names the ref it resolved the way a repository with no
+// shadowing names would: a version-looking request is a tag, HEAD is
+// HEAD, and anything else is a branch. resolvedRef, when set, overrides
+// that for every answer. panicValue, when set, is raised once the gate
+// has been passed, standing in for a bug inside the probe.
+type lsRemoteStub struct {
+	gate         chan struct{}
+	panicValue   any
+	hash         string
+	resolvedRef  string
+	calls        atomic.Int32
+	ignoreCancel bool
+}
+
+// venv returns an in-memory bundle whose git is the stub.
+func (s *lsRemoteStub) venv() *venv.Venv {
+	return venvtest.New().WithExec(newStubGitExec(
+		func(ctx context.Context, inv vexec.Invocation) vexec.Result {
+			if len(inv.Args) == 0 || inv.Args[0] != "ls-remote" {
+				return vexec.Result{}
+			}
+
+			s.calls.Add(1)
+
+			if s.gate != nil && s.ignoreCancel {
+				<-s.gate
+			}
+
+			if s.gate != nil && !s.ignoreCancel {
+				select {
+				case <-s.gate:
+				case <-ctx.Done():
+					return vexec.Result{Err: ctx.Err()}
+				}
+			}
+
+			if s.panicValue != nil {
+				panic(s.panicValue)
+			}
+
+			return vexec.Result{Stdout: []byte(s.hash + "\t" + s.resolved(inv.Args[len(inv.Args)-1]) + "\n")}
+		},
+	))
+}
+
+// resolved returns the ref name the stub reports for the requested ref.
+func (s *lsRemoteStub) resolved(ref string) string {
+	if s.resolvedRef != "" {
+		return s.resolvedRef
+	}
+
+	if ref == "HEAD" {
+		return ref
+	}
+
+	if cas.IsSemverTag("refs/tags/" + ref) {
+		return "refs/tags/" + ref
+	}
+
+	return "refs/heads/" + ref
+}
+
+// gitExecRecorder wraps a real exec, counting git subcommands by name.
+// When gate is set, every ls-remote waits on it before running, and
+// firstLsRemote closes the first time one is prepared, so a test can
+// hold the network step open while it lines up more callers.
+type gitExecRecorder struct {
+	inner         vexec.Exec
+	gate          chan struct{}
+	firstLsRemote chan struct{}
+	counts        map[string]int
+	once          sync.Once
+	mu            sync.Mutex
+}
+
+// newGitExecRecorder wraps inner. A nil gate leaves ls-remote ungated.
+func newGitExecRecorder(inner vexec.Exec, gate chan struct{}) *gitExecRecorder {
+	return &gitExecRecorder{
+		inner:         inner,
+		gate:          gate,
+		firstLsRemote: make(chan struct{}),
+		counts:        make(map[string]int),
+	}
+}
+
+func (r *gitExecRecorder) Command(ctx context.Context, name string, args ...string) vexec.Cmd {
+	sub := ""
+	if len(args) > 0 {
+		sub = args[0]
+	}
+
+	r.mu.Lock()
+	r.counts[sub]++
+	r.mu.Unlock()
+
+	cmd := r.inner.Command(ctx, name, args...)
+
+	if sub != "ls-remote" {
+		return cmd
+	}
+
+	r.once.Do(func() { close(r.firstLsRemote) })
+
+	if r.gate == nil {
+		return cmd
+	}
+
+	return &gatedCmd{Cmd: cmd, ctx: ctx, gate: r.gate}
+}
+
+func (r *gitExecRecorder) LookPath(file string) (string, error) {
+	return r.inner.LookPath(file)
+}
+
+// count returns how many times the git subcommand sub was prepared.
+func (r *gitExecRecorder) count(sub string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.counts[sub]
+}
+
+// gatedCmd delays Run until gate closes, giving up when the command's
+// context ends first.
+type gatedCmd struct {
+	vexec.Cmd
+	ctx  context.Context
+	gate chan struct{}
+}
+
+func (c *gatedCmd) Run() error {
+	select {
+	case <-c.gate:
+		return c.Cmd.Run()
+	case <-c.ctx.Done():
+		return c.ctx.Err()
+	}
+}

--- a/internal/cas/flight.go
+++ b/internal/cas/flight.go
@@ -1,0 +1,229 @@
+package cas
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"sync"
+)
+
+// flights coalesces the remote probe and the tree ingest of every CAS
+// instance in the process. It is package state rather than a CAS field
+// because each call site constructs a CAS per unit, so a `run --all` over
+// units sharing one source builds one CAS each; a group hanging off the
+// instance would never see a second caller. Keys carry the store path,
+// since what a flight produces (a probe-cache entry, a stored tree) lives
+// in one store and instances over different stores must not share it.
+var flights struct {
+	probe  flightGroup[probeResult]
+	ingest flightGroup[string]
+}
+
+// flightGroup coalesces concurrent calls that share a key into one
+// execution, the way golang.org/x/sync/singleflight does, with one change
+// to the context contract. singleflight runs the shared call under the
+// first caller's context, so that caller giving up (its unit finished or
+// its context expired) fails every waiter with the leader's cancellation.
+// Here the call runs under a context detached from any single caller and
+// canceled only once the last waiter has left, while each waiter still
+// returns as soon as its own context ends.
+type flightGroup[T any] struct {
+	flights map[string]*flight[T]
+	mu      sync.Mutex
+}
+
+// flight is one in-progress shared call.
+type flight[T any] struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	done     chan struct{}
+	err      error
+	panic    *flightPanic
+	val      T
+	waiters  int
+	exited   bool
+	finished bool
+}
+
+// flightPanic carries a panic out of the goroutine that ran the shared
+// call and into every waiter. The stack is captured where the panic
+// happened, since re-raising it on a waiter's goroutine would otherwise
+// point at the flight machinery instead of the bug.
+type flightPanic struct {
+	value any
+	stack []byte
+}
+
+func (p *flightPanic) Error() string {
+	return fmt.Sprintf("%v\n\n%s", p.value, p.stack)
+}
+
+// Unwrap returns the panic value when it is itself an error, and nil
+// otherwise.
+func (p *flightPanic) Unwrap() error {
+	err, ok := p.value.(error)
+	if !ok {
+		return nil
+	}
+
+	return err
+}
+
+// do runs fn once for key across concurrent callers and returns its
+// result to each of them. A caller whose ctx ends before the call
+// completes receives ctx.Err(); the call keeps running for the others.
+// A panic in fn is re-raised on every caller still waiting, and fn
+// calling runtime.Goexit exits every waiter the same way, so the shared
+// call cannot escape the recover a caller's goroutine already has. A
+// panic with no caller left to raise it crashes the process from the
+// flight's own goroutine, the way singleflight does, rather than
+// vanishing.
+//
+// fn receives the flight's context, which carries the values of the
+// first caller's ctx (telemetry, logger) but not its cancellation.
+func (g *flightGroup[T]) do(
+	ctx context.Context,
+	key string,
+	fn func(context.Context) (T, error),
+) (T, error) {
+	f := g.join(ctx, key, fn)
+
+	select {
+	case <-f.done:
+		f.raise()
+
+		return f.val, f.err
+	case <-ctx.Done():
+		if g.leave(f) {
+			f.raise()
+		}
+
+		var zero T
+
+		return zero, ctx.Err()
+	}
+}
+
+// join registers the caller on the flight for key, starting one when
+// none is in progress.
+func (g *flightGroup[T]) join(
+	ctx context.Context,
+	key string,
+	fn func(context.Context) (T, error),
+) *flight[T] {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.flights == nil {
+		g.flights = make(map[string]*flight[T])
+	}
+
+	// A flight whose context is already done was abandoned by its last
+	// waiter and is winding down with a cancellation nobody here asked
+	// for, so it is replaced rather than joined.
+	f, ok := g.flights[key]
+	if !ok || f.ctx.Err() != nil {
+		flightCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+
+		f = &flight[T]{ctx: flightCtx, cancel: cancel, done: make(chan struct{})}
+		g.flights[key] = f
+
+		go g.run(key, f, fn)
+	}
+
+	f.waiters++
+
+	return f
+}
+
+// run executes fn for f and publishes the result. The map entry goes
+// before done closes so a caller arriving after completion starts a fresh
+// flight instead of joining a finished one; an entry that already points
+// at a replacement flight is left alone.
+//
+// fn returning normally, panicking, and calling runtime.Goexit are told
+// apart the way singleflight does: recover reports the panic, and a
+// deferred function that runs with neither a normal return nor a
+// recovered value observed is unwinding from Goexit.
+func (g *flightGroup[T]) run(key string, f *flight[T], fn func(context.Context) (T, error)) {
+	returned := false
+	recovered := false
+
+	defer func() {
+		if !returned && !recovered {
+			f.exited = true
+		}
+
+		g.mu.Lock()
+
+		if g.flights[key] == f {
+			delete(g.flights, key)
+		}
+
+		// Waiters that receive through done never leave, so a zero count
+		// here means every caller has already left and none will raise;
+		// a caller leaving after this point raises instead (see leave).
+		f.finished = true
+		orphaned := f.waiters == 0
+
+		g.mu.Unlock()
+
+		f.cancel()
+		close(f.done)
+
+		if orphaned && f.panic != nil {
+			panic(f.panic)
+		}
+	}()
+
+	func() {
+		defer func() {
+			if returned {
+				return
+			}
+
+			if r := recover(); r != nil {
+				f.panic = &flightPanic{value: r, stack: debug.Stack()}
+			}
+		}()
+
+		f.val, f.err = fn(f.ctx)
+		returned = true
+	}()
+
+	if !returned {
+		recovered = true
+	}
+}
+
+// raise replays on the calling goroutine whatever ended fn abnormally.
+func (f *flight[T]) raise() {
+	if f.panic != nil {
+		panic(f.panic)
+	}
+
+	if f.exited {
+		runtime.Goexit()
+	}
+}
+
+// leave drops a waiter from f and cancels the call once nobody is left
+// to receive its result. It reports whether the leaving waiter must
+// raise what ended the call: the call finished under the same lock the
+// count is kept under, so exactly one of run and the last waiter sees
+// the flight both finished and empty.
+func (g *flightGroup[T]) leave(f *flight[T]) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	f.waiters--
+
+	if f.waiters > 0 {
+		return false
+	}
+
+	f.cancel()
+
+	return f.finished
+}

--- a/internal/cas/flight_test.go
+++ b/internal/cas/flight_test.go
@@ -1,0 +1,228 @@
+package cas_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+)
+
+// errProbeBug stands in for a bug inside the shared probe.
+var errProbeBug = errors.New("probe bug")
+
+// TestGitResolver_ProbePanicReachesEveryCallerWithRacing pins that a panic
+// inside the shared probe is raised again on each caller's own goroutine,
+// where the command-level recover lives, instead of unwinding the flight's
+// goroutine and aborting the process without a panic report. The value
+// is an error so the assertion can match it by identity through the
+// wrapper the flight adds.
+func TestGitResolver_ProbePanicReachesEveryCallerWithRacing(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		stub := &lsRemoteStub{hash: stubHash, gate: make(chan struct{}), panicValue: errProbeBug}
+		v := stub.venv()
+		url := "https://example.com/flight-panic.git"
+
+		const callers = 4
+
+		recovered := make([]any, callers)
+		errs := make([]error, callers)
+
+		var wg sync.WaitGroup
+
+		for i := range callers {
+			wg.Go(func() {
+				defer func() { recovered[i] = recover() }()
+
+				r := &cas.GitResolver{Venv: v, Branch: "main"}
+				_, errs[i] = r.Probe(t.Context(), url)
+			})
+		}
+
+		synctest.Wait()
+		require.Equal(t, int32(1), stub.calls.Load(), "every caller must be waiting on one ls-remote")
+
+		close(stub.gate)
+		wg.Wait()
+
+		for i := range callers {
+			require.NoError(t, errs[i], "caller %d must not see the panic as a returned error", i)
+			require.NotNil(t, recovered[i], "caller %d must see the panic on its own goroutine", i)
+
+			err, ok := recovered[i].(error)
+			require.True(t, ok, "caller %d: the panic must carry the original value as an error", i)
+			assert.ErrorIs(t, err, errProbeBug, "caller %d", i)
+		}
+	})
+}
+
+// TestGitResolver_ProbeConcurrentCallersShareOneLsRemoteWithRacing pins the
+// in-process probe flight: 32 resolvers built independently (the shape
+// `run --all` produces, one CAS per unit) probing the same URL and ref at
+// once cost one ls-remote between them. synctest parks every caller before
+// the held ls-remote is released, so the coalescing is observed rather than
+// assumed.
+func TestGitResolver_ProbeConcurrentCallersShareOneLsRemoteWithRacing(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		stub := &lsRemoteStub{hash: stubHash, gate: make(chan struct{})}
+		v := stub.venv()
+
+		const callers = 32
+
+		url := "https://example.com/flight-share.git"
+		hashes := make([]string, callers)
+		errs := make([]error, callers)
+
+		var wg sync.WaitGroup
+
+		for i := range callers {
+			wg.Go(func() {
+				r := &cas.GitResolver{Venv: v, Branch: "main"}
+				hashes[i], errs[i] = r.Probe(t.Context(), url)
+			})
+		}
+
+		synctest.Wait()
+		require.Equal(t, int32(1), stub.calls.Load(), "one ls-remote must be in flight for every caller")
+
+		close(stub.gate)
+		wg.Wait()
+
+		for i := range callers {
+			require.NoError(t, errs[i], "caller %d", i)
+			assert.Equal(t, stubHash, hashes[i], "caller %d", i)
+		}
+
+		assert.Equal(t, int32(1), stub.calls.Load())
+	})
+}
+
+// TestGitResolver_ProbeLeaderCancellationLeavesFollowersIntactWithRacing pins
+// the context contract of the flight: the caller that started the ls-remote
+// cancelling returns its own cancellation, while the flight carries on and
+// still answers everyone who joined it with the single network call.
+func TestGitResolver_ProbeLeaderCancellationLeavesFollowersIntactWithRacing(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		stub := &lsRemoteStub{hash: stubHash, gate: make(chan struct{})}
+		v := stub.venv()
+		url := "https://example.com/flight-leader-cancel.git"
+
+		leaderCtx, cancelLeader := context.WithCancel(t.Context())
+		defer cancelLeader()
+
+		var leaderErr error
+
+		leaderDone := make(chan struct{})
+
+		go func() {
+			defer close(leaderDone)
+
+			r := &cas.GitResolver{Venv: v, Branch: "main"}
+			_, leaderErr = r.Probe(leaderCtx, url)
+		}()
+
+		synctest.Wait()
+		require.Equal(t, int32(1), stub.calls.Load(), "the leader must be parked inside ls-remote")
+
+		const followers = 4
+
+		hashes := make([]string, followers)
+		errs := make([]error, followers)
+
+		var wg sync.WaitGroup
+
+		for i := range followers {
+			wg.Go(func() {
+				r := &cas.GitResolver{Venv: v, Branch: "main"}
+				hashes[i], errs[i] = r.Probe(t.Context(), url)
+			})
+		}
+
+		synctest.Wait()
+
+		cancelLeader()
+		<-leaderDone
+		require.ErrorIs(t, leaderErr, context.Canceled)
+
+		synctest.Wait()
+		require.Equal(t, int32(1), stub.calls.Load(), "the leader leaving must not restart the ls-remote")
+
+		close(stub.gate)
+		wg.Wait()
+
+		for i := range followers {
+			require.NoError(t, errs[i], "follower %d", i)
+			assert.Equal(t, stubHash, hashes[i], "follower %d", i)
+		}
+
+		assert.Equal(t, int32(1), stub.calls.Load())
+	})
+}
+
+// TestGitResolver_ProbeAbandonedFlightIsReplacedForLateCallerWithRacing
+// pins the other half of the context contract: once every waiter has left,
+// the flight is cancelled, and a caller arriving while that cancelled call
+// is still unwinding must get a fresh ls-remote rather than the abandoned
+// call's cancellation.
+func TestGitResolver_ProbeAbandonedFlightIsReplacedForLateCallerWithRacing(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		stub := &lsRemoteStub{hash: stubHash, gate: make(chan struct{}), ignoreCancel: true}
+		v := stub.venv()
+		url := "https://example.com/flight-abandoned.git"
+
+		leaderCtx, cancelLeader := context.WithCancel(t.Context())
+		defer cancelLeader()
+
+		leaderDone := make(chan error, 1)
+
+		go func() {
+			_, err := (&cas.GitResolver{Venv: v, Branch: "main"}).Probe(leaderCtx, url)
+			leaderDone <- err
+		}()
+
+		synctest.Wait()
+		require.Equal(t, int32(1), stub.calls.Load())
+
+		cancelLeader()
+		require.ErrorIs(t, <-leaderDone, context.Canceled)
+
+		// The abandoned call is still parked on the gate, ignoring its
+		// cancellation, when the late caller arrives.
+		synctest.Wait()
+
+		lateDone := make(chan struct{})
+
+		var (
+			lateHash string
+			lateErr  error
+		)
+
+		go func() {
+			defer close(lateDone)
+
+			lateHash, lateErr = (&cas.GitResolver{Venv: v, Branch: "main"}).Probe(t.Context(), url)
+		}()
+
+		synctest.Wait()
+		require.Equal(t, int32(2), stub.calls.Load(), "the late caller must start its own ls-remote")
+
+		close(stub.gate)
+		<-lateDone
+
+		require.NoError(t, lateErr)
+		assert.Equal(t, stubHash, lateHash)
+	})
+}

--- a/internal/cas/gitstore.go
+++ b/internal/cas/gitstore.go
@@ -2,8 +2,6 @@ package cas
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -19,6 +17,8 @@ import (
 
 const (
 	gitStoreURLHashLen = 16
+	// gitStoreURLHashAlgorithm names the per-URL directories under git/.
+	gitStoreURLHashAlgorithm = HashSHA256
 	// gitStoreLockTimeout bounds how long EnsureRef waits for the per-URL
 	// lock before giving up and letting the caller fall back to a temporary
 	// clone. Generous enough to outlast a typical fetch, short enough that a
@@ -282,16 +282,15 @@ func (s *GitStore) RootPath() string {
 }
 
 // EntryPathForURL returns the directory used for the bare repository
-// belonging to url. Exported so tests can place blocking files at the path.
-func EntryPathForURL(rootPath, url string) string {
-	sum := sha256.Sum256([]byte(url))
-	name := hex.EncodeToString(sum[:])[:gitStoreURLHashLen]
-
-	return filepath.Join(rootPath, name)
+// belonging to url, hashed with alg so a caller that records the algorithm
+// in the path above this one derives every component with it. Exported so
+// tests can place blocking files at the path.
+func EntryPathForURL(rootPath, url string, alg HashAlgorithm) string {
+	return filepath.Join(rootPath, alg.Sum([]byte(url))[:gitStoreURLHashLen])
 }
 
 func (s *GitStore) repoPaths(url string) (dir, repo, lockPath string) {
-	dir = EntryPathForURL(s.rootPath, url)
+	dir = EntryPathForURL(s.rootPath, url, gitStoreURLHashAlgorithm)
 	repo = filepath.Join(dir, "repo")
 	lockPath = filepath.Join(dir, "lock")
 

--- a/internal/cas/giturl.go
+++ b/internal/cas/giturl.go
@@ -28,3 +28,17 @@ func StripGitURLParams(u *url.URL) (*url.URL, string) {
 
 	return stripped, ref
 }
+
+// RedactURL returns rawURL with any userinfo removed, so a token embedded
+// in an https URL never reaches an error or a log line. Input net/url
+// cannot parse (SCP form, which carries no secret) comes back unchanged.
+func RedactURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.User == nil {
+		return rawURL
+	}
+
+	u.User = nil
+
+	return u.String()
+}

--- a/internal/cas/giturl_test.go
+++ b/internal/cas/giturl_test.go
@@ -74,3 +74,47 @@ func TestStripGitURLParams(t *testing.T) {
 		})
 	}
 }
+
+func TestRedactURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "userinfo dropped",
+			in:   "https://user:token@example.com/org/repo.git",
+			want: "https://example.com/org/repo.git",
+		},
+		{
+			name: "user only dropped",
+			in:   "https://oauth2@example.com/org/repo.git",
+			want: "https://example.com/org/repo.git",
+		},
+		{
+			name: "no userinfo unchanged",
+			in:   "https://example.com/org/repo.git",
+			want: "https://example.com/org/repo.git",
+		},
+		{
+			name: "scp form unchanged",
+			in:   "git@github.com:org/repo.git",
+			want: "git@github.com:org/repo.git",
+		},
+		{
+			name: "ssh url userinfo dropped",
+			in:   "ssh://git@example.com/org/repo.git",
+			want: "ssh://example.com/org/repo.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, cas.RedactURL(tt.in))
+		})
+	}
+}

--- a/internal/cas/probecache.go
+++ b/internal/cas/probecache.go
@@ -1,0 +1,233 @@
+package cas
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/semver"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+)
+
+// ProbeMode selects how [GitResolver.Probe] treats the network and the
+// persisted probe cache.
+type ProbeMode int
+
+const (
+	// ProbeModeOnline serves a persisted probe that is still within its
+	// TTL and runs ls-remote otherwise.
+	ProbeModeOnline ProbeMode = iota
+	// ProbeModeRefresh never reads the persisted cache, so every probe
+	// reaches the network unless it joins one already in flight. Answers
+	// are still recorded for later runs.
+	ProbeModeRefresh
+	// ProbeModeOffline never runs ls-remote. The persisted cache answers
+	// regardless of TTL and a miss fails with [OfflineMissError].
+	ProbeModeOffline
+)
+
+// DefaultImmutableProbeTTL is how long a persisted probe of a source that
+// cannot change upstream is served without probing again. A semver tag and
+// a version-pinned object are held in place by convention, and nothing
+// enforces it, so the answer is re-checked daily. [ProbeTTL] gives every
+// other source the caller's mutable TTL.
+const DefaultImmutableProbeTTL = 24 * time.Hour
+
+// probeDigestAlgorithm hashes every name the probe cache derives and names
+// the directory every entry is filed under, so the two cannot drift.
+const probeDigestAlgorithm = HashSHA256
+
+const (
+	probeCacheDirName = "probes"
+	probeCacheKeyLen  = 16
+	// probeCacheMaxEntrySize bounds how much of an entry file is read. A
+	// well-formed entry measures 189 bytes with a SHA-1 commit hash and 213
+	// with a SHA-256 one, plus up to 10 more for a timestamp carrying
+	// fractional seconds. Anything approaching this bound is damage and is
+	// read as a miss.
+	probeCacheMaxEntrySize = 512
+)
+
+// ProbeEntry is one persisted probe answer. Every field is fixed width,
+// so an entry is a couple of hundred bytes whatever the source was called
+// and nothing a remote or a configuration chose is written verbatim.
+type ProbeEntry struct {
+	// ProbedAt is when the probe returned Key.
+	ProbedAt time.Time `json:"probed_at"`
+	// RefDigest confirms which ref the entry answers for, against the
+	// shorter digest [ProbeCache.EntryPath] files it under. [ProbeCache]
+	// fills it; callers leave it alone.
+	RefDigest string `json:"ref_digest"`
+	// Key is the cache key the probe produced: a commit hash for git, a
+	// tree-store key from [ContentKey] or [OpaqueKey] for every other
+	// resolver. Hex either way.
+	Key string `json:"key"`
+	// Immutable reports that the source this answers for cannot change
+	// upstream, so the entry is served for [DefaultImmutableProbeTTL]
+	// rather than the caller's mutable TTL.
+	Immutable bool `json:"immutable"`
+}
+
+// ProbeCache persists what each probe resolved a source to under the CAS
+// store, so a later process can skip the probe for a source whose TTL has
+// not run out and so --cas-offline has something to answer from. Entries
+// are partitioned per URL; see [ProbeCache.EntryPath] for how one is
+// addressed.
+//
+// Expired entries stay on disk; nothing here removes them. An expired
+// entry is still a usable one: --cas-offline serves any entry whatever
+// its age, and the default mutable TTL of zero expires a branch's entry
+// the moment it is written. A TTL here is a freshness question, and
+// eviction is out of scope.
+type ProbeCache struct {
+	rootPath string
+}
+
+// NewProbeCache returns a [ProbeCache] rooted at rootPath. Directories
+// are created on first write.
+func NewProbeCache(rootPath string) *ProbeCache {
+	return &ProbeCache{rootPath: rootPath}
+}
+
+// RootPath returns the directory that contains every per-URL entry.
+func (p *ProbeCache) RootPath() string {
+	return p.rootPath
+}
+
+// Lookup returns the entry recorded for (url, ref). ok is false when
+// nothing was recorded or the entry cannot be read or decoded; a damaged
+// entry is never fatal because the next successful probe overwrites it.
+func (p *ProbeCache) Lookup(fsys vfs.FS, url, ref string) (ProbeEntry, bool) {
+	data, err := vfs.ReadFileLimit(fsys, p.EntryPath(url, ref), probeCacheMaxEntrySize)
+	if err != nil {
+		return ProbeEntry{}, false
+	}
+
+	var entry ProbeEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return ProbeEntry{}, false
+	}
+
+	// The path digest is truncated, so a second ref can land on one entry
+	// file. The full digest here tells them apart; a mismatch is treated
+	// as a miss and the next successful probe overwrites the entry.
+	if entry.RefDigest != RefDigest(ref) || entry.Key == "" {
+		return ProbeEntry{}, false
+	}
+
+	return entry, true
+}
+
+// Store records entry as the answer for (url, ref), stamping its
+// timestamp and ref digest in place first. The entry is written to a
+// temporary file and renamed into place, so a concurrent reader sees
+// either the previous entry or this one, never a torn write.
+func (p *ProbeCache) Store(fsys vfs.FS, url, ref string, entry *ProbeEntry) error {
+	path := p.EntryPath(url, ref)
+	dir := filepath.Dir(path)
+
+	if err := fsys.MkdirAll(dir, DefaultDirPerms); err != nil {
+		return fmt.Errorf("create probe cache dir %s: %w", dir, err)
+	}
+
+	entry.ProbedAt = entry.ProbedAt.UTC()
+	entry.RefDigest = RefDigest(ref)
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("encode probe entry for %s: %w", path, err)
+	}
+
+	tmp, err := vfs.CreateTemp(fsys, dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create probe cache temp file in %s: %w", dir, err)
+	}
+
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		return errors.Join(fmt.Errorf("write %s: %w", tmpPath, err), tmp.Close(), fsys.Remove(tmpPath))
+	}
+
+	if err := tmp.Close(); err != nil {
+		return errors.Join(fmt.Errorf("close %s: %w", tmpPath, err), fsys.Remove(tmpPath))
+	}
+
+	if err := fsys.Rename(tmpPath, path); err != nil {
+		return errors.Join(fmt.Errorf("rename %s to %s: %w", tmpPath, path, err), fsys.Remove(tmpPath))
+	}
+
+	return nil
+}
+
+// EntryPath returns the file the answer for (url, ref) is recorded in:
+// <root>/<algorithm>/<url hash>/<ref hash>.json. Both hashed components
+// are hashed because a URL carries characters that are not path-safe and a
+// ref may contain slashes. The URL is redacted first, so a token rotated
+// between runs still finds the answer recorded for the repository it
+// addresses instead of leaving an entry nothing reads again.
+//
+// The algorithm names the directory rather than prefixing each file, which
+// keeps the names legal on Windows, where a colon cannot appear in a path.
+// A later algorithm gets its own subtree, so entries never collide across
+// the two and old ones stay identifiable.
+func (p *ProbeCache) EntryPath(url, ref string) string {
+	name := RefDigest(ref)[:probeCacheKeyLen] + ".json"
+	root := filepath.Join(p.rootPath, string(probeDigestAlgorithm))
+
+	return filepath.Join(EntryPathForURL(root, RedactURL(url), probeDigestAlgorithm), name)
+}
+
+// RefDigest returns the digest an entry records for ref and the name
+// [ProbeCache.EntryPath] truncates for its file. It carries no algorithm
+// label of its own: the directory the entry sits in names the algorithm.
+// Exported so tests can build an entry the cache will accept.
+func RefDigest(ref string) string {
+	return probeDigestAlgorithm.Sum([]byte(probeRefName(ref)))
+}
+
+// ProbeTTL returns how long entry stays fresh: [DefaultImmutableProbeTTL]
+// when it records an immutable source, mutableTTL for everything else
+// (git branches and non-version tags, and every object or endpoint whose
+// URL does not pin a version).
+func ProbeTTL(entry *ProbeEntry, mutableTTL time.Duration) time.Duration {
+	if entry.Immutable {
+		return DefaultImmutableProbeTTL
+	}
+
+	return mutableTTL
+}
+
+// schemeProbeRef namespaces the entries of a resolver whose URL is the
+// whole identity of a source, so they stay clear of the git entries for
+// the same URL. A git ref cannot contain a colon, so no ref reaches this
+// namespace.
+func schemeProbeRef(scheme string) string {
+	return "scheme:" + scheme
+}
+
+// IsSemverTag reports whether ref is a full tag name (refs/tags/...) for
+// a semantic version, with or without a leading "v". A bare name such as
+// v1.2.3 does not qualify: ls-remote lists a branch of that name ahead
+// of the tag, so only the resolved ref says which one answered.
+func IsSemverTag(ref string) bool {
+	name, isTag := strings.CutPrefix(ref, "refs/tags/")
+	if !isTag {
+		return false
+	}
+
+	return semver.IsExact(name)
+}
+
+// probeRefName maps the empty ref to the name ls-remote resolves it as,
+// so an empty branch and an explicit HEAD share one cache entry.
+func probeRefName(ref string) string {
+	if ref == "" {
+		return "HEAD"
+	}
+
+	return ref
+}

--- a/internal/cas/probecache_test.go
+++ b/internal/cas/probecache_test.go
@@ -1,0 +1,399 @@
+package cas_test
+
+import (
+	"path/filepath"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+const probeCacheRoot = "/store/probes"
+
+// newCachingResolver returns a resolver over v whose persisted cache lives
+// on v.FS. Freshness is measured against time.Now, which inside a synctest
+// bubble is the bubble's synthetic clock.
+func newCachingResolver(v *venv.Venv, branch string) *cas.GitResolver {
+	return &cas.GitResolver{
+		Venv:   v,
+		Logger: logger.CreateLogger(),
+		Cache:  cas.NewProbeCache(probeCacheRoot),
+		Branch: branch,
+	}
+}
+
+func TestGitResolver_SemverTagProbeServedFromCacheUntilTTL(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		stub := &lsRemoteStub{hash: stubHash}
+		v := stub.venv()
+		url := "https://example.com/probe-semver.git"
+		r := newCachingResolver(v, "v1.2.3")
+
+		got, err := r.Probe(t.Context(), url)
+		require.NoError(t, err)
+		assert.Equal(t, stubHash, got)
+		require.Equal(t, int32(1), stub.calls.Load())
+
+		got, err = r.Probe(t.Context(), url)
+		require.NoError(t, err)
+		assert.Equal(t, stubHash, got)
+		assert.Equal(t, int32(1), stub.calls.Load(), "a fresh semver probe must be served from the cache")
+
+		synctest.Sleep(cas.DefaultImmutableProbeTTL - time.Minute)
+
+		_, err = r.Probe(t.Context(), url)
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), stub.calls.Load(), "the entry is still inside its TTL")
+
+		synctest.Sleep(2 * time.Minute)
+
+		_, err = r.Probe(t.Context(), url)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), stub.calls.Load(), "an expired entry must be re-probed")
+	})
+}
+
+func TestGitResolver_MutableRefProbeNotServedFromCacheByDefault(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		stub := &lsRemoteStub{hash: stubHash}
+		v := stub.venv()
+		url := "https://example.com/probe-mutable.git"
+		r := newCachingResolver(v, "main")
+
+		_, err := r.Probe(t.Context(), url)
+		require.NoError(t, err)
+
+		_, err = r.Probe(t.Context(), url)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), stub.calls.Load(), "a branch must be re-probed so a push is seen")
+
+		_, ok := r.Cache.Lookup(v.FS, url, "main")
+		assert.True(t, ok, "the answer is still recorded so offline mode can use it")
+	})
+}
+
+func TestGitResolver_MutableRefProbeServedWithinConfiguredTTL(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		stub := &lsRemoteStub{hash: stubHash}
+		v := stub.venv()
+		url := "https://example.com/probe-mutable-ttl.git"
+		r := newCachingResolver(v, "main")
+		r.MutableTTL = time.Hour
+
+		_, err := r.Probe(t.Context(), url)
+		require.NoError(t, err)
+
+		_, err = r.Probe(t.Context(), url)
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), stub.calls.Load())
+
+		synctest.Sleep(2 * time.Hour)
+
+		_, err = r.Probe(t.Context(), url)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), stub.calls.Load())
+	})
+}
+
+// TestGitResolver_BranchNamedLikeVersionIsNotServedAsSemver pins that
+// the semver TTL follows what ls-remote resolved, not the requested
+// name: a branch called v1.2.3 (which ls-remote lists ahead of a tag of
+// the same name) is re-probed like any other branch.
+func TestGitResolver_BranchNamedLikeVersionIsNotServedAsSemver(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		stub := &lsRemoteStub{hash: stubHash, resolvedRef: "refs/heads/v1.2.3"}
+		v := stub.venv()
+		url := "https://example.com/probe-version-branch.git"
+		r := newCachingResolver(v, "v1.2.3")
+
+		_, err := r.Probe(t.Context(), url)
+		require.NoError(t, err)
+
+		_, err = r.Probe(t.Context(), url)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), stub.calls.Load(), "a branch must be re-probed whatever it is called")
+
+		entry, ok := r.Cache.Lookup(v.FS, url, "v1.2.3")
+		require.True(t, ok)
+		assert.False(t, entry.Immutable, "a branch is mutable however it is named")
+	})
+}
+
+func TestGitResolver_RefreshModeBypassesCacheButStillRecords(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		stub := &lsRemoteStub{hash: stubHash}
+		v := stub.venv()
+		url := "https://example.com/probe-refresh.git"
+		r := newCachingResolver(v, "v2.0.0")
+		r.Mode = cas.ProbeModeRefresh
+
+		_, err := r.Probe(t.Context(), url)
+		require.NoError(t, err)
+
+		_, err = r.Probe(t.Context(), url)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), stub.calls.Load(), "refresh must ignore the entry it just wrote")
+
+		entry, ok := r.Cache.Lookup(v.FS, url, "v2.0.0")
+		require.True(t, ok)
+		assert.Equal(t, stubHash, entry.Key)
+	})
+}
+
+func TestGitResolver_CorruptCacheEntryIsIgnoredAndRewritten(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		stub := &lsRemoteStub{hash: stubHash}
+		v := stub.venv()
+		url := "https://example.com/probe-corrupt.git"
+		r := newCachingResolver(v, "v3.0.0")
+
+		path := r.Cache.EntryPath(url, "v3.0.0")
+		require.NoError(t, v.FS.MkdirAll(filepath.Dir(path), cas.DefaultDirPerms))
+		require.NoError(t, vfs.WriteFile(v.FS, path, []byte("{not json"), cas.RegularFilePerms))
+
+		got, err := r.Probe(t.Context(), url)
+		require.NoError(t, err)
+		assert.Equal(t, stubHash, got)
+		assert.Equal(t, int32(1), stub.calls.Load(), "a damaged entry must fall through to ls-remote")
+
+		entry, ok := r.Cache.Lookup(v.FS, url, "v3.0.0")
+		require.True(t, ok, "the damaged entry must have been replaced")
+		assert.Equal(t, stubHash, entry.Key)
+	})
+}
+
+func TestGitResolver_OfflineServesAnyRecordedProbeAndFailsOnMiss(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		stub := &lsRemoteStub{hash: stubHash}
+		v := stub.venv()
+		url := "https://user:token@example.com/probe-offline.git"
+
+		_, err := newCachingResolver(v, "main").Probe(t.Context(), url)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), stub.calls.Load())
+
+		// Well past any TTL a mutable ref could be given.
+		synctest.Sleep(48 * time.Hour)
+
+		offline := newCachingResolver(v, "main")
+		offline.Mode = cas.ProbeModeOffline
+
+		got, err := offline.Probe(t.Context(), url)
+		require.NoError(t, err)
+		assert.Equal(t, stubHash, got)
+		assert.Equal(t, int32(1), stub.calls.Load(), "offline must never reach ls-remote")
+
+		missing := newCachingResolver(v, "feature")
+		missing.Mode = cas.ProbeModeOffline
+
+		_, err = missing.Probe(t.Context(), url)
+		require.ErrorIs(t, err, cas.ErrCASOffline)
+
+		var miss *cas.OfflineMissError
+
+		require.ErrorAs(t, err, &miss)
+		assert.Equal(t, "https://example.com/probe-offline.git", miss.Source, "credentials must not reach the error")
+		assert.Equal(t, "feature", miss.Ref)
+		assert.Equal(t, int32(1), stub.calls.Load())
+	})
+}
+
+// TestGitResolver_OfflineServesProbeRecordedUnderRotatedCredential is the
+// resolver-level half of TestProbeCache_CredentialRotationSharesEntry: an
+// offline run reaching a repository with a new token is answered from the
+// probe the old one recorded, instead of failing on a source the store
+// holds.
+func TestGitResolver_OfflineServesProbeRecordedUnderRotatedCredential(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		stub := &lsRemoteStub{hash: stubHash}
+		v := stub.venv()
+
+		_, err := newCachingResolver(v, "main").
+			Probe(t.Context(), "https://x:token-a@example.com/probe-rotated.git")
+		require.NoError(t, err)
+		require.Equal(t, int32(1), stub.calls.Load())
+
+		offline := newCachingResolver(v, "main")
+		offline.Mode = cas.ProbeModeOffline
+
+		got, err := offline.Probe(t.Context(), "https://x:token-b@example.com/probe-rotated.git")
+		require.NoError(t, err)
+		assert.Equal(t, stubHash, got)
+		assert.Equal(t, int32(1), stub.calls.Load(), "offline must never reach ls-remote")
+	})
+}
+
+func TestProbeCache_StoreAndLookupRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	cache := cas.NewProbeCache(probeCacheRoot)
+	probedAt := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+
+	_, ok := cache.Lookup(fsys, "https://example.com/a.git", "")
+	assert.False(t, ok)
+
+	require.NoError(t, cache.Store(fsys, "https://example.com/a.git", "", &cas.ProbeEntry{
+		ProbedAt: probedAt,
+		Key:      stubHash,
+	}))
+
+	entry, ok := cache.Lookup(fsys, "https://example.com/a.git", "")
+	require.True(t, ok)
+	assert.Equal(t,
+		cas.ProbeEntry{ProbedAt: probedAt, RefDigest: cas.RefDigest("HEAD"), Key: stubHash},
+		entry)
+
+	entry, ok = cache.Lookup(fsys, "https://example.com/a.git", "HEAD")
+	require.True(t, ok, "an empty ref and an explicit HEAD share one entry")
+	assert.Equal(t, stubHash, entry.Key)
+
+	_, ok = cache.Lookup(fsys, "https://example.com/b.git", "")
+	assert.False(t, ok, "entries are partitioned per URL")
+
+	assert.NotEqual(t,
+		cache.EntryPath("https://example.com/a.git", "main"),
+		cache.EntryPath("https://example.com/a.git", "release/main"),
+	)
+}
+
+// TestProbeCache_CredentialRotationSharesEntry pins that the token in a
+// source URL does not partition the cache: a run whose credential was
+// rotated since the store was filled must still find the answer recorded
+// for the repository, or --cas-offline fails on content it already has.
+func TestProbeCache_CredentialRotationSharesEntry(t *testing.T) {
+	t.Parallel()
+
+	fsys := vfs.NewMemMapFS()
+	cache := cas.NewProbeCache(probeCacheRoot)
+
+	require.NoError(t, cache.Store(fsys, "https://x:token-a@example.com/a.git", "main", &cas.ProbeEntry{
+		ProbedAt: time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC),
+		Key:      stubHash,
+	}))
+
+	entry, ok := cache.Lookup(fsys, "https://x:token-b@example.com/a.git", "main")
+	require.True(t, ok, "a rotated credential must find the answer recorded for the same repository")
+	assert.Equal(t, stubHash, entry.Key)
+
+	_, ok = cache.Lookup(fsys, "https://x:token-b@example.com/b.git", "main")
+	assert.False(t, ok, "entries are still partitioned per repository")
+}
+
+func TestProbeCache_LookupRejectsEntryWithWrongRefOrHash(t *testing.T) {
+	t.Parallel()
+
+	cache := cas.NewProbeCache(probeCacheRoot)
+	url := "https://example.com/a.git"
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "ref digest mismatch",
+			body: `{"ref_digest":"` + cas.RefDigest("other") + `","key":"` + stubHash +
+				`","probed_at":"2026-09-07T12:00:00Z"}`,
+		},
+		{
+			name: "no key",
+			body: `{"ref_digest":"` + cas.RefDigest("main") + `","probed_at":"2026-09-07T12:00:00Z"}`,
+		},
+		{name: "empty file", body: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// The entry path is a pure function of (root, URL, ref), so the
+			// cases would otherwise read each other's bodies and the one
+			// that lost the race would assert against the wrong guard.
+			fsys := vfs.NewMemMapFS()
+			path := cache.EntryPath(url, "main")
+			require.NoError(t, fsys.MkdirAll(filepath.Dir(path), cas.DefaultDirPerms))
+			require.NoError(t, vfs.WriteFile(fsys, path, []byte(tt.body), cas.RegularFilePerms))
+
+			_, ok := cache.Lookup(fsys, url, "main")
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestIsSemverTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{ref: "refs/tags/v1.2.3", want: true},
+		{ref: "refs/tags/1.2.3", want: true},
+		{ref: "refs/tags/v1.2.3-rc.1", want: true},
+		{ref: "refs/tags/v1.2.3+build.7", want: true},
+		{ref: "refs/tags/v1.2", want: false},
+		{ref: "refs/tags/v1", want: false},
+		{ref: "refs/tags/latest", want: false},
+		{ref: "refs/tags/release-1.2.3", want: false},
+		{ref: "refs/tags/01.2.3", want: false},
+		{ref: "refs/tags/1.2.3.4", want: false},
+		{ref: "refs/heads/v1.2.3", want: false},
+		{ref: "refs/heads/main", want: false},
+		{ref: "v1.2.3", want: false},
+		{ref: "main", want: false},
+		{ref: "HEAD", want: false},
+		{ref: "", want: false},
+		{ref: stubHash, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, cas.IsSemverTag(tt.ref))
+		})
+	}
+}
+
+func TestProbeTTL(t *testing.T) {
+	t.Parallel()
+
+	immutable := cas.ProbeEntry{Immutable: true}
+	mutable := cas.ProbeEntry{}
+
+	assert.Equal(t, cas.DefaultImmutableProbeTTL, cas.ProbeTTL(&immutable, 0))
+	assert.Equal(t, cas.DefaultImmutableProbeTTL, cas.ProbeTTL(&immutable, time.Hour),
+		"the mutable TTL never applies to an immutable source")
+	assert.Equal(t, time.Duration(0), cas.ProbeTTL(&mutable, 0))
+	assert.Equal(t, time.Hour, cas.ProbeTTL(&mutable, time.Hour))
+}
+
+func TestOfflineMissError_UnwrapsToErrCASOffline(t *testing.T) {
+	t.Parallel()
+
+	err := &cas.OfflineMissError{Source: "https://example.com/a.git", Ref: "main"}
+	assert.ErrorIs(t, err, cas.ErrCASOffline)
+}

--- a/internal/cas/probeorigin_test.go
+++ b/internal/cas/probeorigin_test.go
@@ -1,0 +1,87 @@
+package cas_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+// probeOriginAttr is the span attribute [cas.CAS.FetchSource] stamps with
+// where the probe answer came from.
+const probeOriginAttr = "probe_origin"
+
+// TestProbeOriginStampedOnlyByFetchSource pins which span carries
+// probe_origin. A fetch reports the origin of the probe it ran, while a
+// probe run outside a fetch, the shape stack generation uses to resolve a
+// component's ref, leaves its caller's span alone rather than labelling
+// that span with a fetch attribute.
+func TestProbeOriginStampedOnlyByFetchSource(t *testing.T) {
+	t.Parallel()
+
+	recorder := tracetest.NewSpanRecorder()
+	tracer := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder)).Tracer("cas_test")
+
+	stub := &lsRemoteStub{hash: stubHash}
+	v := stub.venv().WithFS(vfs.NewOSFS())
+	l := logger.CreateLogger()
+
+	c, err := cas.New(v, cas.WithStorePath(filepath.Join(helpers.TmpDirWOSymlinks(t), "store")))
+	require.NoError(t, err)
+
+	fetchCtx, fetchSpan := tracer.Start(t.Context(), "cas_fetch_source")
+	require.NoError(t, c.FetchSource(fetchCtx, l, v, &cas.CloneOptions{Dir: filepath.Join(t.TempDir(), "dst")},
+		cas.SourceRequest{
+			Scheme:       "git",
+			URL:          "https://example.com/probe-origin.git",
+			Resolver:     &cas.GitResolver{Venv: v, Branch: "main"},
+			Fetch:        ingestFixture(t, c),
+			ProbeCaching: cas.ProbeCachedByResolver,
+		}))
+	fetchSpan.End()
+
+	stackCtx, stackSpan := tracer.Start(t.Context(), "stack_generate_unit")
+	_, err = (&cas.GitResolver{Venv: v, Branch: "main"}).
+		Probe(stackCtx, "https://example.com/probe-origin.git")
+	require.NoError(t, err)
+	stackSpan.End()
+
+	origins := map[string]string{}
+
+	for _, span := range recorder.Ended() {
+		for _, attr := range span.Attributes() {
+			if string(attr.Key) == probeOriginAttr {
+				origins[span.Name()] = attr.Value.AsString()
+			}
+		}
+	}
+
+	assert.Equal(t, map[string]string{"cas_fetch_source": "ls_remote"}, origins)
+}
+
+// ingestFixture returns a fetcher that writes one file into a temporary
+// directory and ingests it under the probe's key.
+func ingestFixture(t *testing.T, c *cas.CAS) cas.SourceFetcher {
+	t.Helper()
+
+	return func(_ context.Context, l log.Logger, v *venv.Venv, suggestedKey string) (string, error) {
+		dir := t.TempDir()
+		if err := vfs.WriteFile(v.FS, filepath.Join(dir, "main.tf"), []byte("# hello\n"), cas.RegularFilePerms); err != nil {
+			return "", err
+		}
+
+		return c.IngestDirectory(l, v, dir, suggestedKey)
+	}
+}

--- a/internal/cas/source.go
+++ b/internal/cas/source.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"maps"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -32,6 +33,13 @@ type SourceResolver interface {
 	// "s3", "gcs", "http").
 	Scheme() string
 
+	// Pinned reports whether rawURL names content that cannot change
+	// upstream, such as an object version or an exact module version. A
+	// pinned source's recorded probe is served for
+	// [DefaultImmutableProbeTTL]; everything else is held only for the
+	// mutable TTL the caller set, which is zero by default.
+	Pinned(rawURL string) bool
+
 	// Probe returns a cache key for rawURL.
 	//
 	// Returns ErrNoVersionMetadata when the source has no cheap
@@ -52,6 +60,24 @@ type SourceFetcher func(
 	ctx context.Context, l log.Logger, v *venv.Venv, suggestedKey string,
 ) (treeKey string, err error)
 
+// ProbeCaching says which layer consults and records the probe cache for
+// a source.
+type ProbeCaching int
+
+const (
+	// ProbeCachedByCAS lets [CAS.FetchSource] share the resolver's
+	// answers: concurrent callers coalesce onto one probe, and a recorded
+	// answer is served while it is fresh. This is the zero value, so a new
+	// resolver gets the sharing without opting in.
+	ProbeCachedByCAS ProbeCaching = iota
+	// ProbeCachedByResolver leaves the resolver to it, which [CAS.Clone]
+	// asks for. The git probe answers a pinned commit from the local bare
+	// repository before the offline gate, files entries under the ref it
+	// probed, and reads immutability from the ref ls-remote matched. The
+	// generic path supports none of those.
+	ProbeCachedByResolver
+)
+
 // SourceRequest is the input to CAS.FetchSource.
 type SourceRequest struct {
 	// Resolver probes the source for a cache key. Nil means always
@@ -68,6 +94,9 @@ type SourceRequest struct {
 	// URL is the canonical source URL. Passed to Resolver.Probe and
 	// used in error messages.
 	URL string
+	// ProbeCaching says whether FetchSource shares and persists this
+	// resolver's probe answers or leaves that to the resolver.
+	ProbeCaching ProbeCaching
 }
 
 // FetchSource routes src through the CAS. On a probe hit it links the
@@ -98,7 +127,7 @@ func (c *CAS) FetchSource(
 	}
 
 	attrs := map[string]any{
-		"url":    src.URL,
+		"url":    RedactURL(src.URL),
 		"scheme": src.Scheme,
 	}
 
@@ -112,7 +141,10 @@ func (c *CAS) FetchSource(
 		"cas_fetch_source",
 		attrs,
 		func(childCtx context.Context, l log.Logger) error {
-			suggestedKey := c.probeSource(childCtx, l, src)
+			suggestedKey, err := c.probeSource(childCtx, l, v, src)
+			if err != nil {
+				return err
+			}
 
 			if suggestedKey != "" && !c.treeStore.NeedsWrite(v, suggestedKey) {
 				recordFetchOutcome(childCtx, true)
@@ -124,7 +156,7 @@ func (c *CAS) FetchSource(
 
 			treeKey, err := src.Fetch(childCtx, l, v, suggestedKey)
 			if err != nil {
-				return fmt.Errorf("fetch %s: %w", src.URL, err)
+				return fmt.Errorf("fetch %s: %w", RedactURL(src.URL), err)
 			}
 
 			return c.linkStoredTree(childCtx, l, v, opts, treeKey)
@@ -223,34 +255,156 @@ func (c *CAS) IngestDirectory(
 }
 
 // probeSource invokes the resolver and returns its cache key, or empty
-// when no resolver is configured or the probe failed. See
-// [SourceResolver.Probe] for the fallback contract.
-func (c *CAS) probeSource(ctx context.Context, l log.Logger, src SourceRequest) string {
+// when no resolver is configured or the probe failed, stamping where the
+// answer came from on the cas_fetch_source span this runs under. See
+// [SourceResolver.Probe] for the fallback contract. Two probe errors are
+// returned rather than absorbed: an offline miss, because the fallback
+// fetch would contact the network the user forbade, and a caller whose
+// context has ended, because the fallback would start work nobody is
+// waiting for.
+func (c *CAS) probeSource(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+	src SourceRequest,
+) (string, error) {
 	if src.Resolver == nil {
-		return ""
+		return "", nil
 	}
 
-	key, err := src.Resolver.Probe(ctx, src.URL)
+	probeCtx, origin := withProbeOriginSink(ctx)
+
+	key, err := c.resolveProbe(probeCtx, l, v, src)
 	if err != nil {
+		if errors.Is(err, ErrCASOffline) || ctx.Err() != nil {
+			return "", err
+		}
+
 		// ErrNoVersionMetadata is the resolver's documented "no cheap
 		// signal" answer, not a degradation, so only real probe errors
 		// count as fallbacks.
 		if !errors.Is(err, ErrNoVersionMetadata) {
 			l.Debugf(
 				"cas: source probe for %s failed (falling back to content hash): %v",
-				src.URL,
+				RedactURL(src.URL),
 				err,
 			)
 			RecordFallback(ctx, l, FallbackReasonProbeFailure, map[string]any{
-				"url":    src.URL,
+				"url":    RedactURL(src.URL),
 				"scheme": src.Scheme,
 			})
 		}
 
-		return ""
+		return "", nil
 	}
 
-	return key
+	origin.stamp(ctx)
+
+	return key, nil
+}
+
+// resolveProbe runs the resolver's probe, coalescing it across every
+// caller in the process and answering from the persisted cache when a
+// recorded answer is still fresh, so a run over many units pointing at one
+// source costs one request rather than one per unit. A resolver that owns
+// its cache is called directly and does all of that itself.
+func (c *CAS) resolveProbe(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+	src SourceRequest,
+) (string, error) {
+	if src.ProbeCaching == ProbeCachedByResolver {
+		return src.Resolver.Probe(ctx, src.URL)
+	}
+
+	ref := schemeProbeRef(src.Resolver.Scheme())
+
+	res, err := flights.probe.do(
+		ctx,
+		probeFlightKey(c.probeCache.RootPath(), src.URL, ref),
+		func(ctx context.Context) (probeResult, error) {
+			return c.probeSourceUncoalesced(ctx, l, v, src, ref)
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	recordProbeOrigin(ctx, res.origin)
+
+	return res.key, nil
+}
+
+// probeSourceUncoalesced answers one source probe from the persisted
+// cache or, when the mode allows it, from the resolver, recording a fresh
+// answer for later processes.
+func (c *CAS) probeSourceUncoalesced(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+	src SourceRequest,
+	ref string,
+) (probeResult, error) {
+	if entry, ok := c.cachedSourceProbe(v, src.URL, ref); ok {
+		return probeResult{key: entry.Key, origin: probeOriginProbeCache}, nil
+	}
+
+	if c.probeMode == ProbeModeOffline {
+		return probeResult{}, &OfflineMissError{Source: RedactURL(src.URL)}
+	}
+
+	key, err := src.Resolver.Probe(ctx, src.URL)
+	if err != nil {
+		return probeResult{}, err
+	}
+
+	c.recordSourceProbe(l, v, src, ref, key)
+
+	return probeResult{key: key, origin: probeOriginResolver}, nil
+}
+
+// cachedSourceProbe returns the recorded answer for (url, ref) when the
+// mode allows serving one and it has not aged past its TTL.
+func (c *CAS) cachedSourceProbe(v *venv.Venv, url, ref string) (ProbeEntry, bool) {
+	if !c.probeCacheEnabled || c.probeMode == ProbeModeRefresh {
+		return ProbeEntry{}, false
+	}
+
+	entry, ok := c.probeCache.Lookup(v.FS, url, ref)
+	if !ok {
+		return ProbeEntry{}, false
+	}
+
+	if c.probeMode == ProbeModeOffline {
+		return entry, true
+	}
+
+	ttl := ProbeTTL(&entry, c.probeTTL)
+	if ttl <= 0 || time.Since(entry.ProbedAt) >= ttl {
+		return ProbeEntry{}, false
+	}
+
+	return entry, true
+}
+
+// recordSourceProbe files key as the answer for (url, ref). A write
+// failure only costs the next run a probe, so it is logged rather than
+// returned.
+func (c *CAS) recordSourceProbe(l log.Logger, v *venv.Venv, src SourceRequest, ref, key string) {
+	if !c.probeCacheEnabled {
+		return
+	}
+
+	entry := ProbeEntry{
+		ProbedAt:  time.Now(),
+		Key:       key,
+		Immutable: src.Resolver.Pinned(src.URL),
+	}
+
+	if err := c.probeCache.Store(v.FS, src.URL, ref, &entry); err != nil {
+		l.Debugf("cas: probe cache write for %s failed: %v", RedactURL(src.URL), err)
+	}
 }
 
 // recordFetchOutcome stamps cache_hit on the active cas_fetch_source span
@@ -262,6 +416,70 @@ func recordFetchOutcome(ctx context.Context, cacheHit bool) {
 	}
 
 	span.SetAttributes(attribute.Bool("cache_hit", cacheHit))
+}
+
+// probeOrigin names where a probe answer came from. It travels as the
+// probe_origin attribute on the cas_fetch_source span.
+type probeOrigin string
+
+const (
+	// probeOriginGitStore is a pinned SHA already present in the local
+	// bare repository.
+	probeOriginGitStore probeOrigin = "git_store"
+	// probeOriginProbeCache is a persisted ls-remote answer within its TTL
+	// (or any persisted answer when offline).
+	probeOriginProbeCache probeOrigin = "probe_cache"
+	// probeOriginLsRemote is a network answer, whether this caller ran
+	// ls-remote or joined a flight that did.
+	probeOriginLsRemote probeOrigin = "ls_remote"
+	// probeOriginResolver is an answer a non-git resolver produced, whether
+	// this caller probed or joined a flight that did.
+	probeOriginResolver probeOrigin = "resolver"
+)
+
+// probeOriginSink collects what a resolver reports about its answer.
+// [CAS.probeSource] puts one in the context it probes under, so a probe
+// run outside a fetch, such as the one that resolves a stack component's
+// ref, reports into nothing instead of stamping probe_origin on whichever
+// span its caller happens to be inside.
+type probeOriginSink struct {
+	origin probeOrigin
+}
+
+// probeOriginSinkKey addresses the sink a context carries.
+type probeOriginSinkKey struct{}
+
+// withProbeOriginSink returns ctx carrying a fresh sink, plus the sink.
+func withProbeOriginSink(ctx context.Context) (context.Context, *probeOriginSink) {
+	sink := &probeOriginSink{}
+
+	return context.WithValue(ctx, probeOriginSinkKey{}, sink), sink
+}
+
+// recordProbeOrigin reports where a probe answer came from to the sink
+// ctx carries, if it carries one.
+func recordProbeOrigin(ctx context.Context, origin probeOrigin) {
+	sink, ok := ctx.Value(probeOriginSinkKey{}).(*probeOriginSink)
+	if !ok {
+		return
+	}
+
+	sink.origin = origin
+}
+
+// stamp puts the reported origin on the active cas_fetch_source span so
+// dashboards can tell cached probes from network ones.
+func (s *probeOriginSink) stamp(ctx context.Context) {
+	if s.origin == "" {
+		return
+	}
+
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	span.SetAttributes(attribute.String("probe_origin", string(s.origin)))
 }
 
 // linkStoredTree materializes the tree at key into opts.Dir.

--- a/internal/cas/source_probecache_test.go
+++ b/internal/cas/source_probecache_test.go
@@ -1,0 +1,278 @@
+package cas_test
+
+import (
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+)
+
+const probeCacheTestURL = "https://example.com/mod.tgz"
+
+// TestFetchSourceSharesOneProbeAcrossUnitsWithRacing pins that units
+// resolving one source at the same time cost a single probe. The first
+// probe is held
+// until every goroutine has started so the others join its flight rather
+// than racing it, and the TTL covers any goroutine the scheduler holds
+// back past the flight's completion, so the count is exact rather than
+// probable.
+func TestFetchSourceSharesOneProbeAcrossUnitsWithRacing(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	v := venvtest.NewOSWithEmptyEnv()
+	l := logger.CreateLogger()
+
+	gate := make(chan struct{})
+	resolver := &fakeResolver{
+		scheme: "http",
+		key:    cas.OpaqueKey("http", probeCacheTestURL, "etag-abc"),
+		gate:   gate,
+	}
+
+	const units = 32
+
+	errs := make([]error, units)
+
+	var started, wg sync.WaitGroup
+
+	started.Add(units)
+
+	for i := range units {
+		wg.Go(func() {
+			started.Done()
+
+			errs[i] = fetchThroughNewCAS(t, storePath, v, l, resolver, []cas.Option{cas.WithProbeTTL(time.Hour)})
+		})
+	}
+
+	started.Wait()
+	close(gate)
+	wg.Wait()
+
+	for i := range units {
+		require.NoError(t, errs[i], "unit %d", i)
+	}
+
+	assert.Equal(t, int32(1), resolver.calls.Load(), "every unit must share one probe")
+}
+
+// TestFetchSourceServesRecordedProbeWithinTTL pins that a later process
+// reuses the recorded answer instead of probing again, so --cas-probe-ttl
+// pays off for a source that is not a git repository.
+func TestFetchSourceServesRecordedProbeWithinTTL(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	v := venvtest.NewOSWithEmptyEnv()
+	l := logger.CreateLogger()
+
+	resolver := &fakeResolver{scheme: "http", key: cas.OpaqueKey("http", probeCacheTestURL, "etag-abc")}
+
+	var fetchCalls atomic.Int32
+
+	fetchOnce := func(c *cas.CAS) error {
+		return c.FetchSource(t.Context(), l, v, &cas.CloneOptions{Dir: filepath.Join(t.TempDir(), "dst")},
+			cas.SourceRequest{
+				Scheme:   "http",
+				URL:      probeCacheTestURL,
+				Resolver: resolver,
+				Fetch:    fakeFetcher(c, map[string]string{"main.tf": "# hello"}, &fetchCalls),
+			})
+	}
+
+	first, err := cas.New(venvtest.NewWithOSFS(),
+		cas.WithStorePath(storePath), cas.WithProbeCache(), cas.WithProbeTTL(time.Hour))
+	require.NoError(t, err)
+	require.NoError(t, fetchOnce(first))
+	require.Equal(t, int32(1), resolver.calls.Load())
+
+	second, err := cas.New(venvtest.NewWithOSFS(),
+		cas.WithStorePath(storePath), cas.WithProbeCache(), cas.WithProbeTTL(time.Hour))
+	require.NoError(t, err)
+	require.NoError(t, fetchOnce(second))
+
+	assert.Equal(t, int32(1), resolver.calls.Load(), "the recorded answer stood in for a second probe")
+}
+
+// TestFetchSourceReProbesWithoutTTL pins the default: a source that can
+// change upstream is probed on every run, so a new object is picked up
+// without the caller having to pass --cas-refresh.
+func TestFetchSourceReProbesWithoutTTL(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	v := venvtest.NewOSWithEmptyEnv()
+	l := logger.CreateLogger()
+
+	resolver := &fakeResolver{scheme: "http", key: cas.OpaqueKey("http", probeCacheTestURL, "etag-abc")}
+
+	require.NoError(t, fetchThroughNewCAS(t, storePath, v, l, resolver, nil))
+	require.NoError(t, fetchThroughNewCAS(t, storePath, v, l, resolver, nil))
+
+	assert.Equal(t, int32(2), resolver.calls.Load())
+}
+
+// TestFetchSourcePinnedSourceOutlivesMutableTTL pins that a URL naming a
+// version keeps its recorded answer for a day even though the caller set
+// no mutable TTL, matching how a semver tag is treated on the git side.
+func TestFetchSourcePinnedSourceOutlivesMutableTTL(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	v := venvtest.NewOSWithEmptyEnv()
+	l := logger.CreateLogger()
+
+	resolver := &fakeResolver{
+		scheme: "s3",
+		key:    cas.OpaqueKey("s3", probeCacheTestURL, "checksum-abc"),
+		pinned: true,
+	}
+
+	require.NoError(t, fetchThroughNewCAS(t, storePath, v, l, resolver, nil))
+	require.NoError(t, fetchThroughNewCAS(t, storePath, v, l, resolver, nil))
+
+	assert.Equal(t, int32(1), resolver.calls.Load())
+}
+
+// TestFetchSourceRefreshIgnoresRecordedProbe pins that --cas-refresh
+// reaches the remote even for an answer that has not expired.
+func TestFetchSourceRefreshIgnoresRecordedProbe(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	v := venvtest.NewOSWithEmptyEnv()
+	l := logger.CreateLogger()
+
+	resolver := &fakeResolver{
+		scheme: "s3",
+		key:    cas.OpaqueKey("s3", probeCacheTestURL, "checksum-abc"),
+		pinned: true,
+	}
+
+	require.NoError(t, fetchThroughNewCAS(t, storePath, v, l, resolver, nil))
+	require.NoError(t, fetchThroughNewCAS(t, storePath, v, l, resolver, []cas.Option{cas.WithProbeRefresh()}))
+
+	assert.Equal(t, int32(2), resolver.calls.Load())
+}
+
+// TestFetchSourceOfflineServesRecordedProbe pins that --cas-offline
+// resolves a non-git source from what an earlier run recorded, however old
+// that answer is, without reaching the remote.
+func TestFetchSourceOfflineServesRecordedProbe(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	v := venvtest.NewOSWithEmptyEnv()
+	l := logger.CreateLogger()
+
+	resolver := &fakeResolver{scheme: "http", key: cas.OpaqueKey("http", probeCacheTestURL, "etag-abc")}
+
+	require.NoError(t, fetchThroughNewCAS(t, storePath, v, l, resolver, nil))
+	require.NoError(t, fetchThroughNewCAS(t, storePath, v, l, resolver, []cas.Option{cas.WithOffline()}))
+
+	assert.Equal(t, int32(1), resolver.calls.Load(), "offline never reached the resolver")
+}
+
+// TestFetchSourceOfflineMissFails pins that an offline run refuses a
+// source nothing recorded, naming it, rather than quietly probing it.
+func TestFetchSourceOfflineMissFails(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	v := venvtest.NewOSWithEmptyEnv()
+	l := logger.CreateLogger()
+
+	resolver := &fakeResolver{scheme: "http", key: cas.OpaqueKey("http", probeCacheTestURL, "etag-abc")}
+
+	err := fetchThroughNewCAS(t, storePath, v, l, resolver, []cas.Option{cas.WithOffline()})
+
+	var miss *cas.OfflineMissError
+
+	require.ErrorAs(t, err, &miss)
+	require.ErrorIs(t, err, cas.ErrCASOffline)
+	assert.Equal(t, probeCacheTestURL, miss.Source)
+	assert.Equal(t, int32(0), resolver.calls.Load())
+}
+
+// TestFetchSourceRecordsNothingWithoutProbeCache pins the gate that keeps
+// recording behind the offline-cas experiment: with no caller asking for
+// the cache, a second process re-probes and the store holds nothing it
+// could have read.
+func TestFetchSourceRecordsNothingWithoutProbeCache(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	v := venvtest.NewOSWithEmptyEnv()
+	l := logger.CreateLogger()
+
+	resolver := &fakeResolver{
+		scheme: "s3",
+		key:    cas.OpaqueKey("s3", probeCacheTestURL, "checksum-abc"),
+		pinned: true,
+	}
+
+	fetch := func() error {
+		c, err := cas.New(venvtest.NewWithOSFS(),
+			cas.WithStorePath(storePath), cas.WithProbeTTL(time.Hour))
+		require.NoError(t, err)
+
+		var fetchCalls atomic.Int32
+
+		return c.FetchSource(t.Context(), l, v, &cas.CloneOptions{Dir: filepath.Join(t.TempDir(), "dst")},
+			cas.SourceRequest{
+				Scheme:   resolver.scheme,
+				URL:      probeCacheTestURL,
+				Resolver: resolver,
+				Fetch:    fakeFetcher(c, map[string]string{"main.tf": "# hello"}, &fetchCalls),
+			})
+	}
+
+	require.NoError(t, fetch())
+	require.NoError(t, fetch())
+
+	assert.Equal(t, int32(2), resolver.calls.Load(), "neither a TTL nor a pin caches an answer")
+	assert.NoDirExists(t, filepath.Join(storePath, "probes"))
+}
+
+// fetchThroughNewCAS runs one FetchSource against a CAS built over
+// storePath, so each call stands for a separate Terragrunt process sharing
+// one store. The persisted probe cache is on, as it is for a run with the
+// offline-cas experiment enabled.
+func fetchThroughNewCAS(
+	t *testing.T,
+	storePath string,
+	v *venv.Venv,
+	l log.Logger,
+	resolver *fakeResolver,
+	opts []cas.Option,
+) error {
+	t.Helper()
+
+	base := make([]cas.Option, 0, len(opts)+2)
+	base = append(base, cas.WithStorePath(storePath), cas.WithProbeCache())
+
+	c, err := cas.New(venvtest.NewWithOSFS(), append(base, opts...)...)
+	require.NoError(t, err)
+
+	var fetchCalls atomic.Int32
+
+	return c.FetchSource(t.Context(), l, v, &cas.CloneOptions{Dir: filepath.Join(t.TempDir(), "dst")},
+		cas.SourceRequest{
+			Scheme:   resolver.scheme,
+			URL:      probeCacheTestURL,
+			Resolver: resolver,
+			Fetch:    fakeFetcher(c, map[string]string{"main.tf": "# hello"}, &fetchCalls),
+		})
+}

--- a/internal/cas/source_test.go
+++ b/internal/cas/source_test.go
@@ -328,15 +328,23 @@ func TestContentKey_DoesNotCollideWithOpaqueKey(t *testing.T) {
 // fakeResolver returns a canned cache key on Probe.
 type fakeResolver struct {
 	err    error
+	gate   chan struct{}
 	scheme string
 	key    string
 	calls  atomic.Int32
+	pinned bool
 }
 
 func (f *fakeResolver) Scheme() string { return f.scheme }
 
+func (f *fakeResolver) Pinned(_ string) bool { return f.pinned }
+
 func (f *fakeResolver) Probe(_ context.Context, _ string) (string, error) {
 	f.calls.Add(1)
+
+	if f.gate != nil {
+		<-f.gate
+	}
 
 	if f.err != nil {
 		return "", f.err

--- a/internal/cas/stacks.go
+++ b/internal/cas/stacks.go
@@ -112,7 +112,7 @@ func (c *CAS) ProcessStackComponent(
 	// stacks; CommitHash returns the user input as-is for the
 	// commit-ref path, and the canonical hash for the symbolic-ref
 	// path.
-	resolved, err := c.resolveReference(ctx, v, cleanURL, ref)
+	resolved, err := c.resolveReference(ctx, l, v, cleanURL, ref)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve reference %q: %w", ref, err)
 	}

--- a/internal/cli/app_errors_test.go
+++ b/internal/cli/app_errors_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli"
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags/shared"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/runner/runall"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 
@@ -67,6 +68,41 @@ func TestUsingAllAndGraphFlagsSimultaneously(t *testing.T) {
 
 	expectedErr := new(shared.AllGraphFlagsError)
 	require.ErrorAs(t, err, &expectedErr)
+}
+
+// TestUsingCASOfflineAndRefreshFlagsSimultaneously pins the refusal to
+// answer only from the probe cache while also ignoring it, in either
+// flag order since each flag's check runs after both are parsed.
+func TestUsingCASOfflineAndRefreshFlagsSimultaneously(t *testing.T) {
+	t.Parallel()
+
+	for _, args := range [][]string{
+		{"run", "--experiment", experiment.OfflineCAS, "--cas-offline", "--cas-refresh"},
+		{"run", "--experiment", experiment.OfflineCAS, "--cas-refresh", "--cas-offline"},
+	} {
+		_, err := runCLI(t, venvtest.New(), args...)
+
+		expectedErr := new(shared.CASOfflineRefreshFlagsError)
+		require.ErrorAs(t, err, &expectedErr)
+	}
+}
+
+// TestCASProbeCacheFlagsRequireExperiment pins that each flag controlling the
+// persisted probe cache is refused until the experiment that gates it is on.
+func TestCASProbeCacheFlagsRequireExperiment(t *testing.T) {
+	t.Parallel()
+
+	for flagName, args := range map[string][]string{
+		shared.CASOfflineFlagName:  {"run", "--cas-offline"},
+		shared.CASRefreshFlagName:  {"run", "--cas-refresh"},
+		shared.CASProbeTTLFlagName: {"run", "--cas-probe-ttl", "10m"},
+	} {
+		_, err := runCLI(t, venvtest.New(), args...)
+
+		gateErr := new(shared.CASExperimentRequiredError)
+		require.ErrorAs(t, err, &gateErr)
+		assert.Equal(t, flagName, gateErr.FlagName)
+	}
 }
 
 // TestShowErrorWhenRunAllInvokedWithoutArguments pins that `run --all` with no

--- a/internal/cli/commands/catalog/tui/load.go
+++ b/internal/cli/commands/catalog/tui/load.go
@@ -82,6 +82,10 @@ func LoadURL(
 		WalkWithSymlinks: walkWithSymlinks,
 		AllowCAS:         allowCAS,
 		CASCloneDepth:    opts.CASCloneDepth,
+		CASProbeTTL:      opts.CASProbeTTL,
+		CASOffline:       opts.CASOffline,
+		CASRefresh:       opts.CASRefresh,
+		CASProbeCache:    opts.Experiments.Evaluate(experiment.OfflineCAS),
 		SlowReporting:    slowReporting,
 		RootWorkingDir:   opts.RootWorkingDir,
 	})

--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -49,11 +49,11 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
 	"github.com/gruntwork-io/terragrunt/internal/os/exec"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
+	semver "github.com/gruntwork-io/terragrunt/internal/semver"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 	"github.com/gruntwork-io/terragrunt/internal/tips"
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
-	"github.com/hashicorp/go-version"
 )
 
 // Command category names.
@@ -246,7 +246,7 @@ func GiveWindowsSymlinksTip(
 	envs map[string]string,
 	providerCacheEnabled bool,
 	tfImpl tfimpl.Type,
-	tfVersion *version.Version,
+	tfVersion *semver.Version,
 ) {
 	if goos != "windows" {
 		return
@@ -287,7 +287,7 @@ func GiveWindowsSymlinksTip(
 	}
 
 	if tfImpl == tfimpl.OpenTofu && tfVersion != nil {
-		minVersion, verErr := version.NewVersion("1.12.0")
+		minVersion, verErr := semver.Parse("1.12.0")
 		if verErr == nil && !tfVersion.LessThan(minVersion) {
 			tip.Message = tips.WindowsSymlinkWarningOpenTofuMessage
 		}
@@ -477,7 +477,7 @@ func setupAutoProviderCacheDir(
 		return errors.New("cannot determine OpenTofu version")
 	}
 
-	requiredVersion, err := version.NewVersion(minTofuVersionForAutoProviderCacheDir)
+	requiredVersion, err := semver.Parse(minTofuVersionForAutoProviderCacheDir)
 	if err != nil {
 		return fmt.Errorf("failed to parse required version: %w", err)
 	}
@@ -672,10 +672,10 @@ func initialSetup(
 	}
 
 	// --- Terragrunt Version
-	terragruntVersion, err := version.NewVersion(cliCtx.Version)
+	terragruntVersion, err := semver.Parse(cliCtx.Version)
 	if err != nil {
 		// Malformed Terragrunt version; set the version to 0.0
-		if terragruntVersion, err = version.NewVersion("0.0"); err != nil {
+		if terragruntVersion, err = semver.Parse("0.0"); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/commands/commands_test.go
+++ b/internal/cli/commands/commands_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands"
+	semver "github.com/gruntwork-io/terragrunt/internal/semver"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/tips"
@@ -12,7 +13,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
-	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,13 +22,13 @@ func TestGiveWindowsSymlinksTip(t *testing.T) {
 	cacheEnv := map[string]string{tf.EnvNameTFPluginCacheDir: "/some/cache/dir"}
 	emptyEnv := map[string]string{}
 
-	openTofuV1120 := version.Must(version.NewVersion("1.12.0"))
-	openTofuV1110 := version.Must(version.NewVersion("1.11.0"))
+	openTofuV1120 := semver.MustParse("1.12.0")
+	openTofuV1110 := semver.MustParse("1.11.0")
 
 	testCases := []struct {
 		fs                   vfs.FS
 		environ              map[string]string
-		tfVersion            *version.Version
+		tfVersion            *semver.Version
 		name                 string
 		goos                 string
 		tfImpl               tfimpl.Type

--- a/internal/cli/commands/run/flags.go
+++ b/internal/cli/commands/run/flags.go
@@ -189,7 +189,8 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv, prefi
 			Name:        NoHooksFlagName,
 			EnvVars:     tgPrefix.EnvVars(NoHooksFlagName),
 			Destination: &opts.NoRunHooks,
-			Usage:       "Disable Terragrunt hooks during run. Requires the 'optional-hooks' experiment.",
+			Usage: flags.ExperimentUsage(opts.Experiments, experiment.OptionalHooks,
+				"Disable Terragrunt hooks during run."),
 			Action: func(_ context.Context, _ *clihelper.Context, value bool) error {
 				if !value {
 					return nil
@@ -207,7 +208,8 @@ func NewFlags(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv, prefi
 			Name:        NoDependencyOutputsFlagName,
 			EnvVars:     tgPrefix.EnvVars(NoDependencyOutputsFlagName),
 			Destination: &opts.SkipOutput,
-			Usage:       "Skip all dependency output resolution. Dependency blocks will not call tofu/terraform output. Requires the 'optional-dependency-outputs' experiment.",
+			Usage: flags.ExperimentUsage(opts.Experiments, experiment.OptionalDependencyOutputs,
+				"Skip all dependency output resolution. Dependency blocks will not call tofu/terraform output."),
 			Action: func(_ context.Context, _ *clihelper.Context, value bool) error {
 				if !value {
 					return nil

--- a/internal/cli/flags/experiment_usage.go
+++ b/internal/cli/flags/experiment_usage.go
@@ -1,0 +1,23 @@
+package flags
+
+import (
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+)
+
+// ExperimentUsage returns usage with a note that the flag needs the named
+// experiment, while that experiment is still ongoing. Once it graduates the
+// note disappears on its own, so a flag cannot go on advertising a gate that
+// no longer holds.
+//
+// Build every gated flag's usage through here rather than writing the
+// sentence into the string: the two are then impossible to update out of
+// step, and moving [experiment.Experiment.Status] to
+// [experiment.StatusCompleted] is the only edit graduation needs.
+func ExperimentUsage(exps experiment.Experiments, name, usage string) string {
+	exp := exps.Find(name)
+	if exp == nil || exp.Status != experiment.StatusOngoing {
+		return usage
+	}
+
+	return usage + " Requires the '" + name + "' experiment."
+}

--- a/internal/cli/flags/experiment_usage_test.go
+++ b/internal/cli/flags/experiment_usage_test.go
@@ -1,0 +1,88 @@
+package flags_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
+	"github.com/gruntwork-io/terragrunt/internal/cli/flags/shared"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+)
+
+const gatedUsage = "Do the thing."
+
+func TestExperimentUsageWhileOngoing(t *testing.T) {
+	t.Parallel()
+
+	exps := experiment.Experiments{{Name: "an-experiment", Status: experiment.StatusOngoing}}
+
+	assert.Equal(t,
+		gatedUsage+" Requires the 'an-experiment' experiment.",
+		flags.ExperimentUsage(exps, "an-experiment", gatedUsage))
+}
+
+// TestExperimentUsageDropsNoteOnGraduation pins the reason the note is built
+// rather than written: moving the experiment to completed is the only edit
+// graduation needs, so no flag is left advertising a gate that is gone.
+func TestExperimentUsageDropsNoteOnGraduation(t *testing.T) {
+	t.Parallel()
+
+	exps := experiment.Experiments{{Name: "an-experiment", Status: experiment.StatusCompleted}}
+
+	assert.Equal(t, gatedUsage, flags.ExperimentUsage(exps, "an-experiment", gatedUsage))
+}
+
+func TestExperimentUsageUnknownExperiment(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, gatedUsage, flags.ExperimentUsage(experiment.Experiments{}, "absent", gatedUsage))
+}
+
+// TestGatedFlagUsageFollowsExperimentStatus pins that the flags actually
+// gated on offline-cas build their usage through [flags.ExperimentUsage],
+// so the note tracks the experiment instead of a hand-written string.
+func TestGatedFlagUsageFollowsExperimentStatus(t *testing.T) {
+	t.Parallel()
+
+	gated := []string{
+		shared.CASOfflineFlagName,
+		shared.CASRefreshFlagName,
+		shared.CASProbeTTLFlagName,
+	}
+
+	t.Run("ongoing", func(t *testing.T) {
+		t.Parallel()
+
+		opts := options.NewTerragruntOptions(vexec.NewOSExec())
+		casFlags := shared.NewCASFlags(opts, flags.Prefix{})
+
+		for _, name := range gated {
+			f := casFlags.Get(name)
+			require.NotNil(t, f, name)
+			assert.Contains(t, f.GetUsage(), "Requires the 'offline-cas' experiment.", name)
+		}
+	})
+
+	t.Run("completed", func(t *testing.T) {
+		t.Parallel()
+
+		opts := options.NewTerragruntOptions(vexec.NewOSExec())
+
+		exp := opts.Experiments.Find(experiment.OfflineCAS)
+		require.NotNil(t, exp)
+		exp.Status = experiment.StatusCompleted
+
+		casFlags := shared.NewCASFlags(opts, flags.Prefix{})
+
+		for _, name := range gated {
+			f := casFlags.Get(name)
+			require.NotNil(t, f, name)
+			assert.NotContains(t, strings.ToLower(f.GetUsage()), "experiment", name)
+		}
+	})
+}

--- a/internal/cli/flags/global/flags.go
+++ b/internal/cli/flags/global/flags.go
@@ -475,14 +475,9 @@ func NewProfileFlags(opts *options.TerragruntOptions, prefix flags.Prefix) clihe
 	}
 }
 
-// profileFlagUsage appends the experiment requirement to the usage text while the profiling experiment is ongoing.
+// profileFlagUsage names the experiment every profiling flag is gated on.
 func profileFlagUsage(opts *options.TerragruntOptions, usage string) string {
-	exp := opts.Experiments.Find(experiment.Profiling)
-	if exp == nil || exp.Status != experiment.StatusOngoing {
-		return usage
-	}
-
-	return usage + " Requires the 'profiling' experiment."
+	return flags.ExperimentUsage(opts.Experiments, experiment.Profiling, usage)
 }
 
 func NewLogLevelFlag(

--- a/internal/cli/flags/shared/cas.go
+++ b/internal/cli/flags/shared/cas.go
@@ -1,8 +1,13 @@
 package shared
 
 import (
+	"context"
+	"errors"
+	"time"
+
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 )
 
@@ -11,13 +16,27 @@ const (
 	NoCASFlagName = "no-cas"
 	// CASCloneDepthFlagName is the name of the flag that controls the git clone depth CAS uses.
 	CASCloneDepthFlagName = "cas-clone-depth"
+	// CASOfflineFlagName is the name of the flag that forbids CAS from contacting a Git remote.
+	CASOfflineFlagName = "cas-offline"
+	// CASRefreshFlagName is the name of the flag that makes CAS ignore its persisted probe cache.
+	CASRefreshFlagName = "cas-refresh"
+	// CASProbeTTLFlagName is the name of the flag that sets how long CAS trusts a
+	// persisted probe of a branch, HEAD, or non-version tag.
+	CASProbeTTLFlagName = "cas-probe-ttl"
 )
 
+var errNegativeProbeTTL = errors.New("must not be negative")
+
 // NewCASFlags creates the flags controlling CAS (Content Addressable Storage)
-// behavior: --no-cas to disable CAS even when the experiment is enabled, and
-// --cas-clone-depth to control the git clone depth CAS uses.
+// behavior: --no-cas to disable CAS even when the experiment is enabled,
+// --cas-clone-depth to control the git clone depth CAS uses, --cas-offline
+// and --cas-refresh to pin or bypass the persisted probe cache, and
+// --cas-probe-ttl to set how long probes of mutable refs are trusted. The last
+// three are gated behind the [experiment.OfflineCAS] experiment.
 func NewCASFlags(opts *options.TerragruntOptions, prefix flags.Prefix) clihelper.Flags {
 	tgPrefix := prefix.Prepend(flags.TgPrefix)
+
+	var probeTTLText string
 
 	return clihelper.Flags{
 		flags.NewFlag(&clihelper.BoolFlag{
@@ -31,6 +50,80 @@ func NewCASFlags(opts *options.TerragruntOptions, prefix flags.Prefix) clihelper
 			EnvVars:     tgPrefix.EnvVars(CASCloneDepthFlagName),
 			Destination: &opts.CASCloneDepth,
 			Usage:       "When using CAS, pass this value to git clone --depth (default 1; -1 clones full history). For negative values use --cas-clone-depth=-1 so the dash doesn't result in the value being parsed as a flag.",
+		}),
+		flags.NewFlag(&clihelper.BoolFlag{
+			Name:        CASOfflineFlagName,
+			EnvVars:     tgPrefix.EnvVars(CASOfflineFlagName),
+			Destination: &opts.CASOffline,
+			Usage: flags.ExperimentUsage(opts.Experiments, experiment.OfflineCAS,
+				"When using CAS, never contact a Git remote: answer every Git source from the local store and the persisted probe cache, and fail on anything missing. Other sources, such as HTTP or S3, still reach their remote."),
+			Action: func(_ context.Context, _ *clihelper.Context, value bool) error {
+				if !value {
+					return nil
+				}
+
+				if !opts.Experiments.Evaluate(experiment.OfflineCAS) {
+					return &CASExperimentRequiredError{FlagName: CASOfflineFlagName}
+				}
+
+				if opts.CASRefresh {
+					return new(CASOfflineRefreshFlagsError)
+				}
+
+				return nil
+			},
+		}),
+		flags.NewFlag(&clihelper.BoolFlag{
+			Name:        CASRefreshFlagName,
+			EnvVars:     tgPrefix.EnvVars(CASRefreshFlagName),
+			Destination: &opts.CASRefresh,
+			Usage: flags.ExperimentUsage(opts.Experiments, experiment.OfflineCAS,
+				"When using CAS, ignore the persisted probe cache and query every source's remote again."),
+			Action: func(_ context.Context, _ *clihelper.Context, value bool) error {
+				if !value {
+					return nil
+				}
+
+				if !opts.Experiments.Evaluate(experiment.OfflineCAS) {
+					return &CASExperimentRequiredError{FlagName: CASRefreshFlagName}
+				}
+
+				if opts.CASOffline {
+					return new(CASOfflineRefreshFlagsError)
+				}
+
+				return nil
+			},
+		}),
+		flags.NewFlag(&clihelper.GenericFlag[string]{
+			Name:        CASProbeTTLFlagName,
+			EnvVars:     tgPrefix.EnvVars(CASProbeTTLFlagName),
+			Destination: &probeTTLText,
+			Usage: flags.ExperimentUsage(opts.Experiments, experiment.OfflineCAS,
+				"When using CAS, trust a persisted probe of a branch, HEAD, or non-version tag for this long (for example 10m) before querying the remote again. Defaults to 0, which re-queries on every run. Version tags are trusted for 24h regardless."),
+			Setter: func(value string) error {
+				ttl, err := time.ParseDuration(value)
+				if err != nil {
+					return err
+				}
+
+				if ttl < 0 {
+					return errNegativeProbeTTL
+				}
+
+				opts.CASProbeTTL = ttl
+
+				return nil
+			},
+			Action: func(_ context.Context, _ *clihelper.Context, value string) error {
+				// A TTL of zero is a valid value and also the default, so only the
+				// raw text distinguishes a flag that was set from one that was not.
+				if value == "" || opts.Experiments.Evaluate(experiment.OfflineCAS) {
+					return nil
+				}
+
+				return &CASExperimentRequiredError{FlagName: CASProbeTTLFlagName}
+			},
 		}),
 	}
 }

--- a/internal/cli/flags/shared/cas_test.go
+++ b/internal/cli/flags/shared/cas_test.go
@@ -1,0 +1,108 @@
+package shared_test
+
+import (
+	"flag"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
+	"github.com/gruntwork-io/terragrunt/internal/cli/flags/shared"
+	"github.com/gruntwork-io/terragrunt/internal/clihelper"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCASProbeTTLFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    clihelper.Args
+		wantTTL time.Duration
+		wantErr bool
+	}{
+		{name: "unset", args: clihelper.Args{}, wantTTL: 0},
+		{name: "minutes", args: clihelper.Args{"--cas-probe-ttl", "10m"}, wantTTL: 10 * time.Minute},
+		{name: "zero", args: clihelper.Args{"--cas-probe-ttl", "0"}, wantTTL: 0},
+		{name: "negative", args: clihelper.Args{"--cas-probe-ttl", "-1h"}, wantErr: true},
+		{name: "not a duration", args: clihelper.Args{"--cas-probe-ttl", "soon"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var opts options.TerragruntOptions
+
+			fs := new(flag.FlagSet)
+			fs.SetOutput(io.Discard)
+
+			for _, f := range shared.NewCASFlags(&opts, flags.Prefix{}) {
+				require.NoError(t, f.Apply(fs, map[string]string{}))
+			}
+
+			err := fs.Parse(tt.args)
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantTTL, opts.CASProbeTTL)
+		})
+	}
+}
+
+func TestCASProbeFlagsRequireExperiment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		env      map[string]string
+		name     string
+		flagName string
+		args     clihelper.Args
+	}{
+		{name: "offline", flagName: shared.CASOfflineFlagName, args: clihelper.Args{"--cas-offline"}, env: map[string]string{}},
+		{name: "refresh", flagName: shared.CASRefreshFlagName, args: clihelper.Args{"--cas-refresh"}, env: map[string]string{}},
+		{name: "probe ttl", flagName: shared.CASProbeTTLFlagName, args: clihelper.Args{"--cas-probe-ttl", "10m"}, env: map[string]string{}},
+		{name: "zero probe ttl", flagName: shared.CASProbeTTLFlagName, args: clihelper.Args{"--cas-probe-ttl", "0"}, env: map[string]string{}},
+		{name: "offline env var", flagName: shared.CASOfflineFlagName, env: map[string]string{"TG_CAS_OFFLINE": "true"}},
+		{name: "refresh env var", flagName: shared.CASRefreshFlagName, env: map[string]string{"TG_CAS_REFRESH": "true"}},
+		{name: "probe ttl env var", flagName: shared.CASProbeTTLFlagName, env: map[string]string{"TG_CAS_PROBE_TTL": "10m"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := options.NewTerragruntOptions(vexec.NewOSExec())
+			casFlags := shared.NewCASFlags(opts, flags.Prefix{})
+
+			require.NoError(t, casFlags.Parse(tt.args, tt.env))
+
+			err := casFlags.RunActions(t.Context(), &clihelper.Context{})
+
+			var gateErr *shared.CASExperimentRequiredError
+			require.ErrorAs(t, err, &gateErr)
+			assert.Equal(t, tt.flagName, gateErr.FlagName)
+
+			require.NoError(t, opts.Experiments.EnableExperiment(experiment.OfflineCAS))
+			require.NoError(t, casFlags.RunActions(t.Context(), &clihelper.Context{}))
+		})
+	}
+}
+
+func TestCASProbeFlagsAllowedWithoutExperimentWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
+	casFlags := shared.NewCASFlags(opts, flags.Prefix{})
+
+	require.NoError(t, casFlags.Parse(clihelper.Args{"--no-cas", "--cas-clone-depth", "3"}, map[string]string{}))
+	require.NoError(t, casFlags.RunActions(t.Context(), &clihelper.Context{}))
+}

--- a/internal/cli/flags/shared/errors.go
+++ b/internal/cli/flags/shared/errors.go
@@ -1,8 +1,28 @@
 package shared
 
+import "github.com/gruntwork-io/terragrunt/internal/experiment"
+
 // AllGraphFlagsError is returned when both --all and --graph flags are used simultaneously.
 type AllGraphFlagsError byte
 
 func (err *AllGraphFlagsError) Error() string {
 	return "Using the `--all` and `--graph` flags simultaneously is not supported."
+}
+
+// CASOfflineRefreshFlagsError is returned when both --cas-offline and --cas-refresh flags are used simultaneously.
+type CASOfflineRefreshFlagsError byte
+
+func (err *CASOfflineRefreshFlagsError) Error() string {
+	return "Using the `--cas-offline` and `--cas-refresh` flags simultaneously is not supported: " +
+		"offline mode answers from the persisted probe cache that refresh ignores."
+}
+
+// CASExperimentRequiredError is returned when a CAS probe cache flag is set without the offline-cas experiment enabled.
+type CASExperimentRequiredError struct {
+	FlagName string
+}
+
+func (err *CASExperimentRequiredError) Error() string {
+	return "--" + err.FlagName + " requires the '" + experiment.OfflineCAS +
+		"' experiment to be enabled (e.g., --experiment=" + experiment.OfflineCAS + ")"
 }

--- a/internal/cli/flags/shared/filter.go
+++ b/internal/cli/flags/shared/filter.go
@@ -113,7 +113,8 @@ func NewFilterFlags(l log.Logger, opts *options.TerragruntOptions, v *venv.Venv)
 				Name:        DiscoveryBoundaryFlagName,
 				EnvVars:     tgPrefix.EnvVars(DiscoveryBoundaryFlagName),
 				Destination: &opts.DiscoveryBoundary,
-				Usage:       "Bound --filter discovery to a directory, not git root. Requires the 'bounded-discovery' experiment.",
+				Usage: flags.ExperimentUsage(opts.Experiments, experiment.BoundedDiscovery,
+					"Bound --filter discovery to a directory, not git root."),
 				Action: func(_ context.Context, _ *clihelper.Context, value string) error {
 					if value == "" {
 						return nil

--- a/internal/configbridge/bridge.go
+++ b/internal/configbridge/bridge.go
@@ -88,6 +88,9 @@ func populateFromOpts(pctx *config.ParsingContext, opts *options.TerragruntOptio
 	pctx.NoStackValidate = opts.NoStackValidate
 	pctx.NoCAS = opts.NoCAS
 	pctx.CASCloneDepth = opts.CASCloneDepth
+	pctx.CASOffline = opts.CASOffline
+	pctx.CASRefresh = opts.CASRefresh
+	pctx.CASProbeTTL = opts.CASProbeTTL
 	pctx.ScaffoldRootFileName = opts.ScaffoldRootFileName
 	pctx.TerragruntStackConfigPath = opts.TerragruntStackConfigPath
 	pctx.ProviderCacheOptions = opts.ProviderCacheOptions
@@ -184,6 +187,9 @@ func NewRunOptions(opts *options.TerragruntOptions) *run.Options {
 	runOpts.DisableBucketUpdate = opts.DisableBucketUpdate
 	runOpts.SourceUpdate = opts.SourceUpdate
 	runOpts.CASCloneDepth = opts.CASCloneDepth
+	runOpts.CASOffline = opts.CASOffline
+	runOpts.CASRefresh = opts.CASRefresh
+	runOpts.CASProbeTTL = opts.CASProbeTTL
 	runOpts.NoCAS = opts.NoCAS
 	runOpts.NoHooks = opts.NoRunHooks
 

--- a/internal/configbridge/copy_test.go
+++ b/internal/configbridge/copy_test.go
@@ -2,6 +2,7 @@ package configbridge_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/configbridge"
 	"github.com/gruntwork-io/terragrunt/internal/engine"
@@ -69,6 +70,9 @@ func TestNewParsingContextCopiesEveryOption(t *testing.T) {
 	assert.True(t, pctx.NoStackValidate)
 	assert.True(t, pctx.NoCAS)
 	assert.Equal(t, opts.CASCloneDepth, pctx.CASCloneDepth)
+	assert.True(t, pctx.CASOffline)
+	assert.True(t, pctx.CASRefresh)
+	assert.Equal(t, opts.CASProbeTTL, pctx.CASProbeTTL)
 	assert.Equal(t, opts.ScaffoldRootFileName, pctx.ScaffoldRootFileName)
 	assert.Equal(t, opts.TerragruntStackConfigPath, pctx.TerragruntStackConfigPath)
 	assert.Equal(t, opts.ProviderCacheOptions, pctx.ProviderCacheOptions)
@@ -155,6 +159,9 @@ func TestNewRunOptionsCopiesEveryOption(t *testing.T) {
 	assert.True(t, runOpts.DisableBucketUpdate)
 	assert.True(t, runOpts.SourceUpdate)
 	assert.Equal(t, opts.CASCloneDepth, runOpts.CASCloneDepth)
+	assert.True(t, runOpts.CASOffline)
+	assert.True(t, runOpts.CASRefresh)
+	assert.Equal(t, opts.CASProbeTTL, runOpts.CASProbeTTL)
 	assert.True(t, runOpts.NoCAS)
 	assert.True(t, runOpts.NoHooks, "NoHooks is fed by NoRunHooks, so before/after hooks stay disabled when asked")
 
@@ -290,6 +297,7 @@ func optionsWithDistinctValues(t *testing.T) *options.TerragruntOptions {
 	opts.TerragruntStackConfigPath = "/copy/unit/terragrunt.stack.hcl"
 	opts.MaxFoldersToCheck = 42
 	opts.CASCloneDepth = 7
+	opts.CASProbeTTL = 90 * time.Second
 	opts.IAMRoleOptions = iam.RoleOptions{
 		RoleARN:               "arn:aws:iam::111111111111:role/resolved",
 		AssumeRoleSessionName: "resolved-session",
@@ -337,6 +345,8 @@ func optionsWithDistinctValues(t *testing.T) *options.TerragruntOptions {
 	opts.CheckDependentUnits = true
 	opts.NoStackValidate = true
 	opts.NoCAS = true
+	opts.CASOffline = true
+	opts.CASRefresh = true
 
 	return opts
 }

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -117,6 +117,9 @@ const (
 	TGLogin = "tg-login"
 	// Base64GzipCompat enables the base64gzip_compat HCL function.
 	Base64GzipCompat = "base64gzip-compat"
+	// OfflineCAS gates the CAS flags that control the persisted probe cache:
+	// --cas-offline, --cas-refresh, and --cas-probe-ttl.
+	OfflineCAS = "offline-cas"
 )
 
 const (
@@ -240,6 +243,9 @@ func NewExperiments() Experiments {
 		},
 		{
 			Name: Base64GzipCompat,
+		},
+		{
+			Name: OfflineCAS,
 		},
 	}
 }

--- a/internal/getter/casgetter_oci_test.go
+++ b/internal/getter/casgetter_oci_test.go
@@ -296,6 +296,8 @@ type movingTagResolver struct {
 
 func (r *movingTagResolver) Scheme() string { return getter.SchemeOCI }
 
+func (r *movingTagResolver) Pinned(string) bool { return false }
+
 func (r *movingTagResolver) Probe(ctx context.Context, rawURL string) (string, error) {
 	digestValue, err := r.ResolveDigest(ctx, rawURL)
 	if err != nil {
@@ -376,6 +378,8 @@ type probeOnlyResolver struct {
 }
 
 func (r *probeOnlyResolver) Scheme() string { return getter.SchemeOCI }
+
+func (r *probeOnlyResolver) Pinned(string) bool { return false }
 
 func (r *probeOnlyResolver) Probe(context.Context, string) (string, error) {
 	return r.key, nil

--- a/internal/getter/resolver_gcs.go
+++ b/internal/getter/resolver_gcs.go
@@ -66,6 +66,10 @@ func NewGCSResolver(v *venv.Venv) *GCSResolver { return &GCSResolver{Venv: v} }
 // Scheme returns "gcs".
 func (r *GCSResolver) Scheme() string { return "gcs" }
 
+// Pinned always reports false: a GCS URL names an object without a
+// generation, so the probe describes whichever one is current.
+func (r *GCSResolver) Pinned(_ string) bool { return false }
+
 // Probe reads object metadata via ObjectHandle.Attrs and returns a
 // content-addressed cache key from MD5 (when present) or CRC32C
 // (always populated by GCS). Errors surface as

--- a/internal/getter/resolver_hg.go
+++ b/internal/getter/resolver_hg.go
@@ -40,6 +40,36 @@ func NewHgResolver(e vexec.Exec) *HgResolver { return &HgResolver{Exec: e} }
 // Scheme returns "hg".
 func (r *HgResolver) Scheme() string { return "hg" }
 
+// Pinned reports whether rawURL names a full changeset node, which
+// addresses one changeset for good.
+func (r *HgResolver) Pinned(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+
+	return isHgNode(u.Query().Get("rev"))
+}
+
+// isHgNode reports whether rev is a full 40-character changeset node
+// rather than a name or an abbreviation, which can both come to mean a
+// different changeset.
+func isHgNode(rev string) bool {
+	const hgNodeLen = 40
+
+	if len(rev) != hgNodeLen {
+		return false
+	}
+
+	for _, r := range rev {
+		if !strings.ContainsRune("0123456789abcdefABCDEF", r) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Probe runs `hg identify --template '{node}\n'` against rawURL and
 // returns the 40-char node hash as a content-addressed cache key. The
 // ref comes from the URL's `rev` query parameter; absent or empty

--- a/internal/getter/resolver_http.go
+++ b/internal/getter/resolver_http.go
@@ -56,6 +56,12 @@ func (r *HTTPResolver) Scheme() string {
 	return r.scheme
 }
 
+// Pinned always reports false. A ?checksum= pin looks like it should
+// qualify, but the parameter is stripped before probing, so two URLs
+// pinning different checksums share one recorded answer keyed on the
+// ETag the endpoint currently serves.
+func (r *HTTPResolver) Pinned(_ string) bool { return false }
+
 // Probe HEADs rawURL and returns a URL-scoped opaque cache key derived
 // from the ETag (preferred) or Last-Modified header.
 //

--- a/internal/getter/resolver_oci.go
+++ b/internal/getter/resolver_oci.go
@@ -39,6 +39,17 @@ func NewOCIResolver(l log.Logger, newStore OCINewStoreFunc) *OCIResolver {
 // Scheme returns "oci".
 func (r *OCIResolver) Scheme() string { return SchemeOCI }
 
+// Pinned reports whether rawURL names a manifest digest, which addresses
+// the manifest content itself. A tag can be moved to another manifest.
+func (r *OCIResolver) Pinned(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+
+	return u.Query().Has(ociDigestQueryKey)
+}
+
 // Probe returns the manifest digest of rawURL as a content-addressed cache
 // key. Any failure returns [cas.ErrNoVersionMetadata] so the fetch falls
 // through to the download-then-content-hash path, surfacing the underlying

--- a/internal/getter/resolver_pinned_test.go
+++ b/internal/getter/resolver_pinned_test.go
@@ -1,0 +1,109 @@
+package getter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+)
+
+// TestResolverPinned pins which URLs each resolver reports as naming
+// content that cannot change upstream. A pinned source keeps its recorded
+// probe for a day; everything else is re-probed unless the caller sets a
+// mutable TTL, so a URL wrongly called pinned serves a stale answer.
+func TestResolverPinned(t *testing.T) {
+	t.Parallel()
+
+	v := venvtest.New()
+
+	tests := []struct {
+		resolver getter.SourceResolver
+		name     string
+		url      string
+		want     bool
+	}{
+		{
+			name:     "s3 object version",
+			resolver: getter.NewS3Resolver(v),
+			url:      "https://bucket.s3.us-west-2.amazonaws.com/key.tgz?version=abc123",
+			want:     true,
+		},
+		{
+			name:     "s3 without a version",
+			resolver: getter.NewS3Resolver(v),
+			url:      "https://bucket.s3.us-west-2.amazonaws.com/key.tgz",
+			want:     false,
+		},
+		{
+			name:     "oci manifest digest",
+			resolver: getter.NewOCIResolver(logger.CreateLogger(), nil),
+			url:      "oci://registry.example.com/mod?digest=sha256:" + hexOf64,
+			want:     true,
+		},
+		{
+			name:     "oci tag",
+			resolver: getter.NewOCIResolver(logger.CreateLogger(), nil),
+			url:      "oci://registry.example.com/mod?tag=latest",
+			want:     false,
+		},
+		{
+			name:     "tfr exact version",
+			resolver: getter.NewTFRResolver(),
+			url:      "tfr://registry.opentofu.org/org/mod/aws?version=1.2.3",
+			want:     true,
+		},
+		{
+			name:     "tfr version constraint",
+			resolver: getter.NewTFRResolver(),
+			url:      "tfr://registry.opentofu.org/org/mod/aws?version=%3E%3D1.2.0",
+			want:     false,
+		},
+		{
+			name:     "tfr without a version",
+			resolver: getter.NewTFRResolver(),
+			url:      "tfr://registry.opentofu.org/org/mod/aws",
+			want:     false,
+		},
+		{
+			name:     "hg changeset node",
+			resolver: getter.NewHgResolver(vexec.NewOSExec()),
+			url:      "https://hg.example.com/repo?rev=" + hexOf40,
+			want:     true,
+		},
+		{
+			name:     "hg branch name",
+			resolver: getter.NewHgResolver(vexec.NewOSExec()),
+			url:      "https://hg.example.com/repo?rev=default",
+			want:     false,
+		},
+		{
+			name:     "gcs object",
+			resolver: getter.NewGCSResolver(v),
+			url:      "gs://bucket/object.zip",
+			want:     false,
+		},
+		{
+			name:     "http with a checksum",
+			resolver: getter.NewHTTPSResolver(),
+			url:      "https://example.com/mod.tgz?checksum=sha256:" + hexOf64,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, tt.resolver.Pinned(tt.url))
+		})
+	}
+}
+
+const (
+	hexOf40 = "0123456789abcdef0123456789abcdef01234567"
+	hexOf64 = hexOf40 + "89abcdef0123456789abcdef"
+)

--- a/internal/getter/resolver_s3.go
+++ b/internal/getter/resolver_s3.go
@@ -91,6 +91,22 @@ func NewS3Resolver(v *venv.Venv) *S3Resolver { return &S3Resolver{Venv: v, Logge
 // Scheme returns "s3".
 func (r *S3Resolver) Scheme() string { return "s3" }
 
+// Pinned reports whether rawURL carries an object version, which S3
+// never reissues.
+func (r *S3Resolver) Pinned(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+
+	target, err := parseS3URL(u)
+	if err != nil {
+		return false
+	}
+
+	return target.Version != ""
+}
+
 // Probe runs HeadObject with ChecksumMode=ENABLED and returns a
 // cache key from the strongest available token. The cascade prefers
 // content-addressed checksums (cross-URL dedupe) over the opaque ETag

--- a/internal/getter/resolver_tfr.go
+++ b/internal/getter/resolver_tfr.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/semver"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -76,6 +77,23 @@ func (r *TFRResolver) WithTofuImplementation(impl tfimpl.Type) *TFRResolver {
 
 // Scheme returns "tfr".
 func (r *TFRResolver) Scheme() string { return SchemeTFR }
+
+// Pinned reports whether rawURL names one exact module version, which a
+// registry publishes once. A constraint can start matching a newer
+// release.
+func (r *TFRResolver) Pinned(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+
+	versions, ok := u.Query()[versionQueryKey]
+	if !ok || len(versions) != 1 {
+		return false
+	}
+
+	return semver.IsExact(versions[0])
+}
 
 // resolverAuth returns r.Auth carrying the resolver's implementation, so credential
 // lookup reads the same implementation's CLI config files as registry-domain selection.

--- a/internal/getter/tfrhelpers.go
+++ b/internal/getter/tfrhelpers.go
@@ -13,12 +13,12 @@ import (
 
 	"errors"
 
+	semver "github.com/gruntwork-io/terragrunt/internal/semver"
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	goversion "github.com/hashicorp/go-version"
 	svchost "github.com/hashicorp/terraform-svchost"
 	"golang.org/x/sync/singleflight"
 )
@@ -243,7 +243,7 @@ func GetLatestModuleVersion(
 		return "", err
 	}
 
-	stable := make([]*goversion.Version, 0, len(versions))
+	stable := make([]*semver.Version, 0, len(versions))
 
 	for _, v := range versions {
 		if v.Prerelease() != "" {
@@ -262,7 +262,7 @@ func GetLatestModuleVersion(
 		)
 	}
 
-	latest := slices.MaxFunc(stable, func(a, b *goversion.Version) int { return a.Compare(b) })
+	latest := slices.MaxFunc(stable, func(a, b *semver.Version) int { return a.Compare(b) })
 
 	return latest.Original(), nil
 }
@@ -282,7 +282,7 @@ func GetMatchingModuleVersion(
 	auth RegistryAuth,
 	registryDomain, moduleRegistryBasePath, modulePath, constraint string,
 ) (string, error) {
-	constraints, err := goversion.NewConstraint(constraint)
+	constraints, err := semver.ParseConstraint(constraint)
 	if err != nil {
 		return "", ConstraintParseErr{constraint: constraint, err: err}
 	}
@@ -300,7 +300,7 @@ func GetMatchingModuleVersion(
 		return "", err
 	}
 
-	matching := make([]*goversion.Version, 0, len(versions))
+	matching := make([]*semver.Version, 0, len(versions))
 
 	for _, v := range versions {
 		if constraints.Check(v) {
@@ -316,7 +316,7 @@ func GetMatchingModuleVersion(
 		}
 	}
 
-	match := slices.MaxFunc(matching, func(a, b *goversion.Version) int { return a.Compare(b) })
+	match := slices.MaxFunc(matching, func(a, b *semver.Version) int { return a.Compare(b) })
 
 	return match.Original(), nil
 }
@@ -388,7 +388,7 @@ func SourceHasVersionConstraint(source string) bool {
 		return false
 	}
 
-	_, err = goversion.NewVersion(version)
+	_, err = semver.Parse(version)
 
 	return err != nil
 }
@@ -489,7 +489,7 @@ func listModuleVersions(
 	c vhttp.Client,
 	auth RegistryAuth,
 	registryDomain, moduleRegistryBasePath, modulePath string,
-) ([]*goversion.Version, error) {
+) ([]*semver.Version, error) {
 	moduleRegistryBasePath = strings.TrimSuffix(moduleRegistryBasePath, "/")
 	modulePath = strings.TrimSuffix(modulePath, "/")
 	modulePath = strings.TrimPrefix(modulePath, "/")
@@ -532,10 +532,10 @@ func listModuleVersions(
 		)
 	}
 
-	parsed := make([]*goversion.Version, 0, len(versionsResp.Modules[0].Versions))
+	parsed := make([]*semver.Version, 0, len(versionsResp.Modules[0].Versions))
 
 	for _, v := range versionsResp.Modules[0].Versions {
-		pv, err := goversion.NewVersion(v.Version)
+		pv, err := semver.Parse(v.Version)
 		if err != nil {
 			l.Debugf("Skipping unparsable version %q for module %s: %v", v.Version, modulePath, err)
 			continue

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -13,11 +13,11 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/internal/os/signal"
+	semver "github.com/gruntwork-io/terragrunt/internal/semver"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/hashicorp/go-version"
 )
 
 const (
@@ -163,7 +163,7 @@ func (g *GitRunner) LatestReleaseTag(ctx context.Context, remote string) (string
 		return "", err
 	}
 
-	var best *version.Version
+	var best *semver.Version
 
 	for _, r := range results {
 		name := strings.TrimPrefix(r.Ref, refsTags)
@@ -172,7 +172,7 @@ func (g *GitRunner) LatestReleaseTag(ctx context.Context, remote string) (string
 			continue
 		}
 
-		v, err := version.NewVersion(name)
+		v, err := semver.Parse(name)
 		if err != nil {
 			continue
 		}

--- a/internal/runner/builder_test.go
+++ b/internal/runner/builder_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	goversion "github.com/hashicorp/go-version"
+	semver "github.com/gruntwork-io/terragrunt/internal/semver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -248,7 +248,7 @@ func TestNew_VersionConstraints(t *testing.T) {
 			writeUnit(t, v, memRoot, "vpc", tc.unitBody)
 
 			opts := newStackOpts(t, memRoot, tf.CommandNamePlan)
-			opts.TerragruntVersion = goversion.Must(goversion.NewVersion("0.1.0"))
+			opts.TerragruntVersion = semver.MustParse("0.1.0")
 
 			rnr, err := runner.New(t.Context(), thlogger.CreateLogger(), v, opts)
 
@@ -277,7 +277,7 @@ func TestCheckUnitVersionConstraints_UnitLeftUnparsed(t *testing.T) {
 	require.Nil(t, unit.Config(), "the unit has no parsed config for the check to reuse")
 
 	opts := newStackOpts(t, memRoot, tf.CommandNamePlan)
-	opts.TerragruntVersion = goversion.Must(goversion.NewVersion("0.1.0"))
+	opts.TerragruntVersion = semver.MustParse("0.1.0")
 
 	l := thlogger.CreateLogger()
 

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -584,7 +584,8 @@ func downloadSource(
 // is recoverable (CAS init failure, CAS-getter download failure). Caller
 // should fall through to the standard getter.
 // Returns (false, err) for fatal misconfiguration the user must fix
-// (e.g. an invalid CASCloneDepth). Caller must propagate the error.
+// (e.g. an invalid CASCloneDepth) and for any failure the caller must not
+// recover from (see [casFailureIsFatal]). Caller must propagate the error.
 func tryCASDownload(
 	ctx context.Context,
 	l log.Logger,
@@ -612,8 +613,26 @@ func tryCASDownload(
 		return false, err
 	}
 
-	c, err := cas.New(v, cas.WithCloneDepth(opts.CASCloneDepth))
+	casOpts := []cas.Option{cas.WithCloneDepth(opts.CASCloneDepth), cas.WithProbeTTL(opts.CASProbeTTL)}
+
+	if opts.Experiments.Evaluate(experiment.OfflineCAS) {
+		casOpts = append(casOpts, cas.WithProbeCache())
+	}
+
+	if opts.CASOffline {
+		casOpts = append(casOpts, cas.WithOffline())
+	}
+
+	if opts.CASRefresh {
+		casOpts = append(casOpts, cas.WithProbeRefresh())
+	}
+
+	c, err := cas.New(v, casOpts...)
 	if err != nil {
+		if casFailureIsFatal(opts, err) {
+			return false, err
+		}
+
 		l.Warnf("Failed to initialize CAS: %v. Falling back to standard getter.", err)
 		cas.RecordFallback(
 			ctx,
@@ -626,6 +645,10 @@ func tryCASDownload(
 	}
 
 	if _, err := git.NewGitRunner(v); err != nil {
+		if casFailureIsFatal(opts, err) {
+			return false, err
+		}
+
 		l.Warnf("Failed to initialize CAS environment: %v. Falling back to standard getter.", err)
 		cas.RecordFallback(
 			ctx,
@@ -679,6 +702,10 @@ func tryCASDownload(
 		Dst: src.DownloadDir,
 		Pwd: opts.CacheDir,
 	}); err != nil {
+		if casFailureIsFatal(opts, err) {
+			return false, err
+		}
+
 		l.Warnf("CAS download failed: %v. Falling back to standard getter.", err)
 		cas.RecordFallback(
 			ctx,
@@ -700,6 +727,19 @@ func tryCASDownload(
 	l.Debugf("Successfully downloaded source using CAS: %s", canonicalSourceURL)
 
 	return true, nil
+}
+
+// casFailureIsFatal reports whether err ends the run instead of sending
+// the source through the standard getter. An offline miss says so
+// outright, and while --cas-offline is set no source reaching here has a
+// fallback left: a local path never gets this far, so every route the
+// standard getter has is to the remote the flag forbids.
+func casFailureIsFatal(opts *Options, err error) bool {
+	if errors.Is(err, cas.ErrCASOffline) {
+		return true
+	}
+
+	return opts.CASOffline
 }
 
 // BuildDownloadClient constructs the go-getter client used for the standard

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -1264,6 +1264,188 @@ func TestDownloadSourceWithCASGitSource(t *testing.T) {
 	assert.FileExists(t, expectedFilePath)
 }
 
+// TestDownloadSourceWithCASOfflineDamagedStoreFails pins the same rule for a
+// store that answers the probe but cannot produce the content: the recorded
+// probe and the tree survive, the file content behind them does not, and the
+// run fails instead of quietly cloning from the remote.
+func TestDownloadSourceWithCASOfflineDamagedStoreFails(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+	cacheDir := filepath.Join(tmpDir, "cache")
+
+	srv := helpers.NewGitServer(t)
+	srv.AddFixtures("test/fixtures/download/hello-world")
+
+	sourceURL := parseURL(t, srv.SourceURL("test/fixtures/download/hello-world", ""))
+
+	newSource := func(name string) *tf.Source {
+		dir := filepath.Join(tmpDir, name)
+
+		return &tf.Source{
+			CanonicalSourceURL: sourceURL,
+			DownloadDir:        dir,
+			WorkingDir:         dir,
+			VersionFile:        filepath.Join(dir, "version-file.txt"),
+		}
+	}
+
+	opts, err := options.NewTerragruntOptionsForTest("./should-not-be-used")
+	require.NoError(t, err)
+
+	opts.Experiments = experiment.NewExperiments()
+	require.NoError(t, opts.Experiments.EnableExperiment(experiment.OfflineCAS))
+
+	cfg := &runcfg.RunConfig{
+		Terraform: runcfg.TerraformConfig{
+			ExtraArgs: []runcfg.TerraformExtraArguments{},
+		},
+	}
+
+	l := logger.CreateLogger()
+	l.SetOptions(log.WithOutput(io.Discard))
+
+	// The store is this test's own, so the online run below is what fills it.
+	v := venvtest.NewOSWithEmptyEnv()
+	platform := *v.Platform
+	platform.UserCacheDir = func() (string, error) { return cacheDir, nil }
+	v.Platform = &platform
+
+	online := newSource("online")
+	_, err = run.DownloadTerraformSourceIfNecessary(
+		t.Context(), l, v, online, configbridge.NewRunOptions(opts), cfg, report.NewReport(),
+	)
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(online.DownloadDir, "main.tf"))
+
+	require.NoError(t, v.FS.RemoveAll(filepath.Join(cacheDir, "terragrunt", "cas", "store", "blobs")))
+
+	opts.CASOffline = true
+
+	offline := newSource("offline")
+	_, err = run.DownloadTerraformSourceIfNecessary(
+		t.Context(), l, v, offline, configbridge.NewRunOptions(opts), cfg, report.NewReport(),
+	)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, cas.ErrCASOffline, "the probe is answered; the store fails on the content behind it")
+
+	assert.NoFileExists(t, filepath.Join(offline.DownloadDir, "main.tf"), "the standard getter must not have fetched the source")
+}
+
+// TestDownloadSourceWithCASOfflineMissFails pins that --cas-offline turns a
+// source the store lacks into the run's error rather than a fallback to the
+// standard getter, which would clone over the network the flag forbids.
+func TestDownloadSourceWithCASOfflineMissFails(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+	downloadDir := filepath.Join(tmpDir, "download")
+
+	srv := helpers.NewGitServer(t)
+	srv.AddFixtures("test/fixtures/download/hello-world")
+
+	src := &tf.Source{
+		CanonicalSourceURL: parseURL(t, srv.SourceURL("test/fixtures/download/hello-world", "")),
+		DownloadDir:        downloadDir,
+		WorkingDir:         downloadDir,
+		VersionFile:        filepath.Join(tmpDir, "version-file.txt"),
+	}
+
+	opts, err := options.NewTerragruntOptionsForTest("./should-not-be-used")
+	require.NoError(t, err)
+
+	opts.Experiments = experiment.NewExperiments()
+	require.NoError(t, opts.Experiments.EnableExperiment(experiment.OfflineCAS))
+	opts.CASOffline = true
+
+	cfg := &runcfg.RunConfig{
+		Terraform: runcfg.TerraformConfig{
+			ExtraArgs: []runcfg.TerraformExtraArguments{},
+		},
+	}
+
+	l := logger.CreateLogger()
+	l.SetOptions(log.WithOutput(io.Discard))
+
+	// The store must be empty for the miss, so the CAS is pointed at a
+	// cache directory of this test's own rather than the machine's.
+	v := venvtest.NewOSWithEmptyEnv()
+	platform := *v.Platform
+	platform.UserCacheDir = func() (string, error) { return filepath.Join(tmpDir, "cache"), nil }
+	v.Platform = &platform
+
+	_, err = run.DownloadTerraformSourceIfNecessary(
+		t.Context(),
+		l,
+		v,
+		src,
+		configbridge.NewRunOptions(opts),
+		cfg,
+		report.NewReport(),
+	)
+	require.ErrorIs(t, err, cas.ErrCASOffline)
+
+	assert.NoFileExists(t, filepath.Join(downloadDir, "main.tf"), "the standard getter must not have fetched the source")
+}
+
+// TestDownloadSourceWithCASOfflineInitFailureFails pins that --cas-offline
+// keeps a Git source out of the standard getter even when the CAS cannot be
+// built at all. Falling back would clone from the remote the flag forbids,
+// so the setup failure is the run's error.
+func TestDownloadSourceWithCASOfflineInitFailureFails(t *testing.T) {
+	t.Parallel()
+
+	errNoCacheDir := errors.New("no cache dir")
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+	downloadDir := filepath.Join(tmpDir, "download")
+
+	srv := helpers.NewGitServer(t)
+	srv.AddFixtures("test/fixtures/download/hello-world")
+
+	src := &tf.Source{
+		CanonicalSourceURL: parseURL(t, srv.SourceURL("test/fixtures/download/hello-world", "")),
+		DownloadDir:        downloadDir,
+		WorkingDir:         downloadDir,
+		VersionFile:        filepath.Join(tmpDir, "version-file.txt"),
+	}
+
+	opts, err := options.NewTerragruntOptionsForTest("./should-not-be-used")
+	require.NoError(t, err)
+
+	opts.Experiments = experiment.NewExperiments()
+	require.NoError(t, opts.Experiments.EnableExperiment(experiment.OfflineCAS))
+	opts.CASOffline = true
+
+	cfg := &runcfg.RunConfig{
+		Terraform: runcfg.TerraformConfig{
+			ExtraArgs: []runcfg.TerraformExtraArguments{},
+		},
+	}
+
+	l := logger.CreateLogger()
+	l.SetOptions(log.WithOutput(io.Discard))
+
+	// A cache directory that cannot be resolved is what makes cas.New fail.
+	v := venvtest.NewOSWithEmptyEnv()
+	platform := *v.Platform
+	platform.UserCacheDir = func() (string, error) { return "", errNoCacheDir }
+	v.Platform = &platform
+
+	_, err = run.DownloadTerraformSourceIfNecessary(
+		t.Context(),
+		l,
+		v,
+		src,
+		configbridge.NewRunOptions(opts),
+		cfg,
+		report.NewReport(),
+	)
+	require.ErrorIs(t, err, errNoCacheDir)
+
+	assert.NoFileExists(t, filepath.Join(downloadDir, "main.tf"), "the standard getter must not have fetched the source")
+}
+
 // TestDownloadSourceCASInitializationFailure tests the fallback behavior when CAS initialization fails
 func TestDownloadSourceCASInitializationFailure(t *testing.T) {
 	t.Parallel()

--- a/internal/runner/run/options.go
+++ b/internal/runner/run/options.go
@@ -69,7 +69,10 @@ type Options struct {
 	StrictControls               strict.Controls
 	MaxFoldersToCheck            int
 	CASCloneDepth                int
+	CASProbeTTL                  time.Duration
 	NoCAS                        bool
+	CASOffline                   bool
+	CASRefresh                   bool
 	NoHooks                      bool
 	TofuCPUProfileUserSet        bool
 	AutoRetry                    bool

--- a/internal/runner/run/version_check.go
+++ b/internal/runner/run/version_check.go
@@ -9,13 +9,13 @@ import (
 	"regexp"
 	"strings"
 
+	semver "github.com/gruntwork-io/terragrunt/internal/semver"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/hashicorp/go-version"
 )
 
 // DefaultTerraformVersionConstraint uses the constraint syntax from https://github.com/hashicorp/go-version
@@ -54,7 +54,7 @@ func PopulateTFVersion(
 	l log.Logger,
 	v *venv.Venv,
 	in PopulateTFVersionInput,
-) (log.Logger, *version.Version, tfimpl.Type, error) {
+) (log.Logger, *semver.Version, tfimpl.Type, error) {
 	versionCache := GetRunVersionCache(ctx)
 	cacheKey := computeVersionFilesCacheKey(
 		v.FS,
@@ -85,7 +85,7 @@ func PopulateTFVersion(
 }
 
 // formatVersionForCache formats the implementation and version for the cache
-func formatVersionForCache(implementation tfimpl.Type, version *version.Version) string {
+func formatVersionForCache(implementation tfimpl.Type, version *semver.Version) string {
 	var implStr string
 
 	switch implementation {
@@ -101,7 +101,7 @@ func formatVersionForCache(implementation tfimpl.Type, version *version.Version)
 }
 
 // parseVersionFromCache parses the cache format back to implementation and version for options
-func parseVersionFromCache(cachedData string) (tfimpl.Type, *version.Version, error) {
+func parseVersionFromCache(cachedData string) (tfimpl.Type, *semver.Version, error) {
 	const expectedParts = 2
 
 	parts := strings.SplitN(cachedData, ":", expectedParts)
@@ -123,7 +123,7 @@ func parseVersionFromCache(cachedData string) (tfimpl.Type, *version.Version, er
 		implementation = tfimpl.Unknown
 	}
 
-	version, err := version.NewVersion(versionStr)
+	version, err := semver.Parse(versionStr)
 	if err != nil {
 		return tfimpl.Unknown, nil, err
 	}
@@ -139,7 +139,7 @@ func GetTFVersion(
 	l log.Logger,
 	v *venv.Venv,
 	tfOpts *tf.TFOptions,
-) (log.Logger, *version.Version, tfimpl.Type, error) {
+) (log.Logger, *semver.Version, tfimpl.Type, error) {
 	// Clone to avoid mutating the caller's options.
 	optsCopy := *tfOpts
 	shellCopy := *optsCopy.ShellOptions
@@ -190,10 +190,10 @@ func GetTFVersion(
 // CheckTerragruntVersionMeetsConstraint checks that the current version of
 // Terragrunt meets the specified constraint and returns an error if it doesn't.
 func CheckTerragruntVersionMeetsConstraint(
-	currentVersion *version.Version,
+	currentVersion *semver.Version,
 	constraint string,
 ) error {
-	versionConstraint, err := version.NewConstraint(constraint)
+	versionConstraint, err := semver.ParseConstraint(constraint)
 	if err != nil {
 		return err
 	}
@@ -222,10 +222,10 @@ func CheckTerragruntVersionMeetsConstraint(
 // CheckTerraformVersionMeetsConstraint checks that the current version of
 // Terraform meets the specified constraint and returns an error if it doesn't.
 func CheckTerraformVersionMeetsConstraint(
-	currentVersion *version.Version,
+	currentVersion *semver.Version,
 	constraint string,
 ) error {
-	versionConstraint, err := version.NewConstraint(constraint)
+	versionConstraint, err := semver.ParseConstraint(constraint)
 	if err != nil {
 		return err
 	}
@@ -241,14 +241,14 @@ func CheckTerraformVersionMeetsConstraint(
 }
 
 // ParseTerraformVersion parses the output of the terraform --version command
-func ParseTerraformVersion(versionCommandOutput string) (*version.Version, error) {
+func ParseTerraformVersion(versionCommandOutput string) (*semver.Version, error) {
 	matches := TerraformVersionRegex.FindStringSubmatch(versionCommandOutput)
 
 	if len(matches) != versionParts {
 		return nil, InvalidTerraformVersionSyntax(versionCommandOutput)
 	}
 
-	return version.NewVersion(matches[2])
+	return semver.Parse(matches[2])
 }
 
 // parseTerraformImplementationType - Parse terraform implementation from --version command output
@@ -321,13 +321,13 @@ func (err InvalidTerraformVersionSyntax) Error() string {
 }
 
 type InvalidTerraformVersion struct {
-	CurrentVersion     *version.Version
-	VersionConstraints version.Constraints
+	CurrentVersion     *semver.Version
+	VersionConstraints semver.Constraints
 }
 
 type InvalidTerragruntVersion struct {
-	CurrentVersion     *version.Version
-	VersionConstraints version.Constraints
+	CurrentVersion     *semver.Version
+	VersionConstraints semver.Constraints
 }
 
 func (err InvalidTerraformVersion) Error() string {

--- a/internal/runner/run/version_check_test.go
+++ b/internal/runner/run/version_check_test.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
 	"github.com/gruntwork-io/terragrunt/internal/runner/run"
+	semver "github.com/gruntwork-io/terragrunt/internal/semver"
 	"github.com/gruntwork-io/terragrunt/internal/shell"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
-	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -116,7 +116,7 @@ func testCheckTerraformVersionMeetsConstraint(
 ) {
 	t.Helper()
 
-	current, err := version.NewVersion(currentVersion)
+	current, err := semver.Parse(currentVersion)
 	if err != nil {
 		t.Fatalf("Invalid current version specified in test: %v", err)
 	}
@@ -144,7 +144,7 @@ func testParseTerraformVersion(
 	actualVersion, actualErr := run.ParseTerraformVersion(versionString)
 
 	if expectedErr == nil {
-		expected, err := version.NewVersion(expectedVersion)
+		expected, err := semver.Parse(expectedVersion)
 		if err != nil {
 			t.Fatalf("Invalid expected version specified in test: %v", err)
 		}
@@ -274,7 +274,7 @@ func testCheckTerragruntVersionMeetsConstraint(
 ) {
 	t.Helper()
 
-	current, err := version.NewVersion(currentVersion)
+	current, err := semver.Parse(currentVersion)
 	if err != nil {
 		t.Fatalf("Invalid current version specified in test: %v", err)
 	}

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -1,0 +1,102 @@
+// Package semver consolidates Terragrunt's version handling behind a single
+// API so callers pick a function that matches their use case rather than
+// picking a library.
+//
+// # When to use what
+//
+// Use [Parse] for a version string written by a tool: an `OpenTofu v1.9.0`
+// banner, a provider version in a lock file, a `git version` line. It is the
+// lenient reading, and it accepts shapes the semantic versioning spec does
+// not, such as a two-part `1.9` or a prerelease with no separator. Most call
+// sites want this, because most of these strings are not under Terragrunt's
+// control.
+//
+// Use [IsExact] to decide whether a string names one specific release rather
+// than a moving target. It holds only for a full three-part version, so `v1`
+// and `v1.2` are rejected. Ask it of a Git tag or a module version before
+// treating what it points at as fixed: a maintainer moves `v1` and does
+// not move `v1.2.3`.
+//
+// Use [ParseConstraint] and [Constraints.Check] to test a version against a
+// range such as `>= 1.2, < 2.0`.
+//
+// Use [CheckConstraint] for the semver_check HCL function, which reads its
+// version argument more strictly than [Parse] does.
+//
+// # Backing libraries
+//
+// [Parse], [MustParse] and [ParseConstraint] are [go-version], which is
+// forgiving about partial and unseparated versions. [IsExact] is
+// [Masterminds/semver], whose strict parser is the only one of the two that
+// tells `v1` from `v1.0.0`: go-version pads the missing parts and does not
+// expose how many were given.
+//
+// [go-version]: https://pkg.go.dev/github.com/hashicorp/go-version
+// [Masterminds/semver]: https://pkg.go.dev/github.com/Masterminds/semver/v3
+package semver
+
+import (
+	"fmt"
+	"strings"
+
+	masterminds "github.com/Masterminds/semver/v3"
+	goversion "github.com/hashicorp/go-version"
+)
+
+// Version is one parsed version. Compare two with [Version.Compare],
+// [Version.LessThan] and their siblings.
+type Version = goversion.Version
+
+// Constraints is a parsed version range, such as the `>= 1.2, < 2.0` a
+// terraform_version_constraint carries. Test a version with
+// [Constraints.Check].
+type Constraints = goversion.Constraints
+
+// Parse reads s as a version, accepting the partial and unseparated shapes
+// tools write: `1.9`, `v1.9.0`, and `1.9.0beta` all parse. Use [IsExact]
+// instead when a partial version must not pass.
+func Parse(s string) (*Version, error) {
+	return goversion.NewVersion(s)
+}
+
+// MustParse is [Parse] for a version string fixed in the source, and panics
+// when it does not parse.
+func MustParse(s string) *Version {
+	return goversion.Must(goversion.NewVersion(s))
+}
+
+// ParseConstraint reads s as a version range such as `>= 1.2, < 2.0`.
+func ParseConstraint(s string) (Constraints, error) {
+	return goversion.NewConstraint(s)
+}
+
+// IsExact reports whether s names one specific release: three dot-separated
+// numbers, with an optional leading `v` and optional pre-release and build
+// suffixes. A partial version such as `v1` or `v1.2` does not qualify, nor
+// does a range, a constraint, or a number with a leading zero.
+//
+// The leading `v` is trimmed before parsing because a Git tag conventionally
+// carries one and a semantic version does not.
+func IsExact(s string) bool {
+	_, err := masterminds.StrictNewVersion(strings.TrimPrefix(s, "v"))
+
+	return err == nil
+}
+
+// CheckConstraint reports whether version satisfies constraint, reading
+// version strictly enough to require a separator before any pre-release, so
+// `1.2.3beta` is rejected where [Parse] accepts it. This backs the
+// semver_check HCL function, whose accepted input is user-facing.
+func CheckConstraint(version, constraint string) (bool, error) {
+	v, err := goversion.NewSemver(version)
+	if err != nil {
+		return false, fmt.Errorf("invalid version %s: %w", version, err)
+	}
+
+	c, err := goversion.NewConstraint(constraint)
+	if err != nil {
+		return false, fmt.Errorf("invalid constraint %s: %w", constraint, err)
+	}
+
+	return c.Check(v), nil
+}

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -1,0 +1,114 @@
+package semver_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/semver"
+)
+
+// TestParseAcceptsToolWrittenVersions pins the lenient reading callers rely
+// on for strings a tool wrote, where a two-part version or an unseparated
+// pre-release is common.
+func TestParseAcceptsToolWrittenVersions(t *testing.T) {
+	t.Parallel()
+
+	for _, s := range []string{"1.9", "v1.9.0", "1.9.0beta", "1.9.0-rc.1", "1", "1.2.3.4"} {
+		v, err := semver.Parse(s)
+		require.NoError(t, err, s)
+		assert.NotNil(t, v)
+	}
+
+	for _, s := range []string{"latest", ">= 1.2", "", "release-1.2.3"} {
+		_, err := semver.Parse(s)
+		require.Error(t, err, s)
+	}
+}
+
+// TestIsExact pins which strings name one specific release. A partial
+// version is a moving target, so treating it as fixed would serve a stale
+// answer once a maintainer moves it.
+func TestIsExact(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{in: "v1.2.3", want: true},
+		{in: "1.2.3", want: true},
+		{in: "v1.2.3-rc.1", want: true},
+		{in: "v1.2.3+build.7", want: true},
+		{in: "v1.2.3-rc.1+build.7", want: true},
+		{in: "v1.2", want: false},
+		{in: "v1", want: false},
+		{in: "1.2.3.4", want: false},
+		{in: "01.2.3", want: false},
+		{in: "latest", want: false},
+		{in: "release-1.2.3", want: false},
+		{in: ">= 1.2.3", want: false},
+		{in: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, semver.IsExact(tt.in))
+		})
+	}
+}
+
+// TestParseIsLenientWhereIsExactIsNot pins the split between the two
+// readings, which is the reason both are exposed.
+func TestParseIsLenientWhereIsExactIsNot(t *testing.T) {
+	t.Parallel()
+
+	for _, s := range []string{"v1", "v1.2", "01.2.3", "1.2.3.4"} {
+		_, err := semver.Parse(s)
+		require.NoError(t, err, s)
+		assert.False(t, semver.IsExact(s), s)
+	}
+}
+
+func TestParseConstraint(t *testing.T) {
+	t.Parallel()
+
+	c, err := semver.ParseConstraint(">= 1.2, < 2.0")
+	require.NoError(t, err)
+
+	assert.True(t, c.Check(semver.MustParse("1.5.0")))
+	assert.False(t, c.Check(semver.MustParse("2.1.0")))
+
+	_, err = semver.ParseConstraint("not a constraint")
+	require.Error(t, err)
+}
+
+// TestCheckConstraint pins what the semver_check HCL function accepts,
+// which is user-facing: it reads its version argument more strictly than
+// [semver.Parse] does.
+func TestCheckConstraint(t *testing.T) {
+	t.Parallel()
+
+	ok, err := semver.CheckConstraint("1.5.0", ">= 1.2, < 2.0")
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = semver.CheckConstraint("2.1.0", ">= 1.2, < 2.0")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	_, err = semver.CheckConstraint("1.2.3beta", ">= 1.2")
+	require.Error(t, err, "an unseparated pre-release is rejected here but not by Parse")
+
+	_, err = semver.CheckConstraint("1.2.3", "not a constraint")
+	require.Error(t, err)
+}
+
+func TestMustParsePanicsOnGarbage(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() { semver.MustParse("latest") })
+}

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -62,9 +62,13 @@ type Repo struct {
 	LatestTag  string
 
 	casCloneDepth int
+	casProbeTTL   time.Duration
 
 	walkWithSymlinks bool
 	allowCAS         bool
+	casOffline       bool
+	casRefresh       bool
+	casProbeCache    bool
 	slowReporting    bool
 	isLocal          bool
 }
@@ -75,8 +79,12 @@ type RepoOpts struct {
 	Path             string
 	RootWorkingDir   string
 	CASCloneDepth    int
+	CASProbeTTL      time.Duration
 	WalkWithSymlinks bool
 	AllowCAS         bool
+	CASOffline       bool
+	CASRefresh       bool
+	CASProbeCache    bool
 	SlowReporting    bool
 }
 
@@ -99,6 +107,10 @@ func NewRepo(ctx context.Context, l log.Logger, v *venv.Venv, opts *RepoOpts) (*
 		walkWithSymlinks: opts.WalkWithSymlinks,
 		allowCAS:         opts.AllowCAS,
 		casCloneDepth:    opts.CASCloneDepth,
+		casProbeTTL:      opts.CASProbeTTL,
+		casOffline:       opts.CASOffline,
+		casRefresh:       opts.CASRefresh,
+		casProbeCache:    opts.CASProbeCache,
 		slowReporting:    opts.SlowReporting,
 		rootWorkingDir:   opts.RootWorkingDir,
 	}
@@ -498,7 +510,21 @@ func (repo *Repo) performClone(
 			return err
 		}
 
-		casStore, err := cas.New(v, cas.WithCloneDepth(cloneDepth))
+		casOpts := []cas.Option{cas.WithCloneDepth(cloneDepth), cas.WithProbeTTL(repo.casProbeTTL)}
+
+		if repo.casProbeCache {
+			casOpts = append(casOpts, cas.WithProbeCache())
+		}
+
+		if repo.casOffline {
+			casOpts = append(casOpts, cas.WithOffline())
+		}
+
+		if repo.casRefresh {
+			casOpts = append(casOpts, cas.WithProbeRefresh())
+		}
+
+		casStore, err := cas.New(v, casOpts...)
 		if err != nil {
 			return err
 		}

--- a/internal/shell/git.go
+++ b/internal/shell/git.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/hashicorp/go-version"
+	semver "github.com/gruntwork-io/terragrunt/internal/semver"
 
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
@@ -107,12 +107,12 @@ func LastReleaseTag(tags []string) string {
 }
 
 // extractSemVerTags - extract semver tags from passed tags slice.
-func extractSemVerTags(tags []string) []*version.Version {
-	var semverTags []*version.Version
+func extractSemVerTags(tags []string) []*semver.Version {
+	var semverTags []*semver.Version
 
 	for _, tag := range tags {
 		t := strings.TrimPrefix(tag, refsTags)
-		if v, err := version.NewVersion(t); err == nil {
+		if v, err := semver.Parse(t); err == nil {
 			// consider only semver tags
 			semverTags = append(semverTags, v)
 		}

--- a/internal/tf/cache/models/provider.go
+++ b/internal/tf/cache/models/provider.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"strings"
 
-	goversion "github.com/hashicorp/go-version"
+	semver "github.com/gruntwork-io/terragrunt/internal/semver"
 )
 
 type Providers []*Provider
@@ -79,7 +79,7 @@ func (versions Versions) FilterValid() (Versions, []string) {
 			continue
 		}
 
-		if _, err := goversion.NewVersion(v.Version); err != nil {
+		if _, err := semver.Parse(v.Version); err != nil {
 			invalid = append(invalid, v.Version)
 			continue
 		}

--- a/internal/tf/getproviders/constraints.go
+++ b/internal/tf/getproviders/constraints.go
@@ -10,10 +10,10 @@ import (
 
 	"errors"
 
+	semver "github.com/gruntwork-io/terragrunt/internal/semver"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
@@ -276,7 +276,7 @@ func normalizeSingleConstraint(constraint string) string {
 
 	const justVersionParts = 1
 	if len(fields) == justVersionParts {
-		if v, err := version.NewVersion(fields[0]); err == nil {
+		if v, err := semver.Parse(fields[0]); err == nil {
 			return v.String()
 		}
 
@@ -288,7 +288,7 @@ func normalizeSingleConstraint(constraint string) string {
 		operator := fields[0]
 		versionStr := fields[1]
 
-		if v, err := version.NewVersion(versionStr); err == nil {
+		if v, err := semver.Parse(versionStr); err == nil {
 			return fmt.Sprintf("%s %s", operator, v.String())
 		}
 	}

--- a/internal/tf/getproviders/lock.go
+++ b/internal/tf/getproviders/lock.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"unicode"
 
+	semver "github.com/gruntwork-io/terragrunt/internal/semver"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -243,12 +243,12 @@ func shouldUpdateConstraints(
 		"",
 	)
 
-	currentConstraints, err := version.NewConstraint(currentConstraintsValue)
+	currentConstraints, err := semver.ParseConstraint(currentConstraintsValue)
 	if err != nil {
 		return true
 	}
 
-	newVersion, err := version.NewVersion(providerVersion)
+	newVersion, err := semver.Parse(providerVersion)
 	if err != nil {
 		return true
 	}
@@ -360,7 +360,7 @@ func UpdateLockfileConstraints(
 			"",
 		)
 
-		currentConstraints, err := version.NewConstraint(currentConstraintsValue)
+		currentConstraints, err := semver.ParseConstraint(currentConstraintsValue)
 		if err != nil {
 			providerBlock.Body().SetAttributeValue("constraints", cty.StringVal(newConstraint))
 
@@ -372,7 +372,7 @@ func UpdateLockfileConstraints(
 		versionAttr := providerBlock.Body().GetAttribute("version")
 		if versionAttr != nil {
 			versionVal := getAttributeValueAsUnquotedString(versionAttr)
-			if v, err := version.NewVersion(versionVal); err == nil && currentConstraints.Check(v) {
+			if v, err := semver.Parse(versionVal); err == nil && currentConstraints.Check(v) {
 				continue
 			}
 		}

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -18,8 +18,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/git"
+	semver "github.com/gruntwork-io/terragrunt/internal/semver"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	tflang "github.com/hashicorp/terraform/lang"
 	"github.com/zclconf/go-cty/cty"
@@ -1843,15 +1843,5 @@ func ConstraintCheck(ctx context.Context, pctx *ParsingContext, args []string) (
 		}
 	}
 
-	v, err := version.NewSemver(args[0])
-	if err != nil {
-		return false, fmt.Errorf("invalid version %s: %w", args[0], err)
-	}
-
-	c, err := version.NewConstraint(args[1])
-	if err != nil {
-		return false, fmt.Errorf("invalid constraint %s: %w", args[1], err)
-	}
-
-	return c.Check(v), nil
+	return semver.CheckConstraint(args[0], args[1])
 }

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -2328,7 +2328,31 @@ func runTerragruntOutputJSON(
 
 	runCfg := cfg.ToRunConfig(l, pctx.Venv.FS)
 
-	// Build run.Options directly from ParsingContext fields.
+	err = run.Run(ctx, l, pctx.Venv, RunOptionsFromParsingContext(pctx), report.NewReport(), runCfg, credentialGetter)
+	if err != nil {
+		return nil, err
+	}
+
+	err = stdoutBufferWriter.Flush()
+	if err != nil {
+		return nil, err
+	}
+
+	jsonString := strings.TrimSpace(stdoutBuffer.String())
+	jsonBytes := []byte(jsonString)
+
+	l.Debugf("Retrieved output from %s as json: %s", targetConfig, jsonString)
+
+	return jsonBytes, nil
+}
+
+// RunOptionsFromParsingContext builds the [run.Options] for the run that
+// reads a dependency's outputs. It is the ParsingContext-sourced twin of
+// the TerragruntOptions-sourced constructor in internal/configbridge: the
+// dependency run is a full run of the target unit, so a flag missing here
+// is a flag that stops applying as soon as a unit is reached through a
+// `dependency` block.
+func RunOptionsFromParsingContext(pctx *ParsingContext) *run.Options {
 	runOpts := run.NewOptions()
 	runOpts.LogShowAbsPaths = pctx.LogShowAbsPaths
 	runOpts.LogDisableErrorSummary = pctx.LogDisableErrorSummary
@@ -2358,24 +2382,13 @@ func runTerragruntOutputJSON(
 	runOpts.BackendBootstrap = pctx.BackendBootstrap
 	runOpts.Telemetry = pctx.Telemetry
 	runOpts.AuthProviderCmd = pctx.AuthProviderCmd
+	runOpts.NoCAS = pctx.NoCAS
 	runOpts.CASCloneDepth = pctx.CASCloneDepth
+	runOpts.CASOffline = pctx.CASOffline
+	runOpts.CASRefresh = pctx.CASRefresh
+	runOpts.CASProbeTTL = pctx.CASProbeTTL
 
-	err = run.Run(ctx, l, pctx.Venv, runOpts, report.NewReport(), runCfg, credentialGetter)
-	if err != nil {
-		return nil, err
-	}
-
-	err = stdoutBufferWriter.Flush()
-	if err != nil {
-		return nil, err
-	}
-
-	jsonString := strings.TrimSpace(stdoutBuffer.String())
-	jsonBytes := []byte(jsonString)
-
-	l.Debugf("Retrieved output from %s as json: %s", targetConfig, jsonString)
-
-	return jsonBytes, nil
+	return runOpts
 }
 
 // shellRunOptsFromPctx builds a *shell.ShellOptions from ParsingContext flat fields.

--- a/pkg/config/dependency_run_options_test.go
+++ b/pkg/config/dependency_run_options_test.go
@@ -1,0 +1,112 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/engine"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/iacargs"
+	"github.com/gruntwork-io/terragrunt/internal/iam"
+	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
+	"github.com/gruntwork-io/terragrunt/internal/telemetry"
+	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunOptionsFromParsingContextCopiesEveryOption pins every field the
+// dependency-output run carries over from the parsing context. A flag that
+// stops being copied here keeps working for a direct run and silently stops
+// applying to any unit reached through a `dependency` block.
+func TestRunOptionsFromParsingContextCopiesEveryOption(t *testing.T) {
+	t.Parallel()
+
+	pctx := parsingContextWithDistinctValues(t)
+
+	runOpts := config.RunOptionsFromParsingContext(pctx)
+	require.NotNil(t, runOpts)
+
+	assert.True(t, runOpts.LogShowAbsPaths)
+	assert.True(t, runOpts.LogDisableErrorSummary)
+	assert.Equal(t, pctx.TerragruntConfigPath, runOpts.TerragruntConfigPath)
+	assert.Equal(t, pctx.OriginalTerragruntConfigPath, runOpts.OriginalTerragruntConfigPath)
+	assert.Equal(t, pctx.WorkingDir, runOpts.UnitDir)
+	assert.Equal(t, pctx.WorkingDir, runOpts.CacheDir)
+	assert.Equal(t, pctx.RootWorkingDir, runOpts.RootWorkingDir)
+	assert.Equal(t, pctx.DownloadDir, runOpts.DownloadDir)
+	assert.Equal(t, pctx.Source, runOpts.Source)
+	assert.Equal(t, pctx.SourceMap, runOpts.SourceMap)
+	assert.Equal(t, pctx.TerraformCommand, runOpts.TerraformCommand)
+	assert.Equal(t, pctx.OriginalTerraformCommand, runOpts.OriginalTerraformCommand)
+	assert.Same(t, pctx.TerraformCliArgs, runOpts.TerraformCliArgs)
+	assert.Equal(t, pctx.IAMRoleOptions, runOpts.IAMRoleOptions)
+	assert.Equal(t, pctx.OriginalIAMRoleOptions, runOpts.OriginalIAMRoleOptions)
+	assert.True(t, runOpts.Experiments.Evaluate(experiment.Stacks))
+	assert.Equal(t, pctx.StrictControls, runOpts.StrictControls)
+	assert.Same(t, pctx.FeatureFlags, runOpts.FeatureFlags)
+	assert.Same(t, pctx.EngineConfig, runOpts.EngineConfig)
+	assert.Same(t, pctx.EngineOptions, runOpts.EngineOptions)
+	assert.Equal(t, pctx.TFPath, runOpts.TFPath)
+	assert.Equal(t, pctx.TofuImplementation, runOpts.TofuImplementation)
+	assert.True(t, runOpts.Headless)
+	assert.True(t, runOpts.Debug)
+	assert.True(t, runOpts.AutoInit)
+	assert.True(t, runOpts.BackendBootstrap)
+	assert.Same(t, pctx.Telemetry, runOpts.Telemetry)
+	assert.Equal(t, pctx.AuthProviderCmd, runOpts.AuthProviderCmd)
+	assert.True(t, runOpts.NoCAS, "--no-cas must keep the CAS disabled for a dependency's source")
+	assert.Equal(t, pctx.CASCloneDepth, runOpts.CASCloneDepth)
+	assert.True(t, runOpts.CASOffline, "--cas-offline must still forbid fetching a dependency's source")
+	assert.True(t, runOpts.CASRefresh)
+	assert.Equal(t, pctx.CASProbeTTL, runOpts.CASProbeTTL)
+}
+
+// parsingContextWithDistinctValues returns a context whose every bridged
+// field holds a value distinguishable from the zero value, so a dropped
+// copy fails an assertion rather than passing on a coincidence.
+func parsingContextWithDistinctValues(t *testing.T) *config.ParsingContext {
+	t.Helper()
+
+	_, pctx := config.NewParsingContext(t.Context(), logger.CreateLogger(), venvtest.New())
+
+	pctx.TerragruntConfigPath = "/dep/unit/terragrunt.hcl"
+	pctx.OriginalTerragruntConfigPath = "/dep/original/terragrunt.hcl"
+	pctx.WorkingDir = "/dep/unit"
+	pctx.RootWorkingDir = "/dep"
+	pctx.DownloadDir = "/dep/unit/.terragrunt-cache"
+	pctx.Source = "github.com/acme/modules//vpc"
+	pctx.SourceMap = map[string]string{"github.com/acme/modules": "/local/modules"}
+	pctx.TerraformCommand = "output"
+	pctx.OriginalTerraformCommand = "plan"
+	pctx.TerraformCliArgs = iacargs.New("output", "-json")
+	pctx.IAMRoleOptions = iam.RoleOptions{RoleARN: "arn:aws:iam::111111111111:role/dep"}
+	pctx.OriginalIAMRoleOptions = iam.RoleOptions{RoleARN: "arn:aws:iam::111111111111:role/original"}
+	pctx.Experiments = experiment.NewExperiments()
+	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.Stacks))
+	pctx.StrictControls = controls.New()
+	pctx.FeatureFlags = xsync.NewMap[string, string]()
+	pctx.EngineConfig = &engine.EngineConfig{Source: "engine-source"}
+	pctx.EngineOptions = &engine.EngineOptions{}
+	pctx.TFPath = "/usr/local/bin/tofu"
+	pctx.TofuImplementation = tfimpl.OpenTofu
+	pctx.Headless = true
+	pctx.Debug = true
+	pctx.AutoInit = true
+	pctx.BackendBootstrap = true
+	pctx.Telemetry = &telemetry.Options{}
+	pctx.AuthProviderCmd = "/usr/local/bin/auth"
+	pctx.NoCAS = true
+	pctx.CASCloneDepth = 7
+	pctx.CASOffline = true
+	pctx.CASRefresh = true
+	pctx.CASProbeTTL = 90 * time.Second
+	pctx.LogShowAbsPaths = true
+	pctx.LogDisableErrorSummary = true
+
+	return pctx
+}

--- a/pkg/config/parsing_context.go
+++ b/pkg/config/parsing_context.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"path/filepath"
 	"slices"
+	"time"
 
 	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/zclconf/go-cty/cty"
@@ -99,6 +100,7 @@ type ParsingContext struct {
 	MaxFoldersToCheck int
 	ParseDepth        int
 	CASCloneDepth     int
+	CASProbeTTL       time.Duration
 
 	TFPathExplicitlySet bool
 	SkipOutput          bool
@@ -115,6 +117,8 @@ type ParsingContext struct {
 	SkipOutputsResolution            bool
 	NoStackValidate                  bool
 	NoCAS                            bool
+	CASOffline                       bool
+	CASRefresh                       bool
 	LogShowAbsPaths                  bool
 	LogDisableErrorSummary           bool
 

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -217,7 +217,7 @@ func GenerateStackFile(
 		return nil
 	}
 
-	cs, err := setupCAS(l, pctx.Venv, casEnabled, pctx.CASCloneDepth)
+	cs, err := setupCAS(l, pctx, casEnabled)
 	if err != nil {
 		return err
 	}
@@ -469,26 +469,55 @@ type casSetup struct {
 
 // setupCAS prepares the CAS bundle for stack generation. A non-nil
 // error is reserved for user-facing misconfiguration (invalid clone
-// depth); transient setup failures log a warning and return an
-// Enabled=false bundle so the caller falls through to the standard
-// getter.
-func setupCAS(l log.Logger, v *venv.Venv, enabled bool, cloneDepth int) (casSetup, error) {
+// depth) and for a setup failure under --cas-offline; other transient
+// setup failures log a warning and return an Enabled=false bundle so the
+// caller falls through to the standard getter.
+func setupCAS(l log.Logger, pctx *ParsingContext, enabled bool) (casSetup, error) {
 	if !enabled {
 		return casSetup{}, nil
 	}
 
-	if err := cas.ValidateCASCloneDepth(cloneDepth); err != nil {
+	if err := cas.ValidateCASCloneDepth(pctx.CASCloneDepth); err != nil {
 		return casSetup{}, err
 	}
 
-	c, err := cas.New(v, cas.WithCloneDepth(cloneDepth))
+	casOpts := []cas.Option{cas.WithCloneDepth(pctx.CASCloneDepth), cas.WithProbeTTL(pctx.CASProbeTTL)}
+
+	if pctx.Experiments.Evaluate(experiment.OfflineCAS) {
+		casOpts = append(casOpts, cas.WithProbeCache())
+	}
+
+	if pctx.CASOffline {
+		casOpts = append(casOpts, cas.WithOffline())
+	}
+
+	if pctx.CASRefresh {
+		casOpts = append(casOpts, cas.WithProbeRefresh())
+	}
+
+	v := pctx.Venv
+
+	c, err := cas.New(v, casOpts...)
 	if err != nil {
+		// A disabled CAS sends every remote component through the standard
+		// getter, which fetches from the network --cas-offline forbids, so
+		// the flag turns a setup failure into the run's error.
+		if pctx.CASOffline {
+			return casSetup{}, err
+		}
+
 		l.Warnf("Failed to initialize CAS for stack generation: %v. CAS features disabled.", err)
+
 		return casSetup{}, nil
 	}
 
 	if _, err := git.NewGitRunner(v); err != nil {
+		if pctx.CASOffline {
+			return casSetup{}, err
+		}
+
 		l.Warnf("Failed to initialize CAS environment: %v. CAS features disabled.", err)
+
 		return casSetup{}, nil
 	}
 
@@ -902,10 +931,12 @@ func fetchComponentSource(
 			return nil
 		}
 
-		// A non-literal source on an update_source_with_cas block can never
-		// be rewritten by CAS, so falling back would silently skip the rewrite
-		// the configuration asked for. Surface the error instead.
-		if errors.Is(casErr, cas.ErrSourceNotLiteral) {
+		// Two failures must not fall back. A non-literal source on an
+		// update_source_with_cas block can never be rewritten by CAS, so the
+		// fallback would silently skip the rewrite the configuration asked
+		// for. An offline miss would be filled by the standard getter over
+		// the network --cas-offline forbids.
+		if errors.Is(casErr, cas.ErrSourceNotLiteral) || errors.Is(casErr, cas.ErrCASOffline) {
 			return fmt.Errorf("failed to fetch %s %q via CAS: %w", kindStr, cmp.name, casErr)
 		}
 

--- a/pkg/config/stack_cas_offline_test.go
+++ b/pkg/config/stack_cas_offline_test.go
@@ -1,0 +1,149 @@
+package config_test
+
+import (
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/experiment"
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/internal/worker"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateStackCASOfflineMissFails pins that --cas-offline turns a unit
+// source the store lacks into a generation error rather than a fallback to
+// the standard getter, which would fetch over the network the flag forbids.
+func TestGenerateStackCASOfflineMissFails(t *testing.T) {
+	t.Parallel()
+
+	srv, err := git.NewServer()
+	require.NoError(t, err)
+
+	t.Cleanup(func() { assert.NoError(t, srv.Close()) })
+
+	require.NoError(t, srv.CommitFile(t.Context(), "main.tf", []byte("# unit\n"), "init"))
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+	stackDir := filepath.Join(tmpDir, "stack")
+	stackPath := filepath.Join(stackDir, "terragrunt.stack.hcl")
+
+	// The store must be empty for the miss, so the CAS is pointed at a
+	// cache directory of this test's own rather than the machine's.
+	v := venvtest.NewOSWithEmptyEnv()
+	platform := *v.Platform
+	platform.UserCacheDir = func() (string, error) { return filepath.Join(tmpDir, "cache"), nil }
+	v.Platform = &platform
+
+	body := `unit "vpc" {
+  source = "git::` + repoURL + `?ref=main"
+  path   = "vpc"
+}
+`
+
+	require.NoError(t, v.FS.MkdirAll(stackDir, 0o755))
+	require.NoError(t, vfs.WriteFile(v.FS, stackPath, []byte(body), 0o644))
+
+	l := logger.CreateLogger()
+	l.SetOptions(log.WithOutput(io.Discard))
+
+	_, pctx := config.NewParsingContext(t.Context(), l, v, config.WithStrictControls(controls.New()))
+	pctx.TerragruntStackConfigPath = stackPath
+	pctx.RootWorkingDir = stackDir
+	pctx.WorkingDir = stackDir
+	pctx.TerragruntConfigPath = stackPath
+	pctx.CASCloneDepth = 1
+	pctx.CASOffline = true
+	pctx.Experiments = experiment.NewExperiments()
+
+	pool := worker.NewWorkerPool(1)
+	pool.Start()
+
+	defer pool.Stop()
+
+	// Components are generated on the pool, so the fetch error surfaces from Wait.
+	genErr := config.GenerateStackFile(t.Context(), l, pctx, pool, stackPath)
+	waitErr := pool.Wait()
+
+	require.ErrorIs(t, errors.Join(genErr, waitErr), cas.ErrCASOffline)
+
+	assert.NoFileExists(t, filepath.Join(stackDir, config.StackDir, "vpc", "main.tf"),
+		"the standard getter must not have fetched the unit")
+}
+
+// TestGenerateStackCASOfflineSetupFailureFails pins that --cas-offline stops
+// stack generation when the CAS cannot be built. Disabling CAS features would
+// send every remote component to the standard getter, over the network the
+// flag forbids.
+func TestGenerateStackCASOfflineSetupFailureFails(t *testing.T) {
+	t.Parallel()
+
+	errNoCacheDir := errors.New("no cache dir")
+
+	srv, err := git.NewServer()
+	require.NoError(t, err)
+
+	t.Cleanup(func() { assert.NoError(t, srv.Close()) })
+
+	require.NoError(t, srv.CommitFile(t.Context(), "main.tf", []byte("# unit\n"), "init"))
+
+	repoURL, err := srv.Start(t.Context())
+	require.NoError(t, err)
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+	stackDir := filepath.Join(tmpDir, "stack")
+	stackPath := filepath.Join(stackDir, "terragrunt.stack.hcl")
+
+	// A cache directory that cannot be resolved is what makes cas.New fail.
+	v := venvtest.NewOSWithEmptyEnv()
+	platform := *v.Platform
+	platform.UserCacheDir = func() (string, error) { return "", errNoCacheDir }
+	v.Platform = &platform
+
+	body := `unit "vpc" {
+  source = "git::` + repoURL + `?ref=main"
+  path   = "vpc"
+}
+`
+
+	require.NoError(t, v.FS.MkdirAll(stackDir, 0o755))
+	require.NoError(t, vfs.WriteFile(v.FS, stackPath, []byte(body), 0o644))
+
+	l := logger.CreateLogger()
+	l.SetOptions(log.WithOutput(io.Discard))
+
+	_, pctx := config.NewParsingContext(t.Context(), l, v, config.WithStrictControls(controls.New()))
+	pctx.TerragruntStackConfigPath = stackPath
+	pctx.RootWorkingDir = stackDir
+	pctx.WorkingDir = stackDir
+	pctx.TerragruntConfigPath = stackPath
+	pctx.CASCloneDepth = 1
+	pctx.CASOffline = true
+	pctx.Experiments = experiment.NewExperiments()
+
+	pool := worker.NewWorkerPool(1)
+	pool.Start()
+
+	defer pool.Stop()
+
+	genErr := config.GenerateStackFile(t.Context(), l, pctx, pool, stackPath)
+	waitErr := pool.Wait()
+
+	require.ErrorIs(t, errors.Join(genErr, waitErr), errNoCacheDir)
+
+	assert.NoFileExists(t, filepath.Join(stackDir, config.StackDir, "vpc", "main.tf"),
+		"the standard getter must not have fetched the unit")
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/iam"
 	pcoptions "github.com/gruntwork-io/terragrunt/internal/providercache/options"
 	"github.com/gruntwork-io/terragrunt/internal/report"
+	semver "github.com/gruntwork-io/terragrunt/internal/semver"
 	"github.com/gruntwork-io/terragrunt/internal/strict"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
@@ -32,7 +33,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
-	"github.com/hashicorp/go-version"
 	"github.com/puzpuzpuz/xsync/v4"
 )
 
@@ -77,7 +77,7 @@ type ctxKey byte
 // TerragruntOptions represents options that configure the behavior of the Terragrunt program
 type TerragruntOptions struct {
 	// Version of terragrunt
-	TerragruntVersion *version.Version `clone:"shadowcopy"`
+	TerragruntVersion *semver.Version `clone:"shadowcopy"`
 	// FeatureFlags is a map of feature flags to enable.
 	FeatureFlags *xsync.Map[string, string] `clone:"shadowcopy"`
 	// EngineConfig holds the resolved engine configuration from HCL.
@@ -89,7 +89,7 @@ type TerragruntOptions struct {
 	// Attributes to override in AWS provider nested within modules as part of the aws-provider-patch command.
 	AwsProviderPatchOverrides map[string]string
 	// Version of terraform (obtained by running 'terraform version')
-	TerraformVersion *version.Version `clone:"shadowcopy"`
+	TerraformVersion *semver.Version `clone:"shadowcopy"`
 	// Errors is a configuration for error handling.
 	Errors *errorconfig.Config
 	// Map to replace terraform source locations.
@@ -194,6 +194,9 @@ type TerragruntOptions struct {
 	// repository. Defaults to 1 (see internal/cas.DefaultCASCloneDepth). Values must be
 	// positive (git rejects --depth 0) or negative (e.g. -1) for a full clone without --depth.
 	CASCloneDepth int
+	// CASProbeTTL is how long CAS trusts a persisted probe of a branch, HEAD, or
+	// non-version tag before querying the remote again. Zero re-queries on every run.
+	CASProbeTTL time.Duration
 	// Output Terragrunt logs in JSON format
 	JSONLogFormat bool
 	// True if terragrunt should run in debug mode
@@ -266,6 +269,12 @@ type TerragruntOptions struct {
 	NoStackValidate bool
 	// NoCAS disables the CAS feature even when the experiment is enabled.
 	NoCAS bool
+	// CASOffline forbids CAS from contacting a Git remote; Git sources are
+	// answered from the local store and the persisted probe cache or fail.
+	// Other sources CAS handles, such as HTTP or S3, still reach their remote.
+	CASOffline bool
+	// CASRefresh makes CAS ignore its persisted probe cache for this run.
+	CASRefresh bool
 	// RunAll runs the provided OpenTofu/Terraform command against a stack.
 	RunAll bool
 	// Graph runs the provided OpenTofu/Terraform against the graph of


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Reduces the cost of CAS probes.

This is done in two ways:

1. A singleflight is used to coordinate probes to memoize results across a run.
2. An opt-in on-disk probe cache that can be used to bypass a remote probe.

Measured over 100 units pointing at one Git module on an Apple M3 Max against a local Git server without the opt-in on-disk cache:

| | before | after | change |
| --- | --- | --- | --- |
| first run | 4.5s | 0.30s | -93% |
| later run | 0.86s | 0.12s | -86% |

With the on-disk cache, behind a new `offline-cas` experiment, a second run over the same 100 units pinned to a version tag spawns no Git commands at all and finishes in ~50ms. 

Three flags control how those recorded answers are used:

- `--cas-offline` never contacts a remote, resolving every source from the local store and the recorded answers and failing on anything missing.
- `--cas-refresh` ignores the recorded answers for one run to refresh the CAS.
- `--cas-probe-ttl` trusts an answer for a source that can change upstream for a chosen duration (e.g. branch name or no ref).

A source pinned to a specific revision keeps its answer for 24 hours: a semantic version tag, an S3 object version, an OCI manifest digest, an exact registry module version, or a full Mercurial changeset node. Everything else is probed on every run, so a push is seen immediately.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added experimental CAS probe caching to reduce repeated remote checks and improve concurrent operations.
  - Added `--cas-offline`, `--cas-refresh`, and `--cas-probe-ttl` controls across catalog, run, and stack commands.
  - Offline mode resolves cached sources without network access and reports clear errors for unavailable content.
  - Added cache-aware handling for Git commits, pinned revisions, and semantic-version tags.
  - Added experiment gating and validation for the new CAS controls.

- **Documentation**
  - Documented the Offline CAS experiment, configuration options, limitations, examples, and fallback behavior.
  - Added command reference entries for the new CAS flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->