### PR TITLE
perf: Tuning FS concurrency

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -147,6 +147,12 @@ linters:
         - pattern: ^filepath\.(Walk|WalkDir|Glob)$
           pkg: ^path/filepath$
           msg: walk the venv's vfs.FS via vfs.WalkDir or vfs.WalkDirParallel instead of the real filesystem
+        - pattern: ^unix\.(Statfs|Fstatfs)$
+          pkg: ^golang.org/x/sys/unix$
+          msg: ask vfs.DetectFSKind, which describes the vfs.FS in hand rather than whatever the real disk holds at that path
+        - pattern: ^windows\.(GetVolumeInformation|GetVolumeInformationByHandle|GetVolumePathName)$
+          pkg: ^golang.org/x/sys/windows$
+          msg: ask vfs.DetectFSKind, which describes the vfs.FS in hand rather than whatever the real disk holds at that path
         - pattern: ^filepath\.EvalSymlinks$
           pkg: ^path/filepath$
           msg: resolve links on the venv's vfs.FS via vfs.EvalSymlinks, or vfs.ResolveForCompare when the result is to be compared against another path

--- a/docs/src/data/changelog/v1.1.5/filesystem-tuned-concurrency.mdx
+++ b/docs/src/data/changelog/v1.1.5/filesystem-tuned-concurrency.mdx
@@ -1,0 +1,26 @@
+---
+version: "v1.1.5"
+category: "performance-improvements"
+---
+
+#### Faster file work, especially on small CI runners
+
+Terragrunt frequently does a lot of small file operations at once: copying a module into its working directory, storing a repository in the [Content Addressable Store (CAS)](/features/caching/cas), and materializing one back out. How many it ran at once scaled with the number of vCPUs seen by the Terragrunt process or the `--parallelism` flag if configured.
+
+Terragrunt now picks that number by probing the filesystem it is about to write to to guess how much throughput it can handle to improve performance.
+
+The gain is largest where the filesystem is much faster or slower than Terragrunt would expect, just scaling off vCPUs.
+
+Materializing a 3,000 file repository on a 2 vCPU runner:
+
+| filesystem | before | after | change |
+| --- | --- | --- | --- |
+| ext4 | 40.8ms | 24.4ms | -40% |
+| btrfs | 48.7ms | 34.2ms | -30% |
+| overlayfs | 71.5ms | 56.4ms | -21% |
+
+On a 16 vCPU machine, storing that repository for the first time is 19% faster on ext4 and 20% faster on btrfs.
+
+`terragrunt hcl fmt` now formats at most 8 files at once by default, which measured about 14% faster than one worker per CPU on a 16 core machine.
+
+Runs with the `fast-copy` strict control enabled also copy module directories faster on macOS, by around 60% in benchmarks on an Apple M3 Max.

--- a/internal/cas/benchmark_test.go
+++ b/internal/cas/benchmark_test.go
@@ -28,18 +28,15 @@ func BenchmarkClone(b *testing.B) {
 	b.Run("fresh clone", func(b *testing.B) {
 		tempDir := b.TempDir()
 
-		b.ResetTimer()
+		i := 0
 
-		for i := 0; b.Loop(); i++ {
-			b.StopTimer()
-
+		for b.Loop() {
 			storePath := filepath.Join(tempDir, "store", strconv.Itoa(i))
 			targetPath := filepath.Join(tempDir, "repo", strconv.Itoa(i))
+			i++
 
 			c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 			require.NoError(b, err)
-
-			b.StartTimer()
 
 			require.NoError(b, c.Clone(b.Context(), l, v, repoURL, cas.WithDir(targetPath),
 				cas.WithDepth(-1)))
@@ -60,17 +57,14 @@ func BenchmarkClone(b *testing.B) {
 				cas.WithDepth(-1)),
 		)
 
-		b.ResetTimer()
+		i := 0
 
-		for i := 0; b.Loop(); i++ {
-			b.StopTimer()
-
+		for b.Loop() {
 			targetPath := filepath.Join(tempDir, "repo", strconv.Itoa(i))
+			i++
 
 			c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 			require.NoError(b, err)
-
-			b.StartTimer()
 
 			require.NoError(b, c.Clone(b.Context(), l, v, repoURL, cas.WithDir(targetPath),
 				cas.WithDepth(-1)))
@@ -91,12 +85,11 @@ func BenchmarkContent(b *testing.B) {
 	v := venvtest.NewOSWithEmptyEnv()
 
 	b.Run("store", func(b *testing.B) {
-		for i := 0; b.Loop(); i++ {
-			b.StopTimer()
+		i := 0
 
+		for b.Loop() {
 			hash := "benchmark" + strconv.Itoa(i)
-
-			b.StartTimer()
+			i++
 
 			require.NoError(b, content.Store(l, v, hash, testData, cas.StoredFilePerms))
 		}

--- a/internal/cas/blob_shards_test.go
+++ b/internal/cas/blob_shards_test.go
@@ -1,0 +1,46 @@
+package cas_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlobShards(t *testing.T) {
+	t.Parallel()
+
+	t.Run("never outnumbers the blobs it serves", func(t *testing.T) {
+		t.Parallel()
+
+		store := t.TempDir()
+
+		for _, pending := range []int{1, 2, 3} {
+			assert.LessOrEqual(t, cas.BlobShards(vfs.NewOSFS(), store, pending), pending)
+		}
+	})
+
+	t.Run("a large tree keeps the filesystem's ceiling", func(t *testing.T) {
+		t.Parallel()
+
+		store := t.TempDir()
+
+		const plenty = 1000
+
+		shards := cas.BlobShards(vfs.NewOSFS(), store, plenty)
+
+		assert.GreaterOrEqual(t, shards, vfs.BTRFSWorkers)
+		assert.LessOrEqual(t, shards, vfs.MaxFSWorkers,
+			"a shard costs a git process, so the count stays bounded")
+	})
+
+	t.Run("an unprobeable store falls back to the default", func(t *testing.T) {
+		t.Parallel()
+
+		missing := filepath.Join(t.TempDir(), "no-such-store")
+
+		assert.Equal(t, vfs.DefaultFSWorkers, cas.BlobShards(vfs.NewOSFS(), missing, 1000))
+	})
+}

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -758,9 +758,9 @@ func (c *CAS) storeTreeRecursive(
 // `git cat-file --batch` process, started only when there is something to
 // read.
 //
-// The pending blobs are split across [vfs.FSWorkers] shards, which
-// overlaps the store's own writes. Shards never outnumber the blobs they
-// serve, so a small tree still starts a single git process.
+// The pending blobs are split across [BlobShards] shards, which overlaps
+// the store's own writes. Shards never outnumber the blobs they serve,
+// so a small tree still starts a single git process.
 func (c *CAS) storeBlobs(
 	ctx context.Context,
 	v *venv.Venv,
@@ -772,7 +772,7 @@ func (c *CAS) storeBlobs(
 		return nil
 	}
 
-	shards := min(vfs.FSWorkers, len(pending))
+	shards := BlobShards(v.FS, c.storePath, len(pending))
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(shards)
@@ -784,6 +784,28 @@ func (c *CAS) storeBlobs(
 	}
 
 	return g.Wait()
+}
+
+// overlayIngestShards is what ingest peaks at on overlayfs, well under
+// the sixteen concurrent writers that filesystem absorbs for a walk.
+//
+// ext4 runs this same subprocess-per-shard workload fastest
+// at 16 shards on 2, 4, 8 and 16 cores, and overlayfs stays at
+// four across the same range.
+const overlayIngestShards = 4
+
+// BlobShards reports how many shards ingest should split pending blobs
+// across when the store lives at storePath on fsys, never more than
+// there are blobs to serve.
+func BlobShards(fsys vfs.FS, storePath string, pending int) int {
+	kind := vfs.DetectFSKind(fsys, storePath)
+
+	shards := vfs.FSWorkersForKind(kind)
+	if kind == vfs.FSOverlay {
+		shards = overlayIngestShards
+	}
+
+	return min(shards, pending)
 }
 
 // storeBlobShard stores the pending blobs at every index congruent to

--- a/internal/cas/cold_ingest_benchmark_test.go
+++ b/internal/cas/cold_ingest_benchmark_test.go
@@ -50,18 +50,16 @@ func BenchmarkColdIngest(b *testing.B) {
 			tempDir := b.TempDir()
 
 			b.ReportAllocs()
-			b.ResetTimer()
 
-			for i := 0; b.Loop(); i++ {
-				b.StopTimer()
+			i := 0
 
+			for b.Loop() {
 				storePath := filepath.Join(tempDir, "store", strconv.Itoa(i))
 				targetPath := filepath.Join(tempDir, "repo", strconv.Itoa(i))
+				i++
 
 				c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
 				require.NoError(b, err)
-
-				b.StartTimer()
 
 				require.NoError(b, c.Clone(b.Context(), l, v, repoURL, cas.WithDir(targetPath),
 					cas.WithDepth(-1)))

--- a/internal/cas/tree.go
+++ b/internal/cas/tree.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 
 	"golang.org/x/sync/errgroup"
@@ -38,6 +37,7 @@ type LinkTreeOption func(*linkTreeOpts)
 type linkTreeOpts struct {
 	maxDepth  int
 	forceCopy bool
+	fsWorkers int
 }
 
 // WithForceCopy makes LinkTree copy blobs from the CAS store into the target
@@ -79,6 +79,10 @@ func LinkTree(
 	for _, opt := range opts {
 		opt(&o)
 	}
+
+	// Probed once here rather than per subtree to avoid paying the
+	// probe cost on every subtree.
+	o.fsWorkers = vfs.FSWorkersFor(v.FS, targetDir)
 
 	return linkTree(ctx, l, v, blobStore, treeStore, t, targetDir, targetDir, 0, &o)
 }
@@ -176,10 +180,7 @@ func linkTree(
 
 	g, ctx := errgroup.WithContext(ctx)
 
-	// Use half the available CPUs (at least 1) to avoid saturating I/O during tree materialization.
-	scalingFactor := 2
-	maxWorkers := max(1, runtime.GOMAXPROCS(0)/scalingFactor)
-	g.SetLimit(maxWorkers)
+	g.SetLimit(o.fsWorkers)
 
 	for _, work := range workItems {
 		g.Go(func() error {

--- a/internal/cas/warm_materialize_benchmark_test.go
+++ b/internal/cas/warm_materialize_benchmark_test.go
@@ -1,0 +1,45 @@
+package cas_test
+
+import (
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+)
+
+// BenchmarkWarmMaterialize clones into a store that already holds every
+// blob, so the timed region is dominated by materializing the tree into
+// a fresh target rather than by ingest.
+func BenchmarkWarmMaterialize(b *testing.B) {
+	l := logger.CreateLogger()
+	v := venvtest.NewOSWithEmptyEnv()
+
+	repoURL := startColdIngestServer(b, 3000)
+	tempDir := b.TempDir()
+	storePath := filepath.Join(tempDir, "store")
+
+	warm, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
+	require.NoError(b, err)
+
+	require.NoError(b, warm.Clone(b.Context(), l, v, repoURL,
+		cas.WithDir(filepath.Join(tempDir, "initial")), cas.WithDepth(-1)))
+
+	target := filepath.Join(tempDir, "target")
+
+	i := 0
+
+	for b.Loop() {
+		c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath))
+		require.NoError(b, err)
+
+		require.NoError(b, c.Clone(b.Context(), l, v, repoURL,
+			cas.WithDir(filepath.Join(target, strconv.Itoa(i))), cas.WithDepth(-1)))
+
+		i++
+	}
+}

--- a/internal/cli/commands/hcl/format/format.go
+++ b/internal/cli/commands/hcl/format/format.go
@@ -41,6 +41,25 @@ var excludePaths = []string{
 	config.StackDir,
 }
 
+// maxFormatWorkers caps the default format fan-out.
+//
+// Experimentally, a good ceiling for this was
+// determined to be 8 workers even on a 16 core machine.
+//
+// Might require additional tuning.
+const maxFormatWorkers = 8
+
+// formatWorkers bounds how many files are formatted at once. An
+// explicit --parallelism is honored as given; the default is the
+// smaller of the machine's cores and [maxFormatWorkers].
+func formatWorkers(parallelism int) int {
+	if parallelism != options.DefaultParallelism {
+		return parallelism
+	}
+
+	return min(runtime.GOMAXPROCS(0), maxFormatWorkers)
+}
+
 func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *options.TerragruntOptions) error {
 	workingDir := opts.WorkingDir
 	targetFile := opts.HclFile
@@ -116,11 +135,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *options.Terragru
 
 	g, _ := errgroup.WithContext(ctx)
 
-	// Use user-specified parallelism, falling back to available CPUs.
-	limit := opts.Parallelism
-	if limit == options.DefaultParallelism {
-		limit = runtime.GOMAXPROCS(0)
-	}
+	limit := formatWorkers(opts.Parallelism)
 
 	g.SetLimit(limit)
 
@@ -157,11 +172,7 @@ func RunForFiles(
 ) error {
 	g, _ := errgroup.WithContext(ctx)
 
-	// Use user-specified parallelism, falling back to available CPUs.
-	limit := opts.Parallelism
-	if limit == options.DefaultParallelism {
-		limit = runtime.GOMAXPROCS(0)
-	}
+	limit := formatWorkers(opts.Parallelism)
 
 	g.SetLimit(limit)
 

--- a/internal/cli/commands/hcl/format/format_bench_test.go
+++ b/internal/cli/commands/hcl/format/format_bench_test.go
@@ -42,7 +42,7 @@ func BenchmarkFormat(b *testing.B) {
 
 			tgOptions.WorkingDir = tmpBase
 			tgOptions.HclExclude = excludeList
-			v := venvtest.New()
+			v := venvtest.NewWithOSFS()
 
 			formatter := logformat.NewFormatter(logformat.NewKeyValueFormatPlaceholders())
 			formatter.SetDisabledColors(true)
@@ -52,8 +52,6 @@ func BenchmarkFormat(b *testing.B) {
 				log.WithFormatter(formatter),
 			)
 			ctx := context.Background()
-
-			b.ResetTimer()
 
 			for b.Loop() {
 				b.StopTimer()

--- a/internal/discovery/benchmark_test.go
+++ b/internal/discovery/benchmark_test.go
@@ -65,8 +65,6 @@ func benchmarkPathExpression(b *testing.B, n int) {
 
 	v := venvtest.NewOSWithEmptyEnv()
 
-	b.ResetTimer()
-
 	for b.Loop() {
 		d := discovery.NewDiscovery(tmpDir).
 			WithDiscoveryContext(&component.DiscoveryContext{WorkingDir: tmpDir}).
@@ -94,8 +92,6 @@ func benchmarkGraphExpression(b *testing.B, n int) {
 	require.NoError(b, err)
 
 	v := venvtest.NewOSWithEmptyEnv()
-
-	b.ResetTimer()
 
 	for b.Loop() {
 		d := discovery.NewDiscovery(tmpDir).
@@ -127,8 +123,6 @@ func benchmarkPathAndGraphExpression(b *testing.B, n int) {
 	require.NoError(b, err)
 
 	v := venvtest.NewOSWithEmptyEnv()
-
-	b.ResetTimer()
 
 	for b.Loop() {
 		d := discovery.NewDiscovery(tmpDir).

--- a/internal/util/benchmark_test.go
+++ b/internal/util/benchmark_test.go
@@ -1,0 +1,108 @@
+package util_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/util"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+)
+
+// buildCopyTree writes a tree shaped like a module cache: nested
+// directories of small config files plus a few provider-sized blobs.
+func buildCopyTree(tb testing.TB, root string, dirs, filesPerDir, fileSize, blobs, blobSize int) {
+	tb.Helper()
+
+	const (
+		fanout   = 8
+		dirPerms = 0o755
+		perms    = 0o644
+	)
+
+	small := make([]byte, fileSize)
+
+	for i := range dirs {
+		dir := filepath.Join(root, strconv.Itoa(i/(fanout*fanout)), strconv.Itoa(i/fanout), strconv.Itoa(i))
+		if err := os.MkdirAll(dir, dirPerms); err != nil {
+			tb.Fatal(err)
+		}
+
+		for j := range filesPerDir {
+			if err := os.WriteFile(filepath.Join(dir, "f"+strconv.Itoa(j)+".tf"), small, perms); err != nil {
+				tb.Fatal(err)
+			}
+		}
+	}
+
+	blob := make([]byte, blobSize)
+
+	for i := range blobs {
+		if err := os.WriteFile(filepath.Join(root, "blob"+strconv.Itoa(i)+".bin"), blob, perms); err != nil {
+			tb.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkCopyFolderContentsFast exercises the fast-copy path, whose
+// per-file work runs on the workers of [vfs.WalkDirParallel].
+func BenchmarkCopyFolderContentsFast(b *testing.B) {
+	const (
+		kb = 1 << 10
+		mb = 1 << 20
+	)
+
+	testCases := []struct {
+		name        string
+		dirs        int
+		filesPerDir int
+		fileSize    int
+		blobs       int
+		blobSize    int
+	}{
+		{name: "small-files", dirs: 400, filesPerDir: 4, fileSize: 2 * kb, blobs: 0, blobSize: 0},
+		{name: "mixed", dirs: 200, filesPerDir: 4, fileSize: 2 * kb, blobs: 4, blobSize: 8 * mb},
+	}
+
+	l := logger.CreateLogger()
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			source := b.TempDir()
+			buildCopyTree(b, source, tc.dirs, tc.filesPerDir, tc.fileSize, tc.blobs, tc.blobSize)
+
+			dests := b.TempDir()
+			fsys := vfs.NewOSFS()
+
+			b.ReportAllocs()
+
+			i := 0
+
+			for b.Loop() {
+				dest := filepath.Join(dests, strconv.Itoa(i))
+				i++
+
+				if err := util.CopyFolderContents(
+					l,
+					fsys,
+					source,
+					dest,
+					".terragrunt-bench-manifest",
+					util.WithFastCopy(),
+				); err != nil {
+					b.Fatal(err)
+				}
+
+				b.StopTimer()
+
+				if err := os.RemoveAll(dest); err != nil {
+					b.Fatal(err)
+				}
+
+				b.StartTimer()
+			}
+		})
+	}
+}

--- a/internal/util/file_tofu_test.go
+++ b/internal/util/file_tofu_test.go
@@ -639,7 +639,6 @@ func BenchmarkIsTFFile(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
 	for b.Loop() {
 		for _, path := range testPaths {
@@ -671,7 +670,6 @@ func BenchmarkDirContainsTFFiles(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
 	for b.Loop() {
 		result, err := util.DirContainsTFFiles(vfs.NewOSFS(), tmpDir)

--- a/internal/vfs/fskind.go
+++ b/internal/vfs/fskind.go
@@ -1,0 +1,131 @@
+package vfs
+
+import "strconv"
+
+// FSKind names the filesystem behind a path, as far as the operating
+// system reports it. It exists so callers can size filesystem
+// concurrency to the filesystem they are about to touch: the ceiling
+// that suits APFS starves overlayfs, and the fan-out overlayfs wants
+// collapses btrfs.
+type FSKind uint8
+
+const (
+	// FSUnknown is a filesystem the platform described but this package
+	// does not name.
+	FSUnknown FSKind = iota
+
+	// FSUnprobed is a path the platform would not describe, usually one
+	// that does not exist yet.
+	FSUnprobed
+
+	// FSVirtual is any filesystem other than [NewOSFS].
+	FSVirtual
+
+	// FSAPFS is the default on macOS.
+	FSAPFS
+
+	// FSHFS is the older macOS filesystem.
+	FSHFS
+
+	// FSExt4 is the default on most Linux distributions.
+	FSExt4
+
+	// FSXFS is the default on Red Hat Enterprise Linux.
+	FSXFS
+
+	// FSBtrfs is the default on Fedora and openSUSE.
+	FSBtrfs
+
+	// FSZFS is a copy-on-write filesystem, common on NAS appliances.
+	FSZFS
+
+	// FSTmpfs keeps its files in memory.
+	FSTmpfs
+
+	// FSOverlay is what a container writes to unless a volume is mounted
+	// over it.
+	FSOverlay
+
+	// FSFUSE is a filesystem served from userspace, e.g. a Docker Desktop
+	// bind mount.
+	FSFUSE
+
+	// FSNetwork is storage reached over a network, e.g. NFS, SMB, or 9p.
+	FSNetwork
+
+	// FSNTFS is the default on Windows.
+	FSNTFS
+
+	// FSReFS is the newer Windows filesystem, used mainly on Windows Server.
+	FSReFS
+
+	// fsKindCount bounds the declared set. It must stay last, because
+	// [FSKind.String] and [FSKinds] treat it as the number of kinds.
+	fsKindCount
+)
+
+// fsKindNames is indexed by [FSKind]. Names are the ones the platform
+// itself uses, so a log line matches what `mount` prints.
+var fsKindNames = [...]string{
+	FSUnknown:  "unknown",
+	FSUnprobed: "unprobed",
+	FSVirtual:  "virtual",
+	FSAPFS:     "apfs",
+	FSHFS:      "hfs",
+	FSExt4:     "ext4",
+	FSXFS:      "xfs",
+	FSBtrfs:    "btrfs",
+	FSZFS:      "zfs",
+	FSTmpfs:    "tmpfs",
+	FSOverlay:  "overlayfs",
+	FSFUSE:     "fuse",
+	FSNetwork:  "network",
+	FSNTFS:     "ntfs",
+	FSReFS:     "refs",
+}
+
+// FSKinds returns every declared kind, in declaration order.
+func FSKinds() []FSKind {
+	kinds := make([]FSKind, 0, fsKindCount)
+
+	for kind := range fsKindCount {
+		kinds = append(kinds, kind)
+	}
+
+	return kinds
+}
+
+// asserts that fsKindNames must hold exactly one entry per kind.
+const (
+	_ = uint(len(fsKindNames) - int(fsKindCount))
+	_ = uint(int(fsKindCount) - len(fsKindNames))
+)
+
+// String returns the filesystem's name.
+func (k FSKind) String() string {
+	if k >= fsKindCount {
+		panic("vfs: FSKind out of range: " + strconv.Itoa(int(k)))
+	}
+
+	return fsKindNames[k]
+}
+
+// DetectFSKind reports the filesystem backing path, using one
+// statfs-family syscall.
+//
+// Returns one of three values:
+//
+// - a real [FSKind] filesystem
+//
+// - [FSUnknown] for a filesystem that the Go runtime recognizes, but hasn't
+// had performance characteristics measured by Terragrunt.
+//
+// - [FSUnprobed] for a path the platform declined to describe at all,
+// which is usually a sign that [path] doesn't exist on disk.
+func DetectFSKind(fsys FS, path string) FSKind {
+	if !IsOSFS(fsys) {
+		return FSVirtual
+	}
+
+	return detectFSKind(path)
+}

--- a/internal/vfs/fskind_darwin.go
+++ b/internal/vfs/fskind_darwin.go
@@ -1,0 +1,32 @@
+//go:build darwin
+
+package vfs
+
+import "golang.org/x/sys/unix"
+
+// fsTypeNameKinds maps the name darwin's statfs reports in
+// f_fstypename. Darwin names the filesystem outright, so there is no
+// magic-number table to keep in step with the kernel.
+var fsTypeNameKinds = map[string]FSKind{
+	"apfs":   FSAPFS,
+	"hfs":    FSHFS,
+	"ntfs":   FSNTFS,
+	"nfs":    FSNetwork,
+	"smbfs":  FSNetwork,
+	"afpfs":  FSNetwork,
+	"webdav": FSNetwork,
+}
+
+func detectFSKind(path string) FSKind {
+	var st unix.Statfs_t
+
+	if err := unix.Statfs(path, &st); err != nil {
+		return FSUnprobed
+	}
+
+	name := unix.ByteSliceToString(st.Fstypename[:])
+
+	// A name with no entry is a real filesystem this package has not
+	// measured, which is [FSUnknown] rather than a failure to look.
+	return fsTypeNameKinds[name]
+}

--- a/internal/vfs/fskind_linux.go
+++ b/internal/vfs/fskind_linux.go
@@ -1,0 +1,39 @@
+//go:build linux
+
+package vfs
+
+import "golang.org/x/sys/unix"
+
+// zfsSuperMagic is ZFS's statfs magic. Unlike the filesystems above it,
+// x/sys/unix carries no constant for it.
+const zfsSuperMagic = 0x2fc12fc1
+
+// fsMagicKinds maps the statfs f_type magic to a kind. The magic numbers
+// are kernel ABI, so a missing entry means a filesystem terragrunt has
+// no measurement for, not a stale table.
+var fsMagicKinds = map[int64]FSKind{
+	unix.EXT4_SUPER_MAGIC:      FSExt4,
+	unix.XFS_SUPER_MAGIC:       FSXFS,
+	unix.BTRFS_SUPER_MAGIC:     FSBtrfs,
+	zfsSuperMagic:              FSZFS,
+	unix.TMPFS_MAGIC:           FSTmpfs,
+	unix.OVERLAYFS_SUPER_MAGIC: FSOverlay,
+	unix.FUSE_SUPER_MAGIC:      FSFUSE,
+	unix.NFS_SUPER_MAGIC:       FSNetwork,
+	unix.SMB_SUPER_MAGIC:       FSNetwork,
+	unix.SMB2_SUPER_MAGIC:      FSNetwork,
+	unix.CIFS_SUPER_MAGIC:      FSNetwork,
+	unix.V9FS_MAGIC:            FSNetwork,
+}
+
+func detectFSKind(path string) FSKind {
+	var st unix.Statfs_t
+
+	if err := unix.Statfs(path, &st); err != nil {
+		return FSUnprobed
+	}
+
+	// A magic with no entry is a real filesystem this package has not
+	// measured, which is [FSUnknown] rather than a failure to look.
+	return fsMagicKinds[int64(st.Type)]
+}

--- a/internal/vfs/fskind_linux.go
+++ b/internal/vfs/fskind_linux.go
@@ -11,7 +11,7 @@ const zfsSuperMagic = 0x2fc12fc1
 // fsMagicKinds maps the statfs f_type magic to a kind. The magic numbers
 // are kernel ABI, so a missing entry means a filesystem terragrunt has
 // no measurement for, not a stale table.
-var fsMagicKinds = map[int64]FSKind{
+var fsMagicKinds = map[uint32]FSKind{
 	unix.EXT4_SUPER_MAGIC:      FSExt4,
 	unix.XFS_SUPER_MAGIC:       FSXFS,
 	unix.BTRFS_SUPER_MAGIC:     FSBtrfs,
@@ -35,5 +35,5 @@ func detectFSKind(path string) FSKind {
 
 	// A magic with no entry is a real filesystem this package has not
 	// measured, which is [FSUnknown] rather than a failure to look.
-	return fsMagicKinds[int64(st.Type)]
+	return fsMagicKinds[uint32(st.Type)]
 }

--- a/internal/vfs/fskind_other.go
+++ b/internal/vfs/fskind_other.go
@@ -1,0 +1,9 @@
+//go:build !linux && !darwin && !windows
+
+package vfs
+
+// detectFSKind has no probe on platforms terragrunt does not ship
+// tuning for. It reports [FSUnknown] rather than [FSUnprobed] because
+// no other path would answer either: a caller that climbs ancestors
+// looking for an answer would only burn syscalls on the way up.
+func detectFSKind(string) FSKind { return FSUnknown }

--- a/internal/vfs/fskind_test.go
+++ b/internal/vfs/fskind_test.go
@@ -1,0 +1,149 @@
+package vfs_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectFSKind(t *testing.T) {
+	t.Parallel()
+
+	t.Run("temp dir resolves to a known kind", func(t *testing.T) {
+		t.Parallel()
+
+		switch runtime.GOOS {
+		case "linux", "darwin", "windows":
+		default:
+			t.Skip("no filesystem probe on " + runtime.GOOS)
+		}
+
+		kind := vfs.DetectFSKind(vfs.NewOSFS(), t.TempDir())
+
+		assert.NotEqual(t, vfs.FSUnknown, kind,
+			"the filesystem behind the temp dir is unrecognized; add it to the probe if it is worth tuning for")
+	})
+
+	// A path the probe cannot describe is worth re-asking about at an
+	// ancestor; one on an unnamed filesystem is not. Only the first
+	// reports FSUnprobed.
+	t.Run("missing path is unprobed, not unknown", func(t *testing.T) {
+		t.Parallel()
+
+		missing := filepath.Join(t.TempDir(), "no-such-dir", "deeper")
+
+		assert.Equal(t, vfs.FSUnprobed, vfs.DetectFSKind(vfs.NewOSFS(), missing))
+	})
+
+	t.Run("a filesystem that is not the real disk never reaches the kernel", func(t *testing.T) {
+		t.Parallel()
+
+		// The path exists on the real disk, so a probe that ignored fsys
+		// would answer with the host's filesystem instead of admitting
+		// the caller is not on it.
+		real := t.TempDir()
+
+		assert.Equal(t, vfs.FSVirtual, vfs.DetectFSKind(vfs.NewMemMapFS(), real))
+		assert.NotEqual(t, vfs.FSVirtual, vfs.DetectFSKind(vfs.NewOSFS(), real))
+		assert.Equal(t, vfs.DefaultFSWorkers, vfs.FSWorkersFor(vfs.NewMemMapFS(), real))
+	})
+
+	t.Run("kind names are stable", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			want string
+			kind vfs.FSKind
+		}{
+			{kind: vfs.FSUnknown, want: "unknown"},
+			{kind: vfs.FSUnprobed, want: "unprobed"},
+			{kind: vfs.FSVirtual, want: "virtual"},
+			{kind: vfs.FSAPFS, want: "apfs"},
+			{kind: vfs.FSExt4, want: "ext4"},
+			{kind: vfs.FSXFS, want: "xfs"},
+			{kind: vfs.FSBtrfs, want: "btrfs"},
+			{kind: vfs.FSOverlay, want: "overlayfs"},
+			{kind: vfs.FSNetwork, want: "network"},
+		}
+
+		for _, tc := range testCases {
+			assert.Equal(t, tc.want, tc.kind.String())
+		}
+	})
+
+	// A kind added without a name would otherwise report "unknown" and
+	// pass for a filesystem the probe could not place.
+	t.Run("every declared kind is named", func(t *testing.T) {
+		t.Parallel()
+
+		seen := make(map[string]vfs.FSKind, len(vfs.FSKinds()))
+
+		for _, kind := range vfs.FSKinds() {
+			name := kind.String()
+
+			assert.NotEmpty(t, name, "kind %d has no name", kind)
+
+			if kind != vfs.FSUnknown {
+				assert.NotEqual(t, vfs.FSUnknown.String(), name,
+					"kind %d reports itself as unknown", kind)
+			}
+
+			if other, ok := seen[name]; ok {
+				t.Errorf("kinds %d and %d share the name %q", other, kind, name)
+			}
+
+			seen[name] = kind
+		}
+	})
+
+	t.Run("a kind outside the declared set panics", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Panics(t, func() {
+			_ = vfs.FSKind(200).String()
+		})
+	})
+}
+
+func TestFSWorkersForKind(t *testing.T) {
+	t.Parallel()
+
+	t.Run("measured filesystems get their own ceiling", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, vfs.MaxFSWorkers, vfs.FSWorkersForKind(vfs.FSExt4))
+		assert.Equal(t, vfs.XFSWorkers, vfs.FSWorkersForKind(vfs.FSXFS))
+		assert.Equal(t, vfs.BTRFSWorkers, vfs.FSWorkersForKind(vfs.FSBtrfs))
+		assert.Equal(t, vfs.APFSWorkers, vfs.FSWorkersForKind(vfs.FSAPFS))
+	})
+
+	t.Run("an unmeasured filesystem gets the conservative ceiling", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, vfs.DefaultFSWorkers, vfs.FSWorkersForKind(vfs.FSUnknown))
+		assert.Equal(t, vfs.DefaultFSWorkers, vfs.FSWorkersForKind(vfs.FSUnprobed))
+		assert.Equal(t, vfs.DefaultFSWorkers, vfs.FSWorkersForKind(vfs.FSVirtual))
+		assert.Equal(t, vfs.DefaultFSWorkers, vfs.FSWorkersForKind(vfs.FSNetwork))
+	})
+
+	t.Run("a probed path is bounded", func(t *testing.T) {
+		t.Parallel()
+
+		workers := vfs.FSWorkersFor(vfs.NewOSFS(), t.TempDir())
+
+		assert.GreaterOrEqual(t, workers, vfs.BTRFSWorkers)
+		assert.LessOrEqual(t, workers, vfs.MaxFSWorkers)
+	})
+}
+
+func TestFSWorkersForNonexistentPath(t *testing.T) {
+	t.Parallel()
+
+	existing := t.TempDir()
+	missing := filepath.Join(existing, "not-created-yet", "deeper")
+
+	assert.Equal(t, vfs.FSWorkersFor(vfs.NewOSFS(), existing), vfs.FSWorkersFor(vfs.NewOSFS(), missing))
+}

--- a/internal/vfs/fskind_windows.go
+++ b/internal/vfs/fskind_windows.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package vfs
+
+import (
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+// fsNameKinds maps the filesystem name GetVolumeInformation reports,
+// lowercased.
+var fsNameKinds = map[string]FSKind{
+	"ntfs":     FSNTFS,
+	"refs":     FSReFS,
+	"nfs":      FSNetwork,
+	"webdav":   FSNetwork,
+	"cifs":     FSNetwork,
+	"9p":       FSNetwork,
+	"drvfs":    FSNetwork,
+	"virtiofs": FSFUSE,
+}
+
+// maxVolumeNameLen bounds both buffers GetVolumeInformation fills.
+// MAX_PATH+1 is what the API documents as sufficient for either.
+const maxVolumeNameLen = windows.MAX_PATH + 1
+
+func detectFSKind(path string) FSKind {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return FSUnprobed
+	}
+
+	// GetVolumeInformation describes a volume root, not an arbitrary
+	// path, so the mount that holds path has to be resolved first.
+	root := make([]uint16, maxVolumeNameLen)
+	if err := windows.GetVolumePathName(pathPtr, &root[0], uint32(len(root))); err != nil {
+		return FSUnprobed
+	}
+
+	fsName := make([]uint16, maxVolumeNameLen)
+
+	err = windows.GetVolumeInformation(
+		&root[0],
+		nil,
+		0,
+		nil,
+		nil,
+		nil,
+		&fsName[0],
+		uint32(len(fsName)),
+	)
+	if err != nil {
+		return FSUnprobed
+	}
+
+	// A name with no entry is a real filesystem this package has not
+	// measured, which is [FSUnknown] rather than a failure to look.
+	return fsNameKinds[strings.ToLower(windows.UTF16ToString(fsName))]
+}

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -494,10 +494,10 @@ func WithFollowSymlinks() WalkDirParallelOption {
 // [fastwalk.Walk]. On any other FS, including [NewMemMapFS], it falls
 // back to the sequential [WalkDir].
 //
-// The parallel walk calls fn concurrently from multiple goroutines and
-// gives no ordering guarantee across directories. Callers that depend
-// on deterministic order, or that write to shared state from fn, must
-// use [WalkDir] or serialize access themselves.
+// The parallel walk calls fn concurrently from up to [FSWorkers]
+// goroutines and gives no ordering guarantee across directories.
+// Callers that depend on deterministic order, or that write to shared
+// state from fn, must use [WalkDir] or serialize access themselves.
 func WalkDirParallel(fsys FS, root string, fn fs.WalkDirFunc, opts ...WalkDirParallelOption) error {
 	if _, ok := fsys.(*osFS); !ok {
 		return WalkDir(fsys, root, fn)
@@ -508,9 +508,11 @@ func WalkDirParallel(fsys FS, root string, fn fs.WalkDirFunc, opts ...WalkDirPar
 		opt(&cfg)
 	}
 
-	var fwCfg *fastwalk.Config
-	if cfg.followSymlinks {
-		fwCfg = &fastwalk.Config{Follow: true}
+	// fastwalk's own default scales with GOMAXPROCS, which overshoots
+	// what the filesystem can absorb once fn does per-file work.
+	fwCfg := &fastwalk.Config{
+		Follow:     cfg.followSymlinks,
+		NumWorkers: FSWorkers,
 	}
 
 	err := fastwalk.Walk(fwCfg, root, fn)

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -67,17 +67,119 @@ type ContextLocker interface {
 	LockContext(ctx context.Context, name string) (Unlocker, error)
 }
 
-// FSWorkers bounds how many goroutines may run filesystem metadata
-// operations at once.
+// APFSWorkers is APFS's ceiling for concurrent per-file work.
 //
-// Measurement on APFS (the default for macOS) puts the ceiling at four
-// before performance starts to degrade. Until we have more granular
-// concurrency controls than `--parallelism`, we should use this as the
-// ceiling for filesystem workers.
+// Measurement on APFS (the default for macOS) puts it at four before
+// performance starts to degrade, and three separate workloads agree:
+// walking a tree while writing a file per entry, ingesting blobs into
+// the store, and materializing a tree out of it.
 //
-// Callers that fan out over per-file work should cap their errgroup here
-// rather than at GOMAXPROCS.
-const FSWorkers = 4
+// Reach for [FSWorkersFor] rather than this constant unless the code is
+// specifically about APFS.
+const APFSWorkers = 4
+
+// DefaultFSWorkers is what a filesystem with no measurement behind it
+// gets: the most conservative ceiling any measured filesystem wanted.
+// It matches [APFSWorkers] today and is named separately because a
+// change to APFS's measurement should not quietly move the fallback for
+// everything unmeasured.
+const DefaultFSWorkers = APFSWorkers
+
+// MaxFSWorkers is the ceiling for filesystems that keep answering more
+// concurrent per-file work with more throughput: ext4, tmpfs and
+// overlayfs were still gaining at sixteen. It is a fixed number rather
+// than a multiple of GOMAXPROCS because the work these bounds govern
+// waits on the disk, not on a core, and a large host must not answer a
+// large tree with a worker per core.
+const MaxFSWorkers = 16
+
+// XFSWorkers is XFS's ceiling, past which its allocator contends.
+const XFSWorkers = 8
+
+// BTRFSWorkers is btrfs's ceiling. Copy-on-write metadata makes it the
+// one measured filesystem that works fastest at two concurrent writers
+// and degrades steeply above four.
+const BTRFSWorkers = 2
+
+// fsWorkersByKind is what each filesystem was measured to absorb for
+// per-file work. It is the starting point for any bound the filesystem
+// governs; a site that has measured its own workload may deviate, and
+// should say so where it does.
+//
+// A kind that is absent has no measurement behind it and gets
+// [DefaultFSWorkers], the most conservative ceiling any measured
+// filesystem wanted.
+var fsWorkersByKind = map[FSKind]int{
+	FSAPFS:    APFSWorkers,
+	FSExt4:    MaxFSWorkers,
+	FSTmpfs:   MaxFSWorkers,
+	FSOverlay: MaxFSWorkers,
+	FSXFS:     XFSWorkers,
+	FSBtrfs:   BTRFSWorkers,
+}
+
+// maxAncestorProbes bounds how far [FSWorkersFor] climbs looking for a
+// path that exists.
+const maxAncestorProbes = 64
+
+// FSWorkersFor returns the concurrency the filesystem under path was
+// measured to absorb for per-file work.
+//
+// A path that does not exist yet is answered by its nearest existing
+// ancestor, so a destination can be sized before it is created.
+func FSWorkersFor(fsys FS, path string) int {
+	for range maxAncestorProbes {
+		if kind := DetectFSKind(fsys, path); kind != FSUnprobed {
+			return FSWorkersForKind(kind)
+		}
+
+		parent := filepath.Dir(path)
+		if parent == path {
+			break
+		}
+
+		path = parent
+	}
+
+	return DefaultFSWorkers
+}
+
+// FSWorkersForKind is [FSWorkersFor] for a filesystem already probed.
+func FSWorkersForKind(kind FSKind) int {
+	if workers, ok := fsWorkersByKind[kind]; ok {
+		return workers
+	}
+
+	return DefaultFSWorkers
+}
+
+// walkWorkersDefault leaves the count to fastwalk, whose own default
+// scales with GOMAXPROCS and never drops below four.
+const walkWorkersDefault = 0
+
+// walkWorkersByKind is what a write-heavy walk was measured to want,
+// where that differs from the filesystem's general ceiling in
+// [FSWorkersForKind]. XFS is the one deviation: it absorbs eight
+// concurrent writers elsewhere but peaks at four under a walk.
+//
+// The kinds absent here keep fastwalk's own default, which already
+// scales with GOMAXPROCS. Raising them to [MaxFSWorkers] measured
+// faster still on ext4 and overlayfs, but only on virtualized storage,
+// so that wants confirmation on real hardware first.
+var walkWorkersByKind = map[FSKind]int{
+	FSAPFS:  APFSWorkers,
+	FSXFS:   APFSWorkers,
+	FSBtrfs: BTRFSWorkers,
+}
+
+// walkWorkers sizes a parallel walk to the filesystem under root.
+func walkWorkers(fsys FS, root string) int {
+	if workers, ok := walkWorkersByKind[DetectFSKind(fsys, root)]; ok {
+		return workers
+	}
+
+	return walkWorkersDefault
+}
 
 const maxSymlinkEvaluations = 255
 
@@ -494,10 +596,11 @@ func WithFollowSymlinks() WalkDirParallelOption {
 // [fastwalk.Walk]. On any other FS, including [NewMemMapFS], it falls
 // back to the sequential [WalkDir].
 //
-// The parallel walk calls fn concurrently from up to [FSWorkers]
-// goroutines and gives no ordering guarantee across directories.
-// Callers that depend on deterministic order, or that write to shared
-// state from fn, must use [WalkDir] or serialize access themselves.
+// The walk fans out over as many goroutines as the filesystem under
+// root was measured to absorb (see [walkWorkersByKind]), and gives no
+// ordering guarantee across directories. Callers that depend on
+// deterministic order, or that write to shared state from fn, must use
+// [WalkDir] or serialize access themselves.
 func WalkDirParallel(fsys FS, root string, fn fs.WalkDirFunc, opts ...WalkDirParallelOption) error {
 	if _, ok := fsys.(*osFS); !ok {
 		return WalkDir(fsys, root, fn)
@@ -508,11 +611,9 @@ func WalkDirParallel(fsys FS, root string, fn fs.WalkDirFunc, opts ...WalkDirPar
 		opt(&cfg)
 	}
 
-	// fastwalk's own default scales with GOMAXPROCS, which overshoots
-	// what the filesystem can absorb once fn does per-file work.
 	fwCfg := &fastwalk.Config{
 		Follow:     cfg.followSymlinks,
-		NumWorkers: FSWorkers,
+		NumWorkers: walkWorkers(fsys, root),
 	}
 
 	err := fastwalk.Walk(fwCfg, root, fn)

--- a/test/benchmarks/integration_auto_provider_cache_dir_bench_test.go
+++ b/test/benchmarks/integration_auto_provider_cache_dir_bench_test.go
@@ -48,8 +48,6 @@ func BenchmarkAutoProviderCacheDirInit(b *testing.B) {
 
 		setup(tmpDir)
 
-		b.ResetTimer()
-
 		for b.Loop() {
 			helpers.RunTerragruntCommand(
 				b,
@@ -59,16 +57,12 @@ func BenchmarkAutoProviderCacheDirInit(b *testing.B) {
 				"--non-interactive",
 				"--working-dir", tmpDir)
 		}
-
-		b.StopTimer()
 	})
 
 	b.Run("init with auto provider cache dir", func(b *testing.B) {
 		tmpDir := b.TempDir()
 
 		setup(tmpDir)
-
-		b.ResetTimer()
 
 		for b.Loop() {
 			helpers.RunTerragruntCommand(
@@ -81,8 +75,6 @@ func BenchmarkAutoProviderCacheDirInit(b *testing.B) {
 				"--working-dir",
 				tmpDir)
 		}
-
-		b.StopTimer()
 	})
 }
 
@@ -180,16 +172,12 @@ func BenchmarkProviderCachingComparison(b *testing.B) {
 
 				args = append(args, cacheType.args...)
 
-				b.ResetTimer()
-
 				for b.Loop() {
 					helpers.RunTerragruntCommand(
 						b,
 						args...,
 					)
 				}
-
-				b.StopTimer()
 			})
 		}
 	}

--- a/test/benchmarks/integration_bench_test.go
+++ b/test/benchmarks/integration_bench_test.go
@@ -267,7 +267,6 @@ terraform {
 	b.Run("default_runner", func(b *testing.B) {
 		// Warmups (not measured)
 		warmupApplies(b, tmpDir, false, 2)
-		b.ResetTimer()
 
 		for b.Loop() {
 			helpers.Apply(b, tmpDir)
@@ -277,7 +276,6 @@ terraform {
 	b.Run("runner_pool", func(b *testing.B) {
 		// Warmups (not measured)
 		warmupApplies(b, tmpDir, true, 2)
-		b.ResetTimer()
 
 		for b.Loop() {
 			helpers.ApplyWithRunnerPool(b, tmpDir)
@@ -337,7 +335,6 @@ terraform {
 	b.Run("default_runner", func(b *testing.B) {
 		// Warmups (not measured)
 		warmupApplies(b, tmpDir, false, 2)
-		b.ResetTimer()
 
 		for b.Loop() {
 			helpers.Apply(b, tmpDir)
@@ -347,7 +344,6 @@ terraform {
 	b.Run("runner_pool", func(b *testing.B) {
 		// Warmups (not measured)
 		warmupApplies(b, tmpDir, true, 2)
-		b.ResetTimer()
 
 		for b.Loop() {
 			helpers.ApplyWithRunnerPool(b, tmpDir)
@@ -432,7 +428,6 @@ dependencies {
 	b.Run("default_runner", func(b *testing.B) {
 		// Warmups (not measured)
 		warmupApplies(b, tmpDir, false, 2)
-		b.ResetTimer()
 
 		for b.Loop() {
 			helpers.Apply(b, tmpDir)
@@ -442,7 +437,6 @@ dependencies {
 	b.Run("runner_pool", func(b *testing.B) {
 		// Warmups (not measured)
 		warmupApplies(b, tmpDir, true, 2)
-		b.ResetTimer()
 
 		for b.Loop() {
 			helpers.ApplyWithRunnerPool(b, tmpDir)
@@ -553,7 +547,6 @@ terraform {
 			b.Run("configstack", func(b *testing.B) {
 				// Warmups (not measured)
 				warmupApplies(b, dir, false, 2)
-				b.ResetTimer()
 
 				for b.Loop() {
 					helpers.Apply(b, dir)
@@ -563,7 +556,6 @@ terraform {
 			b.Run("runner_pool", func(b *testing.B) {
 				// Warmups (not measured)
 				warmupApplies(b, dir, true, 2)
-				b.ResetTimer()
 
 				for b.Loop() {
 					helpers.ApplyWithRunnerPool(b, dir)

--- a/test/benchmarks/integration_cas_bench_test.go
+++ b/test/benchmarks/integration_cas_bench_test.go
@@ -48,8 +48,6 @@ func BenchmarkCASInit(b *testing.B) {
 
 		setup(tmpDir)
 
-		b.ResetTimer()
-
 		for b.Loop() {
 			helpers.RunTerragruntCommand(
 				b,
@@ -61,16 +59,12 @@ func BenchmarkCASInit(b *testing.B) {
 				"--source-update",
 				"--working-dir", tmpDir)
 		}
-
-		b.StopTimer()
 	})
 
 	b.Run("remote init with CAS", func(b *testing.B) {
 		tmpDir := b.TempDir()
 
 		setup(tmpDir)
-
-		b.ResetTimer()
 
 		for b.Loop() {
 			helpers.RunTerragruntCommand(
@@ -83,8 +77,6 @@ func BenchmarkCASInit(b *testing.B) {
 				"--working-dir",
 				tmpDir)
 		}
-
-		b.StopTimer()
 	})
 }
 
@@ -168,16 +160,12 @@ func BenchmarkCASWithManyUnits(b *testing.B) {
 					args = append(args, "--no-cas")
 				}
 
-				b.ResetTimer()
-
 				for b.Loop() {
 					helpers.RunTerragruntCommand(
 						b,
 						args...,
 					)
 				}
-
-				b.StopTimer()
 			})
 		}
 	}

--- a/test/benchmarks/integration_stack_output_bench_test.go
+++ b/test/benchmarks/integration_stack_output_bench_test.go
@@ -88,8 +88,6 @@ func BenchmarkStackOutputParallelism(b *testing.B) {
 		seen[level] = struct{}{}
 
 		b.Run("parallelism="+strconv.Itoa(level), func(b *testing.B) {
-			b.ResetTimer()
-
 			for b.Loop() {
 				helpers.RunTerragruntCommand(
 					b,
@@ -99,8 +97,6 @@ func BenchmarkStackOutputParallelism(b *testing.B) {
 					"--working-dir", livePath,
 				)
 			}
-
-			b.StopTimer()
 		})
 	}
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds a Filesystem probe used to detect the filesystem a user is running in, and adjusts filesystem based concurrency controls based on it.

In #6838 I noted that 4 workers was the sweet spot for `git cat-file --batch` shards on APFS, and that with more extensive benchmarking we might want to tune the worker count differently on Linux and Windows. This is that benchmarking.

TL;DR: the number of concurrent file operations a machine can absorb varies pretty widely by filesystem. Measuring the same workload across filesystems at 2, 4, 8 and 16 vCPU in Docker containers. 

ext4 kept gaining out to 16 workers whether it had 2 cores or 16. 
btrfs wanted 2 everywhere. 
APFS wanted 4 everywhere.

So we now have a filesystem probe in `vfs.DetectFSKind`. `vfs.FSWorkersForKind` takes that `FSKind` and returns a worker count that the CAS, the tree materializer and the parallel walk all leverage. A filesystem with no measurement behind it keeps a conservative default, and an in-memory `vfs.FS` bypasses the probe.

Measured on Linux in Docker with `--cpus`, against a fresh store, cold ingest of a 3,000 file repository:

| filesystem | vCPU | before | after | change |
| --- | --- | --- | --- | --- |
| ext4 | 16 | 138.3ms | 112.4ms | -19% |
| btrfs | 16 | 266.4ms | 213.6ms | -20% |

Materializing that repository out of a warm store, where the old `GOMAXPROCS/2` was worst:

| filesystem | vCPU | before | after | change |
| --- | --- | --- | --- | --- |
| ext4 | 2 | 40.8ms | 24.4ms | -40% |
| btrfs | 2 | 48.7ms | 34.2ms | -30% |
| overlayfs | 2 | 71.5ms | 56.4ms | -21% |
| btrfs | 16 | 42.0ms | 38.1ms | -9% |
| overlayfs | 16 | 50.4ms | 46.1ms | -9% |

On an Apple M3 Max, capping the parallel walk at 4 workers took a fast copy of a module directory from 325ms to 104ms (-68%) for many small files and 170ms to 63ms (-63%) for a mix including a few large ones.

`terragrunt hcl fmt` got tuned too. 16 workers ran about 65% slower than 8. It now defaults to `min(GOMAXPROCS, 8)`. Formatting 1,024 files went from 24.9ms to 21.3ms (-14%).

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved file-operation concurrency by detecting filesystem characteristics and applying appropriate worker limits.
  - Added more efficient handling for content ingestion, directory traversal, and materialization across supported filesystems.
  - Improved macOS module-directory copying with fast-copy support.
  - Added an eight-worker default limit for `terragrunt hcl fmt`; explicitly configured parallelism remains unchanged.

- **Documentation**
  - Added release documentation covering filesystem-aware concurrency and benchmark improvements for ext4, btrfs, and overlayfs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->