### PR TITLE
fix(getter): pin S3-compatible endpoint independently of URL credentials

### DIFF
--- a/docs/src/data/changelog/v1.1.5/s3-compatible-endpoint-env-credentials.mdx
+++ b/docs/src/data/changelog/v1.1.5/s3-compatible-endpoint-env-credentials.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### Fixed S3-compatible source downloads with environment credentials
+
+Downloading unit sources from S3-compatible services (`s3::https://minio.example.com/...`) now works when credentials are supplied via environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) or IAM roles rather than embedded in the URL query string. Previously, the custom endpoint was only pinned when credentials were present in the URL, causing the AWS SDK to redirect requests to `amazonaws.com` and fail with `InvalidAccessKeyId`.

--- a/internal/getter/s3.go
+++ b/internal/getter/s3.go
@@ -288,17 +288,6 @@ func ParseS3FetchURL(u *url.URL) (S3FetchTarget, error) {
 	return target, nil
 }
 
-// s3EndpointScheme normalizes the URL scheme to a transport the HTTP client
-// supports. The upstream s3 getter claims `s3://` URLs without rewriting the
-// scheme, so the raw value may be "s3" rather than "http" or "https".
-func s3EndpointScheme(scheme string) string {
-	if scheme == SchemeHTTP {
-		return SchemeHTTP
-	}
-
-	return SchemeHTTPS
-}
-
 // S3Region resolves the region for u. An AWS host encodes it in the first
 // label; any other host belongs to an S3-compatible service, which carries it
 // in the query instead.
@@ -368,4 +357,15 @@ func S3ClientForTarget(
 	}
 
 	return b.BuildS3Client(ctx, l, v)
+}
+
+// s3EndpointScheme normalizes the URL scheme to a transport the HTTP client
+// supports. The upstream s3 getter claims `s3://` URLs without rewriting the
+// scheme, so the raw value may be "s3" rather than "http" or "https".
+func s3EndpointScheme(scheme string) string {
+	if scheme == SchemeHTTP {
+		return SchemeHTTP
+	}
+
+	return SchemeHTTPS
 }

--- a/internal/getter/s3.go
+++ b/internal/getter/s3.go
@@ -246,10 +246,10 @@ func redactedURL(u *url.URL) string {
 // the AWS virtual-host and modern path-style forms, so only
 // `<host>/<bucket>/<key>` reaches here.
 //
-// Credentials supplied in the query are also the signal that the URL names an
-// S3-compatible service rather than AWS, so they pin the endpoint to the URL's
-// own host in path style. That mirrors the upstream getter, which callers rely
-// on to reach non-AWS object stores.
+// A non-AWS host pins the endpoint to the URL's own host with path-style
+// addressing, regardless of how credentials are supplied. Credentials in the
+// query build a static provider; otherwise the default credential chain
+// (env vars, IAM role, etc.) applies.
 func ParseS3FetchURL(u *url.URL) (S3FetchTarget, error) {
 	pathParts := strings.SplitN(u.Path, "/", s3PathParts)
 	if len(pathParts) != s3PathParts || pathParts[1] == "" || pathParts[2] == "" {
@@ -272,16 +272,31 @@ func ParseS3FetchURL(u *url.URL) (S3FetchTarget, error) {
 
 	target.Region = region
 
+	// Pin endpoint for non-AWS hosts so the SDK does not redirect to amazonaws.com.
+	if !strings.Contains(u.Host, "amazonaws.com") {
+		target.Endpoint = s3EndpointScheme(u.Scheme) + "://" + u.Host
+	}
+
 	keyID := q.Get("aws_access_key_id")
 	secret := q.Get("aws_access_key_secret")
 	token := q.Get("aws_access_token")
 
 	if cmp.Or(keyID, secret, token) != "" {
 		target.Creds = credentials.NewStaticCredentialsProvider(keyID, secret, token)
-		target.Endpoint = u.Scheme + "://" + u.Host
 	}
 
 	return target, nil
+}
+
+// s3EndpointScheme normalizes the URL scheme to a transport the HTTP client
+// supports. The upstream s3 getter claims `s3://` URLs without rewriting the
+// scheme, so the raw value may be "s3" rather than "http" or "https".
+func s3EndpointScheme(scheme string) string {
+	if scheme == SchemeHTTP {
+		return SchemeHTTP
+	}
+
+	return SchemeHTTPS
 }
 
 // S3Region resolves the region for u. An AWS host encodes it in the first

--- a/internal/getter/s3_fetch_test.go
+++ b/internal/getter/s3_fetch_test.go
@@ -58,11 +58,12 @@ func TestParseS3FetchURL(t *testing.T) {
 			wantProfile: "dev",
 		},
 		{
-			name:       "s3-compatible host takes its region from the query",
-			raw:        "https://minio.example.com/bucket/key?region=us-west-2",
-			wantRegion: "us-west-2",
-			wantBucket: "bucket",
-			wantKey:    "key",
+			name:         "s3-compatible host takes its region from the query",
+			raw:          "https://minio.example.com/bucket/key?region=us-west-2",
+			wantRegion:   "us-west-2",
+			wantBucket:   "bucket",
+			wantKey:      "key",
+			wantEndpoint: "https://minio.example.com",
 		},
 	}
 
@@ -112,6 +113,67 @@ func TestParseS3FetchURLInURLCredentials(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "key", creds.AccessKeyID)
 	assert.Equal(t, "secret", creds.SecretAccessKey)
+}
+
+// TestParseS3FetchURLEnvCredentials is the regression test for #6821: a
+// non-AWS S3-compatible URL without query credentials must still pin the
+// endpoint so the SDK does not redirect to amazonaws.com.
+func TestParseS3FetchURLEnvCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		raw          string
+		wantEndpoint string
+		wantCreds    bool
+	}{
+		{
+			name:         "custom host without query creds pins endpoint",
+			raw:          "https://s3.example.internal/example-bucket/module.zip",
+			wantEndpoint: "https://s3.example.internal",
+		},
+		{
+			name:         "custom host with query creds pins endpoint and sets creds",
+			raw:          "https://s3.example.internal/bucket/key?aws_access_key_id=k&aws_access_key_secret=s",
+			wantEndpoint: "https://s3.example.internal",
+			wantCreds:    true,
+		},
+		{
+			name:         "localhost MinIO pins endpoint without creds",
+			raw:          "http://127.0.0.1:9000/bucket/modules/mod.tar.gz",
+			wantEndpoint: "http://127.0.0.1:9000",
+		},
+		{
+			name:         "s3 scheme on custom host normalizes to https",
+			raw:          "s3://minio.corp.internal/bucket/module.zip",
+			wantEndpoint: "https://minio.corp.internal",
+		},
+		{
+			name:         "AWS host never pins a custom endpoint",
+			raw:          "s3://s3.amazonaws.com/bucket/key",
+			wantEndpoint: "",
+		},
+		{
+			name:         "regional AWS host never pins a custom endpoint",
+			raw:          "s3://s3-eu-west-1.amazonaws.com/bucket/key",
+			wantEndpoint: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(tc.raw)
+			require.NoError(t, err)
+
+			got, err := getter.ParseS3FetchURL(u)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantEndpoint, got.Endpoint)
+			assert.Equal(t, tc.wantCreds, got.Creds != nil)
+		})
+	}
 }
 
 // TestParseS3FetchURLRejectsIncomplete pins that a URL naming no key is


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

- Decouple endpoint pinning from URL credential presence in ParseS3FetchURL
- Normalize s3:// scheme to https:// via s3EndpointScheme helper

Fixes #6821.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed downloads from S3-compatible services when credentials are supplied through environment variables or IAM roles.
  * Custom S3-compatible endpoints now remain correctly pinned for supported URL formats, including `s3://` URLs.
  * Preserved standard AWS endpoint behavior for global and regional AWS hosts.

* **Documentation**
  * Added a changelog entry describing the S3-compatible endpoint and credential handling fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->