### PR TITLE
fix: set span status and error.type on failed operations

### DIFF
--- a/docs/src/data/changelog/v1.1.5/telemetry-error-status.mdx
+++ b/docs/src/data/changelog/v1.1.5/telemetry-error-status.mdx
@@ -1,0 +1,15 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### Failed operations now mark their span as errored
+
+When an operation failed, Terragrunt recorded an `exception` event on the span but never
+set the span status or the `error.type` attribute. OpenTelemetry-native backends (such as
+New Relic) classify errors by span status, not by the presence of an exception event, so a
+failed run was indistinguishable from a successful one.
+
+Terragrunt now sets the span status to `Error` with the error message as its description,
+and records the `error.type` attribute with the error's type, per the
+[OpenTelemetry recording-errors convention](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/recording-errors.md).

--- a/internal/telemetry/error_status_test.go
+++ b/internal/telemetry/error_status_test.go
@@ -1,0 +1,78 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func newTestTracer(t *testing.T) (*Tracer, *tracetest.InMemoryExporter) {
+	t.Helper()
+
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(exporter)))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	return &Tracer{
+		Tracer:       provider.Tracer("test"),
+		provider:     provider,
+		spanExporter: exporter,
+	}, exporter
+}
+
+// TestTraceSetsErrorStatusAndType verifies that a failed operation records the
+// span status and error.type attribute, per the OpenTelemetry recording-errors
+// convention, so backends that classify errors by span status detect failures.
+func TestTraceSetsErrorStatusAndType(t *testing.T) {
+	t.Parallel()
+
+	tracer, exporter := newTestTracer(t)
+
+	sentinel := errors.New("boom")
+
+	err := tracer.Trace(t.Context(), "op", nil, func(context.Context) error {
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+
+	span := spans[0]
+
+	require.Equal(t, codes.Error, span.Status.Code, "span status must be Error")
+	require.Equal(t, "boom", span.Status.Description, "span status description must carry the error message")
+
+	var errorType string
+
+	for _, kv := range span.Attributes {
+		if kv.Key == attribute.Key("error.type") {
+			errorType = kv.Value.AsString()
+		}
+	}
+
+	require.Equal(t, "*errors.errorString", errorType, "error.type must be set to the error's type")
+}
+
+// TestTraceSuccessLeavesStatusUnset verifies that a successful operation does
+// not mark the span as errored.
+func TestTraceSuccessLeavesStatusUnset(t *testing.T) {
+	t.Parallel()
+
+	tracer, exporter := newTestTracer(t)
+
+	require.NoError(t, tracer.Trace(t.Context(), "op", nil, func(context.Context) error {
+		return nil
+	}))
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+
+	require.Equal(t, codes.Unset, spans[0].Status.Code, "successful span must not be marked as errored")
+}

--- a/internal/telemetry/tracer.go
+++ b/internal/telemetry/tracer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -14,6 +15,8 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -223,12 +226,26 @@ func (tracer *Tracer) Trace(
 	defer span.End()
 
 	if err := fn(ctx); err != nil {
-		// record error in span
+		// record error in span, set span status and error.type per the
+		// OpenTelemetry recording-errors convention so backends that
+		// classify errors by span status (not by exception events) see them.
 		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		span.SetAttributes(attribute.String("error.type", errorTypeName(err)))
 		return err
 	}
 
 	return nil
+}
+
+// errorTypeName returns the canonical Go type name of an error, used as a
+// low-cardinality value for the OpenTelemetry `error.type` attribute.
+func errorTypeName(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	return reflect.TypeOf(err).String()
 }
 
 // openSpan creates a new span with attributes.


### PR DESCRIPTION
## Description

Fixes #6852.

When an operation fails, Terragrunt currently records only an `exception` event on the span via `span.RecordError(err)`. It never sets the span status or the `error.type` attribute, so OpenTelemetry-native backends that classify errors by span status (rather than by the presence of an exception event) cannot distinguish failed runs from successful ones.

This PR updates `Tracer.Trace`'s error path to:

1. Set the span status to `Error` with the error message as the description, alongside the existing `RecordError`.
2. Set the `error.type` attribute to the error's canonical Go type name (a low-cardinality default), keeping `RecordError` for the full message and stack.

Per the [OpenTelemetry recording-errors convention](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/recording-errors.md).

The metric-side change (adding `error.type` to the `*_duration` histograms) is intentionally left out of this PR and can be a follow-up; the existing `*_errors_count` counters remain for backwards compatibility.

## TODOs

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Failed operations now mark telemetry spans with an `Error` status, include the error message, and record the error type according to OpenTelemetry conventions.
  - Successful operations continue to leave span status unchanged.

- **Documentation**
  - Added a changelog entry describing the telemetry error-status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->