### PR TITLE
fix: Keep queue failure propagation from crossing the up/down boundary

### DIFF
--- a/docs/src/data/changelog/v1.1.5/mixed-direction-early-exit-hang.mdx
+++ b/docs/src/data/changelog/v1.1.5/mixed-direction-early-exit-hang.mdx
@@ -16,6 +16,7 @@ completed the process went silent forever: no summary, no error report, no child
 external kill would end it.
 
 Failure propagation now respects direction the same way readiness does. A failed destroy cancels only
-the other destroys that depend on it; a failed plan cancels only the other plans that depend on it.
+its down-command dependencies (the destroys that would have run after it); a failed plan cancels only
+its up-command dependents.
 The failure is reported in the run's error and summary as before, and every unit that never gated on
 the failed one runs to completion.

--- a/docs/src/data/changelog/v1.1.5/mixed-direction-early-exit-hang.mdx
+++ b/docs/src/data/changelog/v1.1.5/mixed-direction-early-exit-hang.mdx
@@ -1,0 +1,21 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### Fixed `run --all --filter-allow-destroy` hanging forever after a deleted unit fails
+
+With a git-range `--filter` and `--filter-allow-destroy`, a single run queue mixes plans of surviving
+units with `plan -destroy` entries for units deleted in the diff. Readiness already ignores edges
+that cross that boundary (a unit being destroyed never gates a unit being planned, and vice
+versa), but failure propagation did not: when a deleted unit's `plan -destroy` failed - for example
+at HCL evaluation, before OpenTofu even ran - the failure early-exited the *surviving* dependencies
+it shared with other surviving units. Those surviving units then waited for a dependency that would
+never be `Succeeded`, nothing could ever schedule or finish them, and once the last running unit
+completed the process went silent forever: no summary, no error report, no child process, only an
+external kill would end it.
+
+Failure propagation now respects direction the same way readiness does. A failed destroy cancels only
+the other destroys that depend on it; a failed plan cancels only the other plans that depend on it.
+The failure is reported in the run's error and summary as before, and every unit that never gated on
+the failed one runs to completion.

--- a/internal/queue/mixed_direction_deadlock_test.go
+++ b/internal/queue/mixed_direction_deadlock_test.go
@@ -1,0 +1,270 @@
+package queue_test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/queue"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// destroyPlan marks a unit as a "down" entry, the way a unit deleted in a git-range filter is
+// scheduled under --filter-allow-destroy.
+func destroyPlan(u *component.Unit) *component.Unit {
+	return u.WithDiscoveryContext(&component.DiscoveryContext{Cmd: "plan", Args: []string{"-destroy"}})
+}
+
+// drainable reports whether a queue with no running entries can still make progress: either it
+// is finished, or something is dispatchable. A queue that is neither is the hang - Controller.Run
+// parks on readyCh with no goroutine left to signal it.
+func drainable(t *testing.T, q *queue.Queue) bool {
+	t.Helper()
+
+	return q.Finished() || len(q.GetReadyWithDependencies(logger.CreateLogger())) > 0
+}
+
+// TestFailedDestroyDoesNotEarlyExitUpDependencies is the regression test for the
+// `run --all --filter-allow-destroy` hang. A deleted unit's `plan -destroy` (down) shares a
+// surviving dependency with surviving units (up):
+//
+//	shared (up) <- consumer (up)
+//	shared (up) <- gone     (down)
+//
+// Readiness already ignores cross-direction edges (#6322): `gone` never waited on `shared`. Failure
+// propagation must not cross them either. Before the fix, FailEntry(gone) marked `shared`
+// EarlyExit; `consumer` needs `shared` to be Succeeded, nothing ever walked from `shared` to
+// `consumer`, and the queue could neither finish nor dispatch anything - forever.
+func TestFailedDestroyDoesNotEarlyExitUpDependencies(t *testing.T) {
+	t.Parallel()
+
+	shared := component.NewUnit("/repo/shared")
+	consumer := component.NewUnit("/repo/consumer")
+	consumer.AddDependency(shared)
+
+	gone := destroyPlan(component.NewUnit("/wt/from/gone"))
+	gone.AddDependency(shared)
+
+	q, err := queue.NewQueue(component.Components{shared, consumer, gone})
+	require.NoError(t, err)
+
+	goneEntry := q.EntryByPath(gone.Path())
+	require.True(t, q.ClaimForRunning(goneEntry))
+	q.FailEntry(goneEntry) // fails while `shared` is still Ready (not yet claimed)
+
+	sharedEntry := q.EntryByPath(shared.Path())
+	assert.Equal(t, queue.StatusReady, sharedEntry.Status,
+		"a failed destroy must not cancel a surviving unit it never gated on")
+	assert.True(t, drainable(t, q), "the queue must still be able to make progress")
+
+	// The surviving chain runs to completion as if `gone` had never been there.
+	require.True(t, q.ClaimForRunning(sharedEntry))
+	q.SetEntryStatus(sharedEntry, queue.StatusSucceeded)
+
+	consumerEntry := q.EntryByPath(consumer.Path())
+	require.ElementsMatch(t, []*queue.Entry{consumerEntry}, q.GetReadyWithDependencies(logger.CreateLogger()))
+	require.True(t, q.ClaimForRunning(consumerEntry))
+	q.SetEntryStatus(consumerEntry, queue.StatusSucceeded)
+
+	assert.True(t, q.Finished())
+	assert.Equal(t, queue.StatusFailed, goneEntry.Status, "the destroy's own failure is still recorded")
+}
+
+// TestFailedPlanDoesNotEarlyExitDownDependents is the mirror image. A surviving unit's plan (up)
+// fails while a deleted unit that depends on it (down) has its own down dependency still gated:
+//
+//	shared (up) <- gone (down) <- goneDep (down)   (goneDep is destroyed after gone)
+//
+// `gone` never waited on `shared`, so its failure must not cancel `gone`. Before the fix,
+// FailEntry(shared) marked `gone` EarlyExit; `goneDep` needs `gone` to be Succeeded before it can be
+// destroyed, and stayed Ready forever.
+func TestFailedPlanDoesNotEarlyExitDownDependents(t *testing.T) {
+	t.Parallel()
+
+	shared := component.NewUnit("/repo/shared")
+	goneDep := destroyPlan(component.NewUnit("/wt/from/gone-dep"))
+	gone := destroyPlan(component.NewUnit("/wt/from/gone"))
+	gone.AddDependency(shared)
+	gone.AddDependency(goneDep)
+
+	q, err := queue.NewQueue(component.Components{shared, gone, goneDep})
+	require.NoError(t, err)
+
+	sharedEntry := q.EntryByPath(shared.Path())
+	require.True(t, q.ClaimForRunning(sharedEntry))
+	q.FailEntry(sharedEntry) // fails while `gone` is still Ready
+
+	goneEntry := q.EntryByPath(gone.Path())
+	assert.Equal(t, queue.StatusReady, goneEntry.Status,
+		"a failed plan must not cancel a destroy that never gated on it")
+	assert.True(t, drainable(t, q))
+
+	require.True(t, q.ClaimForRunning(goneEntry))
+	q.SetEntryStatus(goneEntry, queue.StatusSucceeded)
+
+	goneDepEntry := q.EntryByPath(goneDep.Path())
+	require.ElementsMatch(t, []*queue.Entry{goneDepEntry}, q.GetReadyWithDependencies(logger.CreateLogger()))
+	require.True(t, q.ClaimForRunning(goneDepEntry))
+	q.SetEntryStatus(goneDepEntry, queue.StatusSucceeded)
+
+	assert.True(t, q.Finished())
+}
+
+// TestSameDirectionPropagationUnchanged pins that the fix is scoped to mixed queues: within one
+// direction, a failure still early-exits everything downstream of it exactly as before.
+func TestSameDirectionPropagationUnchanged(t *testing.T) {
+	t.Parallel()
+
+	t.Run("up: failure early-exits dependents", func(t *testing.T) {
+		t.Parallel()
+
+		a := component.NewUnit("/repo/a")
+		b := component.NewUnit("/repo/b")
+		c := component.NewUnit("/repo/c")
+		b.AddDependency(a)
+		c.AddDependency(b)
+
+		q, err := queue.NewQueue(component.Components{a, b, c})
+		require.NoError(t, err)
+
+		aEntry := q.EntryByPath(a.Path())
+		require.True(t, q.ClaimForRunning(aEntry))
+		q.FailEntry(aEntry)
+
+		assert.Equal(t, queue.StatusEarlyExit, q.EntryByPath(b.Path()).Status)
+		assert.Equal(t, queue.StatusEarlyExit, q.EntryByPath(c.Path()).Status)
+		assert.True(t, q.Finished())
+	})
+
+	t.Run("down: failure early-exits dependencies", func(t *testing.T) {
+		t.Parallel()
+
+		a := destroyPlan(component.NewUnit("/wt/a"))
+		b := destroyPlan(component.NewUnit("/wt/b"))
+		c := destroyPlan(component.NewUnit("/wt/c"))
+		b.AddDependency(a)
+		c.AddDependency(b)
+
+		q, err := queue.NewQueue(component.Components{a, b, c})
+		require.NoError(t, err)
+
+		// Destroy order is c, b, a; c fails first.
+		cEntry := q.EntryByPath(c.Path())
+		require.True(t, q.ClaimForRunning(cEntry))
+		q.FailEntry(cEntry)
+
+		assert.Equal(t, queue.StatusEarlyExit, q.EntryByPath(b.Path()).Status)
+		assert.Equal(t, queue.StatusEarlyExit, q.EntryByPath(a.Path()).Status)
+		assert.True(t, q.Finished())
+	})
+}
+
+// TestIncidentShapeDrainsAfterDestroyFailure reproduces the dependency shape from the production
+// incident this fixes (Optimuse infrastructure PR deleting 11 dev units; two CI runs hung for 3h
+// and 20h respectively). The deleted `workflows/ifc-lift` (down) failed at HCL evaluation and
+// early-exited its surviving dependencies `agent-core` and - via the deleted `engines/ifc-lift` -
+// `otel-collector`, which had not started yet. Every surviving `engines/*` unit gated on
+// `otel-collector`, and every surviving `workflows/*` unit gated on `agent-core`, then sat Ready
+// forever. With the fix, the destroy failure is contained to the deleted units.
+func TestIncidentShapeDrainsAfterDestroyFailure(t *testing.T) {
+	t.Parallel()
+
+	// Surviving (up).
+	ciAuth := component.NewUnit("/repo/ci-auth")
+	jena := component.NewUnit("/repo/jena")
+	batch := component.NewUnit("/repo/batch")
+	agentCore := component.NewUnit("/repo/agent-core")
+	otelCollector := component.NewUnit("/repo/otel-collector")
+	engineEnergyplus := component.NewUnit("/repo/engines/energyplus")
+	workflowSimE2E := component.NewUnit("/repo/workflows/simulation-e2e")
+	agentCore.AddDependency(ciAuth)
+	agentCore.AddDependency(jena)
+	otelCollector.AddDependency(batch)
+	engineEnergyplus.AddDependency(otelCollector)
+	engineEnergyplus.AddDependency(batch)
+	workflowSimE2E.AddDependency(engineEnergyplus)
+	workflowSimE2E.AddDependency(agentCore)
+
+	// Deleted (down), discovered from the origin/main worktree.
+	engineIfcLift := destroyPlan(component.NewUnit("/wt/engines/ifc-lift"))
+	engineIfcLift.AddDependency(ciAuth)
+	engineIfcLift.AddDependency(batch)
+	engineIfcLift.AddDependency(otelCollector)
+	engineIfcLift.AddDependency(jena)
+	workflowIfcLift := destroyPlan(component.NewUnit("/wt/workflows/ifc-lift"))
+	workflowIfcLift.AddDependency(batch)
+	workflowIfcLift.AddDependency(engineIfcLift)
+	workflowIfcLift.AddDependency(agentCore)
+
+	q, err := queue.NewQueue(component.Components{
+		ciAuth, jena, batch, agentCore, otelCollector, engineEnergyplus, workflowSimE2E,
+		engineIfcLift, workflowIfcLift,
+	})
+	require.NoError(t, err)
+
+	l := logger.CreateLogger()
+
+	// Pass 1 as the Controller would do it: ci-auth, jena, batch (no deps) and workflows/ifc-lift
+	// (down, nothing depends on it) are claimed. agent-core / otel-collector are gated.
+	for _, e := range q.GetReadyWithDependencies(l) {
+		require.True(t, q.ClaimForRunning(e))
+	}
+
+	require.ElementsMatch(t,
+		[]string{ciAuth.Path(), jena.Path(), batch.Path(), workflowIfcLift.Path()},
+		paths(runningEntries(q)))
+
+	// The deleted workflow fails at HCL evaluation while its surviving dependencies are still gated.
+	q.FailEntry(q.EntryByPath(workflowIfcLift.Path()))
+
+	assert.Equal(t, queue.StatusEarlyExit, q.EntryByPath(engineIfcLift.Path()).Status,
+		"the other deleted unit, destroyed after its dependent, is correctly cancelled")
+	assert.Equal(t, queue.StatusReady, q.EntryByPath(agentCore.Path()).Status,
+		"a surviving unit must not be cancelled by a deleted unit's failure")
+	assert.Equal(t, queue.StatusReady, q.EntryByPath(otelCollector.Path()).Status)
+
+	// Drive the surviving graph to completion: everything up must finish.
+	for _, e := range runningEntries(q) {
+		q.SetEntryStatus(e, queue.StatusSucceeded)
+	}
+
+	for range 10 {
+		ready := q.GetReadyWithDependencies(l)
+		if len(ready) == 0 {
+			break
+		}
+
+		for _, e := range ready {
+			require.True(t, q.ClaimForRunning(e))
+			q.SetEntryStatus(e, queue.StatusSucceeded)
+		}
+	}
+
+	require.True(t, q.Finished(), "with the fix the queue drains; before it, 4 surviving units stayed Ready forever")
+
+	for _, u := range []*component.Unit{ciAuth, jena, batch, agentCore, otelCollector, engineEnergyplus, workflowSimE2E} {
+		assert.Equal(t, queue.StatusSucceeded, q.EntryByPath(u.Path()).Status, u.Path())
+	}
+}
+
+func paths(entries []*queue.Entry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Component.Path())
+	}
+
+	return out
+}
+
+func runningEntries(q *queue.Queue) []*queue.Entry {
+	var out []*queue.Entry
+
+	for _, e := range q.Entries {
+		if e.Status == queue.StatusRunning {
+			out = append(out, e)
+		}
+	}
+
+	return out
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -487,9 +487,15 @@ func (q *Queue) FailEntry(e *Entry) {
 }
 
 // earlyExitDependents - Recursively mark all entries that are dependent on this one as early exit.
+//
+// Only up-command dependents are marked. A down-command (destroy) dependent never waited on this
+// entry - areDependentsReadyUnsafe and UpdateBlocked skip up-command entries for it - so it must
+// not be cancelled by this entry's failure either. Marking it EarlyExit would leave any down-command
+// dependency it gates (which needs it to be *Succeeded*) Ready forever, with no goroutine left to
+// wake the controller: the queue never finishes and run --all hangs.
 func (q *Queue) earlyExitDependents(e *Entry) {
 	for _, entry := range q.Entries {
-		if len(entry.Component.Dependencies()) == 0 {
+		if len(entry.Component.Dependencies()) == 0 || !entry.IsUp() {
 			continue
 		}
 
@@ -510,6 +516,13 @@ func (q *Queue) earlyExitDependents(e *Entry) {
 }
 
 // earlyExitDependencies - Recursively mark all entries that are dependencies on this one as early exit.
+//
+// Only down-command dependencies are marked. An up-command (plan/apply) dependency never waited on
+// this entry - areDependenciesReadyUnsafe and UpdateBlocked skip down-command entries for it - so a
+// failed destroy must not cancel it. Marking it EarlyExit would leave every up-command entry gated
+// on it (which needs it to be *Succeeded*) Ready forever; that is the `run --all --filter-allow-destroy`
+// hang where a deleted unit's failed `plan -destroy` early-exits a surviving shared dependency and the
+// surviving units downstream of it are never scheduled or finished.
 func (q *Queue) earlyExitDependencies(e *Entry) {
 	if len(e.Component.Dependencies()) == 0 {
 		return
@@ -517,7 +530,7 @@ func (q *Queue) earlyExitDependencies(e *Entry) {
 
 	for _, dep := range e.Component.Dependencies() {
 		depEntry := q.entryByPathUnsafe(dep.Path())
-		if depEntry == nil {
+		if depEntry == nil || depEntry.IsUp() {
 			continue
 		}
 

--- a/internal/runner/mixed_direction_hang_test.go
+++ b/internal/runner/mixed_direction_hang_test.go
@@ -49,27 +49,28 @@ func TestControllerFinishesAfterDownEntryFailsWithPendingUpChain(t *testing.T) {
 	require.NoError(t, err)
 
 	errGoneFailed := errors.New("plan -destroy failed")
-	goneReturned := make(chan struct{})
+	goneFailed := make(chan struct{})
+	goneEntry := q.EntryByPath(gone.Path())
 
 	runUnit := func(ctx context.Context, u *component.Unit) error {
 		switch u.Path() {
 		case gone.Path():
-			close(goneReturned)
+			// The controller calls FailEntry only after this runner returns, so there is no
+			// hook to wait on for "the failure has propagated". Propagate it here first, under
+			// the queue lock, then release `base`: `shared` is guaranteed to still be Ready
+			// (gated on base, not Running) when gone's dependencies are walked, with no
+			// scheduler-dependent sleep. The controller's own FailEntry that follows is an
+			// idempotent repeat and is still exercised.
+			q.FailEntry(goneEntry)
+			close(goneFailed)
 
 			return errGoneFailed
 		case base.Path():
-			// Hold `base` open until `gone` has returned its error, so `shared` is still Ready
-			// (gated on base, not Running) when the controller's FailEntry walks gone's
-			// dependencies. FailEntry runs on the controller goroutine right after the runner
-			// returns; the short pause lets it land. Entry statuses are only read after Run
-			// returns, so this test never touches them concurrently with the controller.
 			select {
-			case <-goneReturned:
+			case <-goneFailed:
 			case <-time.After(5 * time.Second):
 				return errors.New("test setup: gone never ran")
 			}
-
-			time.Sleep(100 * time.Millisecond)
 
 			return nil
 		default:

--- a/internal/runner/mixed_direction_hang_test.go
+++ b/internal/runner/mixed_direction_hang_test.go
@@ -1,0 +1,100 @@
+package runner_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/component"
+	"github.com/gruntwork-io/terragrunt/internal/queue"
+	"github.com/gruntwork-io/terragrunt/internal/runner"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestControllerFinishesAfterDownEntryFailsWithPendingUpChain drives the real Controller through
+// the `run --all --filter-allow-destroy` hang, with the dispatch order the Controller actually uses
+// (it claims every currently-ready entry as Running in one pass before any of them run, so the
+// affected unit has to be one that was still gated at the moment of failure):
+//
+//	base (up) <- shared (up) <- consumer (up)
+//	                shared (up) <- gone (down: plan -destroy of a deleted unit)
+//
+// Pass 1 claims `base` and `gone`. `gone` fails while `base` is still running, so `shared` is still
+// Ready. Before the fix, FailEntry -> earlyExitDependencies marked `shared` EarlyExit across the
+// direction boundary, `consumer` was gated forever on it, and Controller.Run never returned: the
+// process sat silent after the last unit's output, with no child process alive, until killed from
+// outside. With the fix, the failure stays on `gone`, the surviving chain completes, and Run returns
+// the failure so it is actually reported.
+func TestControllerFinishesAfterDownEntryFailsWithPendingUpChain(t *testing.T) {
+	t.Parallel()
+
+	base := component.NewUnit("/repo/base")
+	shared := component.NewUnit("/repo/shared")
+	consumer := component.NewUnit("/repo/consumer")
+	shared.AddDependency(base)
+	consumer.AddDependency(shared)
+
+	gone := component.NewUnit("/wt/from/gone").WithDiscoveryContext(&component.DiscoveryContext{
+		Cmd:  "plan",
+		Args: []string{"-destroy"},
+	})
+	gone.AddDependency(shared)
+
+	units := []*component.Unit{base, shared, consumer, gone}
+
+	q, err := queue.NewQueue(component.Components{base, shared, consumer, gone})
+	require.NoError(t, err)
+
+	errGoneFailed := errors.New("plan -destroy failed")
+	goneReturned := make(chan struct{})
+
+	runUnit := func(ctx context.Context, u *component.Unit) error {
+		switch u.Path() {
+		case gone.Path():
+			close(goneReturned)
+
+			return errGoneFailed
+		case base.Path():
+			// Hold `base` open until `gone` has returned its error, so `shared` is still Ready
+			// (gated on base, not Running) when the controller's FailEntry walks gone's
+			// dependencies. FailEntry runs on the controller goroutine right after the runner
+			// returns; the short pause lets it land. Entry statuses are only read after Run
+			// returns, so this test never touches them concurrently with the controller.
+			select {
+			case <-goneReturned:
+			case <-time.After(5 * time.Second):
+				return errors.New("test setup: gone never ran")
+			}
+
+			time.Sleep(100 * time.Millisecond)
+
+			return nil
+		default:
+			return nil
+		}
+	}
+
+	ctrl := runner.NewController(q, units, runner.WithRunner(runUnit), runner.WithMaxConcurrency(4))
+
+	done := make(chan error, 1)
+
+	go func() { done <- ctrl.Run(t.Context(), logger.CreateLogger()) }()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, errGoneFailed, "the destroy failure must be reported, not lost")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Controller.Run did not return: the queue is wedged (the pre-fix hang)")
+	}
+
+	assert.True(t, q.Finished())
+	assert.Equal(t, queue.StatusFailed, q.EntryByPath(gone.Path()).Status)
+
+	for _, u := range []*component.Unit{base, shared, consumer} {
+		assert.Equal(t, queue.StatusSucceeded, q.EntryByPath(u.Path()).Status,
+			"%s is a surviving unit and must run to completion regardless of the destroy failure", u.Path())
+	}
+}

--- a/test/integration_filter_mixed_direction_tf_test.go
+++ b/test/integration_filter_mixed_direction_tf_test.go
@@ -1,0 +1,121 @@
+//go:build tf
+
+package test_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terragrunt/internal/report"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTFRunAllFilterAllowDestroyFinishesAfterDeletedUnitFails is a regression test for a
+// `run --all --filter-allow-destroy` hang. When a unit deleted in the git range fails its
+// `plan -destroy` (here: at HCL evaluation, before OpenTofu runs), the failure used to early-exit
+// the deleted unit's *surviving* dependencies even though readiness never lets a destroy gate a
+// plan. Surviving units downstream of those then waited forever for a dependency that would never
+// be "succeeded", and the run went silent after the last running unit finished - no summary, no
+// error, until killed from outside.
+//
+// Graph (up = surviving plan, down = deleted, plan -destroy):
+//
+//	base (up, slow) <- a (up) <- b (up)
+//	gone1 (down, fails) -> base, a         gone1 fails while `a` is still gated on the slow `base`
+//	gone2 (down, ok)    -> b               exists only so `b` is selected into the queue
+//
+// Only direct dependencies of changed units join the queue, which is why gone1 names `base` too.
+func TestTFRunAllFilterAllowDestroyFinishesAfterDeletedUnitFails(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+	runner := helpers.InitTestGitRunner(t, tmpDir)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, ".gitignore"),
+		[]byte(".terragrunt-cache/\n.terraform/\n.terraform.lock.hcl\n*.tfstate*\n"),
+		0644,
+	))
+
+	writeUnit := func(name, hcl string) {
+		t.Helper()
+
+		dir := filepath.Join(tmpDir, name)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "terragrunt.hcl"), []byte(hcl), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"),
+			[]byte(`output "name" { value = "`+name+`" }`), 0644))
+	}
+
+	dependency := func(name string) string {
+		return `
+dependency "` + name + `" {
+  config_path = "../` + name + `"
+  mock_outputs = { name = "mock" }
+  mock_outputs_allowed_terraform_commands = ["plan"]
+}
+`
+	}
+
+	// `base` sleeps so that `a` is still gated (Ready, not Running) when gone1 fails.
+	writeUnit("base", `
+terraform {
+  before_hook "slow" {
+    commands = ["plan"]
+    execute  = ["sleep", "5"]
+  }
+}
+`)
+	writeUnit("a", dependency("base"))
+	writeUnit("b", dependency("a"))
+	writeUnit("gone1", dependency("base")+dependency("a")+`
+inputs = { broken = does_not_exist.value }
+`)
+	writeUnit("gone2", dependency("b"))
+
+	require.NoError(t, runner.Add(t.Context(), "."))
+	require.NoError(t, runner.Commit(t.Context(), "Initial commit"))
+
+	require.NoError(t, os.RemoveAll(filepath.Join(tmpDir, "gone1")))
+	require.NoError(t, os.RemoveAll(filepath.Join(tmpDir, "gone2")))
+	require.NoError(t, runner.Add(t.Context(), "."))
+	require.NoError(t, runner.Commit(t.Context(), "Delete gone1 and gone2"))
+
+	// Before the fix this invocation never returned; the context deadline turns that into a
+	// clean failure instead of a hung test.
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	cmd := "terragrunt run --all --no-color --non-interactive --working-dir " + tmpDir +
+		" --no-filters-file --filter-allow-destroy --filter '...[HEAD~1...HEAD]...'" +
+		" --report-file " + helpers.ReportFile + " -- plan"
+
+	stdout, stderr, err := helpers.RunTerragruntCommandWithOutputWithContext(t, ctx, cmd)
+	output := stdout + stderr
+
+	require.NoError(t, ctx.Err(), "run --all did not finish: the queue is wedged\n%s", output)
+	require.Error(t, err, "gone1's evaluation error must fail the run")
+	assert.False(t, errors.Is(err, context.DeadlineExceeded))
+	assert.Contains(t, output, "does_not_exist", "the deleted unit's own error must be reported")
+
+	results := map[string]string{}
+	for _, run := range helpers.ReadReport(t, tmpDir, helpers.ReportFile) {
+		results[filepath.Base(run.Name)] = run.Result
+	}
+
+	for _, unit := range []string{"base", "a", "b", "gone2"} {
+		assert.Equal(t, string(report.ResultSucceeded), results[unit],
+			"%s never gated on gone1 and must run to completion; report: %v", unit, results)
+	}
+
+	assert.Equal(t, string(report.ResultFailed), results["gone1"], "report: %v", results)
+	assert.NotContains(t, strings.ToLower(output), "early exit",
+		"no surviving unit should be cancelled by the deleted unit's failure")
+}


### PR DESCRIPTION
## Description

Fixes #6860.

With a git-range `--filter` and `--filter-allow-destroy`, one run queue mixes plans of surviving units ("up") with `plan -destroy` entries for units deleted in the diff ("down"). #6322 made the two readiness checks in `internal/queue/queue.go` ignore edges that cross that boundary — a unit being destroyed never gates a unit being planned, and vice versa — but the two failure-propagation helpers still crossed it. When a deleted unit's `plan -destroy` failed, `earlyExitDependencies` marked its *surviving* dependencies `EarlyExit`; every surviving unit gated on one of those then waited for a dependency that would never be `Succeeded`, nothing could schedule or finish it, and once the last running unit completed `Controller.Run` parked on `readyCh` forever. The process went silent — no summary, no `Run failed`, no child process — until killed from outside.

### Change

`earlyExitDependents` (called for a failed up entry) now skips down dependents, and `earlyExitDependencies` (called for a failed down entry) skips up dependencies — the same rule the readiness checks already apply. Two conditions, 4 lines of logic; the rest of the diff is comments and tests.

- A failed destroy still cancels its down-command dependencies (the destroys that would have run after it); a failed plan still cancels its up-command dependents.
- Pure plan/apply queues (all up) and pure destroy queues (all down) are unchanged — pinned by `TestSameDirectionPropagationUnchanged`.
- The mirror image (a failed plan early-exiting a deleted unit whose own down dependency then waits forever) is fixed by the same change and covered by `TestFailedPlanDoesNotEarlyExitDownDependents`.

### Tests

- `internal/queue/mixed_direction_deadlock_test.go` — the minimal unfinishable queue, the mirror image, the same-direction pin, and a test that rebuilds the dependency shape of the production run where this was hit (a failed deleted workflow, two shared surviving dependencies, four surviving engines and four surviving workflows left `Ready` forever).
- `internal/runner/mixed_direction_hang_test.go` — drives the real `Controller.Run`; without the fix it never returns (`Controller.Run did not return: the queue is wedged`).
- `test/integration_filter_mixed_direction_tf_test.go` (`tf` tag) — end to end against a real OpenTofu binary with the fixture from the issue; without the fix it runs into its 2-minute context deadline, with it the run finishes in ~5s, the surviving units are all `succeeded` in the report and the deleted unit's error is reported.

All three fail on `main` without `internal/queue/queue.go` and pass with it (output below).

### Backwards compatibility

Behaviour changes only for mixed up/down queues, i.e. `--filter-allow-destroy` runs where an entry fails. There, units that never gated on the failed entry now run to completion instead of being cancelled or hanging; the failure itself is still recorded and reported. No flags, config or output formats change.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.

<details>
<summary>Test output</summary>

```
$ go version
go version go1.27.0 darwin/arm64

$ go build ./... && go vet ./...
(no output: clean)

$ go test -race -count=3 ./internal/queue/... ./internal/runner/
ok  	github.com/gruntwork-io/terragrunt/internal/queue	1.989s
ok  	github.com/gruntwork-io/terragrunt/internal/runner	3.013s

$ go test -race -run "TestFailedDestroyDoesNotEarlyExitUpDependencies|TestFailedPlanDoesNotEarlyExitDownDependents|TestSameDirectionPropagationUnchanged|TestIncidentShapeDrainsAfterDestroyFailure|TestControllerFinishesAfterDownEntryFailsWithPendingUpChain" -v ./internal/queue/... ./internal/runner/ | grep -E "^(--- |ok)"
--- PASS: TestFailedDestroyDoesNotEarlyExitUpDependencies (0.00s)
--- PASS: TestIncidentShapeDrainsAfterDestroyFailure (0.00s)
--- PASS: TestFailedPlanDoesNotEarlyExitDownDependents (0.00s)
--- PASS: TestSameDirectionPropagationUnchanged (0.00s)
ok  	github.com/gruntwork-io/terragrunt/internal/queue	1.826s
--- PASS: TestControllerFinishesAfterDownEntryFailsWithPendingUpChain (0.10s)
ok  	github.com/gruntwork-io/terragrunt/internal/runner	2.429s

$ go test -tags=tf -run TestTFRunAllFilterAllowDestroyFinishesAfterDeletedUnitFails -v ./test/ | grep -E "^(--- |ok)"
--- PASS: TestTFRunAllFilterAllowDestroyFinishesAfterDeletedUnitFails (5.53s)
ok  	github.com/gruntwork-io/terragrunt/test	6.367s

# Same tests against main without the fix (internal/queue/queue.go reverted):
--- FAIL: TestIncidentShapeDrainsAfterDestroyFailure (0.00s)
--- FAIL: TestFailedDestroyDoesNotEarlyExitUpDependencies (0.00s)
--- FAIL: TestFailedPlanDoesNotEarlyExitDownDependents (0.00s)
--- FAIL: TestControllerFinishesAfterDownEntryFailsWithPendingUpChain (10.00s)
    mixed_direction_hang_test.go:90: Controller.Run did not return: the queue is wedged (the pre-fix hang)
--- FAIL: TestTFRunAllFilterAllowDestroyFinishesAfterDeletedUnitFails (120.12s)
    integration_filter_mixed_direction_tf_test.go:103: run --all did not finish: the queue is wedged
        context deadline exceeded
```

`gofmt -l` reports nothing for the touched files. `golangci-lint` was not run locally.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a hang in `run --all --filter-allow-destroy` when a deleted unit fails during destroy planning.
  - Surviving units now continue processing and can complete successfully instead of being cancelled incorrectly.
  - Failures are reported correctly in command results and summaries, including the failed deleted unit.
- **Tests**
  - Added coverage for mixed plan and destroy failure scenarios, including an end-to-end integration case and successful completion of unaffected units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->