### PR TITLE
chore: Asserting context cache is installed correctly

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -120,11 +120,16 @@ func (c *ExpiringCache[V]) Put(ctx context.Context, key string, value V, expirat
 	c.Cache[key] = ExpiringItem[V]{Value: value, Expiration: expiration}
 }
 
-// ContextCache returns cache from the context. If the cache is nil, it creates a new instance.
+// ContextCache returns the cache installed on ctx under key.
+//
+// Every command installs the caches it reads before running, so a missing one is a wiring
+// mistake rather than a state to recover from. Returning a detached cache instead would keep
+// working while silently caching nothing, turning the mistake into a slow run that no test
+// fails on, and leaving a caller that primes the cache to find its entries gone.
 func ContextCache[T any](ctx context.Context, key any) *Cache[T] {
 	cacheInstance, ok := ctx.Value(key).(*Cache[T])
 	if !ok || cacheInstance == nil {
-		cacheInstance = NewCache[T](fmt.Sprintf("%v", key))
+		panic(fmt.Sprintf("cache %v is not installed on the context", key))
 	}
 
 	return cacheInstance

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -120,16 +120,12 @@ func (c *ExpiringCache[V]) Put(ctx context.Context, key string, value V, expirat
 	c.Cache[key] = ExpiringItem[V]{Value: value, Expiration: expiration}
 }
 
-// ContextCache returns the cache installed on ctx under key.
-//
-// Every command installs the caches it reads before running, so a missing one is a wiring
-// mistake rather than a state to recover from. Returning a detached cache instead would keep
-// working while silently caching nothing, turning the mistake into a slow run that no test
-// fails on, and leaving a caller that primes the cache to find its entries gone.
+// ContextCache returns the cache installed on ctx under key. It panics when no cache is
+// installed there.
 func ContextCache[T any](ctx context.Context, key any) *Cache[T] {
 	cacheInstance, ok := ctx.Value(key).(*Cache[T])
 	if !ok || cacheInstance == nil {
-		panic(fmt.Sprintf("cache %v is not installed on the context", key))
+		panic(fmt.Sprintf("cache %T(%v) is not installed on the context", key, key))
 	}
 
 	return cacheInstance

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -100,10 +100,11 @@ func TestContextCache(t *testing.T) {
 
 	ctx := t.Context()
 
-	// Missing entry returns a fresh detached instance.
-	c := cache.ContextCache[int](ctx, "not-installed")
-	require.NotNil(t, c)
-	c.Put(ctx, "k", 7)
+	// A missing entry is a wiring mistake, not a state to recover from. Handing back a detached
+	// instance would let a caller prime a cache nothing else can read.
+	assert.Panics(t, func() {
+		cache.ContextCache[int](ctx, "not-installed")
+	})
 
 	// Installed entry round-trips.
 	installed := cache.NewCache[int]("installed")

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -100,8 +100,6 @@ func TestContextCache(t *testing.T) {
 
 	ctx := t.Context()
 
-	// A missing entry is a wiring mistake, not a state to recover from. Handing back a detached
-	// instance would let a caller prime a cache nothing else can read.
 	assert.Panics(t, func() {
 		cache.ContextCache[int](ctx, "not-installed")
 	})

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -107,11 +107,10 @@ func (app *App) RunContext(
 
 	ctx = app.registerGracefullyShutdown(ctx, l)
 
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 	// configure engine context
 	ctx = engine.WithEngineValues(ctx)
 
-	ctx = run.WithRunVersionCache(ctx)
 	ctx = run.WithModuleVersionResolver(ctx, v)
 
 	args = removeNoColorFlagDuplicates(args)

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1061,7 +1061,9 @@ func runAppTest(
 	}
 	app.ExitErrHandler = cli.ExitErrHandler
 
-	err := app.Run(append([]string{"--"}, args...))
+	ctx := config.WithCaches(context.Background())
+
+	err := app.RunContext(ctx, append([]string{"--"}, args...))
 
 	return opts, err
 }

--- a/internal/cli/commands/catalog/catalog_test.go
+++ b/internal/cli/commands/catalog/catalog_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -36,7 +37,7 @@ func TestRunOnEmptyWorkspaceWritesNothing(t *testing.T) {
 	require.NoError(t, v.FS.MkdirAll(workDir, 0o755))
 
 	err := catalog.Run(
-		t.Context(), logger.CreateLogger(), v, newOptions(t, workDir, catalog.FormatJSONL), "",
+		config.WithCaches(t.Context()), logger.CreateLogger(), v, newOptions(t, workDir, catalog.FormatJSONL), "",
 	)
 
 	require.NoError(t, err)
@@ -90,7 +91,7 @@ func TestRunReportsEveryUnreachableSource(t *testing.T) {
 			}
 
 			err := catalog.Run(
-				t.Context(), logger.CreateLogger(), v, newOptions(t, workDir, catalog.FormatJSONL), "",
+				config.WithCaches(t.Context()), logger.CreateLogger(), v, newOptions(t, workDir, catalog.FormatJSONL), "",
 			)
 
 			var loadErr *tui.SourceLoadError
@@ -128,7 +129,7 @@ func TestRunLoadsARepoNamedTwiceOnce(t *testing.T) {
 	))
 
 	err := catalog.Run(
-		t.Context(), logger.CreateLogger(), v, newOptions(t, rootDir, catalog.FormatJSONL), "",
+		config.WithCaches(t.Context()), logger.CreateLogger(), v, newOptions(t, rootDir, catalog.FormatJSONL), "",
 	)
 
 	var loadErr *tui.SourceLoadError
@@ -166,7 +167,7 @@ func TestRunWritesComponentsFromTheCatalogBlock(t *testing.T) {
 	))
 
 	err := catalog.Run(
-		t.Context(), logger.CreateLogger(), v, newOptions(t, rootDir, catalog.FormatJSONL), "",
+		config.WithCaches(t.Context()), logger.CreateLogger(), v, newOptions(t, rootDir, catalog.FormatJSONL), "",
 	)
 
 	require.NoError(t, err)
@@ -191,7 +192,7 @@ func TestRunToleratesAnUnparseableCatalogConfig(t *testing.T) {
 	))
 
 	err := catalog.Run(
-		t.Context(), logger.CreateLogger(), v, newOptions(t, rootDir, catalog.FormatJSONL), "",
+		config.WithCaches(t.Context()), logger.CreateLogger(), v, newOptions(t, rootDir, catalog.FormatJSONL), "",
 	)
 
 	require.NoError(t, err)
@@ -210,7 +211,7 @@ func TestRunWithAnExplicitRepoURLSkipsDiscovery(t *testing.T) {
 	writeUnit(t, v, filepath.Join(workDir, "vpc"), "github.com/acme/discovered//modules/x")
 
 	err := catalog.Run(
-		t.Context(), logger.CreateLogger(), v,
+		config.WithCaches(t.Context()), logger.CreateLogger(), v,
 		newOptions(t, workDir, catalog.FormatJSONL), "github.com/acme/explicit",
 	)
 
@@ -225,7 +226,7 @@ func TestRunRejectsAnUnknownFormat(t *testing.T) {
 	t.Parallel()
 
 	err := catalog.Run(
-		t.Context(), logger.CreateLogger(), venvtest.New(),
+		config.WithCaches(t.Context()), logger.CreateLogger(), venvtest.New(),
 		newOptions(t, "/catalog-unknown-format", "yaml"), "github.com/acme/vpc",
 	)
 

--- a/internal/cli/commands/catalog/tui/source_discovery_test.go
+++ b/internal/cli/commands/catalog/tui/source_discovery_test.go
@@ -127,7 +127,7 @@ inputs = {
 `), 0o644))
 
 	l := logger.CreateLogger()
-	ctx, pctx := config.NewParsingContext(t.Context(), l, venvtest.NewWithOSFS(), config.WithStrictControls(controls.New()))
+	ctx, pctx := config.NewParsingContext(config.WithCaches(t.Context()), l, venvtest.NewWithOSFS(), config.WithStrictControls(controls.New()))
 	pctx.RootWorkingDir = tmpDir
 
 	urls, err := tui.DiscoverSourceURLs(ctx, l, pctx)
@@ -145,7 +145,7 @@ func TestDiscoverSourceURLs_EmptyDir(t *testing.T) {
 	tmpDir := helpers.TmpDirWOSymlinks(t)
 
 	l := logger.CreateLogger()
-	ctx, pctx := config.NewParsingContext(t.Context(), l, venvtest.NewWithOSFS(), config.WithStrictControls(controls.New()))
+	ctx, pctx := config.NewParsingContext(config.WithCaches(t.Context()), l, venvtest.NewWithOSFS(), config.WithStrictControls(controls.New()))
 	pctx.RootWorkingDir = tmpDir
 
 	urls, err := tui.DiscoverSourceURLs(ctx, l, pctx)

--- a/internal/cli/commands/find/cli_test.go
+++ b/internal/cli/commands/find/cli_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -137,7 +138,7 @@ func TestNewCommandBeforeResolvesFormatAndMode(t *testing.T) {
 			cmd := find.NewCommand(newTestLogger(t), tgOpts, v)
 			require.NoError(t, cmd.Flags.Parse(clihelper.Args(tc.args), map[string]string{}))
 
-			err := cmd.Before(t.Context(), &clihelper.Context{})
+			err := cmd.Before(config.WithCaches(t.Context()), &clihelper.Context{})
 			if tc.wantErr {
 				require.Error(t, err)
 
@@ -150,7 +151,7 @@ func TestNewCommandBeforeResolvesFormatAndMode(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.NoError(t, cmd.Action(t.Context(), &clihelper.Context{}))
+			require.NoError(t, cmd.Action(config.WithCaches(t.Context()), &clihelper.Context{}))
 			assert.Equal(t, tc.wantOutput, buf.String())
 		})
 	}
@@ -195,7 +196,7 @@ func TestNewFlagsHiddenFlagRunsTheStrictControl(t *testing.T) {
 			flags := find.NewFlags(newTestLogger(t), find.NewOptions(tgOpts), venvtest.New(), nil)
 			require.NoError(t, flags.Parse(clihelper.Args(tc.args), map[string]string{}))
 
-			err := flags.RunActions(t.Context(), &clihelper.Context{})
+			err := flags.RunActions(config.WithCaches(t.Context()), &clihelper.Context{})
 			if tc.wantErr {
 				require.Error(t, err)
 
@@ -236,7 +237,7 @@ func TestNewFlagsExternalFlagAddsAGraphFilter(t *testing.T) {
 
 			flags := find.NewFlags(newTestLogger(t), opts, venvtest.New(), nil)
 			require.NoError(t, flags.Parse(clihelper.Args(tc.args), map[string]string{}))
-			require.NoError(t, flags.RunActions(t.Context(), &clihelper.Context{}))
+			require.NoError(t, flags.RunActions(config.WithCaches(t.Context()), &clihelper.Context{}))
 			assert.Len(t, opts.Filters, tc.wantFilters)
 		})
 	}

--- a/internal/cli/commands/find/find_test.go
+++ b/internal/cli/commands/find/find_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -519,7 +520,7 @@ locals {
 			r, w, err := os.Pipe()
 			require.NoError(t, err)
 
-			err = find.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
+			err = find.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 			if tt.format == "invalid" || tt.mode == "invalid" {
 				require.Error(t, err)
 				return
@@ -581,7 +582,7 @@ dependency "target" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = find.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
+	err = find.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	require.NoError(t, w.Close())
@@ -696,7 +697,7 @@ exclude {
 	var buf strings.Builder
 
 	v := venvtest.New().WithFS(fsys).WithWriter(&buf)
-	require.NoError(t, find.Run(t.Context(), newTestLogger(t), v, opts))
+	require.NoError(t, find.Run(config.WithCaches(t.Context()), newTestLogger(t), v, opts))
 
 	var found find.FoundComponents
 
@@ -735,7 +736,7 @@ func TestRunFailsWhenTheWriterFails(t *testing.T) {
 			opts.Format = tc.format
 
 			v := venvtest.New().WithFS(fsys).WithWriter(failingWriter{})
-			require.ErrorIs(t, find.Run(t.Context(), newTestLogger(t), v, opts), errWriteFailed)
+			require.ErrorIs(t, find.Run(config.WithCaches(t.Context()), newTestLogger(t), v, opts), errWriteFailed)
 		})
 	}
 }
@@ -780,7 +781,7 @@ func TestRunRejectsUnsupportedOptions(t *testing.T) {
 
 			v := venvtest.New().WithFS(fsys).WithWriter(&buf)
 
-			require.Error(t, find.Run(t.Context(), newTestLogger(t), v, opts))
+			require.Error(t, find.Run(config.WithCaches(t.Context()), newTestLogger(t), v, opts))
 			assert.Empty(t, buf.String())
 		})
 	}

--- a/internal/cli/commands/hcl/validate/validate_test.go
+++ b/internal/cli/commands/hcl/validate/validate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/hcl/validate"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -134,7 +135,7 @@ func TestRunValidateInputsDoesNotLeakEnvBetweenUnits(t *testing.T) {
 
 	opts.AuthProviderCmd = "fake-auth-provider"
 
-	err = validate.RunValidateInputs(t.Context(), l, v, opts)
+	err = validate.RunValidateInputs(config.WithCaches(t.Context()), l, v, opts)
 	require.Error(
 		t,
 		err,
@@ -160,6 +161,6 @@ func TestRunValidateInputsPassesWhenInputsDefined(t *testing.T) {
 	opts, err := options.NewTerragruntOptionsForTest(filepath.Join(tmpDir, "terragrunt.hcl"))
 	require.NoError(t, err)
 
-	err = validate.RunValidateInputs(t.Context(), l, v, opts)
+	err = validate.RunValidateInputs(config.WithCaches(t.Context()), l, v, opts)
 	require.NoError(t, err)
 }

--- a/internal/cli/commands/list/cli_test.go
+++ b/internal/cli/commands/list/cli_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
 	"github.com/gruntwork-io/terragrunt/internal/strict/controls"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -106,7 +107,7 @@ func TestNewCommandBeforeResolvesTheFormat(t *testing.T) {
 			cmd := newListCommand(t, &buf)
 			require.NoError(t, cmd.Flags.Parse(clihelper.Args(tc.args), map[string]string{}))
 
-			err := cmd.Before(t.Context(), &clihelper.Context{})
+			err := cmd.Before(config.WithCaches(t.Context()), &clihelper.Context{})
 			if tc.wantErr {
 				require.Error(t, err)
 
@@ -119,7 +120,7 @@ func TestNewCommandBeforeResolvesTheFormat(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.NoError(t, cmd.Action(t.Context(), &clihelper.Context{}))
+			require.NoError(t, cmd.Action(config.WithCaches(t.Context()), &clihelper.Context{}))
 			assert.Equal(t, tc.wantOutput, buf.String())
 		})
 	}
@@ -158,8 +159,8 @@ func TestNewCommandBeforeResolvesTheMode(t *testing.T) {
 
 			cmd := newListCommand(t, &buf)
 			require.NoError(t, cmd.Flags.Parse(clihelper.Args(tc.args), map[string]string{}))
-			require.NoError(t, cmd.Before(t.Context(), &clihelper.Context{}))
-			require.NoError(t, cmd.Action(t.Context(), &clihelper.Context{}))
+			require.NoError(t, cmd.Before(config.WithCaches(t.Context()), &clihelper.Context{}))
+			require.NoError(t, cmd.Action(config.WithCaches(t.Context()), &clihelper.Context{}))
 			assert.Equal(t, tc.wantPaths, strings.Fields(buf.String()))
 		})
 	}
@@ -186,8 +187,8 @@ func TestNewCommandTreeFlagRendersATree(t *testing.T) {
 
 			cmd := newListCommand(t, &buf)
 			require.NoError(t, cmd.Flags.Parse(clihelper.Args(tc.args), map[string]string{}))
-			require.NoError(t, cmd.Before(t.Context(), &clihelper.Context{}))
-			require.NoError(t, cmd.Action(t.Context(), &clihelper.Context{}))
+			require.NoError(t, cmd.Before(config.WithCaches(t.Context()), &clihelper.Context{}))
+			require.NoError(t, cmd.Action(config.WithCaches(t.Context()), &clihelper.Context{}))
 			assert.Equal(t, []string{".", "alpha", "zulu"}, treeLabels(buf.String()))
 		})
 	}
@@ -232,7 +233,7 @@ func TestNewFlagsHiddenFlagRunsTheStrictControl(t *testing.T) {
 			flags := list.NewFlags(newTestLogger(t), list.NewOptions(tgOpts), venvtest.New(), nil)
 			require.NoError(t, flags.Parse(clihelper.Args(tc.args), map[string]string{}))
 
-			err := flags.RunActions(t.Context(), &clihelper.Context{})
+			err := flags.RunActions(config.WithCaches(t.Context()), &clihelper.Context{})
 			if tc.wantErr {
 				require.Error(t, err)
 
@@ -273,7 +274,7 @@ func TestNewFlagsExternalFlagAddsAGraphFilter(t *testing.T) {
 
 			flags := list.NewFlags(newTestLogger(t), opts, venvtest.New(), nil)
 			require.NoError(t, flags.Parse(clihelper.Args(tc.args), map[string]string{}))
-			require.NoError(t, flags.RunActions(t.Context(), &clihelper.Context{}))
+			require.NoError(t, flags.RunActions(config.WithCaches(t.Context()), &clihelper.Context{}))
 			assert.Len(t, opts.Filters, tc.wantFilters)
 		})
 	}

--- a/internal/cli/commands/list/list_test.go
+++ b/internal/cli/commands/list/list_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/view/dag"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -76,7 +77,7 @@ func TestBasicDiscovery(t *testing.T) {
 
 	l.Formatter().SetDisabledColors(true)
 
-	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(writer), opts)
+	err = list.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(writer), opts)
 	require.NoError(t, err)
 
 	// Close the write end of the pipe
@@ -153,7 +154,7 @@ func TestHiddenDiscovery(t *testing.T) {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
+	err = list.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	// Close the write end of the pipe
@@ -228,7 +229,7 @@ dependency "unit2" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
+	err = list.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	// Close the write end of the pipe
@@ -303,7 +304,7 @@ dependency "unit3" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
+	err = list.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	// Close the write end of the pipe
@@ -417,7 +418,7 @@ dependency "C" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
+	err = list.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	// Close the write end of the pipe
@@ -557,7 +558,7 @@ dependency "unit1" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
+	err = list.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()
@@ -617,7 +618,7 @@ func TestDotFormatWithoutDependencies(t *testing.T) {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
+	err = list.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()
@@ -690,7 +691,7 @@ dependency "unit2" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
+	err = list.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()
@@ -768,7 +769,7 @@ dependency "unit2" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
+	err = list.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()
@@ -839,7 +840,7 @@ dependency "unit1" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
+	err = list.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()
@@ -906,7 +907,7 @@ exclude {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
+	err = list.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()
@@ -988,7 +989,7 @@ dependency "unit3" {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 
-	err = list.Run(t.Context(), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
+	err = list.Run(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv().WithWriter(w), opts)
 	require.NoError(t, err)
 
 	w.Close()
@@ -1060,7 +1061,7 @@ dependency "zulu" {
 
 			v := venvtest.New().WithFS(fsys).WithWriter(&buf)
 
-			require.NoError(t, list.Run(t.Context(), newTestLogger(t), v, opts))
+			require.NoError(t, list.Run(config.WithCaches(t.Context()), newTestLogger(t), v, opts))
 			assert.Equal(t, tc.wantOutput, buf.String())
 		})
 	}
@@ -1120,7 +1121,7 @@ dependency "zulu" {
 
 			v := venvtest.New().WithFS(fsys).WithWriter(&buf)
 
-			require.NoError(t, list.Run(t.Context(), newTestLogger(t), v, opts))
+			require.NoError(t, list.Run(config.WithCaches(t.Context()), newTestLogger(t), v, opts))
 			assert.Equal(t, tc.wantLabels, treeLabels(buf.String()))
 		})
 	}
@@ -1147,7 +1148,7 @@ func TestTextFormatGivesAWidePathItsOwnLine(t *testing.T) {
 
 	v := venvtest.New().WithFS(fsys).WithWriter(&buf)
 
-	require.NoError(t, list.Run(t.Context(), newTestLogger(t), v, opts))
+	require.NoError(t, list.Run(config.WithCaches(t.Context()), newTestLogger(t), v, opts))
 
 	wantPaths := []string{
 		filepath.Join(widePathPrefix, "one"),
@@ -1198,7 +1199,7 @@ func TestRunRejectsUnsupportedOptions(t *testing.T) {
 
 			v := venvtest.New().WithFS(fsys).WithWriter(&buf)
 
-			require.Error(t, list.Run(t.Context(), newTestLogger(t), v, opts))
+			require.Error(t, list.Run(config.WithCaches(t.Context()), newTestLogger(t), v, opts))
 			assert.Empty(t, buf.String())
 		})
 	}
@@ -1233,7 +1234,7 @@ func TestRunFailsWhenTheWriterFails(t *testing.T) {
 			opts.Format = tc.format
 
 			v := venvtest.New().WithFS(fsys).WithWriter(failingWriter{})
-			require.ErrorIs(t, list.Run(t.Context(), newTestLogger(t), v, opts), errWriteFailed)
+			require.ErrorIs(t, list.Run(config.WithCaches(t.Context()), newTestLogger(t), v, opts), errWriteFailed)
 		})
 	}
 }

--- a/internal/cli/commands/populate_tf_implementation_test.go
+++ b/internal/cli/commands/populate_tf_implementation_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
@@ -45,7 +46,7 @@ func TestPopulateTFImplementation(t *testing.T) {
 		opts := options.NewTerragruntOptions(vexec.NewOSExec())
 		opts.TFPath = "terraform"
 
-		require.NoError(t, commands.PopulateTFImplementation(t.Context(), logger.CreateLogger(), opts, v))
+		require.NoError(t, commands.PopulateTFImplementation(config.WithCaches(t.Context()), logger.CreateLogger(), opts, v))
 		assert.Equal(t, tfimpl.Terraform, opts.TofuImplementation)
 		assert.NotNil(t, opts.TerraformVersion)
 	})
@@ -58,7 +59,7 @@ func TestPopulateTFImplementation(t *testing.T) {
 		opts.TerraformVersion = version.Must(version.NewVersion("1.0.0"))
 
 		// venvtest's fail-closed exec errors on any spawn, so success proves no probe ran.
-		require.NoError(t, commands.PopulateTFImplementation(t.Context(), logger.CreateLogger(), opts, venvtest.New()))
+		require.NoError(t, commands.PopulateTFImplementation(config.WithCaches(t.Context()), logger.CreateLogger(), opts, venvtest.New()))
 		assert.Equal(t, tfimpl.OpenTofu, opts.TofuImplementation)
 	})
 
@@ -68,7 +69,7 @@ func TestPopulateTFImplementation(t *testing.T) {
 		opts := options.NewTerragruntOptions(vexec.NewOSExec())
 		opts.TFPath = "terraform"
 
-		require.Error(t, commands.PopulateTFImplementation(t.Context(), logger.CreateLogger(), opts, venvtest.New()))
+		require.Error(t, commands.PopulateTFImplementation(config.WithCaches(t.Context()), logger.CreateLogger(), opts, venvtest.New()))
 		assert.Equal(t, tfimpl.Unknown, opts.TofuImplementation)
 		assert.Nil(t, opts.TerraformVersion)
 	})
@@ -112,7 +113,7 @@ func TestRunActionDetectsImplementationForProviderCache(t *testing.T) {
 
 		l, output := newTestLogger()
 
-		require.NoError(t, commands.RunAction(t.Context(), nil, l, opts, v, action))
+		require.NoError(t, commands.RunAction(config.WithCaches(t.Context()), nil, l, opts, v, action))
 		assert.Equal(t, tfimpl.Terraform, opts.TofuImplementation)
 		assert.NotContains(t, output.String(), "falls back to OpenTofu's CLI config file locations")
 	})
@@ -127,7 +128,7 @@ func TestRunActionDetectsImplementationForProviderCache(t *testing.T) {
 
 		l, output := newDebugTestLogger()
 
-		require.NoError(t, commands.RunAction(t.Context(), nil, l, opts, v, action))
+		require.NoError(t, commands.RunAction(config.WithCaches(t.Context()), nil, l, opts, v, action))
 		assert.Equal(t, tfimpl.Unknown, opts.TofuImplementation)
 		assert.Contains(t, output.String(), "falls back to OpenTofu's CLI config file locations")
 	})
@@ -198,7 +199,7 @@ provider_installation {
 		return err
 	}
 
-	require.NoError(t, commands.RunAction(t.Context(), nil, logger.CreateLogger(), opts, v, action))
+	require.NoError(t, commands.RunAction(config.WithCaches(t.Context()), nil, logger.CreateLogger(), opts, v, action))
 
 	generated, err := vfs.ReadFile(v.FS, workDir+"/.terraformrc")
 	require.NoError(t, err, "a matching implementation must go through the cache and generate its CLI config")

--- a/internal/cli/commands/render/render_test.go
+++ b/internal/cli/commands/render/render_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/render"
 	"github.com/gruntwork-io/terragrunt/internal/ctyhelper"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -31,7 +32,7 @@ func TestRenderJSON_Basic(t *testing.T) {
 	opts.Write = false
 
 	err := render.Run(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		venvtest.NewOSWithEmptyEnv().WithWriter(&outputBuffer),
 		opts,
@@ -59,7 +60,7 @@ func TestRenderJSON_WithMetadata(t *testing.T) {
 	opts.Write = false
 
 	err := render.Run(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		venvtest.NewOSWithEmptyEnv().WithWriter(&outputBuffer),
 		opts,
@@ -86,7 +87,7 @@ func TestRenderJSON_WriteToFile(t *testing.T) {
 	opts.OutputPath = outputPath
 
 	err := render.Run(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		venvtest.NewOSWithEmptyEnv().WithWriter(io.Discard),
 		opts,
@@ -149,7 +150,7 @@ func TestRenderWriteWithoutOutputPath(t *testing.T) {
 			opts.Write = true
 
 			err := render.Run(
-				t.Context(),
+				config.WithCaches(t.Context()),
 				logger.CreateLogger(),
 				venvtest.NewOSWithEmptyEnv().WithWriter(io.Discard),
 				opts,
@@ -227,7 +228,7 @@ func renderToFilePerm(t *testing.T, format, outputPath string) os.FileMode {
 	opts.OutputPath = outputPath
 
 	err := render.Run(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		venvtest.NewOSWithEmptyEnv().WithWriter(io.Discard),
 		opts,
@@ -247,7 +248,7 @@ func TestRenderJSON_InvalidFormat(t *testing.T) {
 	opts.Format = "invalid"
 
 	err := render.Run(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		venvtest.NewOSWithEmptyEnv().WithWriter(io.Discard),
 		opts,
@@ -265,7 +266,7 @@ func TestRenderJSON_HCLFormat(t *testing.T) {
 	var renderedBuffer bytes.Buffer
 
 	err := render.Run(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		venvtest.NewOSWithEmptyEnv().WithWriter(&renderedBuffer),
 		opts,
@@ -287,7 +288,7 @@ func TestRenderJSON_NumberOutOfRange(t *testing.T) {
 	opts.Write = false
 
 	err := render.Run(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		venvtest.NewOSWithEmptyEnv().WithWriter(io.Discard),
 		opts,

--- a/internal/cli/commands/scaffold/copy_test.go
+++ b/internal/cli/commands/scaffold/copy_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/scaffold"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -142,7 +143,8 @@ func TestScaffoldRefusesToOverwriteWhenCopying(t *testing.T) {
 	opts.WorkingDir = outputDir
 	opts.NonInteractive = true
 
-	err = scaffold.Run(t.Context(), logger.CreateLogger(), venvtest.NewOSWithEmptyEnv(), opts, source, "")
+	ctx := config.WithCaches(t.Context())
+	err = scaffold.Run(ctx, logger.CreateLogger(), venvtest.NewOSWithEmptyEnv(), opts, source, "")
 	require.Error(t, err)
 
 	assert.NoFileExists(t, filepath.Join(outputDir, "terragrunt.hcl"))
@@ -176,9 +178,11 @@ func runScaffold(t *testing.T, source string) string {
 	opts.WorkingDir = outputDir
 	opts.NonInteractive = true
 
+	ctx := config.WithCaches(t.Context())
+
 	require.NoError(
 		t,
-		scaffold.Run(t.Context(), logger.CreateLogger(), venvtest.NewOSWithEmptyEnv(), opts, source, ""),
+		scaffold.Run(ctx, logger.CreateLogger(), venvtest.NewOSWithEmptyEnv(), opts, source, ""),
 	)
 
 	return outputDir

--- a/internal/cli/commands/scaffold/interactive_test.go
+++ b/internal/cli/commands/scaffold/interactive_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/cli/commands/scaffold"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/view/tui/form"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -43,7 +44,7 @@ func prepare(t *testing.T, source string) *scaffold.Plan {
 	v := venv.OSVenv()
 
 	plan, err := scaffold.Prepare(
-		t.Context(), logger.CreateLogger(), v, opts, source, "",
+		config.WithCaches(t.Context()), logger.CreateLogger(), v, opts, source, "",
 	)
 	require.NoError(t, err)
 
@@ -121,7 +122,7 @@ func TestRunInteractiveNonInteractiveSkipsTheForm(t *testing.T) {
 	opts.NonInteractive = true
 
 	require.NoError(t, scaffold.RunInteractive(
-		t.Context(), logger.CreateLogger(), venv.OSVenv(), opts, source, "",
+		config.WithCaches(t.Context()), logger.CreateLogger(), venv.OSVenv(), opts, source, "",
 	))
 
 	values := readFile(t, filepath.Join(outputDir, "terragrunt.values.hcl"))
@@ -153,7 +154,7 @@ func TestRunInteractiveWithoutTerminalSkipsTheForm(t *testing.T) {
 	opts.WorkingDir = outputDir
 
 	require.NoError(t, scaffold.RunInteractive(
-		t.Context(), logger.CreateLogger(), venv.OSVenv(), opts, source, "",
+		config.WithCaches(t.Context()), logger.CreateLogger(), venv.OSVenv(), opts, source, "",
 	))
 
 	assert.FileExists(t, filepath.Join(outputDir, "terragrunt.hcl"))

--- a/internal/cli/commands/scaffold/scaffold_test.go
+++ b/internal/cli/commands/scaffold/scaffold_test.go
@@ -114,9 +114,11 @@ func TestDefaultTemplateVariables(t *testing.T) {
 	opts, err := options.NewTerragruntOptionsForTest(filepath.Join(outputDir, "terragrunt.hcl"))
 	require.NoError(t, err)
 
-	_, pctx := configbridge.NewParsingContext(t.Context(), l, venvtest.NewWithOSFS(), opts)
+	ctx, pctx := configbridge.NewParsingContext(
+		config.WithCaches(t.Context()), l, venvtest.NewWithOSFS(), opts,
+	)
 	cfg, err := config.ReadTerragruntConfig(
-		t.Context(),
+		ctx,
 		l,
 		pctx,
 		config.DefaultParserOptions(l, pctx.Venv, opts.StrictControls),
@@ -221,9 +223,11 @@ func TestDefaultTemplateUserValueOverridesTODO(t *testing.T) {
 	opts, err := options.NewTerragruntOptionsForTest(filepath.Join(outputDir, "terragrunt.hcl"))
 	require.NoError(t, err)
 
-	_, pctx := configbridge.NewParsingContext(t.Context(), l, venvtest.NewWithOSFS(), opts)
+	ctx, pctx := configbridge.NewParsingContext(
+		config.WithCaches(t.Context()), l, venvtest.NewWithOSFS(), opts,
+	)
 	cfg, err := config.ReadTerragruntConfig(
-		t.Context(),
+		ctx,
 		l,
 		pctx,
 		config.DefaultParserOptions(l, pctx.Venv, opts.StrictControls),
@@ -456,8 +460,10 @@ catalog {
 			l := logger.CreateLogger()
 
 			// First, verify catalog config parsing
-			_, catalogPctx := configbridge.NewParsingContext(context.Background(), l, venvtest.NewWithOSFS(), opts)
-			catalogCfg, err := config.ReadCatalogConfig(context.Background(), l, catalogPctx)
+			ctx, catalogPctx := configbridge.NewParsingContext(
+				config.WithCaches(context.Background()), l, venvtest.NewWithOSFS(), opts,
+			)
+			catalogCfg, err := config.ReadCatalogConfig(ctx, l, catalogPctx)
 			require.NoError(t, err)
 			require.NotNil(t, catalogCfg, tc.description)
 
@@ -550,8 +556,10 @@ catalog {
 	l := logger.CreateLogger()
 
 	// Parse the configuration
-	_, catalogPctx := configbridge.NewParsingContext(context.Background(), l, venvtest.NewWithOSFS(), opts)
-	catalogCfg, err := config.ReadCatalogConfig(context.Background(), l, catalogPctx)
+	ctx, catalogPctx := configbridge.NewParsingContext(
+		config.WithCaches(context.Background()), l, venvtest.NewWithOSFS(), opts,
+	)
+	catalogCfg, err := config.ReadCatalogConfig(ctx, l, catalogPctx)
 	require.NoError(t, err)
 	require.NotNil(t, catalogCfg)
 
@@ -589,8 +597,10 @@ catalog {
 	l := logger.CreateLogger()
 
 	// Parse the configuration
-	_, catalogPctx := configbridge.NewParsingContext(context.Background(), l, venvtest.NewWithOSFS(), opts)
-	catalogCfg, err := config.ReadCatalogConfig(context.Background(), l, catalogPctx)
+	ctx, catalogPctx := configbridge.NewParsingContext(
+		config.WithCaches(context.Background()), l, venvtest.NewWithOSFS(), opts,
+	)
+	catalogCfg, err := config.ReadCatalogConfig(ctx, l, catalogPctx)
 	require.NoError(t, err)
 	require.NotNil(t, catalogCfg)
 

--- a/internal/discovery/concurrent_parse_race_test.go
+++ b/internal/discovery/concurrent_parse_race_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/require"
@@ -79,6 +80,6 @@ func TestDiscovery_GraphConcurrentConfigAccessWithRacing(t *testing.T) {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: repoRoot}).
 		WithFilters(filters)
 
-	_, err = d.Discover(t.Context(), l, v, opts)
+	_, err = d.Discover(config.WithCaches(t.Context()), l, v, opts)
 	require.NoError(t, err)
 }

--- a/internal/discovery/discovery_boundary_test.go
+++ b/internal/discovery/discovery_boundary_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
@@ -93,7 +94,7 @@ func (f *boundaryFixture) discover(t *testing.T, v *venv.Venv, query, boundary s
 		d = d.WithDiscoveryBoundary(boundary)
 	}
 
-	return d.Discover(t.Context(), logger.CreateLogger(), v, opts)
+	return d.Discover(config.WithCaches(t.Context()), logger.CreateLogger(), v, opts)
 }
 
 // Test that a dependent found by the upstream walk is returned when the
@@ -344,7 +345,7 @@ func TestDiscoveryBoundary_SurvivesFilterEvaluationWithRelationships(t *testing.
 				d = d.WithDiscoveryBoundary(tc.boundary)
 			}
 
-			configs, err := d.Discover(t.Context(), logger.CreateLogger(), v, opts)
+			configs, err := d.Discover(config.WithCaches(t.Context()), logger.CreateLogger(), v, opts)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, paths, configs.Filter(component.UnitKind).Paths())
 		})
@@ -407,7 +408,7 @@ func TestDiscoveryBoundary_WithholdingAcrossFilterShapes(t *testing.T) {
 				WithFilters(filters).
 				WithRelationships().
 				WithDiscoveryBoundary(".").
-				Discover(t.Context(), logger.CreateLogger(), v, opts)
+				Discover(config.WithCaches(t.Context()), logger.CreateLogger(), v, opts)
 			require.NoError(t, err)
 
 			assert.ElementsMatch(t, paths, configs.Filter(component.UnitKind).Paths())
@@ -478,7 +479,7 @@ func TestDiscoveryBoundary_UnfilteredRunWithholdsOnlyWhatTraversalReached(t *tes
 	configs, err := discovery.NewDiscovery(f.stagingDir).
 		WithRelationships().
 		WithDiscoveryBoundary(".").
-		Discover(t.Context(), logger.CreateLogger(), v, opts)
+		Discover(config.WithCaches(t.Context()), logger.CreateLogger(), v, opts)
 	require.NoError(t, err)
 
 	// production/external is edge's dependency, reached across the boundary.
@@ -561,7 +562,7 @@ func TestDiscoveryBoundary_ExcludedDependencyStaysLinked(t *testing.T) {
 				WithFilters(filters).
 				WithRelationships().
 				WithDiscoveryBoundary(tc.boundary).
-				Discover(t.Context(), logger.CreateLogger(), v, opts)
+				Discover(config.WithCaches(t.Context()), logger.CreateLogger(), v, opts)
 			require.NoError(t, err)
 
 			assert.ElementsMatch(t, expected, configs.Filter(component.UnitKind).Paths())

--- a/internal/discovery/discovery_integration_test.go
+++ b/internal/discovery/discovery_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -85,7 +86,7 @@ func TestDiscovery_BasicWithHiddenDirectories(t *testing.T) {
 				WorkingDir: tmpDir,
 			}
 
-			ctx := t.Context()
+			ctx := config.WithCaches(t.Context())
 
 			d := discovery.NewDiscovery(tmpDir).WithDiscoveryContext(&component.DiscoveryContext{
 				WorkingDir: tmpDir,
@@ -124,7 +125,7 @@ func TestDiscovery_StackHiddenDiscovered(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// By default, .terragrunt-stack contents should be discovered
 	d := discovery.NewDiscovery(tmpDir).
@@ -192,7 +193,7 @@ func TestDiscovery_WithDependencies(t *testing.T) {
 		RootWorkingDir: internalDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	t.Run("discovery with relationships", func(t *testing.T) {
 		t.Parallel()
@@ -309,7 +310,7 @@ dependency "foo" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	filters, err := filter.ParseFilterQueries(l, []string{"{./**}..."})
 	require.NoError(t, err)
@@ -378,7 +379,7 @@ dependency "foo" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	filters, err := filter.ParseFilterQueries(l, []string{"{./**}..."})
 	require.NoError(t, err)
@@ -448,7 +449,7 @@ exclude {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// WithParseExclude sets requiresParse=true which triggers the parse phase,
 	// allowing exclude blocks to be parsed and accessible on the units.
@@ -529,7 +530,7 @@ func TestDiscovery_WithCustomConfigFilenames(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	t.Run("discover only custom config filename", func(t *testing.T) {
 		t.Parallel()
@@ -600,7 +601,7 @@ func TestDiscovery_WithReadFiles(t *testing.T) {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Use a reading filter to trigger parsing and populate the reading field
 	filters, err := filter.ParseFilterQueries(l, []string{"reading=shared.hcl"})
@@ -693,7 +694,7 @@ inputs = {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	d := discovery.NewDiscovery(tmpDir).
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
@@ -749,7 +750,7 @@ func TestDiscovery_IncludeExcludeFilterSemantics(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	tests := []struct {
 		name    string
@@ -813,7 +814,7 @@ func TestDiscovery_HiddenIncludedByIncludeDirs(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	filters, err := filter.ParseFilterQueries(l, []string{"./.hidden/**"})
 	require.NoError(t, err)
@@ -860,7 +861,7 @@ func TestDiscovery_ExternalDependencies(t *testing.T) {
 		RootWorkingDir: internalDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	filters, err := filter.ParseFilterQueries(l, []string{"{./**}..."})
 	require.NoError(t, err)
@@ -938,7 +939,7 @@ dependency "foo" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	filters, err := filter.ParseFilterQueries(l, []string{"{./**}..."})
 	require.NoError(t, err)
@@ -974,7 +975,7 @@ func TestDiscovery_WithNumWorkers(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	d := discovery.NewDiscovery(tmpDir).
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
@@ -1031,7 +1032,7 @@ dependency "d" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	t.Run("full depth discovers all", func(t *testing.T) {
 		t.Parallel()
@@ -1101,7 +1102,7 @@ terraform {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	d := discovery.NewDiscovery(tmpDir).
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
@@ -1184,7 +1185,7 @@ dependency "dependency" {
 				TerraformCommand: "plan",
 			}
 
-			ctx := t.Context()
+			ctx := config.WithCaches(t.Context())
 
 			d := discovery.NewDiscovery(tmpDir).
 				WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
@@ -1266,7 +1267,7 @@ dependency "db" {
 		OriginalTerragruntConfigPath: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Use a dependency traversal filter (app...) to trigger parsing
 	filters, err := filter.ParseFilterQueries(l, []string{"app..."})

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -260,7 +261,7 @@ func TestDiscovery_SimpleFilesystem(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Test: discover all components
 	d := discovery.NewDiscovery(tmpDir).WithDiscoveryContext(&component.DiscoveryContext{
@@ -295,7 +296,7 @@ func TestDiscovery_WithPathFilter(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Test: filter to apps/* only
 	filters, err := filter.ParseFilterQueries(l, []string{"./apps/*"})
@@ -335,7 +336,7 @@ func TestDiscovery_WithNegatedFilter(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Test: exclude ./bar
 	filters, err := filter.ParseFilterQueries(l, []string{"!./bar"})
@@ -380,7 +381,7 @@ func TestDiscovery_CombinedFilters(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Test: ./apps/* but not ./apps/baz
 	filters, err := filter.ParseFilterQueries(l, []string{"./apps/*", "!./apps/baz"})
@@ -506,7 +507,7 @@ func TestDiscovery_PopulatesReadingField(t *testing.T) {
 	}
 
 	l := logger.CreateLogger()
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Discover components with ReadFiles enabled to populate Reading field
 	d := discovery.NewDiscovery(tmpDir).
@@ -564,7 +565,7 @@ func TestDiscovery_BothHclAndStackFileInSameDir(t *testing.T) {
 	d := discovery.NewDiscovery(tmpDir).
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir})
 
-	_, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	_, err := d.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.Error(t, err)
 
 	var coexistErr discovery.CoexistenceError
@@ -595,7 +596,7 @@ func TestDiscovery_SingleUnitNoDuplicateError(t *testing.T) {
 	d := discovery.NewDiscovery(tmpDir).
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir})
 
-	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := d.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 	assert.Len(t, components, 1)
 	assert.Equal(t, component.UnitKind, components[0].Kind())
@@ -640,7 +641,7 @@ unit "app" {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithParseStackConfigs()
 
-	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := d.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	stacks := make(map[string]*component.Stack)

--- a/internal/discovery/filter_test.go
+++ b/internal/discovery/filter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -30,7 +31,7 @@ func TestDiscovery_GraphExpressionFilters(t *testing.T) {
 
 	runner = runner.WithWorkDir(tmpDir)
 
-	err = runner.Init(t.Context())
+	err = runner.Init(config.WithCaches(t.Context()))
 	require.NoError(t, err)
 
 	// Create dependency graph: vpc -> db -> app
@@ -70,7 +71,7 @@ dependency "vpc" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	tests := []struct {
 		name          string
@@ -121,7 +122,7 @@ func TestDiscovery_GraphExpressionFilters_ComplexGraph(t *testing.T) {
 
 	runner = runner.WithWorkDir(tmpDir)
 
-	err = runner.Init(t.Context())
+	err = runner.Init(config.WithCaches(t.Context()))
 	require.NoError(t, err)
 
 	// Create complex graph: vpc -> [db, cache] -> app
@@ -170,7 +171,7 @@ dependency "vpc" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	t.Run("dependency traversal from app finds all dependencies", func(t *testing.T) {
 		t.Parallel()
@@ -228,7 +229,7 @@ dependency "db" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	t.Run("graph expression only discovers dependencies of matching component", func(t *testing.T) {
 		t.Parallel()
@@ -293,7 +294,7 @@ dependency "vpc" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	t.Run("additional filters applied after graph discovery", func(t *testing.T) {
 		t.Parallel()
@@ -410,7 +411,7 @@ locals {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	tests := []struct {
 		name          string
@@ -531,7 +532,7 @@ locals {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Test with absolute path filter
 	filterQueries := []string{"reading=" + sharedFile}
@@ -657,7 +658,7 @@ unit "test" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	tests := []struct {
 		name          string
@@ -781,7 +782,7 @@ func TestDiscovery_FilterEdgeCases(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	tests := []struct {
 		name       string
@@ -908,7 +909,7 @@ func TestDiscovery_FilterErrorHandling(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -986,7 +987,7 @@ dependency "external" {
 		RootWorkingDir: internalDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	t.Run("external=true filter", func(t *testing.T) {
 		t.Parallel()
@@ -1036,7 +1037,7 @@ func TestDiscovery_DependentDiscovery_Standalone(t *testing.T) {
 
 	runner = runner.WithWorkDir(tmpDir)
 
-	err = runner.Init(t.Context())
+	err = runner.Init(config.WithCaches(t.Context()))
 	require.NoError(t, err)
 
 	// Create dependency graph: app -> db -> vpc
@@ -1076,7 +1077,7 @@ dependency "vpc" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Use ...vpc to find all dependents of vpc
 	filters, err := filter.ParseFilterQueries(l, []string{"...vpc"})
@@ -1108,7 +1109,7 @@ func TestDiscovery_DependentDiscovery_ExcludeTarget(t *testing.T) {
 
 	runner = runner.WithWorkDir(tmpDir)
 
-	err = runner.Init(t.Context())
+	err = runner.Init(config.WithCaches(t.Context()))
 	require.NoError(t, err)
 
 	// Create dependency graph: app -> vpc
@@ -1141,7 +1142,7 @@ dependency "vpc" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Use ...^vpc to find dependents but exclude the target (vpc)
 	filters, err := filter.ParseFilterQueries(l, []string{"...^vpc"})
@@ -1179,7 +1180,7 @@ func TestDiscovery_DependencyDiscovery_ExcludeTarget(t *testing.T) {
 
 	runner = runner.WithWorkDir(tmpDir)
 
-	err = runner.Init(t.Context())
+	err = runner.Init(config.WithCaches(t.Context()))
 	require.NoError(t, err)
 
 	// Create dependency graph: app -> db -> vpc
@@ -1218,7 +1219,7 @@ dependency "vpc" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Use ^app... to find dependencies but exclude the target (app)
 	filters, err := filter.ParseFilterQueries(l, []string{"^app..."})
@@ -1254,7 +1255,7 @@ func TestDiscovery_DependentDiscovery_Bidirectional(t *testing.T) {
 
 	runner = runner.WithWorkDir(tmpDir)
 
-	err = runner.Init(t.Context())
+	err = runner.Init(config.WithCaches(t.Context()))
 	require.NoError(t, err)
 
 	// Create dependency graph: app -> db -> vpc
@@ -1293,7 +1294,7 @@ dependency "vpc" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Use ...db... to find both dependencies and dependents of db
 	filters, err := filter.ParseFilterQueries(l, []string{"...db..."})
@@ -1327,7 +1328,7 @@ func TestDiscovery_DependentDiscovery_OutsideWorkingDir(t *testing.T) {
 
 	runner = runner.WithWorkDir(tmpDir)
 
-	err = runner.Init(t.Context())
+	err = runner.Init(config.WithCaches(t.Context()))
 	require.NoError(t, err)
 
 	// Create structure:
@@ -1371,7 +1372,7 @@ dependency "vpc" {
 		RootWorkingDir: appDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Use ...vpc to find dependents of vpc
 	// consumer is outside the working directory (app/) but should be found
@@ -1413,7 +1414,7 @@ func TestDiscovery_DependentDiscovery_OutsideWorkingDir_MultipleLevels(t *testin
 
 	runner = runner.WithWorkDir(tmpDir)
 
-	err = runner.Init(t.Context())
+	err = runner.Init(config.WithCaches(t.Context()))
 	require.NoError(t, err)
 
 	// Create structure:
@@ -1467,7 +1468,7 @@ dependency "api" {
 		RootWorkingDir: infraDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Use ...vpc to find dependents of vpc
 	// api and frontend are both outside the working directory (infra/)
@@ -1512,7 +1513,7 @@ func TestDiscovery_DependentDiscovery_DirectDependentOnly(t *testing.T) {
 
 	runner = runner.WithWorkDir(tmpDir)
 
-	err = runner.Init(t.Context())
+	err = runner.Init(config.WithCaches(t.Context()))
 	require.NoError(t, err)
 
 	// Create dependency graph: api -> db, web -> db
@@ -1554,7 +1555,7 @@ dependency "db" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Use ...db to find all dependents of db
 	filters, err := filter.ParseFilterQueries(l, []string{"...db"})
@@ -1631,7 +1632,7 @@ func TestDiscovery_NegatedGraphFilters(t *testing.T) {
 
 			runner = runner.WithWorkDir(tmpDir)
 
-			err = runner.Init(t.Context())
+			err = runner.Init(config.WithCaches(t.Context()))
 			require.NoError(t, err)
 
 			vpcDir := filepath.Join(tmpDir, "vpc")
@@ -1669,7 +1670,7 @@ dependency "vpc" {
 				RootWorkingDir: tmpDir,
 			}
 
-			ctx := t.Context()
+			ctx := config.WithCaches(t.Context())
 
 			filters, err := filter.ParseFilterQueries(l, tt.filters)
 			require.NoError(t, err)

--- a/internal/discovery/graph_boundary_test.go
+++ b/internal/discovery/graph_boundary_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 )
@@ -85,7 +86,7 @@ func (f *graphBoundaryFixture) discover(t *testing.T, v *venv.Venv, query string
 
 	configs, err := discovery.NewDiscovery(f.stagingDir).
 		WithFilters(filters).
-		Discover(t.Context(), logger.CreateLogger(), v, opts)
+		Discover(config.WithCaches(t.Context()), logger.CreateLogger(), v, opts)
 	require.NoError(t, err)
 
 	return configs
@@ -172,7 +173,7 @@ func TestDiscoveryGraphBoundary_ValidatesBoundary(t *testing.T) {
 
 			_, err = discovery.NewDiscovery(f.stagingDir).
 				WithFilters(filters).
-				Discover(t.Context(), logger.CreateLogger(), v, opts)
+				Discover(config.WithCaches(t.Context()), logger.CreateLogger(), v, opts)
 			require.ErrorAs(t, err, tc.errAs)
 		})
 	}
@@ -214,7 +215,7 @@ dependency "vpc" {
 
 		configs, err := discovery.NewDiscovery(repoRoot).
 			WithFilters(filters).
-			Discover(t.Context(), logger.CreateLogger(), v, opts)
+			Discover(config.WithCaches(t.Context()), logger.CreateLogger(), v, opts)
 		require.NoError(t, err)
 
 		return configs

--- a/internal/discovery/graph_dependency_race_test.go
+++ b/internal/discovery/graph_dependency_race_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -87,7 +88,7 @@ func TestGraphPhase_ConcurrentDependencyDiscoveryWithRacing(t *testing.T) {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workingDir}).
 		WithFilters(filters)
 
-	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := d.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	paths := components.Paths()
@@ -180,7 +181,7 @@ func TestGraphPhase_ConcurrentUpstreamDownstreamSharedDependencyWithRacing(t *te
 		WithGitRoot(workingDir).
 		WithFilters(filters)
 
-	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := d.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	require.Contains(t, components.Paths(), filepath.Join(extDir, "shared"))
@@ -279,6 +280,6 @@ func TestGraphPhase_UpstreamCandidatePublishBeforeContextWithRacing(t *testing.T
 		WithGitRoot(gitRoot).
 		WithFilters(filters)
 
-	_, err = d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	_, err = d.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 }

--- a/internal/discovery/graph_target_test.go
+++ b/internal/discovery/graph_target_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -59,7 +60,7 @@ dependency "db" {
 		WithGraphTarget(vpcDir)
 
 	configs, err := d.Discover(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		v,
 		opts,
@@ -114,14 +115,14 @@ dependency "db" {
 	configsA, err := discovery.NewDiscovery(tmpDir).
 		WithFilters(depsFilters).
 		WithFilters(filters).
-		Discover(t.Context(), logger.CreateLogger(), v, opts)
+		Discover(config.WithCaches(t.Context()), logger.CreateLogger(), v, opts)
 	require.NoError(t, err)
 
 	// Path B: graph target marker
 	configsB, err := discovery.NewDiscovery(tmpDir).
 		WithFilters(depsFilters).
 		WithGraphTarget(vpcDir).
-		Discover(t.Context(), logger.CreateLogger(), v, opts)
+		Discover(config.WithCaches(t.Context()), logger.CreateLogger(), v, opts)
 	require.NoError(t, err)
 
 	assert.ElementsMatch(
@@ -159,7 +160,7 @@ func TestDiscoveryWithGraphTarget_NoDependents(t *testing.T) {
 		WithGraphTarget(vpcDir)
 
 	configs, err := d.Discover(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		v,
 		opts,
@@ -204,7 +205,7 @@ dependency "vpc" {
 		WithOptions(graphTargetOpt)
 
 	configs, err := d.Discover(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		v,
 		opts,

--- a/internal/discovery/phase_relationship_race_test.go
+++ b/internal/discovery/phase_relationship_race_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -66,7 +67,7 @@ func TestRelationshipPhase_ConcurrentSharedDependencyWithRacing(t *testing.T) {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workingDir}).
 		WithRelationships()
 
-	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := d.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	sharedPath := filepath.Join(extDir, "shared")

--- a/internal/discovery/phase_relationship_test.go
+++ b/internal/discovery/phase_relationship_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -55,7 +56,7 @@ dependencies {
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
 		WithRelationships()
 
-	components, err := d.Discover(t.Context(), logger.CreateLogger(), v, opts)
+	components, err := d.Discover(config.WithCaches(t.Context()), logger.CreateLogger(), v, opts)
 	require.NoError(t, err)
 
 	app := components.FilterByPath(appDir)

--- a/internal/discovery/phase_test.go
+++ b/internal/discovery/phase_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/component"
 	"github.com/gruntwork-io/terragrunt/internal/discovery"
 	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -49,7 +50,7 @@ func TestFilesystemPhase_BasicDiscovery(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Run filesystem phase via full discovery
 	d := discovery.NewDiscovery(tmpDir).
@@ -93,7 +94,7 @@ func TestFilesystemPhase_SkipsIgnorableDirs(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	d := discovery.NewDiscovery(tmpDir).
 		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir})
@@ -127,7 +128,7 @@ func TestFilesystemPhase_WithNoHidden(t *testing.T) {
 		WorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	t.Run("without noHidden", func(t *testing.T) {
 		t.Parallel()
@@ -183,7 +184,7 @@ locals {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Filter with reading= attribute requires parsing
 	filters, err := filter.ParseFilterQueries(l, []string{"reading=shared.hcl"})
@@ -243,7 +244,7 @@ dependency "vpc" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Use graph filter to trigger graph phase
 	filters, err := filter.ParseFilterQueries(l, []string{"app..."})
@@ -320,7 +321,7 @@ dependency "vpc" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Using dependent filter (...vpc) without pre-built relationships
 	// Currently, the implementation requires relationships to be built
@@ -377,7 +378,7 @@ dependency "db" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Use WithRelationships to enable relationship phase
 	d := discovery.NewDiscovery(tmpDir).
@@ -774,7 +775,7 @@ dependency "vpc" {
 		RootWorkingDir: tmpDir,
 	}
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	// Using dependent filter (...vpc) should now work with pre-built graph
 	filters, err := filter.ParseFilterQueries(l, []string{"...vpc"})

--- a/internal/discovery/phase_worktree_expansion_integration_test.go
+++ b/internal/discovery/phase_worktree_expansion_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
@@ -79,7 +80,7 @@ func discoverExpansionChanges(
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
 	w, err := worktrees.NewWorktrees(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		l,
 		venvtest.NewOSWithEmptyEnv(),
 		worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: gitExpressions},
@@ -87,7 +88,7 @@ func discoverExpansionChanges(
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS()))
+		require.NoError(t, w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS()))
 	})
 
 	filters := make(filter.Filters, 0, len(gitExpressions)+len(extraFilters))
@@ -105,9 +106,11 @@ func discoverExpansionChanges(
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.FilterFlag))
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.BlockIteration))
 
+	ctx := config.WithCaches(t.Context())
+
 	require.NoError(
 		t,
-		generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w),
+		generate.NewGenerator().GenerateStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), opts, w),
 	)
 
 	d := discovery.NewDiscovery(tmpDir).
@@ -119,7 +122,7 @@ func discoverExpansionChanges(
 		d = d.WithSuppressParseErrors()
 	}
 
-	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := d.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	pair, ok := w.WorktreePairs["[HEAD~1...HEAD]"]

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -477,11 +478,11 @@ func TestWorktreePhase_Integration_CommandArgs(t *testing.T) {
 				WorkingDir:     tmpDir,
 				GitExpressions: gitExpressions,
 			}
-			w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
+			w, err := worktrees.NewWorktrees(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+				cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 				require.NoError(t, cleanupErr)
 			})
 
@@ -508,7 +509,7 @@ func TestWorktreePhase_Integration_CommandArgs(t *testing.T) {
 
 			discovery = discovery.WithFilters(filters)
 
-			components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+			components, err := discovery.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 
 			if tt.expectError {
 				require.Error(t, err, "Expected error for: %s", tt.description)
@@ -579,7 +580,7 @@ func TestWorktreePhase_Integration_EmptyFilters(t *testing.T) {
 	tmpDir, runner := setupGitRepo(t)
 
 	// Create initial empty commit
-	require.NoError(t, runner.Commit(t.Context(), "Initial commit", "--allow-empty"))
+	require.NoError(t, runner.Commit(config.WithCaches(t.Context()), "Initial commit", "--allow-empty"))
 
 	// Create a second commit with only non-terragrunt files
 	readmePath := filepath.Join(tmpDir, "README.md")
@@ -604,10 +605,10 @@ func TestWorktreePhase_Integration_EmptyDiffs(t *testing.T) {
 	tmpDir, runner := setupGitRepo(t)
 
 	// Create initial empty commit
-	require.NoError(t, runner.Commit(t.Context(), "Initial commit", "--allow-empty"))
+	require.NoError(t, runner.Commit(config.WithCaches(t.Context()), "Initial commit", "--allow-empty"))
 
 	// Create a second empty commit
-	require.NoError(t, runner.Commit(t.Context(), "Empty commit", "--allow-empty"))
+	require.NoError(t, runner.Commit(config.WithCaches(t.Context()), "Empty commit", "--allow-empty"))
 
 	// Run worktree discovery
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
@@ -763,11 +764,11 @@ unit "unit_to_be_untouched" {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
+	w, err := worktrees.NewWorktrees(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -783,7 +784,8 @@ unit "unit_to_be_untouched" {
 	err = opts.Experiments.EnableExperiment(experiment.FilterFlag)
 	require.NoError(t, err)
 
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
+	ctx := config.WithCaches(t.Context())
+	err = generate.NewGenerator().GenerateStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// Run discovery
@@ -805,7 +807,7 @@ unit "unit_to_be_untouched" {
 
 	discovery = discovery.WithFilters(filters)
 
-	components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := discovery.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Verify that components were discovered
@@ -918,11 +920,11 @@ func TestWorktreePhase_Integration_StackSourceOnlyInOneRef(t *testing.T) {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
+	w, err := worktrees.NewWorktrees(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -938,7 +940,7 @@ func TestWorktreePhase_Integration_StackSourceOnlyInOneRef(t *testing.T) {
 	// The from-ref stack references catalog/units/app, which was removed from the checked-out
 	// tree; before the fix, get_repo_root() resolved to the original checkout and generation
 	// failed to fetch the source.
-	err = generate.WorktreeStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
+	err = generate.WorktreeStacks(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	pair := w.WorktreePairs["[HEAD~1...HEAD]"]
@@ -1221,11 +1223,11 @@ locals {
 				WorkingDir:     tmpDir,
 				GitExpressions: filters.UniqueGitFilters(),
 			}
-			w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
+			w, err := worktrees.NewWorktrees(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+				cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 				require.NoError(t, cleanupErr)
 			})
 
@@ -1242,7 +1244,7 @@ locals {
 				WithWorktrees(w).
 				WithFilters(filters)
 
-			components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+			components, err := discovery.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 
 			// Filter results by type
@@ -1319,11 +1321,11 @@ locals {
 		WorkingDir:     basicDir,
 		GitExpressions: filters.UniqueGitFilters(),
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
+	w, err := worktrees.NewWorktrees(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -1340,7 +1342,7 @@ locals {
 		WithWorktrees(w).
 		WithFilters(filters)
 
-	components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := discovery.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Filter results by type
@@ -1596,11 +1598,11 @@ locals {
 				WorkingDir:     tmpDir,
 				GitExpressions: filters.UniqueGitFilters(),
 			}
-			w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
+			w, err := worktrees.NewWorktrees(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+				cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 				require.NoError(t, cleanupErr)
 			})
 
@@ -1617,7 +1619,7 @@ locals {
 				WithWorktrees(w).
 				WithFilters(filters)
 
-			components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+			components, err := discovery.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 
 			// Filter results by type
@@ -1704,11 +1706,11 @@ func TestWorktreePhase_Integration_FromSubdirectory_MultipleCommits(t *testing.T
 				WorkingDir:     basicDir,
 				GitExpressions: filters.UniqueGitFilters(),
 			}
-			w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
+			w, err := worktrees.NewWorktrees(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+				cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 				require.NoError(t, cleanupErr)
 			})
 
@@ -1725,7 +1727,7 @@ func TestWorktreePhase_Integration_FromSubdirectory_MultipleCommits(t *testing.T
 				WithWorktrees(w).
 				WithFilters(filters)
 
-			components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+			components, err := discovery.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 			require.NoError(t, err)
 
 			// Filter results by type
@@ -1764,8 +1766,8 @@ func setupGitRepo(t *testing.T) (string, *git.GitRunner) {
 func commitChanges(t *testing.T, runner *git.GitRunner, message string) {
 	t.Helper()
 
-	require.NoError(t, runner.Add(t.Context(), "."))
-	require.NoError(t, runner.Commit(t.Context(), message))
+	require.NoError(t, runner.Add(config.WithCaches(t.Context()), "."))
+	require.NoError(t, runner.Commit(config.WithCaches(t.Context()), message))
 }
 
 // createUnit creates a unit directory with terragrunt.hcl.
@@ -1893,11 +1895,11 @@ unit "app" {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
+	w, err := worktrees.NewWorktrees(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -1914,7 +1916,8 @@ unit "app" {
 	err = opts.Experiments.EnableExperiment(experiment.FilterFlag)
 	require.NoError(t, err)
 
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
+	ctx := config.WithCaches(t.Context())
+	err = generate.NewGenerator().GenerateStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// Run discovery
@@ -1936,7 +1939,7 @@ unit "app" {
 
 	disc = disc.WithFilters(filters)
 
-	components, err := disc.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := disc.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Get worktree paths
@@ -2087,11 +2090,11 @@ unit "app" {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
+	w, err := worktrees.NewWorktrees(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2107,7 +2110,8 @@ unit "app" {
 	err = opts.Experiments.EnableExperiment(experiment.FilterFlag)
 	require.NoError(t, err)
 
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
+	ctx := config.WithCaches(t.Context())
+	err = generate.NewGenerator().GenerateStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// Run discovery
@@ -2129,7 +2133,7 @@ unit "app" {
 
 	disc = disc.WithFilters(filters)
 
-	components, err := disc.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := disc.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Get worktree pair path
@@ -2271,11 +2275,11 @@ unit "app" {
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
+	w, err := worktrees.NewWorktrees(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2291,7 +2295,8 @@ unit "app" {
 	err = opts.Experiments.EnableExperiment(experiment.FilterFlag)
 	require.NoError(t, err)
 
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
+	ctx := config.WithCaches(t.Context())
+	err = generate.NewGenerator().GenerateStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// Run discovery
@@ -2313,7 +2318,7 @@ unit "app" {
 
 	disc = disc.WithFilters(filters)
 
-	components, err := disc.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := disc.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Get worktree paths
@@ -2436,14 +2441,15 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
+	ctx := config.WithCaches(t.Context())
+	w, err := worktrees.NewWorktrees(ctx, l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2461,7 +2467,7 @@ unit "myapp" {
 
 	// Generate stacks — using tmpDir as working directory so that only
 	// worktreeStacksToGenerate can cause generation inside worktrees.
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
+	err = generate.NewGenerator().GenerateStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// Verify: no .terragrunt-stack directories should exist in the worktrees,
@@ -2577,14 +2583,15 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
+	ctx := config.WithCaches(t.Context())
+	w, err := worktrees.NewWorktrees(ctx, l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2605,7 +2612,7 @@ unit "myapp" {
 	require.NoError(t, err)
 
 	// Generate stacks
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
+	err = generate.NewGenerator().GenerateStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// The marker file should NOT exist — the land-mine stack should not have been parsed.
@@ -2703,14 +2710,15 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
+	ctx := config.WithCaches(t.Context())
+	w, err := worktrees.NewWorktrees(ctx, l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2734,7 +2742,7 @@ unit "myapp" {
 	err = opts.Experiments.EnableExperiment(experiment.FilterFlag)
 	require.NoError(t, err)
 
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
+	err = generate.NewGenerator().GenerateStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 
 	// The marker file should NOT exist — negation should prevent parsing
@@ -2760,11 +2768,11 @@ func runWorktreeDiscovery(
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	}
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
+	w, err := worktrees.NewWorktrees(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), wtOpts)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2790,7 +2798,7 @@ func runWorktreeDiscovery(
 		WithWorktrees(w).
 		WithFilters(filters)
 
-	components, err := discovery.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := discovery.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	return components, w
@@ -2873,14 +2881,15 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
+	ctx := config.WithCaches(t.Context())
+	w, err := worktrees.NewWorktrees(ctx, l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2901,13 +2910,14 @@ unit "myapp" {
 		fromOpts := opts.Clone()
 		fromOpts.WorkingDir = pair.FromWorktree.Path
 		fromOpts.RootWorkingDir = pair.FromWorktree.Path
-		err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), fromOpts, w)
+		ctx := config.WithCaches(t.Context())
+		err = generate.NewGenerator().GenerateStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), fromOpts, w)
 		require.NoError(t, err)
 
 		toOpts := opts.Clone()
 		toOpts.WorkingDir = pair.ToWorktree.Path
 		toOpts.RootWorkingDir = pair.ToWorktree.Path
-		err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), toOpts, w)
+		err = generate.NewGenerator().GenerateStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), toOpts, w)
 		require.NoError(t, err)
 	}
 
@@ -2929,7 +2939,7 @@ unit "myapp" {
 
 	d = d.WithFilters(filters)
 
-	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := d.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	// Collect component paths and kinds for debugging
@@ -3027,14 +3037,15 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
+	ctx := config.WithCaches(t.Context())
+	w, err := worktrees.NewWorktrees(ctx, l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS()))
+		require.NoError(t, w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS()))
 	})
 
 	opts := options.NewTerragruntOptions(vexec.NewOSExec())
@@ -3050,7 +3061,7 @@ unit "app" {
 
 	require.NoError(
 		t,
-		generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w),
+		generate.NewGenerator().GenerateStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), opts, w),
 	)
 
 	readingAffectedDirs := make([]string, 0, len(w.ReadingAffectedStacks))
@@ -3152,14 +3163,15 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
+	ctx := config.WithCaches(t.Context())
+	w, err := worktrees.NewWorktrees(ctx, l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS()))
+		require.NoError(t, w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS()))
 	})
 
 	opts := options.NewTerragruntOptions(vexec.NewOSExec())
@@ -3175,7 +3187,7 @@ unit "app" {
 
 	require.NoError(
 		t,
-		generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w),
+		generate.NewGenerator().GenerateStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), opts, w),
 	)
 
 	readingAffectedDirs := make([]string, 0, len(w.ReadingAffectedStacks))
@@ -3252,14 +3264,15 @@ locals {
 	filters, parseErr := filter.ParseFilterQueries(l, filterQueries)
 	require.NoError(t, parseErr)
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
+	ctx := config.WithCaches(t.Context())
+	w, err := worktrees.NewWorktrees(ctx, l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: filters.UniqueGitFilters(),
 	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -3276,7 +3289,7 @@ locals {
 		WithRelationships().
 		WithFilters(filters)
 
-	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := d.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	unitPaths := components.Filter(component.UnitKind).Paths()
@@ -3335,14 +3348,15 @@ locals {
 	filters, parseErr := filter.ParseFilterQueries(l, []string{"[HEAD~1...HEAD]", "!./land-mine"})
 	require.NoError(t, parseErr)
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
+	ctx := config.WithCaches(t.Context())
+	w, err := worktrees.NewWorktrees(ctx, l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: filters.UniqueGitFilters(),
 	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -3357,7 +3371,7 @@ locals {
 		WithFilters(filters)
 
 	// If the land-mine unit is parsed, run_cmd("exit 1") causes a fatal error.
-	components, err := d.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := d.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	unitPaths := components.Filter(component.UnitKind).Paths()
@@ -3441,14 +3455,15 @@ unit "myapp" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
+	ctx := config.WithCaches(t.Context())
+	w, err := worktrees.NewWorktrees(ctx, l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -3466,7 +3481,7 @@ unit "myapp" {
 
 	// GenerateStacks internally calls discoverStacks with reading filters.
 	// If the land-mine unit is parsed, run_cmd("exit 1") causes a fatal error.
-	err = generate.NewGenerator().GenerateStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w)
+	err = generate.NewGenerator().GenerateStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), opts, w)
 	require.NoError(t, err)
 }
 
@@ -3546,14 +3561,15 @@ unit "app" {
 	l := logger.CreateLogger()
 	gitExpressions := filter.GitExpressions{filter.NewGitExpression("HEAD~1", "HEAD")}
 
-	w, err := worktrees.NewWorktrees(t.Context(), l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
+	ctx := config.WithCaches(t.Context())
+	w, err := worktrees.NewWorktrees(ctx, l, venvtest.NewOSWithEmptyEnv(), worktrees.WorktreeOpts{
 		WorkingDir:     tmpDir,
 		GitExpressions: gitExpressions,
 	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(config.WithCaches(t.Context())), l, vfs.NewOSFS())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -3568,7 +3584,7 @@ unit "app" {
 	opts.Experiments = experiment.NewExperiments()
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.FilterFlag))
 
-	require.NoError(t, generate.WorktreeStacks(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts, w))
+	require.NoError(t, generate.WorktreeStacks(ctx, l, venvtest.NewOSWithEmptyEnv(), opts, w))
 
 	// The working tree must stay untouched: no stack was generated under it.
 	_, statErr := os.Stat(filepath.Join(stackDir, ".terragrunt-stack"))
@@ -3590,7 +3606,7 @@ unit "app" {
 		WithWorktrees(w).
 		WithFilters(filters)
 
-	components, err := disc.Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	components, err := disc.Discover(config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), opts)
 	require.NoError(t, err)
 
 	require.Contains(t, w.WorktreePairs, "[HEAD~1...HEAD]")

--- a/internal/discovery/symlinks_test.go
+++ b/internal/discovery/symlinks_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -57,7 +58,7 @@ func TestDiscoverySymlinksExperiment(t *testing.T) {
 		}
 
 		components, err := discovery.NewDiscovery(root).
-			Discover(t.Context(), logger.CreateLogger(), v, opts)
+			Discover(config.WithCaches(t.Context()), logger.CreateLogger(), v, opts)
 		require.NoError(t, err)
 
 		return components.Filter(component.UnitKind).Paths()

--- a/internal/runner/builder_test.go
+++ b/internal/runner/builder_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	thlogger "github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
@@ -33,7 +34,7 @@ func TestNew(t *testing.T) {
 		require.NoError(t, v.FS.MkdirAll(memRoot, 0o755))
 
 		rnr, err := runner.New(
-			t.Context(),
+			config.WithCaches(t.Context()),
 			thlogger.CreateLogger(),
 			v,
 			newStackOpts(t, memRoot, tf.CommandNamePlan),
@@ -50,7 +51,7 @@ func TestNew(t *testing.T) {
 		writeUnit(t, v, memRoot, "app", dependencyBlock("../vpc"))
 
 		rnr, err := runner.New(
-			t.Context(),
+			config.WithCaches(t.Context()),
 			thlogger.CreateLogger(),
 			v,
 			newStackOpts(t, memRoot, tf.CommandNamePlan),
@@ -78,7 +79,7 @@ func TestNew(t *testing.T) {
 		opts := newStackOpts(t, memRoot, tf.CommandNamePlan)
 		opts.WorkingDir = filepath.Join(memRoot, "app")
 
-		rnr, err := runner.New(t.Context(), thlogger.CreateLogger(), v, opts)
+		rnr, err := runner.New(config.WithCaches(t.Context()), thlogger.CreateLogger(), v, opts)
 		require.NoError(t, err)
 		assert.Len(
 			t,
@@ -99,7 +100,7 @@ func TestNew(t *testing.T) {
 		opts.RootWorkingDir = ""
 		opts.WorkingDir = filepath.Join(memRoot, "app")
 
-		rnr, err := runner.New(t.Context(), thlogger.CreateLogger(), v, opts)
+		rnr, err := runner.New(config.WithCaches(t.Context()), thlogger.CreateLogger(), v, opts)
 		require.NoError(t, err)
 
 		units := rnr.GetStack().Units
@@ -121,7 +122,7 @@ func TestNew(t *testing.T) {
 		opts := newStackOpts(t, memRoot, tf.CommandNamePlan)
 		opts.TerragruntConfigPath = filepath.Join(memRoot, "custom.hcl")
 
-		rnr, err := runner.New(t.Context(), thlogger.CreateLogger(), v, opts)
+		rnr, err := runner.New(config.WithCaches(t.Context()), thlogger.CreateLogger(), v, opts)
 		require.NoError(t, err)
 
 		units := rnr.GetStack().Units
@@ -146,7 +147,7 @@ func TestNew(t *testing.T) {
 		opts.DiscoveryBoundary = memRoot
 
 		rnr, err := runner.New(
-			t.Context(),
+			config.WithCaches(t.Context()),
 			l,
 			v,
 			opts,
@@ -166,7 +167,7 @@ func TestNew(t *testing.T) {
 		writeUnit(t, v, memRoot, "vpc", invalidHCL)
 
 		_, err := runner.New(
-			t.Context(),
+			config.WithCaches(t.Context()),
 			thlogger.CreateLogger(),
 			v,
 			newStackOpts(t, memRoot, tf.CommandNamePlan),
@@ -184,7 +185,7 @@ func TestNew(t *testing.T) {
 		opts.WorkingDir = filepath.Join(memRoot, "does-not-exist")
 		opts.RootWorkingDir = opts.WorkingDir
 
-		_, err := runner.New(t.Context(), thlogger.CreateLogger(), v, opts)
+		_, err := runner.New(config.WithCaches(t.Context()), thlogger.CreateLogger(), v, opts)
 		require.Error(t, err)
 	})
 }
@@ -250,7 +251,7 @@ func TestNew_VersionConstraints(t *testing.T) {
 			opts := newStackOpts(t, memRoot, tf.CommandNamePlan)
 			opts.TerragruntVersion = goversion.Must(goversion.NewVersion("0.1.0"))
 
-			rnr, err := runner.New(t.Context(), thlogger.CreateLogger(), v, opts)
+			rnr, err := runner.New(config.WithCaches(t.Context()), thlogger.CreateLogger(), v, opts)
 
 			if tc.assertErr != nil {
 				tc.assertErr(t, err)
@@ -284,7 +285,7 @@ func TestCheckUnitVersionConstraints_UnitLeftUnparsed(t *testing.T) {
 	unitOpts, unitLogger, err := runner.BuildUnitOpts(l, opts, unit)
 	require.NoError(t, err)
 
-	err = runner.CheckUnitVersionConstraints(t.Context(), l, v, unitOpts, unitLogger, unit)
+	err = runner.CheckUnitVersionConstraints(config.WithCaches(t.Context()), l, v, unitOpts, unitLogger, unit)
 
 	var target run.InvalidTerragruntVersion
 
@@ -312,7 +313,7 @@ func TestNew_TerraformBinaryOverridesVersionProbe(t *testing.T) {
 	writeUnit(t, v, memRoot, "vpc", `terraform_binary = "custom-tofu"`)
 
 	_, err := runner.New(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		thlogger.CreateLogger(),
 		v,
 		newStackOpts(t, memRoot, tf.CommandNamePlan),

--- a/internal/runner/controller_test.go
+++ b/internal/runner/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/runner"
 
 	"github.com/gruntwork-io/terragrunt/internal/queue"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/assert"
 )
@@ -77,7 +78,7 @@ func TestRunnerPool_LinearDependency(t *testing.T) {
 		runner.WithRunner(rnr),
 		runner.WithMaxConcurrency(2),
 	)
-	err = dagRunner.Run(t.Context(), logger.CreateLogger())
+	err = dagRunner.Run(config.WithCaches(t.Context()), logger.CreateLogger())
 	require.NoError(t, err)
 }
 
@@ -112,7 +113,7 @@ func TestRunnerPool_ParallelExecution(t *testing.T) {
 		runner.WithRunner(rnr),
 		runner.WithMaxConcurrency(2),
 	)
-	err = dagRunner.Run(t.Context(), logger.CreateLogger())
+	err = dagRunner.Run(config.WithCaches(t.Context()), logger.CreateLogger())
 	require.NoError(t, err)
 }
 
@@ -150,7 +151,7 @@ func TestRunnerPool_FailFast(t *testing.T) {
 		runner.WithRunner(rnr),
 		runner.WithMaxConcurrency(2),
 	)
-	err = dagRunner.Run(t.Context(), logger.CreateLogger())
+	err = dagRunner.Run(config.WithCaches(t.Context()), logger.CreateLogger())
 	require.Error(t, err)
 
 	for _, want := range []string{"unit A failed", "Unit 'B' did not run", "Unit 'C' did not run"} {
@@ -167,7 +168,7 @@ func TestRunnerPool_RunnerNotSet(t *testing.T) {
 	q, err := queue.NewQueue(component.Components{units[0]})
 	require.NoError(t, err)
 
-	err = runner.NewController(q, units).Run(t.Context(), logger.CreateLogger())
+	err = runner.NewController(q, units).Run(config.WithCaches(t.Context()), logger.CreateLogger())
 	require.ErrorIs(t, err, runner.ErrRunnerNotSet)
 }
 
@@ -221,7 +222,7 @@ func TestRunnerPool_NonPositiveConcurrencyRunsSerially(t *testing.T) {
 			}),
 			runner.WithMaxConcurrency(0),
 		)
-		require.NoError(t, dagRunner.Run(t.Context(), logger.CreateLogger()))
+		require.NoError(t, dagRunner.Run(config.WithCaches(t.Context()), logger.CreateLogger()))
 
 		mu.Lock()
 		defer mu.Unlock()
@@ -247,7 +248,7 @@ func TestRunnerPool_UnitMissingFromDiscoveredUnits(t *testing.T) {
 		runner.WithRunner(func(context.Context, *component.Unit) error { return nil }),
 	)
 
-	err = dagRunner.Run(t.Context(), logger.CreateLogger())
+	err = dagRunner.Run(config.WithCaches(t.Context()), logger.CreateLogger())
 
 	var target runner.UnitNotDiscoveredError
 
@@ -263,7 +264,7 @@ func TestRunnerPool_ContextCancelled(t *testing.T) {
 	q, err := queue.NewQueue(component.Components{units[0]})
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(config.WithCaches(t.Context()))
 	started := make(chan struct{})
 	release := make(chan struct{})
 
@@ -338,7 +339,7 @@ func TestRunnerPool_ComplexDependency_BFails(t *testing.T) {
 		runner.WithRunner(rnr),
 		runner.WithMaxConcurrency(8),
 	)
-	err = dagRunner.Run(t.Context(), logger.CreateLogger())
+	err = dagRunner.Run(config.WithCaches(t.Context()), logger.CreateLogger())
 	require.Error(t, err)
 
 	for _, want := range []string{"unit B failed", "Unit 'D' did not run", "Unit 'E' did not run"} {
@@ -374,7 +375,7 @@ func TestRunnerPool_ComplexDependency_AFails_FailFast(t *testing.T) {
 		runner.WithRunner(rnr),
 		runner.WithMaxConcurrency(8),
 	)
-	err = dagRunner.Run(t.Context(), logger.CreateLogger())
+	err = dagRunner.Run(config.WithCaches(t.Context()), logger.CreateLogger())
 	require.Error(t, err)
 
 	for _, want := range []string{
@@ -416,7 +417,7 @@ func TestRunnerPool_ComplexDependency_BFails_FailFast(t *testing.T) {
 		runner.WithRunner(rnr),
 		runner.WithMaxConcurrency(8),
 	)
-	err = dagRunner.Run(t.Context(), logger.CreateLogger())
+	err = dagRunner.Run(config.WithCaches(t.Context()), logger.CreateLogger())
 	require.Error(t, err)
 
 	for _, want := range []string{"unit B failed", "Unit 'D' did not run", "Unit 'E' did not run"} {

--- a/internal/runner/graph_fallback_test.go
+++ b/internal/runner/graph_fallback_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/filter"
 	"github.com/gruntwork-io/terragrunt/internal/runner"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	thlogger "github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -24,7 +25,7 @@ import (
 func TestTFGraphFallbackMatchesFilterExperiment(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 	l := thlogger.CreateLogger()
 
 	tmpDir := helpers.TmpDirWOSymlinks(t)

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"oras.land/oras-go/v2/registry/remote/auth"
@@ -366,7 +367,7 @@ func TestDownloadTerraformSourceIfNecessaryRemoteUrlToAlreadyDownloadedDirSameVe
 	terraformSource.VersionFile = filepath.Join(downloadDir, ".terragrunt-source-version")
 
 	_, err = run.DownloadTerraformSourceIfNecessary(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		venvtest.NewOSWithEmptyEnv(),
 		terraformSource,
@@ -434,7 +435,7 @@ func TestDownloadTerraformSourceIfNecessaryInvalidTerraformSource(t *testing.T) 
 	require.NoError(t, err)
 
 	_, err = run.DownloadTerraformSourceIfNecessary(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		venvtest.NewOSWithEmptyEnv(),
 		terraformSource,
@@ -593,7 +594,7 @@ func testDownloadTerraformSourceIfNecessary(
 	require.NoError(t, err)
 
 	_, err = run.DownloadTerraformSourceIfNecessary(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		venvtest.NewOSWithEmptyEnv(),
 		terraformSource,
@@ -681,7 +682,7 @@ func createConfig(
 
 	versionV := venvtest.New().WithExec(versionExec).WithEnv(venvtest.NewOSWithEmptyEnv().Env)
 	_, ver, impl, err := run.PopulateTFVersion(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		l,
 		versionV,
 		run.PopulateTFVersionInput{
@@ -942,7 +943,7 @@ func TestDownloadWithNoSourceCreatesCache(t *testing.T) {
 
 	// sourceURL "." represents the current directory (no terraform.source specified)
 	updatedOpts, err := run.DownloadTerraformSource(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		l,
 		venvtest.NewOSWithEmptyEnv(),
 		".",
@@ -1003,7 +1004,7 @@ func TestDownloadSourceWithCASExperimentDisabled(t *testing.T) {
 	r := report.NewReport()
 
 	_, err = run.DownloadTerraformSourceIfNecessary(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		l,
 		venvtest.NewOSWithEmptyEnv(),
 		src,
@@ -1051,7 +1052,7 @@ func TestDownloadSourceWithCASExperimentEnabled(t *testing.T) {
 	r := report.NewReport()
 
 	_, err = run.DownloadTerraformSourceIfNecessary(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		l,
 		venvtest.NewOSWithEmptyEnv(),
 		src,
@@ -1126,7 +1127,7 @@ func TestDownloadSourceOCIThroughCASExperimentGate(t *testing.T) {
 				WithUserHomeDir(func() (string, error) { return hermeticHome, nil })
 
 			_, err = run.DownloadTerraformSourceIfNecessary(
-				t.Context(),
+				config.WithCaches(t.Context()),
 				l,
 				v,
 				src,
@@ -1203,7 +1204,7 @@ func TestDownloadSourceOCIAgainstLocalRegistry(t *testing.T) {
 	v.HTTP = registry.Client()
 
 	_, err = run.DownloadTerraformSourceIfNecessary(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		l,
 		v,
 		src,
@@ -1249,7 +1250,7 @@ func TestDownloadSourceWithCASGitSource(t *testing.T) {
 	r := report.NewReport()
 
 	_, err = run.DownloadTerraformSourceIfNecessary(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		l,
 		venvtest.NewOSWithEmptyEnv(),
 		src,
@@ -1295,7 +1296,7 @@ func TestDownloadSourceCASInitializationFailure(t *testing.T) {
 	r := report.NewReport()
 
 	_, err = run.DownloadTerraformSourceIfNecessary(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		l,
 		venvtest.NewOSWithEmptyEnv(),
 		src,
@@ -1341,7 +1342,7 @@ func TestDownloadSourceUpdateSourceWithCASRequiresCAS(t *testing.T) {
 	l.SetOptions(log.WithOutput(io.Discard))
 
 	_, err = run.DownloadTerraformSourceIfNecessary(
-		t.Context(), l, venvtest.NewOSWithEmptyEnv(), src,
+		config.WithCaches(t.Context()), l, venvtest.NewOSWithEmptyEnv(), src,
 		configbridge.NewRunOptions(opts),
 		cfg, report.NewReport(),
 	)
@@ -1405,7 +1406,7 @@ func TestDownloadSourceWithCASMultipleSources(t *testing.T) {
 			}
 
 			_, err = run.DownloadTerraformSourceIfNecessary(
-				t.Context(),
+				config.WithCaches(t.Context()),
 				l,
 				venvtest.NewOSWithEmptyEnv(),
 				src,
@@ -1473,7 +1474,7 @@ func TestHTTPGetterNetrcAuthentication(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, err = client.Get(t.Context(), &getter.Request{
+	_, err = client.Get(config.WithCaches(t.Context()), &getter.Request{
 		Src:     server.URL + "/module.tf",
 		Dst:     dst,
 		GetMode: getter.ModeFile,
@@ -1550,7 +1551,7 @@ func TestDownloadTerraformSourceRejectsNonOSFilesystemPerSource(t *testing.T) {
 			l.SetOptions(log.WithOutput(io.Discard))
 
 			_, err = run.DownloadTerraformSource(
-				t.Context(),
+				config.WithCaches(t.Context()),
 				l,
 				v,
 				tc.source,
@@ -1581,7 +1582,7 @@ func TestDownloadTerraformSourceIfNecessaryPanicsOnNilSource(t *testing.T) {
 
 	require.PanicsWithValue(t, run.ErrNilSource, func() {
 		run.DownloadTerraformSourceIfNecessary(
-			t.Context(),
+			config.WithCaches(t.Context()),
 			logger.CreateLogger(),
 			venvtest.NewOSWithEmptyEnv(),
 			nil,
@@ -1614,7 +1615,7 @@ func TestDownloadTerraformSourceIfNecessaryRejectsNonOSFilesystem(t *testing.T) 
 	require.NoError(t, err)
 
 	_, err = run.DownloadTerraformSourceIfNecessary(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		logger.CreateLogger(),
 		v,
 		src,
@@ -1674,7 +1675,7 @@ func TestBuildDownloadClientOCIExperimentGate(t *testing.T) {
 
 			dst := filepath.Join(t.TempDir(), "module")
 
-			_, err = client.Get(t.Context(), &getter.Request{
+			_, err = client.Get(config.WithCaches(t.Context()), &getter.Request{
 				Src:     "oci://127.0.0.1:5000/terraform-modules/vpc?bogus=1",
 				Dst:     dst,
 				GetMode: getter.ModeDir,
@@ -1723,7 +1724,7 @@ func TestBuildDownloadClientThreadsVenvToOCIStore(t *testing.T) {
 	ociGetter, found := findGetter[*getter.OCIGetter](client.Getters)
 	require.True(t, found, "the oci getter must be registered when the experiment is on")
 
-	store, err := ociGetter.NewStore(t.Context(), "registry.example.com", "modules/vpc")
+	store, err := ociGetter.NewStore(config.WithCaches(t.Context()), "registry.example.com", "modules/vpc")
 	require.NoError(t, err)
 
 	remoteStore, castOK := store.(getter.OCIRemoteStore)
@@ -1732,7 +1733,7 @@ func TestBuildDownloadClientThreadsVenvToOCIStore(t *testing.T) {
 	authClient, castOK := remoteStore.Repo.Client.(*auth.Client)
 	require.True(t, castOK)
 
-	cred, err := authClient.Credential(t.Context(), "registry.example.com")
+	cred, err := authClient.Credential(config.WithCaches(t.Context()), "registry.example.com")
 	require.NoError(t, err)
 	assert.Equal(t, "wired", cred.Username,
 		"BuildDownloadClient must thread the run's venv into the OCI credential store")

--- a/internal/runner/run/version_check_test.go
+++ b/internal/runner/run/version_check_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/tfimpl"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/hashicorp/go-version"
@@ -216,7 +217,7 @@ func TestPopulateTFVersionRespectsTFPath(t *testing.T) {
 	}
 	e := vexec.NewMemExec(handler)
 
-	ctx := run.WithRunVersionCache(t.Context())
+	ctx := config.WithCaches(t.Context())
 	l := logger.CreateLogger()
 
 	tfOpts := func(binary string) *tf.TFOptions {

--- a/internal/runner/runner_functions_test.go
+++ b/internal/runner/runner_functions_test.go
@@ -128,7 +128,7 @@ func TestNewFromComponents_Empty(t *testing.T) {
 	l := thlogger.CreateLogger()
 
 	rnr, err := runner.NewFromComponents(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		l,
 		opts,
 		component.Components{},
@@ -170,7 +170,7 @@ func TestNewFromComponents_WithPreventDestroy(t *testing.T) {
 	l := thlogger.CreateLogger()
 
 	rnr, err := runner.NewFromComponents(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		l,
 		opts,
 		component.Components{vpc, app},
@@ -213,7 +213,7 @@ func TestNewFromComponents_FilterAllowDestroy(t *testing.T) {
 	l := thlogger.CreateLogger()
 
 	rnr, err := runner.NewFromComponents(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		l,
 		opts,
 		component.Components{vpc},
@@ -306,7 +306,7 @@ func TestNewFromComponents_PreventDestroyExcludesDependencies(t *testing.T) {
 	opts.TerraformCommand = tf.CommandNameDestroy
 
 	rnr, err := runner.NewFromComponents(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		thlogger.CreateLogger(),
 		opts,
 		component.Components{vpc, app},
@@ -329,7 +329,7 @@ func TestNewFromComponents_DestroyWithoutProtectedUnits(t *testing.T) {
 	opts.TerraformCommand = tf.CommandNameDestroy
 
 	rnr, err := runner.NewFromComponents(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		thlogger.CreateLogger(),
 		opts,
 		component.Components{vpc},
@@ -355,7 +355,7 @@ func TestNewFromComponents_FilterAllowDestroyKeepsUnit(t *testing.T) {
 	opts.FilterAllowDestroy = true
 
 	rnr, err := runner.NewFromComponents(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		thlogger.CreateLogger(),
 		opts,
 		component.Components{vpc},
@@ -371,7 +371,7 @@ func TestNewFromComponents_UnitWithoutParsedConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	rnr, err := runner.NewFromComponents(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		thlogger.CreateLogger(),
 		opts,
 		component.Components{component.NewUnit("/tmp/test/vpc")},
@@ -466,7 +466,7 @@ func TestNewFromComponents_PreventDestroyWalksTheDependencyGraph(t *testing.T) {
 			opts.TerraformCommand = tf.CommandNameDestroy
 
 			rnr, err := runner.NewFromComponents(
-				t.Context(),
+				config.WithCaches(t.Context()),
 				thlogger.CreateLogger(),
 				opts,
 				tc.components(),
@@ -519,7 +519,7 @@ func TestNewFromComponents_PreventDestroyStopsAtTraversalDepth(t *testing.T) {
 	opts.TerraformCommand = tf.CommandNameDestroy
 
 	rnr, err := runner.NewFromComponents(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		thlogger.CreateLogger(),
 		opts,
 		components,
@@ -590,7 +590,7 @@ func TestNewFromComponents_WithGitRefsAndStateBackends(t *testing.T) {
 			require.NoError(t, err)
 
 			rnr, err := runner.NewFromComponents(
-				t.Context(),
+				config.WithCaches(t.Context()),
 				thlogger.CreateLogger(),
 				opts,
 				component.Components{unit},
@@ -613,7 +613,7 @@ func TestNewFromComponents_IgnoresStackComponents(t *testing.T) {
 	}
 
 	rnr, err := runner.NewFromComponents(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		thlogger.CreateLogger(),
 		opts,
 		discovered,
@@ -677,7 +677,7 @@ func buildTestRunnerFromUnits(
 
 	l := thlogger.CreateLogger()
 
-	rnr, err := runner.NewFromComponents(t.Context(), l, opts, components)
+	rnr, err := runner.NewFromComponents(config.WithCaches(t.Context()), l, opts, components)
 	require.NoError(t, err)
 
 	return rnr

--- a/internal/runner/runner_run_test.go
+++ b/internal/runner/runner_run_test.go
@@ -44,7 +44,7 @@ func TestRunnerRun_ExcludedUnitsAreReported(t *testing.T) {
 	l := thlogger.CreateLogger()
 
 	rnr, err := runner.NewFromComponents(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		l,
 		opts,
 		component.Components{vpc, app},
@@ -53,7 +53,7 @@ func TestRunnerRun_ExcludedUnitsAreReported(t *testing.T) {
 
 	r := report.NewReport().WithWorkingDir(memRoot)
 
-	require.NoError(t, rnr.Run(t.Context(), l, v, opts, r))
+	require.NoError(t, rnr.Run(config.WithCaches(t.Context()), l, v, opts, r))
 
 	for _, unit := range []*component.Unit{vpc, app} {
 		run, err := r.GetRun(unit.Path())
@@ -84,7 +84,7 @@ func TestRunnerRun_ReportsFailureAndAncestorEarlyExit(t *testing.T) {
 	l := thlogger.CreateLogger()
 
 	rnr, err := runner.NewFromComponents(
-		t.Context(),
+		config.WithCaches(t.Context()),
 		l,
 		opts,
 		component.Components{vpc, db, app},
@@ -93,7 +93,7 @@ func TestRunnerRun_ReportsFailureAndAncestorEarlyExit(t *testing.T) {
 
 	r := report.NewReport().WithWorkingDir(memRoot)
 
-	require.Error(t, rnr.Run(t.Context(), l, v, opts, r))
+	require.Error(t, rnr.Run(config.WithCaches(t.Context()), l, v, opts, r))
 
 	vpcRun, err := r.GetRun(vpc.Path())
 	require.NoError(t, err)
@@ -129,12 +129,12 @@ func TestRunnerRun_FailedUnitWithFailedDependencyIsEarlyExit(t *testing.T) {
 
 	l := thlogger.CreateLogger()
 
-	rnr, err := runner.NewFromComponents(t.Context(), l, opts, component.Components{vpc, app})
+	rnr, err := runner.NewFromComponents(config.WithCaches(t.Context()), l, opts, component.Components{vpc, app})
 	require.NoError(t, err)
 
 	r := report.NewReport().WithWorkingDir(memRoot)
 
-	require.Error(t, rnr.Run(t.Context(), l, v, opts, r))
+	require.Error(t, rnr.Run(config.WithCaches(t.Context()), l, v, opts, r))
 
 	appRun, err := r.GetRun(app.Path())
 	require.NoError(t, err)
@@ -155,10 +155,10 @@ func TestRunnerRun_WithoutReport(t *testing.T) {
 
 	l := thlogger.CreateLogger()
 
-	rnr, err := runner.NewFromComponents(t.Context(), l, opts, component.Components{vpc})
+	rnr, err := runner.NewFromComponents(config.WithCaches(t.Context()), l, opts, component.Components{vpc})
 	require.NoError(t, err)
 
-	require.Error(t, rnr.Run(t.Context(), l, v, opts, nil))
+	require.Error(t, rnr.Run(config.WithCaches(t.Context()), l, v, opts, nil))
 	assert.Contains(
 		t,
 		opts.TerraformCliArgs.Slice(),
@@ -188,10 +188,10 @@ func TestRunnerRun_AuthProviderFailureFailsUnit(t *testing.T) {
 
 	l := thlogger.CreateLogger()
 
-	rnr, err := runner.NewFromComponents(t.Context(), l, opts, component.Components{vpc})
+	rnr, err := runner.NewFromComponents(config.WithCaches(t.Context()), l, opts, component.Components{vpc})
 	require.NoError(t, err)
 
-	require.ErrorIs(t, rnr.Run(t.Context(), l, v, opts, nil), vexec.ErrNoSpawn)
+	require.ErrorIs(t, rnr.Run(config.WithCaches(t.Context()), l, v, opts, nil), vexec.ErrNoSpawn)
 }
 
 // TestRunnerRun_UnitRunFailsWithoutBinary pins the error a parsed unit hits when no binary may be spawned.
@@ -205,10 +205,10 @@ func TestRunnerRun_UnitRunFailsWithoutBinary(t *testing.T) {
 
 	l := thlogger.CreateLogger()
 
-	rnr, err := runner.NewFromComponents(t.Context(), l, opts, component.Components{vpc})
+	rnr, err := runner.NewFromComponents(config.WithCaches(t.Context()), l, opts, component.Components{vpc})
 	require.NoError(t, err)
 
-	require.ErrorIs(t, rnr.Run(t.Context(), l, v, opts, nil), vexec.ErrNoSpawn)
+	require.ErrorIs(t, rnr.Run(config.WithCaches(t.Context()), l, v, opts, nil), vexec.ErrNoSpawn)
 }
 
 // TestRunnerRun_UnitTerraformBinaryOverride pins that the unit run spawns a unit's terraform_binary.
@@ -222,9 +222,9 @@ func TestRunnerRun_UnitTerraformBinaryOverride(t *testing.T) {
 
 	l := thlogger.CreateLogger()
 
-	rnr, err := runner.NewFromComponents(t.Context(), l, opts, component.Components{vpc})
+	rnr, err := runner.NewFromComponents(config.WithCaches(t.Context()), l, opts, component.Components{vpc})
 	require.NoError(t, err)
-	require.NoError(t, rnr.Run(t.Context(), l, v, opts, nil))
+	require.NoError(t, rnr.Run(config.WithCaches(t.Context()), l, v, opts, nil))
 
 	plan := commandInvocation(t, invocations(), tf.CommandNamePlan)
 	assert.Equal(t, "custom-tofu", plan.Name, "the plan runs the unit's terraform_binary")
@@ -239,12 +239,12 @@ func TestRunnerRun_EmptyStack(t *testing.T) {
 
 	l := thlogger.CreateLogger()
 
-	rnr, err := runner.NewFromComponents(t.Context(), l, opts, component.Components{})
+	rnr, err := runner.NewFromComponents(config.WithCaches(t.Context()), l, opts, component.Components{})
 	require.NoError(t, err)
 
 	require.NoError(
 		t,
-		rnr.Run(t.Context(), l, v, opts, report.NewReport().WithWorkingDir(memRoot)),
+		rnr.Run(config.WithCaches(t.Context()), l, v, opts, report.NewReport().WithWorkingDir(memRoot)),
 	)
 }
 
@@ -341,13 +341,13 @@ func TestRunnerRun_SyncsUnitCliArgs(t *testing.T) {
 			l := thlogger.CreateLogger()
 
 			rnr, err := runner.NewFromComponents(
-				t.Context(),
+				config.WithCaches(t.Context()),
 				l,
 				opts,
 				component.Components{vpc},
 			)
 			require.NoError(t, err)
-			require.NoError(t, rnr.Run(t.Context(), l, v, opts, nil))
+			require.NoError(t, rnr.Run(config.WithCaches(t.Context()), l, v, opts, nil))
 
 			if tc.jsonOutput {
 				exists, err := vfs.FileExists(v.FS, vpc.OutputJSONFile(memRoot, opts.JSONOutputFolder))
@@ -429,9 +429,9 @@ func TestRunnerRun_PlanWithRemoteStateErrors(t *testing.T) {
 
 			l := thlogger.CreateLogger()
 
-			rnr, err := runner.NewFromComponents(t.Context(), l, opts, components)
+			rnr, err := runner.NewFromComponents(config.WithCaches(t.Context()), l, opts, components)
 			require.NoError(t, err)
-			require.NoError(t, rnr.Run(t.Context(), l, v, opts, nil))
+			require.NoError(t, rnr.Run(config.WithCaches(t.Context()), l, v, opts, nil))
 		})
 	}
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -35,7 +35,7 @@ func TestDiscoveryResolverMatchesLegacyPaths(t *testing.T) {
 
 	l := thlogger.CreateLogger()
 
-	rnr, err := runner.NewFromComponents(t.Context(), l, opts, discovered)
+	rnr, err := runner.NewFromComponents(config.WithCaches(t.Context()), l, opts, discovered)
 	require.NoError(t, err)
 
 	units := rnr.GetStack().Units

--- a/pkg/config/catalog_test.go
+++ b/pkg/config/catalog_test.go
@@ -134,9 +134,9 @@ func TestCatalogParseConfigFile(t *testing.T) {
 			t.Parallel()
 
 			l := logger.CreateLogger()
-			_, catalogPctx := newTestParsingContext(t, venvtest.NewWithOSFS(), tt.configPath)
+			ctx, catalogPctx := newTestParsingContext(t, venvtest.NewWithOSFS(), tt.configPath)
 			catalogPctx.ScaffoldRootFileName = filepath.Base(tt.configPath)
-			config, err := config.ReadCatalogConfig(t.Context(), l, catalogPctx)
+			config, err := config.ReadCatalogConfig(ctx, l, catalogPctx)
 
 			if tt.expectedErr == nil {
 				require.NoError(t, err)

--- a/pkg/config/config_helpers_hcl_mem_test.go
+++ b/pkg/config/config_helpers_hcl_mem_test.go
@@ -28,7 +28,7 @@ func TestHCLGetRepoRoot(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), "/synthetic/repo/root/unit/terragrunt.hcl")
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 
 	const hcl = `locals {
   repo = get_repo_root()
@@ -57,7 +57,7 @@ func TestHCLGetPathFromRepoRoot(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), "/repo/services/api/terragrunt.hcl")
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 	pctx.WorkingDir = "/repo/services/api"
 
 	const hcl = `locals {
@@ -81,7 +81,7 @@ func TestHCLGetPathToRepoRoot(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), "/repo/services/api/terragrunt.hcl")
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 	pctx.WorkingDir = "/repo/services/api"
 
 	const hcl = `locals {
@@ -105,7 +105,7 @@ func TestHCLGetRepoRootPropagatesGitError(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), "/not/a/repo/terragrunt.hcl")
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 
 	const hcl = `locals {
   repo = get_repo_root()
@@ -130,7 +130,7 @@ func TestHCLRunCmd(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir()+"/terragrunt.hcl")
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 
 	const hcl = `locals {
   account = run_cmd("--terragrunt-quiet", "describe", "--account", "prod")

--- a/pkg/config/config_helpers_mem_test.go
+++ b/pkg/config/config_helpers_mem_test.go
@@ -31,7 +31,7 @@ func TestRunCommandMemExec(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 
 	out, err := config.RunCommand(ctx, pctx, l, []string{"echoer", "hello"})
 	require.NoError(t, err)
@@ -55,7 +55,7 @@ func TestRunCommandCacheHitsCollapseSubprocessForks(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 
 	args := []string{"expensive-cmd", "--flag"}
 
@@ -87,7 +87,7 @@ func TestRunCommandNoCacheRefuses(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 
 	for range 3 {
 		_, err := config.RunCommand(ctx, pctx, l, []string{"--terragrunt-no-cache", "cmd"})
@@ -113,7 +113,7 @@ func TestRunCommandSurfacesSubprocessFailure(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 
 	_, err := config.RunCommand(ctx, pctx, l, []string{"failing-cmd"})
 	require.Error(t, err)
@@ -135,7 +135,7 @@ func TestRunCommandGlobalCacheSharesAcrossWorkingDirs(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctxA := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 
 	_, pctxB := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
 
@@ -187,7 +187,7 @@ func TestRunCommandConflictingCacheFlags(t *testing.T) {
 
 			l := logger.CreateLogger()
 			ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
-			ctx = config.WithConfigValues(ctx)
+			ctx = config.WithCaches(ctx)
 
 			_, err := config.RunCommand(ctx, pctx, l, tc.args)
 			require.Error(t, err)
@@ -210,7 +210,7 @@ func TestRunCommandDoesNotMutateCallerArgs(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 
 	args := []string{"--terragrunt-quiet", "--terragrunt-global-cache", "cmd", "subarg"}
 	want := slices.Clone(args)
@@ -234,7 +234,7 @@ func TestRunCommandEmptyParamsErrors(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 
 	_, err := config.RunCommand(ctx, pctx, l, nil)
 	require.Error(t, err)
@@ -257,7 +257,7 @@ func TestRunCommandReceivesPctxEnv(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.New().WithExec(exec), t.TempDir())
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 	pctx.Venv.Env = map[string]string{"TG_TEST_TOKEN": "abc123"}
 
 	_, err := config.RunCommand(ctx, pctx, l, []string{"reader"})

--- a/pkg/config/config_helpers_test.go
+++ b/pkg/config/config_helpers_test.go
@@ -580,10 +580,10 @@ unit "test" {
 	require.NoError(t, err)
 
 	l := logger.CreateLogger()
-	_, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), stackHclPath)
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), stackHclPath)
 	pctx.WorkingDir = tempDir
 
-	stackConfig, err := config.ReadStackConfigFile(t.Context(), l, pctx, stackHclPath, nil)
+	stackConfig, err := config.ReadStackConfigFile(ctx, l, pctx, stackHclPath, nil)
 	require.NoError(t, err)
 	require.NotNil(t, stackConfig)
 
@@ -608,7 +608,7 @@ func TestFindInParentFoldersSharedRunContext(t *testing.T) {
 
 	l := logger.CreateLogger()
 	baseCtx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), first)
-	ctx := config.WithConfigValues(baseCtx)
+	ctx := config.WithCaches(baseCtx)
 
 	firstPath, err := config.FindInParentFolders(ctx, pctx, l, []string{"root.hcl"})
 	require.NoError(t, err)
@@ -628,7 +628,7 @@ func TestFindInParentFoldersSharedRunContext(t *testing.T) {
 	require.NoError(t, os.WriteFile(nearerPath, nil, 0644))
 
 	nextRunPath, err := config.FindInParentFolders(
-		config.WithConfigValues(baseCtx),
+		config.WithCaches(baseCtx),
 		pctx,
 		l,
 		[]string{"root.hcl"},
@@ -657,7 +657,7 @@ func TestFindInParentFoldersSharedRunContextWithRacing(t *testing.T) {
 
 	l := logger.CreateLogger()
 	baseCtx, basePctx := newTestParsingContext(t, venvtest.NewWithOSFS(), configPaths[0])
-	ctx := config.WithConfigValues(baseCtx)
+	ctx := config.WithCaches(baseCtx)
 
 	group, groupCtx := errgroup.WithContext(ctx)
 
@@ -1084,7 +1084,7 @@ func newTestParsingContext(
 
 	l := logger.CreateLogger()
 	ctx, pctx := config.NewParsingContext(
-		config.WithConfigValues(tb.Context()),
+		config.WithCaches(tb.Context()),
 		l,
 		v,
 		config.WithStrictControls(controls.New()),

--- a/pkg/config/config_helpers_test.go
+++ b/pkg/config/config_helpers_test.go
@@ -1084,7 +1084,7 @@ func newTestParsingContext(
 
 	l := logger.CreateLogger()
 	ctx, pctx := config.NewParsingContext(
-		tb.Context(),
+		config.WithConfigValues(tb.Context()),
 		l,
 		v,
 		config.WithStrictControls(controls.New()),

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -6,6 +6,7 @@ import (
 	azurermbackend "github.com/gruntwork-io/terragrunt/internal/remotestate/backend/azurerm"
 
 	"github.com/gruntwork-io/terragrunt/internal/cache"
+	"github.com/gruntwork-io/terragrunt/internal/runner/run"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
 )
@@ -34,8 +35,13 @@ const (
 	parentFileProbeCacheName   = "parentFileProbeCache"
 )
 
-// WithConfigValues add to context default values for configuration.
-func WithConfigValues(ctx context.Context) context.Context {
+// WithCaches installs every cache Terragrunt reads while parsing and running a command.
+func WithCaches(ctx context.Context) context.Context {
+	return run.WithRunVersionCache(withConfigValues(ctx))
+}
+
+// withConfigValues adds to context default values for configuration.
+func withConfigValues(ctx context.Context) context.Context {
 	ctx = context.WithValue(ctx, HclCacheContextKey, cache.NewCache[*hclparse.File](hclCacheName))
 	ctx = context.WithValue(
 		ctx,

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1135,11 +1135,8 @@ func getTerragruntOutput(
 }
 
 // CollectStackUnitOutputs aggregates per-unit outputs keyed by unit name for dependency.<stack>.outputs.<unit>.<key> resolution.
-//
-// Every element of an expanded unit carries its block's label, so keying by name alone would
-// keep only the last one, each element having read a different generated directory. An expanded
-// unit nests its elements under their iteration key instead, reaching one as
-// dependency.<stack>.outputs.<unit>["<key>"], the address `terragrunt stack output` gives it.
+// An expanded unit nests its elements under their iteration key, reaching one as
+// dependency.<stack>.outputs.<unit>["<key>"].
 func CollectStackUnitOutputs(
 	ctx context.Context,
 	pctx *ParsingContext,

--- a/pkg/config/dependency_state_eligibility_test.go
+++ b/pkg/config/dependency_state_eligibility_test.go
@@ -460,7 +460,7 @@ inputs = {
 	require.NoError(t, vfs.WriteFile(v.FS, consumerPath, []byte(consumer), 0o600))
 
 	ctx, pctx := newTestParsingContext(t, v, consumerPath)
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 	pctx.OriginalTerragruntConfigPath = consumerPath
 	pctx.NoDependencyFetchOutputFromState = testCase.optOut
 

--- a/pkg/config/dependency_state_test.go
+++ b/pkg/config/dependency_state_test.go
@@ -925,7 +925,7 @@ inputs = {
 	require.NoError(t, vfs.WriteFile(v.FS, consumerPath, []byte(consumer), 0o600))
 
 	ctx, pctx := newTestParsingContext(t, v, consumerPath)
-	ctx = config.WithConfigValues(ctx)
+	ctx = config.WithCaches(ctx)
 	pctx.OriginalTerragruntConfigPath = consumerPath
 	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.DependencyFetchOutputFromState))
 

--- a/pkg/config/early_stack_eval_test.go
+++ b/pkg/config/early_stack_eval_test.go
@@ -123,7 +123,7 @@ func TestEarlyStackParseFunctions_GetEnvReadsPctxEnv(t *testing.T) {
 	pctx := newStackParsePctx(t, baseDir)
 	pctx.Venv.Env = map[string]string{"PLAN_KEY": "plan_value"}
 
-	funcs, err := config.EarlyStackParseFunctions(t.Context(), logger.CreateLogger(), baseDir, pctx)
+	funcs, err := config.EarlyStackParseFunctions(config.WithCaches(t.Context()), logger.CreateLogger(), baseDir, pctx)
 	require.NoError(t, err)
 
 	got, err := funcs[config.FuncNameGetEnv].Call([]cty.Value{cty.StringVal("PLAN_KEY")})
@@ -208,7 +208,7 @@ func TestEarlyStackParseFunctions_GetTerraformCommandReadsPctx(t *testing.T) {
 	pctx := newStackParsePctx(t, baseDir)
 	pctx.TerraformCommand = "plan"
 
-	funcs, err := config.EarlyStackParseFunctions(t.Context(), logger.CreateLogger(), baseDir, pctx)
+	funcs, err := config.EarlyStackParseFunctions(config.WithCaches(t.Context()), logger.CreateLogger(), baseDir, pctx)
 	require.NoError(t, err)
 
 	got, err := funcs[config.FuncNameGetTerraformCommand].Call(nil)
@@ -224,7 +224,7 @@ func TestEarlyStackParseFunctions_GetTerraformCLIArgsReadsPctx(t *testing.T) {
 	pctx.TerraformCliArgs = iacargs.New()
 	pctx.TerraformCliArgs.InsertArguments(0, "-auto-approve")
 
-	funcs, err := config.EarlyStackParseFunctions(t.Context(), logger.CreateLogger(), baseDir, pctx)
+	funcs, err := config.EarlyStackParseFunctions(config.WithCaches(t.Context()), logger.CreateLogger(), baseDir, pctx)
 	require.NoError(t, err)
 
 	got, err := funcs[config.FuncNameGetTerraformCLIArgs].Call(nil)
@@ -240,7 +240,7 @@ func TestEarlyStackParseFunctions_MarkAsReadAppendsToPctxFilesRead(t *testing.T)
 	pctx := newStackParsePctx(t, baseDir)
 	pctx.FilesRead = config.NewFilesRead()
 
-	funcs, err := config.EarlyStackParseFunctions(t.Context(), logger.CreateLogger(), baseDir, pctx)
+	funcs, err := config.EarlyStackParseFunctions(config.WithCaches(t.Context()), logger.CreateLogger(), baseDir, pctx)
 	require.NoError(t, err)
 
 	got, err := funcs[config.FuncNameMarkAsRead].Call([]cty.Value{cty.StringVal("inputs.yaml")})
@@ -289,7 +289,7 @@ unit "vpc" {
 
 	pctx := newStackParsePctx(t, stackDir)
 	funcsFor := func(dir string) (map[string]function.Function, error) {
-		return config.EarlyStackParseFunctions(t.Context(), logger.CreateLogger(), dir, pctx)
+		return config.EarlyStackParseFunctions(config.WithCaches(t.Context()), logger.CreateLogger(), dir, pctx)
 	}
 
 	paths, err := inthclparse.UnitPathsFromStackDir(
@@ -332,7 +332,7 @@ unit "vpc" {
 	)
 
 	funcsFor := func(dir string) (map[string]function.Function, error) {
-		return config.EarlyStackParseFunctions(t.Context(), logger.CreateLogger(), dir, pctx)
+		return config.EarlyStackParseFunctions(config.WithCaches(t.Context()), logger.CreateLogger(), dir, pctx)
 	}
 
 	paths, err := inthclparse.UnitPathsFromStackDir(

--- a/pkg/config/external_test.go
+++ b/pkg/config/external_test.go
@@ -433,7 +433,7 @@ inputs = {
 }
 `
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 	ctx, pctx := config.NewParsingContext(ctx, l, venvtest.NewWithOSFS())
 	cfg, err := config.ParseConfigString(
 		ctx,
@@ -468,7 +468,7 @@ unit "db" {
 }
 `
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 	ctx, pctx := config.NewParsingContext(ctx, l, venvtest.NewWithOSFS())
 
 	v := cty.ObjectVal(map[string]cty.Value{})
@@ -510,7 +510,7 @@ unit "db" {
 }
 `
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 	ctx, pctx := config.NewParsingContext(ctx, l, venvtest.NewWithOSFS())
 
 	sc, err := config.ReadStackConfigString(
@@ -550,7 +550,7 @@ unit "db" {
 }
 `
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 	ctx, pctx := config.NewParsingContext(ctx, l, venvtest.NewWithOSFS())
 
 	v := cty.ObjectVal(map[string]cty.Value{
@@ -594,7 +594,7 @@ region   = "us-west-2"
 		os.WriteFile(filepath.Join(dir, "terragrunt.values.hcl"), valuesContent, 0644),
 	)
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 	ctx, pctx := config.NewParsingContext(ctx, l, venvtest.NewWithOSFS())
 
 	// Read values from the file on disk.
@@ -640,7 +640,7 @@ region = "eu-west-1"
 		os.WriteFile(filepath.Join(dir, "terragrunt.values.hcl"), valuesContent, 0644),
 	)
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 	ctx, pctx := config.NewParsingContext(ctx, l, venvtest.NewWithOSFS())
 
 	// Use a configPath inside the temp dir so ParseConfig discovers the

--- a/pkg/config/find_in_parent_folders_bench_test.go
+++ b/pkg/config/find_in_parent_folders_bench_test.go
@@ -29,7 +29,7 @@ func BenchmarkFindInParentFolders(b *testing.B) {
 				for b.Loop() {
 					// A fresh cache per iteration: caches are per run, so a run
 					// never starts warm.
-					ctx := config.WithConfigValues(baseCtx)
+					ctx := config.WithCaches(baseCtx)
 
 					for _, configPath := range configPaths {
 						pctx.TerragruntConfigPath = configPath

--- a/pkg/config/sops_race_test.go
+++ b/pkg/config/sops_race_test.go
@@ -66,7 +66,7 @@ func TestSOPSDecryptConcurrencyWithRacing(t *testing.T) {
 		barrier = make(chan struct{})
 	)
 
-	ctx := config.WithConfigValues(t.Context())
+	ctx := config.WithCaches(t.Context())
 
 	for i, f := range files {
 		wg.Add(1)
@@ -129,7 +129,7 @@ func TestSOPSDecryptDistinctPathsOverlapWithRacing(t *testing.T) {
 			return os.ReadFile(path)
 		})
 
-	ctx := config.WithConfigValues(t.Context())
+	ctx := config.WithCaches(t.Context())
 
 	var wg sync.WaitGroup
 
@@ -187,7 +187,7 @@ func TestSOPSDecryptDeduplicatesSamePathWithRacing(t *testing.T) {
 		barrier = make(chan struct{})
 	)
 
-	ctx := config.WithConfigValues(t.Context())
+	ctx := config.WithCaches(t.Context())
 
 	for range numGoroutines {
 		wg.Go(func() {

--- a/pkg/config/sops_test.go
+++ b/pkg/config/sops_test.go
@@ -72,7 +72,7 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) {
 		t.Parallel()
 
 		l := logger.CreateLogger()
-		ctx := config.WithConfigValues(t.Context())
+		ctx := config.WithCaches(t.Context())
 		v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: "fresh-token"})
 
 		_, pctx := config.NewParsingContext(ctx, l, v, config.WithStrictControls(controls.New()))
@@ -87,7 +87,7 @@ func TestSOPSDecryptEnvPropagation(t *testing.T) {
 		t.Parallel()
 
 		l := logger.CreateLogger()
-		ctx := config.WithConfigValues(t.Context())
+		ctx := config.WithCaches(t.Context())
 		v := venvtest.NewWithOSFS().WithEnv(map[string]string{})
 
 		_, pctx := config.NewParsingContext(ctx, l, v, config.WithStrictControls(controls.New()))
@@ -113,7 +113,7 @@ func TestSOPSDecryptLeavesProcessEnvAlone(t *testing.T) { // t.Setenv bars t.Par
 	})
 
 	l := logger.CreateLogger()
-	ctx := config.WithConfigValues(t.Context())
+	ctx := config.WithCaches(t.Context())
 	v := venvtest.NewWithOSFS().WithEnv(map[string]string{authKey: "venv-token"})
 
 	_, pctx := config.NewParsingContext(ctx, l, v, config.WithStrictControls(controls.New()))

--- a/pkg/config/stack_unit_outputs_test.go
+++ b/pkg/config/stack_unit_outputs_test.go
@@ -51,23 +51,7 @@ func TestCollectStackUnitOutputsNestsExpandedElements(t *testing.T) {
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, v, filepath.Join(stackUnitOutputsRoot, "terragrunt.hcl"))
 
-	// The caches the fetch path reads live on the context, and only WithConfigValues puts
-	// them there. Without it every lookup below builds a throwaway cache and misses.
-	ctx = config.WithConfigValues(ctx)
-
-	// Priming the fetch cache is what keeps this off a real tofu binary: the venv's exec is
-	// fail-closed, so a cache miss would surface as an error rather than a shell-out.
 	jsonCache := cache.ContextCache[[]byte](ctx, config.JSONOutputCacheContextKey)
-
-	// ContextCache hands back a detached instance when the key is absent, so dropping the call
-	// above would leave every Put below invisible to the fetch path and quietly send this test
-	// looking for a real tofu binary. Two lookups agreeing on one pointer prove it is installed.
-	require.Same(
-		t,
-		jsonCache,
-		cache.ContextCache[[]byte](ctx, config.JSONOutputCacheContextKey),
-		"the output cache is not on the context, so priming it below would do nothing",
-	)
 
 	for unitPath, out := range outputs {
 		jsonCache.Put(ctx, filepath.Join(
@@ -95,8 +79,6 @@ func TestCollectStackUnitOutputsNestsExpandedElements(t *testing.T) {
 
 	aurora := collected["aurora"]
 
-	// Asserted before reading an element, so a collapse reports the shape it collapsed to
-	// rather than panicking on a missing attribute.
 	for _, key := range []string{"web", "api"} {
 		require.Truef(
 			t,
@@ -110,7 +92,6 @@ func TestCollectStackUnitOutputsNestsExpandedElements(t *testing.T) {
 	assert.Equal(t, "web", role(aurora.GetAttr("web")))
 	assert.Equal(t, "api", role(aurora.GetAttr("api")))
 
-	// A unit with no expansion keeps the flat address it always had.
 	require.Contains(t, collected, "vpc")
 	assert.Equal(t, "vpc", role(collected["vpc"]))
 }

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -59,7 +59,7 @@ const (
 func TestCatalogGitRepoUpdate(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
+	ctx := config.WithConfigValues(t.Context())
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	cloneURL := helpers.LocalGitRemote(t, testFixtureLocalCatalog)
@@ -90,7 +90,7 @@ func TestCatalogGitRepoUpdate(t *testing.T) {
 func TestScaffoldGitRepo(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
+	ctx := config.WithConfigValues(t.Context())
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	cloneURL := helpers.LocalGitRemote(t, testFixtureLocalCatalog)
@@ -114,7 +114,7 @@ func TestScaffoldGitRepo(t *testing.T) {
 func TestScaffoldGitModule(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
+	ctx := config.WithConfigValues(t.Context())
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	cloneURL := helpers.LocalGitRemote(t, testFixtureLocalCatalog)
@@ -202,9 +202,14 @@ func readConfig(t *testing.T, opts *options.TerragruntOptions) *config.Terragrun
 	require.NoError(t, err)
 
 	l := logger.CreateLogger()
-	_, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), opts)
+	ctx, pctx := configbridge.NewParsingContext(
+		config.WithConfigValues(t.Context()),
+		l,
+		venv.OSVenv(),
+		opts,
+	)
 	cfg, err := config.ReadTerragruntConfig(
-		t.Context(),
+		ctx,
 		l,
 		pctx,
 		config.DefaultParserOptions(l, venvtest.NewWithOSFS(), opts.StrictControls),

--- a/test/integration_catalog_test.go
+++ b/test/integration_catalog_test.go
@@ -59,7 +59,7 @@ const (
 func TestCatalogGitRepoUpdate(t *testing.T) {
 	t.Parallel()
 
-	ctx := config.WithConfigValues(t.Context())
+	ctx := config.WithCaches(t.Context())
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	cloneURL := helpers.LocalGitRemote(t, testFixtureLocalCatalog)
@@ -90,7 +90,7 @@ func TestCatalogGitRepoUpdate(t *testing.T) {
 func TestScaffoldGitRepo(t *testing.T) {
 	t.Parallel()
 
-	ctx := config.WithConfigValues(t.Context())
+	ctx := config.WithCaches(t.Context())
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	cloneURL := helpers.LocalGitRemote(t, testFixtureLocalCatalog)
@@ -114,7 +114,7 @@ func TestScaffoldGitRepo(t *testing.T) {
 func TestScaffoldGitModule(t *testing.T) {
 	t.Parallel()
 
-	ctx := config.WithConfigValues(t.Context())
+	ctx := config.WithCaches(t.Context())
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 	cloneURL := helpers.LocalGitRemote(t, testFixtureLocalCatalog)
@@ -203,7 +203,7 @@ func readConfig(t *testing.T, opts *options.TerragruntOptions) *config.Terragrun
 
 	l := logger.CreateLogger()
 	ctx, pctx := configbridge.NewParsingContext(
-		config.WithConfigValues(t.Context()),
+		config.WithCaches(t.Context()),
 		l,
 		venv.OSVenv(),
 		opts,

--- a/test/integration_catalog_tf_test.go
+++ b/test/integration_catalog_tf_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -20,7 +21,7 @@ import (
 func TestTFScaffoldGitModuleHttps(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
+	ctx := config.WithCaches(t.Context())
 
 	tempDir := helpers.TmpDirWOSymlinks(t)
 

--- a/test/integration_parse_test.go
+++ b/test/integration_parse_test.go
@@ -84,7 +84,7 @@ func TestParseAllFixtureFiles(t *testing.T) {
 			l := logger.CreateLogger()
 
 			ctx, pctx := configbridge.NewParsingContext(
-				context.TODO(), // Using context.TODO() instead of t.Context() here because we end up storing way too much in context otherwise.
+				config.WithCaches(context.TODO()), // Using context.TODO() instead of t.Context() here because we end up storing way too much in context otherwise.
 				l,
 				venv.OSVenv(),
 				opts,

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -1921,10 +1921,8 @@ func newStackDepsParsingContext(
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.StackDependencies))
 	opts.TerragruntConfigPath = configPath
 
-	// The caches the parse path reads are installed once per run, by the CLI. A test entering
-	// below that has to install them itself.
 	return configbridge.NewParsingContext(
-		config.WithConfigValues(t.Context()),
+		config.WithCaches(t.Context()),
 		l,
 		venv.OSVenv(),
 		opts,

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -362,7 +362,9 @@ func TestStackDepsDAGExpandsStackToUnits(t *testing.T) {
 	)
 
 	l := logger.CreateLogger()
-	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), options.NewTerragruntOptions(vexec.NewOSExec()))
+	ctx, pctx := configbridge.NewParsingContext(
+		config.WithCaches(t.Context()), l, venv.OSVenv(), options.NewTerragruntOptions(vexec.NewOSExec()),
+	)
 
 	unitPaths, err := inthclparse.UnitPathsFromStackDir(
 		vfs.NewOSFS(),
@@ -405,7 +407,9 @@ func TestStackDepsUnitPathsFromNestedOnlyStack(t *testing.T) {
 	)
 
 	l := logger.CreateLogger()
-	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), options.NewTerragruntOptions(vexec.NewOSExec()))
+	ctx, pctx := configbridge.NewParsingContext(
+		config.WithCaches(t.Context()), l, venv.OSVenv(), options.NewTerragruntOptions(vexec.NewOSExec()),
+	)
 
 	unitPaths, err := inthclparse.UnitPathsFromStackDir(
 		vfs.NewOSFS(),
@@ -431,7 +435,9 @@ func TestStackDepsUnitPathsFromMissingStackFile(t *testing.T) {
 	root := helpers.TmpDirWOSymlinks(t)
 
 	l := logger.CreateLogger()
-	ctx, pctx := configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), options.NewTerragruntOptions(vexec.NewOSExec()))
+	ctx, pctx := configbridge.NewParsingContext(
+		config.WithCaches(t.Context()), l, venv.OSVenv(), options.NewTerragruntOptions(vexec.NewOSExec()),
+	)
 
 	unitPaths, err := inthclparse.UnitPathsFromStackDir(
 		vfs.NewOSFS(),

--- a/test/integration_stack_dependencies_test.go
+++ b/test/integration_stack_dependencies_test.go
@@ -1921,7 +1921,14 @@ func newStackDepsParsingContext(
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.StackDependencies))
 	opts.TerragruntConfigPath = configPath
 
-	return configbridge.NewParsingContext(t.Context(), l, venv.OSVenv(), opts)
+	// The caches the parse path reads are installed once per run, by the CLI. A test entering
+	// below that has to install them itself.
+	return configbridge.NewParsingContext(
+		config.WithConfigValues(t.Context()),
+		l,
+		venv.OSVenv(),
+		opts,
+	)
 }
 
 // partialParseDiscovery partial parses a unit config the way discovery does, with the


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Asserts that the context cache is set correctly where it's accessed so that we can't accidentally forget it and use a placeholder cache instead.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.
