### PR TITLE
perf: Reuse already-parsed configs when discovering dependents

### DIFF
--- a/docs/src/data/changelog/v1.1.5/dependents-filter-single-parse.mdx
+++ b/docs/src/data/changelog/v1.1.5/dependents-filter-single-parse.mdx
@@ -1,0 +1,20 @@
+---
+version: "v1.1.5"
+category: "performance-improvements"
+---
+
+#### Faster dependents filters
+
+A filter with `...` before its target, such as `...vpc`, finds [dependents](/features/filter/graph#include-dependents) by walking the directory tree around the target and parsing each configuration it passes to see whether it depends on the target. That walk parsed every configuration from scratch, even one Terragrunt had earlier in the same command, and it runs again from each dependent it finds. On a large repository, one query could read and parse the same unrelated unit once per dependent it selected.
+
+Terragrunt now reuses a configuration it has already parsed, so each unit is read from disk about once per query.
+
+In [benchmarks](https://github.com/gruntwork-io/terragrunt/blob/main/internal/discovery/benchmark_dependents_test.go) on an Apple M3 Max, querying the dependents of a unit from its own directory, where every other unit depends on it:
+
+| units | before | after |
+| --- | --- | --- |
+| 10 | 15.3ms | 10.0ms |
+| 50 | 235ms | 150ms |
+| 200 | 3.19s | 2.09s |
+
+From the repository root, where the walk only has to rule out the units that do not depend on the target, the same query over a 1,024-unit repository went from 250ms to 131ms.

--- a/internal/discovery/benchmark_dependents_test.go
+++ b/internal/discovery/benchmark_dependents_test.go
@@ -1,0 +1,84 @@
+package discovery_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// dependentUnitCounts sizes the dependents fixtures: every unit but the target
+// depends on the target, so the count is also the size of the selection.
+var dependentUnitCounts = []int{10, 50, 200}
+
+// BenchmarkDependentsFilter benchmarks a dependents query against a target that
+// every other unit in the fixture depends on. The dependents sit at four
+// different directory depths, so the upstream dependent walk climbs through
+// directories that hold no config of their own before reaching the units that
+// name the target.
+func BenchmarkDependentsFilter(b *testing.B) {
+	b.Run("from_repo_root", func(b *testing.B) {
+		for _, n := range dependentUnitCounts {
+			b.Run(fmt.Sprintf("units_%d", n), func(b *testing.B) {
+				benchmarkDependents(b, dependentsFromRepoRoot, fanInDependentsFixture(n))
+			})
+		}
+	})
+
+	b.Run("from_target_dir", func(b *testing.B) {
+		for _, n := range dependentUnitCounts {
+			b.Run(fmt.Sprintf("units_%d", n), func(b *testing.B) {
+				benchmarkDependents(b, dependentsFromTargetDir, fanInDependentsFixture(n))
+			})
+		}
+	})
+}
+
+// fanInDependentsFixture builds a fixture of n units in which every unit but the
+// target depends on the target, so the query selects the whole fixture.
+func fanInDependentsFixture(n int) dependentsFixture {
+	return func(tb testing.TB, dir string) (string, int) {
+		tb.Helper()
+
+		return createDependentsFixture(tb, dir, n), n
+	}
+}
+
+// createDependentsFixture writes n units under tmpDir and returns the target's
+// path. One unit is the target; the other n-1 each declare a dependency on it,
+// nested one to four directories deep under svc/.
+func createDependentsFixture(tb testing.TB, tmpDir string, n int) string {
+	tb.Helper()
+
+	target := filepath.Join(tmpDir, "vpc")
+	require.NoError(tb, os.MkdirAll(target, 0755))
+	require.NoError(tb, os.WriteFile(
+		filepath.Join(target, "terragrunt.hcl"),
+		[]byte("# Target unit\n"),
+		0644,
+	))
+
+	for i := range n - 1 {
+		dir := filepath.Join(tmpDir, "svc")
+
+		for level := range i%4 + 1 {
+			dir = filepath.Join(dir, fmt.Sprintf("level-%d", level))
+		}
+
+		dir = filepath.Join(dir, fmt.Sprintf("dependent-%04d", i))
+		require.NoError(tb, os.MkdirAll(dir, 0755))
+
+		rel, err := filepath.Rel(dir, target)
+		require.NoError(tb, err)
+
+		require.NoError(tb, os.WriteFile(
+			filepath.Join(dir, "terragrunt.hcl"),
+			fmt.Appendf(nil, "dependency \"vpc\" {\n  config_path = %q\n}\n", rel),
+			0644,
+		))
+	}
+
+	return target
+}

--- a/internal/discovery/benchmark_test.go
+++ b/internal/discovery/benchmark_test.go
@@ -44,6 +44,92 @@ func BenchmarkDiscovery(b *testing.B) {
 			})
 		}
 	})
+
+	b.Run("dependents_expression", func(b *testing.B) {
+		for _, n := range unitCounts {
+			b.Run(fmt.Sprintf("units_%d", n), func(b *testing.B) {
+				benchmarkDependents(b, dependentsFromRepoRoot, chainedDependentsFixture(n))
+			})
+		}
+	})
+
+	b.Run("dependents_expression_from_target", func(b *testing.B) {
+		for _, n := range unitCounts {
+			b.Run(fmt.Sprintf("units_%d", n), func(b *testing.B) {
+				benchmarkDependents(b, dependentsFromTargetDir, chainedDependentsFixture(n))
+			})
+		}
+	})
+}
+
+// dependentsPlacement names where a dependents benchmark runs discovery from.
+type dependentsPlacement int
+
+const (
+	// dependentsFromRepoRoot runs discovery from the fixture root.
+	dependentsFromRepoRoot dependentsPlacement = iota
+	// dependentsFromTargetDir runs discovery from the target unit's directory.
+	dependentsFromTargetDir
+)
+
+// dependentsFixture builds a fixture under dir and returns the path of the unit
+// a dependents query targets, along with the number of components that query
+// selects.
+type dependentsFixture func(tb testing.TB, dir string) (target string, selected int)
+
+// chainedDependentsFixture builds the shared n-unit layout and targets
+// infra-0000, whose only dependent is infra-0001, so the upstream dependent walk
+// covers the whole fixture to find that one dependent.
+func chainedDependentsFixture(n int) dependentsFixture {
+	return func(tb testing.TB, dir string) (string, int) {
+		tb.Helper()
+
+		createFixtures(tb, dir, n)
+
+		return filepath.Join(dir, "infra", "infra-0000"), 2
+	}
+}
+
+// benchmarkDependents benchmarks discovery with a dependents filter over
+// fixture, running from the directory placement names.
+//
+// Both placements are worth measuring, because they cost differently: from the
+// repository root the filesystem phase has already found every dependent, so
+// the upstream walk parses nothing it has not already seen, while from the
+// target's own directory the walk is what finds them, and it re-sweeps the
+// boundary tree once per dependent it finds.
+func benchmarkDependents(b *testing.B, placement dependentsPlacement, fixture dependentsFixture) {
+	b.Helper()
+
+	tmpDir := b.TempDir()
+	target, selected := fixture(b, tmpDir)
+
+	workingDir := tmpDir
+	if placement == dependentsFromTargetDir {
+		workingDir = target
+	}
+
+	l := newDiscardLogger()
+	opts := &options.TerragruntOptions{WorkingDir: workingDir, RootWorkingDir: workingDir}
+
+	filterQueries, err := filter.ParseFilterQueries(l, []string{"...{" + target + "}"})
+	require.NoError(b, err)
+
+	v := venvtest.NewOSWithEmptyEnv()
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		d := discovery.NewDiscovery(workingDir).
+			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workingDir}).
+			WithGitRoot(tmpDir).
+			WithFilters(filterQueries).
+			WithSuppressParseErrors()
+
+		components, err := d.Discover(b.Context(), l, v, opts)
+		require.NoError(b, err)
+		require.Len(b, components, selected)
+	}
 }
 
 // benchmarkPathExpression benchmarks discovery with a path-only filter.
@@ -147,8 +233,8 @@ func newDiscardLogger() log.Logger {
 //   - n/2 "app" units in apps/app-NNNN/terragrunt.hcl (minimal, no dependencies)
 //   - n/2 "infra" units in infra/infra-NNNN/terragrunt.hcl (paired dependency chains:
 //     odd-numbered units depend on the preceding even unit, e.g. infra-0001 → infra-0000)
-func createFixtures(b *testing.B, tmpDir string, n int) {
-	b.Helper()
+func createFixtures(tb testing.TB, tmpDir string, n int) {
+	tb.Helper()
 
 	half := n / 2
 
@@ -156,8 +242,8 @@ func createFixtures(b *testing.B, tmpDir string, n int) {
 
 	for i := range half {
 		dir := filepath.Join(appsDir, fmt.Sprintf("app-%04d", i))
-		require.NoError(b, os.MkdirAll(dir, 0755))
-		require.NoError(b, os.WriteFile(
+		require.NoError(tb, os.MkdirAll(dir, 0755))
+		require.NoError(tb, os.WriteFile(
 			filepath.Join(dir, "terragrunt.hcl"),
 			[]byte("# Minimal config\n"),
 			0644,
@@ -168,7 +254,7 @@ func createFixtures(b *testing.B, tmpDir string, n int) {
 
 	for i := range half {
 		dir := filepath.Join(infraDir, fmt.Sprintf("infra-%04d", i))
-		require.NoError(b, os.MkdirAll(dir, 0755))
+		require.NoError(tb, os.MkdirAll(dir, 0755))
 
 		var content string
 
@@ -179,7 +265,7 @@ func createFixtures(b *testing.B, tmpDir string, n int) {
 			content = "# Leaf unit\n"
 		}
 
-		require.NoError(b, os.WriteFile(
+		require.NoError(tb, os.WriteFile(
 			filepath.Join(dir, "terragrunt.hcl"),
 			[]byte(content),
 			0644,

--- a/internal/discovery/graph_dependents_context_test.go
+++ b/internal/discovery/graph_dependents_context_test.go
@@ -1,0 +1,160 @@
+package discovery_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+// TestGraphPhase_UpstreamCandidateContextOwnership pins which component ends up
+// with which discovery context when the upstream dependent walk canonicalises a
+// candidate.
+//
+// The walk assigns the target's context to the throwaway component it minted,
+// then canonicalises. Canonicalising keeps whichever component the shared set
+// already holds, so the assignment reaches the shared set only when the walk's
+// own component is the one adopted. A unit the filesystem walk already found
+// therefore keeps the origin it was discovered under, while a unit above the
+// working directory, which only the upstream walk reaches, carries the graph
+// origin copied from the target.
+//
+// Assigning to the component canonicalisation returns instead would rewrite the
+// first case, and doing it after canonicalisation would publish a component
+// before its working directory is set.
+func TestGraphPhase_UpstreamCandidateContextOwnership(t *testing.T) {
+	t.Parallel()
+
+	workingDir := repoPath("svc")
+
+	v := memRepoRootVenv(t, corpusRepoRoot)
+
+	writeFixture(t, v, map[string]string{
+		repoPath("svc", "vpc", "terragrunt.hcl"):   "",
+		repoPath("svc", "near", "terragrunt.hcl"):  unitHCL("../vpc"),
+		repoPath("svc", "noise", "terragrunt.hcl"): "",
+		repoPath("above", "terragrunt.hcl"):        unitHCL("../svc/vpc"),
+	})
+
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
+	opts.WorkingDir = workingDir
+	opts.RootWorkingDir = workingDir
+
+	l := logger.CreateLogger()
+
+	// The second query keeps a unit the walk processes as a candidate but never
+	// selects as a dependent in the result set, so its context stays observable.
+	filters, err := filter.ParseFilterQueries(l, []string{
+		"...{" + repoPath("svc", "vpc") + "}",
+		"./noise",
+	})
+	require.NoError(t, err)
+
+	components, err := discovery.NewDiscovery(workingDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workingDir}).
+		WithGitRoot(corpusRepoRoot).
+		WithFilters(filters).
+		Discover(t.Context(), l, v, opts)
+	require.NoError(t, err)
+
+	origins := make(map[string]component.Origin, len(components))
+	for _, c := range components {
+		origins[c.Path()] = c.Origin()
+	}
+
+	assert.Equal(t, map[string]component.Origin{
+		repoPath("svc", "vpc"):   component.OriginPathDiscovery,
+		repoPath("svc", "near"):  component.OriginPathDiscovery,
+		repoPath("svc", "noise"): component.OriginPathDiscovery,
+		repoPath("above"):        component.OriginGraphDiscovery,
+	}, origins)
+}
+
+// TestGraphPhase_UpstreamCandidateBailKeepsExternalMark pins that a candidate
+// the upstream dependent walk abandons leaves no trace in the shared component
+// set.
+//
+// The walk parses whatever the set already holds for a candidate's path, so it
+// looks the component up instead of publishing its own. Publishing first would
+// leave an abandoned candidate in the set carrying the target's working
+// directory, and a non-empty working directory is what tells the dependency
+// resolver that a component has already been classified. A dependency later
+// reaching that same path would then skip the external mark, which backs the
+// external filter attribute and the runner's queue construction.
+//
+// The fixture puts the abandoned unit one directory above the working directory
+// and the unit depending on it one directory above that, so the walk reaches the
+// abandoned unit in an earlier frame than the dependent that would otherwise
+// classify it.
+func TestGraphPhase_UpstreamCandidateBailKeepsExternalMark(t *testing.T) {
+	t.Parallel()
+
+	// The dependency block itself parses, so the walk gets past the parse and
+	// abandons the candidate on the unresolvable config_path instead.
+	const unresolvableDependencyHCL = "dependency \"oops\" {\n  config_path =\n}\n"
+
+	workingDir := repoPath("env", "staging")
+
+	v := memRepoRootVenv(t, corpusRepoRoot)
+
+	writeFixture(t, v, map[string]string{
+		repoPath("env", "staging", "vpc", "terragrunt.hcl"): "",
+		repoPath("env", "abandoned", "terragrunt.hcl"):      unresolvableDependencyHCL,
+		repoPath("consumer", "terragrunt.hcl"): unitHCL(
+			"../env/abandoned",
+			"../env/staging/vpc",
+		),
+	})
+
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
+	opts.WorkingDir = workingDir
+	opts.RootWorkingDir = workingDir
+
+	l := logger.CreateLogger()
+
+	filters, err := filter.ParseFilterQueries(l, []string{
+		"...{" + repoPath("env", "staging", "vpc") + "}",
+	})
+	require.NoError(t, err)
+
+	components, err := discovery.NewDiscovery(workingDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workingDir}).
+		WithGitRoot(corpusRepoRoot).
+		WithFilters(filters).
+		WithSuppressParseErrors().
+		Discover(t.Context(), l, v, opts)
+	require.NoError(t, err)
+
+	paths := components.Paths()
+	slices.Sort(paths)
+
+	require.Equal(t, []string{repoPath("consumer"), repoPath("env", "staging", "vpc")}, paths)
+
+	var consumer component.Component
+
+	for _, c := range components {
+		if c.Path() == repoPath("consumer") {
+			consumer = c
+		}
+	}
+
+	require.NotNil(t, consumer)
+
+	external := make(map[string]bool, len(consumer.Dependencies()))
+	for _, dep := range consumer.Dependencies() {
+		external[dep.Path()] = dep.External()
+	}
+
+	assert.Equal(t, map[string]bool{
+		repoPath("env", "abandoned"):      true,
+		repoPath("env", "staging", "vpc"): false,
+	}, external)
+}

--- a/internal/discovery/graph_dependents_corpus_test.go
+++ b/internal/discovery/graph_dependents_corpus_test.go
@@ -1,0 +1,373 @@
+package discovery_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+// corpusRepoRoot is the git root every corpus fixture is laid out under. The
+// fixtures live on an in-memory filesystem, so the path never touches disk.
+const corpusRepoRoot = string(filepath.Separator) + "repo"
+
+// dependentsCase is one entry in the dependents-discovery corpus: a fixture
+// tree, the queries run over it, and the components the run has to select.
+//
+// The corpus is a differential harness, not a set of one-off tests. Every entry
+// records the selection the upstream dependent walk produces today, so a change
+// to that walk is checked by running the whole corpus and comparing selections
+// rather than by reasoning about which shapes the change could disturb.
+type dependentsCase struct {
+	// files maps an absolute config file path to its HCL contents.
+	files map[string]string
+	// name identifies the fixture in test output.
+	name string
+	// workingDir is the directory discovery runs from.
+	workingDir string
+	// queries are the filter queries applied to the discovered set.
+	queries []string
+	// configNames overrides the config filenames discovery looks for, for
+	// fixtures that exercise a non-default config name.
+	configNames []string
+	// expected is the sorted set of component paths the run has to select.
+	expected []string
+	// noHidden excludes hidden directories from the filesystem walk.
+	noHidden bool
+}
+
+// run executes discovery over the fixture and returns the selected component
+// paths, sorted. Stacks count alongside units, since a dependents query can
+// select either. Discovery hands its results back in the order its phases
+// happened to finish, so the order carries no contract and the comparison is
+// over sets.
+func (tc *dependentsCase) run(t *testing.T) []string {
+	t.Helper()
+
+	v := memRepoRootVenv(t, corpusRepoRoot)
+
+	writeFixture(t, v, tc.files)
+
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
+	opts.WorkingDir = tc.workingDir
+	opts.RootWorkingDir = tc.workingDir
+
+	l := logger.CreateLogger()
+
+	filters, err := filter.ParseFilterQueries(l, tc.queries)
+	require.NoError(t, err)
+
+	d := discovery.NewDiscovery(tc.workingDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tc.workingDir}).
+		WithGitRoot(corpusRepoRoot).
+		WithFilters(filters)
+
+	if len(tc.configNames) > 0 {
+		d = d.WithConfigFilenames(tc.configNames)
+	}
+
+	if tc.noHidden {
+		d = d.WithNoHidden()
+	}
+
+	components, err := d.Discover(t.Context(), l, v, opts)
+	require.NoError(t, err)
+
+	paths := components.Paths()
+	slices.Sort(paths)
+
+	return paths
+}
+
+// writeFixture materializes a fixture tree on the venv's filesystem.
+func writeFixture(t *testing.T, v *venv.Venv, files map[string]string) {
+	t.Helper()
+
+	for path, contents := range files {
+		require.NoError(t, vfs.WriteFile(v.FS, path, []byte(contents), 0o644))
+	}
+}
+
+// repoPath joins path segments onto the corpus repo root.
+func repoPath(segments ...string) string {
+	return filepath.Join(append([]string{corpusRepoRoot}, segments...)...)
+}
+
+// unitHCL renders a unit whose dependencies are the given relative paths.
+func unitHCL(deps ...string) string {
+	var hcl strings.Builder
+
+	for i, dep := range deps {
+		fmt.Fprintf(&hcl, "dependency \"d%d\" {\n  config_path = %q\n}\n", i, dep)
+	}
+
+	return hcl.String()
+}
+
+// dependentsCorpus is the fixture corpus the differential test runs over. The
+// shapes are the ones the upstream dependent walk is most likely to get wrong:
+// a diamond, a dependent above another dependent, a unit reached through two
+// directories, a target nobody depends on, a boundary the walk must not cross,
+// a unit above the working directory whose config file is not the default one,
+// a directory above the working directory holding two config files, a unit above
+// the working directory sharing its directory with a stack, a
+// dependent hidden from the filesystem walk, and a dependent reachable only
+// through a unit a negated query excludes.
+func dependentsCorpus() []dependentsCase {
+	return []dependentsCase{
+		{
+			name: "diamond from the repo root",
+			files: map[string]string{
+				repoPath("vpc", "terragrunt.hcl"): "",
+				repoPath("a", "terragrunt.hcl"):   unitHCL("../vpc"),
+				repoPath("b", "terragrunt.hcl"):   unitHCL("../vpc"),
+				repoPath("top", "terragrunt.hcl"): unitHCL("../a", "../b"),
+			},
+			workingDir: corpusRepoRoot,
+			queries:    []string{"...{" + repoPath("vpc") + "}"},
+			expected: []string{
+				repoPath("a"),
+				repoPath("b"),
+				repoPath("top"),
+				repoPath("vpc"),
+			},
+		},
+		{
+			name: "diamond from the target's own directory",
+			files: map[string]string{
+				repoPath("vpc", "terragrunt.hcl"): "",
+				repoPath("a", "terragrunt.hcl"):   unitHCL("../vpc"),
+				repoPath("b", "terragrunt.hcl"):   unitHCL("../vpc"),
+				repoPath("top", "terragrunt.hcl"): unitHCL("../a", "../b"),
+			},
+			workingDir: repoPath("vpc"),
+			queries:    []string{"...{" + repoPath("vpc") + "}"},
+			expected: []string{
+				repoPath("a"),
+				repoPath("b"),
+				repoPath("top"),
+				repoPath("vpc"),
+			},
+		},
+		{
+			name: "dependent above another dependent",
+			files: map[string]string{
+				repoPath("svc", "net", "vpc", "terragrunt.hcl"):    "",
+				repoPath("svc", "net", "nearby", "terragrunt.hcl"): unitHCL("../vpc"),
+				repoPath("shared", "terragrunt.hcl"):               unitHCL("../svc/net/nearby"),
+				repoPath("noise", "one", "terragrunt.hcl"):         "",
+				repoPath("noise", "two", "terragrunt.hcl"):         "",
+			},
+			workingDir: repoPath("svc", "net"),
+			queries:    []string{"...{" + repoPath("svc", "net", "vpc") + "}"},
+			expected: []string{
+				repoPath("shared"),
+				repoPath("svc", "net", "nearby"),
+				repoPath("svc", "net", "vpc"),
+			},
+		},
+		{
+			name: "dependent reached through two directories",
+			files: map[string]string{
+				repoPath("vpc", "terragrunt.hcl"):      "",
+				repoPath("x", "a", "terragrunt.hcl"):   unitHCL("../../vpc"),
+				repoPath("y", "b", "terragrunt.hcl"):   unitHCL("../../x/a"),
+				repoPath("y", "c", "terragrunt.hcl"):   unitHCL("../../x/a"),
+				repoPath("z", "far", "terragrunt.hcl"): "",
+			},
+			workingDir: repoPath("vpc"),
+			queries:    []string{"...{" + repoPath("vpc") + "}"},
+			expected: []string{
+				repoPath("vpc"),
+				repoPath("x", "a"),
+				repoPath("y", "b"),
+				repoPath("y", "c"),
+			},
+		},
+		{
+			name: "target with no dependents",
+			files: map[string]string{
+				repoPath("vpc", "terragrunt.hcl"): "",
+				repoPath("a", "terragrunt.hcl"):   "",
+				repoPath("b", "terragrunt.hcl"):   unitHCL("../a"),
+			},
+			workingDir: corpusRepoRoot,
+			queries:    []string{"...{" + repoPath("vpc") + "}"},
+			expected:   []string{repoPath("vpc")},
+		},
+		{
+			name: "dependents crossing the git root",
+			files: map[string]string{
+				repoPath("environments", "staging", "vpc", "terragrunt.hcl"): "",
+				repoPath("environments", "staging", "app", "terragrunt.hcl"): unitHCL("../vpc"),
+				repoPath("environments", "production", "consumer", "terragrunt.hcl"): unitHCL(
+					"../../staging/vpc",
+				),
+			},
+			workingDir: repoPath("environments", "staging"),
+			queries: []string{
+				"...{" + repoPath("environments", "staging", "vpc") + "}",
+			},
+			expected: []string{
+				repoPath("environments", "production", "consumer"),
+				repoPath("environments", "staging", "app"),
+				repoPath("environments", "staging", "vpc"),
+			},
+		},
+		{
+			name: "dependents confined by an inline boundary",
+			files: map[string]string{
+				repoPath("environments", "staging", "vpc", "terragrunt.hcl"): "",
+				repoPath("environments", "staging", "app", "terragrunt.hcl"): unitHCL("../vpc"),
+				repoPath("environments", "production", "consumer", "terragrunt.hcl"): unitHCL(
+					"../../staging/vpc",
+				),
+			},
+			workingDir: repoPath("environments", "staging"),
+			queries: []string{
+				"(" + repoPath("environments", "staging") + ")...{" +
+					repoPath("environments", "staging", "vpc") + "}",
+			},
+			expected: []string{
+				repoPath("environments", "staging", "app"),
+				repoPath("environments", "staging", "vpc"),
+			},
+		},
+		{
+			// The unit above the working directory is reached as a dependency of a
+			// nearer unit first, so the shared component set already holds it under
+			// the default config filename by the time the walk reaches its own
+			// directory. Parsing that component instead of the walked one reads a
+			// file that does not exist.
+			name: "unit above the working directory with a non-default config name",
+			files: map[string]string{
+				repoPath("svc", "net", "vpc", "terragrunt.hcl"):    "",
+				repoPath("svc", "net", "nearby", "terragrunt.hcl"): unitHCL("../vpc"),
+				repoPath("svc", "mid", "terragrunt.hcl"):           unitHCL("../net/vpc", "../../shared"),
+				repoPath("shared", "custom.hcl"):                   unitHCL("../svc/net/vpc"),
+			},
+			workingDir:  repoPath("svc", "net"),
+			configNames: []string{"terragrunt.hcl", "custom.hcl"},
+			queries:     []string{"...{" + repoPath("svc", "net", "vpc") + "}"},
+			expected: []string{
+				repoPath("shared"),
+				repoPath("svc", "mid"),
+				repoPath("svc", "net", "nearby"),
+				repoPath("svc", "net", "vpc"),
+			},
+		},
+		{
+			// A directory above the working directory holds two config files, so
+			// the walk mints two candidates reporting the same path, and only the
+			// one the query never names declares the dependency on the target.
+			name: "two config files in one directory above the working directory",
+			files: map[string]string{
+				repoPath("svc", "net", "vpc", "terragrunt.hcl"):    "",
+				repoPath("svc", "net", "nearby", "terragrunt.hcl"): unitHCL("../vpc"),
+				repoPath("dual", "terragrunt.hcl"):                 "",
+				repoPath("dual", "custom.hcl"):                     unitHCL("../svc/net/vpc"),
+			},
+			workingDir:  repoPath("svc", "net"),
+			configNames: []string{"terragrunt.hcl", "custom.hcl"},
+			queries:     []string{"...{" + repoPath("svc", "net", "vpc") + "}"},
+			expected: []string{
+				repoPath("dual"),
+				repoPath("svc", "net", "nearby"),
+				repoPath("svc", "net", "vpc"),
+			},
+		},
+		{
+			// Coexistence validation only covers what the filesystem walk reached,
+			// so a directory above the working directory can hold both a unit and a
+			// stack config. The nearer unit's dependency mints the stack into the
+			// shared set first, leaving a stack published at the unit candidate's
+			// own path.
+			name: "unit sharing a directory with a stack above the working directory",
+			files: map[string]string{
+				repoPath("svc", "net", "vpc", "terragrunt.hcl"):    "",
+				repoPath("svc", "net", "nearby", "terragrunt.hcl"): unitHCL("../vpc"),
+				repoPath("svc", "mid", "terragrunt.hcl"):           unitHCL("../net/vpc", "../../mixed"),
+				repoPath("mixed", "terragrunt.stack.hcl"):          "",
+				repoPath("mixed", "terragrunt.hcl"):                unitHCL("../svc/net/vpc"),
+				repoPath("other", "terragrunt.hcl"):                unitHCL("../mixed"),
+			},
+			workingDir: repoPath("svc", "net"),
+			queries:    []string{"...{" + repoPath("svc", "net", "vpc") + "}"},
+			expected: []string{
+				repoPath("mixed"),
+				repoPath("other"),
+				repoPath("svc", "mid"),
+				repoPath("svc", "net", "nearby"),
+				repoPath("svc", "net", "vpc"),
+			},
+		},
+		{
+			// The filesystem walk skips hidden directories under noHidden; the
+			// upstream dependent walk does not, so the hidden dependent is selected.
+			name: "dependent inside a hidden directory",
+			files: map[string]string{
+				repoPath("vpc", "terragrunt.hcl"):               "",
+				repoPath("plain", "terragrunt.hcl"):             unitHCL("../vpc"),
+				repoPath(".hidden", "sneaky", "terragrunt.hcl"): unitHCL("../../vpc"),
+			},
+			workingDir: corpusRepoRoot,
+			noHidden:   true,
+			queries:    []string{"...{" + repoPath("vpc") + "}"},
+			expected: []string{
+				repoPath(".hidden", "sneaky"),
+				repoPath("plain"),
+				repoPath("vpc"),
+			},
+		},
+		{
+			// A negated query excludes the intermediate unit from the discovered
+			// set, but its own dependent still reaches the target through it.
+			name: "dependent behind a negated intermediate",
+			files: map[string]string{
+				repoPath("vpc", "terragrunt.hcl"):            "",
+				repoPath("apps", "a", "terragrunt.hcl"):      unitHCL("../../vpc"),
+				repoPath("apps", "b", "terragrunt.hcl"):      unitHCL("../a"),
+				repoPath("apps", "spare", "terragrunt.hcl"):  "",
+				repoPath("infra", "other", "terragrunt.hcl"): "",
+			},
+			workingDir: corpusRepoRoot,
+			queries: []string{
+				"...{" + repoPath("vpc") + "}",
+				"!./apps/a",
+			},
+			expected: []string{
+				repoPath("apps", "b"),
+				repoPath("vpc"),
+			},
+		},
+	}
+}
+
+// TestGraphPhase_DependentsCorpus pins the selection every corpus fixture
+// produces. Discovery decides which units a command runs against, so a change
+// to the upstream dependent walk that drops a unit narrows a plan or an apply
+// silently; running the whole corpus is what catches that.
+func TestGraphPhase_DependentsCorpus(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range dependentsCorpus() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, tc.run(t))
+		})
+	}
+}

--- a/internal/discovery/graph_dependents_race_test.go
+++ b/internal/discovery/graph_dependents_race_test.go
@@ -1,0 +1,137 @@
+package discovery_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+)
+
+// TestGraphPhase_ConcurrentDependentsSharedParseWithRacing pins that many
+// dependents of one target are discovered while sharing a single parse of each
+// unit they reach.
+//
+// The upstream dependent walk mints a throwaway component for every config file
+// it passes and canonicalises it against the shared component set, so concurrent
+// candidates converge on one component per directory and race to parse it. Every
+// dependent the walk finds restarts it over the same directories, so those
+// components are reached again from the recursions while the first pass is still
+// running.
+//
+// The dependents live above the working directory, where the filesystem walk
+// never reaches them, so the upstream walk is what discovers all of them. They
+// share a dependency with each other as well as the target, so the convergence
+// is not only on the component the query names.
+func TestGraphPhase_ConcurrentDependentsSharedParseWithRacing(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	gitRoot := tmpDir
+	workingDir := filepath.Join(tmpDir, "root")
+
+	const fanIn = 24
+
+	writeUnit := func(baseDir, name string, deps ...string) {
+		dir := filepath.Join(baseDir, name)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+
+		var hcl strings.Builder
+
+		hcl.WriteString("# " + name + "\n")
+
+		for i, dep := range deps {
+			fmt.Fprintf(&hcl, "dependency \"d%d\" {\n  config_path = %q\n}\n", i, dep)
+		}
+
+		require.NoError(
+			t,
+			os.WriteFile(filepath.Join(dir, "terragrunt.hcl"), []byte(hcl.String()), 0644),
+		)
+	}
+
+	writeUnit(workingDir, "vpc")
+	writeUnit(gitRoot, "shared", "../root/vpc")
+
+	expected := make([]string, 0, fanIn+2)
+	expected = append(
+		expected,
+		filepath.Join(workingDir, "vpc"),
+		filepath.Join(gitRoot, "shared"),
+	)
+
+	for i := range fanIn {
+		name := fmt.Sprintf("dep%02d", i)
+
+		writeUnit(gitRoot, name, "../root/vpc", "../shared")
+
+		expected = append(expected, filepath.Join(gitRoot, name))
+	}
+
+	l := logger.CreateLogger()
+	opts := &options.TerragruntOptions{
+		WorkingDir:     workingDir,
+		RootWorkingDir: workingDir,
+	}
+
+	filters, err := filter.ParseFilterQueries(l, []string{
+		"...{" + filepath.Join(workingDir, "vpc") + "}",
+	})
+	require.NoError(t, err)
+
+	components, err := discovery.NewDiscovery(workingDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workingDir}).
+		WithGitRoot(gitRoot).
+		WithFilters(filters).
+		Discover(t.Context(), l, venvtest.NewOSWithEmptyEnv(), opts)
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, expected, components.Filter(component.UnitKind).Paths())
+}
+
+// TestGraphPhase_UnitSharingDirectoryWithStackWithRacing pins that the selection
+// for a dependents query does not depend on how the walk's candidates interleave.
+//
+// Coexistence validation only covers what the filesystem walk reached, so a
+// directory above the working directory can hold both a unit config and a stack
+// config. Each mints its own candidate reporting that directory as its path, and
+// the walk fans its candidates out concurrently, so the two race to be checked
+// against the target. The walk records the paths it has already checked, and a
+// stack claiming the path first would drop the unit from the selection along
+// with every unit reachable only through it.
+//
+// The repetitions are what make the losing interleaving show up: a single run
+// picks whichever candidate the scheduler happened to start first.
+func TestGraphPhase_UnitSharingDirectoryWithStackWithRacing(t *testing.T) {
+	t.Parallel()
+
+	const (
+		fixtureName = "unit sharing a directory with a stack above the working directory"
+		attempts    = 40
+	)
+
+	corpus := dependentsCorpus()
+
+	idx := slices.IndexFunc(corpus, func(tc dependentsCase) bool {
+		return tc.name == fixtureName
+	})
+	require.NotEqual(t, -1, idx, "corpus has no entry named %q", fixtureName)
+
+	tc := corpus[idx]
+
+	for attempt := range attempts {
+		require.Equal(t, tc.expected, tc.run(t), "attempt %d", attempt)
+	}
+}

--- a/internal/discovery/graph_dependents_reads_test.go
+++ b/internal/discovery/graph_dependents_reads_test.go
@@ -1,0 +1,227 @@
+package discovery_test
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/discovery"
+	"github.com/gruntwork-io/terragrunt/internal/filter"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/options"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+// countingFS tallies how often each path is opened beneath it. Discovery reads
+// a unit's configuration by opening its config file and lists a directory by
+// opening the directory, so the tally is what makes redundant parses and
+// redundant directory listings countable without asserting on log output.
+type countingFS struct {
+	vfs.FS
+	opens map[string]int
+	mu    sync.Mutex
+}
+
+// newCountingFS wraps fsys so every subsequent open is counted.
+func newCountingFS(fsys vfs.FS) *countingFS {
+	return &countingFS{FS: fsys, opens: map[string]int{}}
+}
+
+// Open counts the open and delegates.
+func (fsys *countingFS) Open(name string) (afero.File, error) {
+	fsys.count(name)
+
+	return fsys.FS.Open(name)
+}
+
+// OpenFile counts the open and delegates.
+func (fsys *countingFS) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	fsys.count(name)
+
+	return fsys.FS.OpenFile(name, flag, perm)
+}
+
+// count records one open of name.
+func (fsys *countingFS) count(name string) {
+	fsys.mu.Lock()
+	defer fsys.mu.Unlock()
+
+	fsys.opens[filepath.Clean(name)]++
+}
+
+// opensOf returns how many times name was opened.
+func (fsys *countingFS) opensOf(name string) int {
+	fsys.mu.Lock()
+	defer fsys.mu.Unlock()
+
+	return fsys.opens[name]
+}
+
+// directoryOpens returns how many opens landed on a directory. Discovery lists
+// a directory by opening it, and every config file in these fixtures carries an
+// .hcl extension, so the paths without one are the directories.
+func (fsys *countingFS) directoryOpens() int {
+	fsys.mu.Lock()
+	defer fsys.mu.Unlock()
+
+	total := 0
+
+	for path, n := range fsys.opens {
+		if filepath.Ext(path) != ".hcl" {
+			total += n
+		}
+	}
+
+	return total
+}
+
+// dependentsReadFixture lays out a repository whose dependents all sit above
+// the working directory, so the whole selection comes from the upstream
+// dependent walk. vpc is the target; a and b depend on it, top depends on both,
+// and the noise units are unrelated work the walk still has to read.
+func dependentsReadFixture() map[string]string {
+	files := map[string]string{
+		repoPath("vpc", "terragrunt.hcl"): "",
+		repoPath("a", "terragrunt.hcl"):   unitHCL("../vpc"),
+		repoPath("b", "terragrunt.hcl"):   unitHCL("../vpc"),
+		repoPath("top", "terragrunt.hcl"): unitHCL("../a", "../b"),
+	}
+
+	for _, name := range []string{"one", "two", "three", "four"} {
+		files[repoPath("noise", name, "terragrunt.hcl")] = ""
+	}
+
+	return files
+}
+
+// discoverWithCountingFS runs a dependents query over the fixture from
+// workingDir and returns the selected unit paths alongside the open tally.
+func discoverWithCountingFS(
+	t *testing.T,
+	files map[string]string,
+	workingDir string,
+) ([]string, *countingFS) {
+	t.Helper()
+
+	v := memRepoRootVenv(t, corpusRepoRoot)
+
+	writeFixture(t, v, files)
+
+	counting := newCountingFS(v.FS)
+	v = v.WithFS(counting)
+
+	opts := options.NewTerragruntOptions(vexec.NewOSExec())
+	opts.WorkingDir = workingDir
+	opts.RootWorkingDir = workingDir
+
+	l := logger.CreateLogger()
+
+	filters, err := filter.ParseFilterQueries(l, []string{"...{" + repoPath("vpc") + "}"})
+	require.NoError(t, err)
+
+	components, err := discovery.NewDiscovery(workingDir).
+		WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: workingDir}).
+		WithGitRoot(corpusRepoRoot).
+		WithFilters(filters).
+		Discover(t.Context(), l, v, opts)
+	require.NoError(t, err)
+
+	return components.Filter(component.UnitKind).Paths(), counting
+}
+
+// TestGraphPhase_DependentsParseEachUnitReadCount caps how often a dependents
+// query reads each unit's configuration, from both placements of the working
+// directory that matter: the repository root, where the pre-graph dependency
+// pass has already read every unit, and the target's own directory, where the
+// upstream walk sweeps the boundary tree again for every dependent it finds.
+//
+// The walk mints a throwaway component for each config file it passes, so
+// parsing that component rather than the one the shared set already holds is
+// what used to read the same file once per unit per target.
+//
+// From the target's own directory the cap is two rather than one. The walk keeps
+// a candidate out of the shared set until it has parsed it and resolved its
+// dependencies, so that a candidate it abandons leaves no half-classified
+// component behind. A unit first reached by the walk and by another unit's
+// dependency resolution at the same moment is therefore minted twice, and
+// whichever component loses the race to be published is read for nothing.
+func TestGraphPhase_DependentsParseEachUnitReadCount(t *testing.T) {
+	t.Parallel()
+
+	files := dependentsReadFixture()
+
+	units := []string{
+		repoPath("vpc"),
+		repoPath("a"),
+		repoPath("b"),
+		repoPath("top"),
+		repoPath("noise", "one"),
+		repoPath("noise", "two"),
+		repoPath("noise", "three"),
+		repoPath("noise", "four"),
+	}
+
+	for _, tc := range []struct {
+		name       string
+		workingDir string
+		maxReads   int
+	}{
+		{name: "repository root", workingDir: corpusRepoRoot, maxReads: 1},
+		{name: "target directory", workingDir: repoPath("vpc"), maxReads: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			selected, counting := discoverWithCountingFS(t, files, tc.workingDir)
+
+			assert.ElementsMatch(t, []string{
+				repoPath("vpc"),
+				repoPath("a"),
+				repoPath("b"),
+				repoPath("top"),
+			}, selected)
+
+			for _, unit := range units {
+				reads := counting.opensOf(filepath.Join(unit, "terragrunt.hcl"))
+
+				assert.Positivef(t, reads, "unit %s was never read", unit)
+				assert.LessOrEqualf(t, reads, tc.maxReads, "unit %s was read %d times", unit, reads)
+			}
+		})
+	}
+}
+
+// TestGraphPhase_DependentsDirectoryListings caps how many directory listings a
+// dependents query costs. The upstream walk restarts from a fresh visited set
+// for every dependent it finds, so the boundary tree is swept once per
+// dependent; the cap is the measured cost of that today, and holds a future
+// change to the walk to it.
+func TestGraphPhase_DependentsDirectoryListings(t *testing.T) {
+	t.Parallel()
+
+	files := dependentsReadFixture()
+
+	for _, tc := range []struct {
+		name       string
+		workingDir string
+		maxOpens   int
+	}{
+		{name: "repository root", workingDir: corpusRepoRoot, maxOpens: 20},
+		{name: "target directory", workingDir: repoPath("vpc"), maxOpens: 41},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, counting := discoverWithCountingFS(t, files, tc.workingDir)
+
+			assert.LessOrEqual(t, counting.directoryOpens(), tc.maxOpens)
+		})
+	}
+}

--- a/internal/discovery/phase_graph.go
+++ b/internal/discovery/phase_graph.go
@@ -695,7 +695,13 @@ func (p *GraphPhase) processUpstreamCandidate(
 	state *upstreamDiscoveryState,
 	candidate component.Component,
 ) component.Component {
-	if loaded := state.checkedForTarget.LoadOrStore(candidate.Path()); loaded {
+	unit, ok := candidate.(*component.Unit)
+	if !ok {
+		return nil
+	}
+
+	claim := filepath.Join(candidate.Path(), unit.ConfigFile())
+	if loaded := state.checkedForTarget.LoadOrStore(claim); loaded {
 		return nil
 	}
 
@@ -703,31 +709,25 @@ func (p *GraphPhase) processUpstreamCandidate(
 		return nil
 	}
 
-	if _, ok := candidate.(*component.Stack); ok {
-		return nil
-	}
-
 	if candidate.Path() == state.target.Path() {
-		return nil
-	}
-
-	unit, ok := candidate.(*component.Unit)
-	if !ok {
 		return nil
 	}
 
 	ctx = contextWithParsePhase(ctx, parsePhaseTagGraphDependents)
 	graphState := state.graphTraversalState
 
+	published := graphState.threadSafeComponents.FindByPath(v.FS, candidate.Path())
+	parseUnit := upstreamParseUnit(published, unit)
+
 	if err := ensureParsed(
 		ctx,
 		l,
 		v,
-		candidate,
+		parseUnit,
 		graphState.opts,
 		graphState.discovery,
 	); err != nil {
-		if !state.graphTraversalState.discovery.suppressParseErrors {
+		if !graphState.discovery.suppressParseErrors {
 			state.errMu.Lock()
 
 			*state.errs = append(*state.errs, err)
@@ -738,7 +738,7 @@ func (p *GraphPhase) processUpstreamCandidate(
 		return nil
 	}
 
-	cfg := unit.Config()
+	cfg := parseUnit.Config()
 
 	deps, err := extractDependencyPaths(v.FS, cfg, candidate)
 	if err != nil {
@@ -753,7 +753,7 @@ func (p *GraphPhase) processUpstreamCandidate(
 
 	var stackErr error
 
-	deps, stackErr = stackDependencyPaths(ctx, l, v, state.graphTraversalState.opts, deps)
+	deps, stackErr = stackDependencyPaths(ctx, l, v, graphState.opts, deps)
 	if stackErr != nil {
 		state.errMu.Lock()
 		*state.errs = append(*state.errs, stackErr)
@@ -773,7 +773,7 @@ func (p *GraphPhase) processUpstreamCandidate(
 		candidate.SetDiscoveryContext(copiedCtx)
 	}
 
-	canonicalCandidate, _ := state.graphTraversalState.threadSafeComponents.EnsureComponent(
+	canonicalCandidate, _ := graphState.threadSafeComponents.EnsureComponent(
 		v.FS,
 		candidate,
 	)
@@ -832,6 +832,23 @@ func (p *GraphPhase) processUpstreamCandidate(
 	}
 
 	return nil
+}
+
+// upstreamParseUnit returns the unit to parse for candidate. It is the unit the
+// shared set already holds for candidate's path when parsing that unit reads the
+// same config file, and candidate itself otherwise.
+func upstreamParseUnit(published component.Component, candidate *component.Unit) *component.Unit {
+	publishedUnit, ok := published.(*component.Unit)
+	if !ok {
+		return candidate
+	}
+
+	if publishedUnit.Path() != candidate.Path() ||
+		publishedUnit.ConfigFile() != candidate.ConfigFile() {
+		return candidate
+	}
+
+	return publishedUnit
 }
 
 // resolveDependency resolves a dependency path to a component.


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Re-use already parsed configs when discovering dependents in dependent discovery.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependent discovery across nested, shared, and concurrent dependency graphs.
  * Corrected candidate handling to preserve accurate component origins and external classifications.
  * Improved consistency when units and stacks share directories or configuration files.
  * Reduced redundant configuration reads and directory scans during dependent discovery.

* **Tests**
  * Added regression coverage for dependency filtering, path boundaries, duplicate configurations, and negated filters.
  * Added benchmarks for dependent discovery across repositories of varying sizes.

* **Documentation**
  * Documented performance improvements for dependent filters and reduced configuration parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->