### PR TITLE
perf: Avoid tracking reading when unnecessary

### DIFF
--- a/docs/src/data/changelog/v1.1.5/reading-tracked-on-demand.mdx
+++ b/docs/src/data/changelog/v1.1.5/reading-tracked-on-demand.mdx
@@ -1,0 +1,20 @@
+---
+version: "v1.1.5"
+category: "performance-improvements"
+---
+
+#### Faster discovery when nothing needs to know what units read
+
+Terragrunt recorded the files every unit reads on every run. That record covers the content of each local module a unit sources, so Terragrunt walked those module directories once per unit, whether or not anything would look at the result.
+
+Only four things consult the record: [reading-based filter expressions](/features/filter/attributes#reading-based-expressions), the `--queue-include-units-reading` flag, `find --reading`, and the file tree in `terragrunt browse`. Terragrunt now keeps it for those and skips the module walk otherwise.
+
+Benchmarks on an Apple M3 Max, running `terragrunt find --dependencies` across 1,000 units that all source the same local module:
+
+| files in the module | before | after | change |
+| --- | --- | --- | --- |
+| 50 | 148 ms | 136 ms | -8% |
+| 150 | 178 ms | 134 ms | -25% |
+| 400 | 259 ms | 136 ms | -47% |
+
+The saving grows with the size of the local modules a repository sources. Runs that ask about reads behave as they did before.

--- a/docs/src/data/changelog/v1.1.5/reading-tracked-on-demand.mdx
+++ b/docs/src/data/changelog/v1.1.5/reading-tracked-on-demand.mdx
@@ -3,18 +3,20 @@ version: "v1.1.5"
 category: "performance-improvements"
 ---
 
-#### Faster discovery when nothing needs to know what units read
+#### Terragrunt no longer records what units read unless something needs it
 
-Terragrunt recorded the files every unit reads on every run. That record covers the content of each local module a unit sources, so Terragrunt walked those module directories once per unit, whether or not anything would look at the result.
+Every parse used to record the files it read. Part of that record is the content of each local module a unit sources, so Terragrunt walked those module directories once per unit, on every command, whether or not anything would look at the result.
 
-Only four things consult the record: [reading-based filter expressions](/features/filter/attributes#reading-based-expressions), the `--queue-include-units-reading` flag, `find --reading`, and the file tree in `terragrunt browse`. Terragrunt now keeps it for those and skips the module walk otherwise.
+Only four things consult the record: [reading-based filter expressions](/features/filter/attributes#reading-based-expressions), the `--queue-include-units-reading` flag, `find --reading`, and the file tree in `terragrunt browse`. Terragrunt now keeps it for those and skips the module walk everywhere else.
 
-Benchmarks on an Apple M3 Max, running `terragrunt find --dependencies` across 1,000 units that all source the same local module:
+Benchmarks on an Apple M3 Max, across 1,000 units that all source the same local module:
 
-| files in the module | before | after | change |
-| --- | --- | --- | --- |
-| 50 | 148 ms | 136 ms | -8% |
-| 150 | 178 ms | 134 ms | -25% |
-| 400 | 259 ms | 136 ms | -47% |
+| files in the module | `find --dependencies` | `render --all` |
+| --- | --- | --- |
+| 50 | 148 ms → 135 ms | 352 ms → 259 ms |
+| 150 | 180 ms → 135 ms | 430 ms → 263 ms |
+| 400 | 268 ms → 137 ms | 631 ms → 270 ms |
 
-The saving grows with the size of the local modules a repository sources. Runs that ask about reads behave as they did before.
+`render --all` performs the same full parse of each unit that `run --all` performs before it invokes OpenTofu, so a run over units with large local modules saves comparable time before the first plan starts.
+
+The saving grows with the size of the local modules a repository sources, and the new times hold steady as those modules grow. Commands that do ask about reads behave as they did before.

--- a/internal/cli/commands/browse/browse.go
+++ b/internal/cli/commands/browse/browse.go
@@ -27,6 +27,7 @@ func Run(ctx context.Context, l log.Logger, v *venv.Venv, opts *Options) error {
 		WithRequiresParse: true,
 		WithRelationships: true,
 		ParseStackConfigs: true,
+		TrackReads:        true,
 		Filters:           opts.Filters,
 	})
 	if err != nil {

--- a/internal/discovery/constructor.go
+++ b/internal/discovery/constructor.go
@@ -21,6 +21,7 @@ type DiscoveryCommandOptions struct {
 	Exclude           bool
 	Include           bool
 	Reading           bool
+	TrackReads        bool
 	ParseStackConfigs bool
 	WithRequiresParse bool
 	WithRelationships bool
@@ -67,6 +68,10 @@ func NewForDiscoveryCommand(l log.Logger, fsys vfs.FS, opts *DiscoveryCommandOpt
 
 	if opts.Reading {
 		d = d.WithReadFiles()
+	}
+
+	if opts.TrackReads {
+		d = d.WithTrackReads()
 	}
 
 	if opts.ParseStackConfigs {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -117,6 +117,7 @@ func (d *Discovery) Discover(
 				"parse_includes":    d.parseIncludes,
 				"parse_exclude":     d.parseExclude,
 				"read_files":        d.readFiles,
+				"track_reads":       d.trackReads,
 				"activation_reason": reasonsStr,
 			}, func(childCtx context.Context, l log.Logger) error {
 				var phaseErr error

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -661,3 +661,101 @@ unit "app" {
 	require.NotNil(t, broken, "broken stack component should still be discovered")
 	assert.Nil(t, broken.Config(), "unparsable stack config should be skipped")
 }
+
+// TestDiscovery_TracksReadsOnlyWhenRequested pins read tracking to the callers that
+// consume it. Recording reads costs a walk of every local module source, so a
+// discovery that parses for an unrelated reason leaves the Reading field empty.
+func TestDiscovery_TracksReadsOnlyWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+	appDir := filepath.Join(tmpDir, "app")
+	require.NoError(t, os.MkdirAll(appDir, 0755))
+
+	sharedHCL := filepath.Join(tmpDir, "shared.hcl")
+	require.NoError(t, os.WriteFile(sharedHCL, []byte(`
+		locals {
+			common_value = "test"
+		}
+	`), 0644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "terragrunt.hcl"), []byte(`
+		locals {
+			shared_config = read_terragrunt_config("../shared.hcl")
+		}
+	`), 0644))
+
+	readingExpr, err := filter.NewAttributeExpression(filter.AttributeReading, "shared.hcl")
+	require.NoError(t, err)
+
+	readingFilters := filter.Filters{filter.NewFilter(readingExpr, readingExpr.String())}
+
+	testCases := []struct {
+		configure   func(*discovery.Discovery) *discovery.Discovery
+		name        string
+		wantTracked bool
+	}{
+		{
+			name: "parsed for an unrelated reason",
+			configure: func(d *discovery.Discovery) *discovery.Discovery {
+				return d.WithRequiresParse().WithRelationships()
+			},
+			wantTracked: false,
+		},
+		{
+			name: "tracking requested outright",
+			configure: func(d *discovery.Discovery) *discovery.Discovery {
+				return d.WithRequiresParse().WithRelationships().WithTrackReads()
+			},
+			wantTracked: true,
+		},
+		{
+			name: "reading filter asks for it",
+			configure: func(d *discovery.Discovery) *discovery.Discovery {
+				return d.WithFilters(readingFilters)
+			},
+			wantTracked: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := &options.TerragruntOptions{
+				WorkingDir:     tmpDir,
+				RootWorkingDir: tmpDir,
+			}
+
+			d := tc.configure(discovery.NewDiscovery(tmpDir))
+
+			components, err := d.Discover(
+				t.Context(),
+				logger.CreateLogger(),
+				venvtest.NewOSWithEmptyEnv(),
+				opts,
+			)
+			require.NoError(t, err)
+
+			var app component.Component
+
+			for _, c := range components {
+				if c.Path() == appDir {
+					app = c
+
+					break
+				}
+			}
+
+			require.NotNil(t, app, "app unit should be discovered")
+
+			if !tc.wantTracked {
+				assert.Empty(t, app.Reading())
+
+				return
+			}
+
+			assert.Contains(t, app.Reading(), sharedHCL)
+		})
+	}
+}

--- a/internal/discovery/doc.go
+++ b/internal/discovery/doc.go
@@ -78,30 +78,6 @@
 //   - Git expressions: [main...develop] (changes between refs)
 //   - Negated expressions: !./internal (exclusion)
 //
-// # Configuration Methods
-//
-// Discovery uses a fluent builder pattern. Available configuration methods include:
-//
-//   - [Discovery.WithFilters]: Set filter queries for component selection
-//   - [Discovery.WithRelationships]: Enable relationship discovery for execution ordering
-//   - [Discovery.WithMaxDependencyDepth]: Set maximum dependency traversal depth (default 1000)
-//   - [Discovery.WithNumWorkers]: Set concurrent worker count (default 4, max 8)
-//   - [Discovery.WithBreakCycles]: Enable cycle detection and removal
-//   - [Discovery.WithNoHidden]: Exclude hidden directories from discovery
-//   - [Discovery.WithRequiresParse]: Force parsing of all Terragrunt configurations
-//   - [Discovery.WithSuppressParseErrors]: Continue discovery despite parse errors
-//   - [Discovery.WithParseExclude]: Parse exclude configurations
-//   - [Discovery.WithParseIncludes]: Parse include configurations
-//   - [Discovery.WithReadFiles]: Parse for file reading information
-//   - [Discovery.WithDiscoveryContext]: Set the discovery context
-//   - [Discovery.WithWorktrees]: Set worktrees for Git-based filters
-//   - [Discovery.WithConfigFilenames]: Set custom config filenames to discover
-//   - [Discovery.WithParserOptions]: Set custom HCL parser options
-//   - [Discovery.WithGitRoot]: Set the git root used as the default dependent-walk ceiling
-//   - [Discovery.WithDiscoveryBoundary]: Enclose graph discovery within a directory instead of the git root
-//   - [Discovery.WithGraphTarget]: Set graph target for pruning results
-//   - [Discovery.WithOptions]: Ingest runner options for parser and graph settings
-//
 // # Example Usage
 //
 //	d := NewDiscovery(workingDir).

--- a/internal/discovery/options.go
+++ b/internal/discovery/options.go
@@ -44,17 +44,18 @@ func (d *Discovery) WithParserOptions(opts []hclparse.Option) *Discovery {
 func (d *Discovery) WithFilters(filters filter.Filters) *Discovery {
 	d.filters = filters
 
-	// If there are any positive filters, exclude by default
 	if d.filters.HasPositiveFilter() {
 		d.excludeByDefault = true
 	}
 
-	// Check if filters require parsing
 	if _, ok := d.filters.RequiresParse(); ok {
 		d.addParseReason(parseReasonFiltersRequireParse)
 	}
 
-	// Collect Git expressions
+	if d.filters.RequiresReading() {
+		d = d.WithTrackReads()
+	}
+
 	d.gitExpressions = d.filters.UniqueGitFilters()
 
 	return d
@@ -111,10 +112,21 @@ func (d *Discovery) WithParseStackConfigs() *Discovery {
 	return d
 }
 
-// WithReadFiles enables parsing for file reading information.
+// WithReadFiles parses every discovered component so that all of them report the
+// files they read, rather than only those a filter forces through the parser.
 func (d *Discovery) WithReadFiles() *Discovery {
 	d.readFiles = true
 	d.addParseReason(parseReasonReadFiles)
+
+	return d.WithTrackReads()
+}
+
+// WithTrackReads records, for each component parsing visits, the files it read.
+// Discovery derives this from the filters it is given; callers that consume
+// [component.Component.Reading] without a reading filter to ask for it, such as
+// the browse TUI, set it themselves.
+func (d *Discovery) WithTrackReads() *Discovery {
+	d.trackReads = true
 
 	return d
 }

--- a/internal/discovery/phase_parse.go
+++ b/internal/discovery/phase_parse.go
@@ -395,6 +395,10 @@ func parseComponent(
 				parsingCtx = parsingCtx.WithParseOption(discovery.parserOptions)
 			}
 
+			if !discovery.trackReads {
+				parsingCtx = parsingCtx.WithoutFileReadTracking()
+			}
+
 			if discovery.suppressParseErrors {
 				parserOpts := parsingCtx.ParserOptions
 				parserOpts = append(parserOpts, hclparse.WithDiagnosticsHandler(func(
@@ -437,7 +441,7 @@ func parseComponent(
 				unit.StoreConfig(cfg)
 			}
 
-			if parsingCtx.FilesRead != nil {
+			if parsingCtx.FilesRead.Tracking() {
 				readFiles := sanitizeReadFiles(parsingCtx.FilesRead.Paths())
 				c.SetReading(readFiles...)
 			}

--- a/internal/discovery/phase_parse.go
+++ b/internal/discovery/phase_parse.go
@@ -395,8 +395,8 @@ func parseComponent(
 				parsingCtx = parsingCtx.WithParseOption(discovery.parserOptions)
 			}
 
-			if !discovery.trackReads {
-				parsingCtx = parsingCtx.WithoutFileReadTracking()
+			if discovery.trackReads {
+				parsingCtx = parsingCtx.WithFileReadTracking()
 			}
 
 			if discovery.suppressParseErrors {

--- a/internal/discovery/phase_worktree.go
+++ b/internal/discovery/phase_worktree.go
@@ -272,6 +272,10 @@ func (d *Discovery) withParseSettingsFrom(parent *Discovery) *Discovery {
 		d = d.WithParserOptions(parent.parserOptions)
 	}
 
+	if parent.trackReads {
+		d = d.WithTrackReads()
+	}
+
 	return d
 }
 

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -183,6 +183,11 @@ type Discovery struct {
 	// readFiles determines whether to parse for reading files.
 	readFiles bool
 
+	// trackReads determines whether parsing records the files each component
+	// reads. Recording them costs a walk of every local module source, so it
+	// stays off until something asks to see them.
+	trackReads bool
+
 	// parseStackConfigs determines whether to parse discovered stack config files.
 	parseStackConfigs bool
 

--- a/internal/filter/filters.go
+++ b/internal/filter/filters.go
@@ -124,6 +124,18 @@ func (f Filters) RequiresParse() (Expression, bool) {
 	return nil, false
 }
 
+// RequiresReading returns true if any filter matches on what a component reads,
+// which is only knowable once parsing records the files each component read.
+func (f Filters) RequiresReading() bool {
+	for _, filter := range f {
+		if containsReadingExpression(filter.expr) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // PartitionReadingFilters splits the filters by whether their top-level expression is a reading
 // attribute filter, preserving the original order within each group. Worktree discovery uses this to
 // separate reading filters (which track files that may be read by other components via a glob) from
@@ -347,6 +359,23 @@ func (f Filters) String() string {
 	}
 
 	return string(jsonBytes)
+}
+
+// containsReadingExpression returns true if the expression tree contains a reading
+// attribute filter.
+func containsReadingExpression(expr Expression) bool {
+	found := false
+
+	WalkExpressions(expr, func(e Expression) bool {
+		if attr, ok := e.(*AttributeExpression); ok && attr.Key == AttributeReading {
+			found = true
+			return false
+		}
+
+		return true
+	})
+
+	return found
 }
 
 // containsGitExpression returns true if the expression tree contains a GitExpression.

--- a/internal/filter/filters_test.go
+++ b/internal/filter/filters_test.go
@@ -1244,3 +1244,65 @@ func TestFilters_GitExpressionAsGraphTarget(t *testing.T) {
 		assert.True(t, filters.HasPositiveFilter(), "Git-graph expression is a positive filter")
 	})
 }
+
+func TestFilters_RequiresReading(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		queries []string
+		want    bool
+	}{
+		{
+			name:    "no filters",
+			queries: nil,
+			want:    false,
+		},
+		{
+			name:    "path and name filters",
+			queries: []string{"./apps/*", "name=db"},
+			want:    false,
+		},
+		{
+			name:    "source filter parses but reads nothing",
+			queries: []string{"source=../modules/vpc"},
+			want:    false,
+		},
+		{
+			name:    "bare reading filter",
+			queries: []string{"reading=shared.hcl"},
+			want:    true,
+		},
+		{
+			name:    "negated reading filter",
+			queries: []string{"!reading=shared.hcl"},
+			want:    true,
+		},
+		{
+			name:    "reading filter as one operand",
+			queries: []string{"name=db | reading=shared.hcl"},
+			want:    true,
+		},
+		{
+			name:    "reading filter as a graph target",
+			queries: []string{"reading=shared.hcl..."},
+			want:    true,
+		},
+		{
+			name:    "reading filter alongside unrelated ones",
+			queries: []string{"./apps/*", "reading=shared.hcl"},
+			want:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			filters, err := filter.ParseFilterQueries(testLogger(), tc.queries)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.want, filters.RequiresReading())
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2392,7 +2392,15 @@ var moduleSourceReadExtensions = map[string]struct{}{
 // rawSource and marks its configuration files as read in pctx.FilesRead. It is a
 // best-effort annotation: non-local sources are skipped and walk errors are
 // swallowed, since a genuinely broken source will surface during download.
+//
+// A pctx that keeps no record of its reads gets no walk. The walk feeds nothing
+// but that record, and is the most expensive thing a parse does for it, so this
+// is where the cost of tracking goes when nobody is asking.
 func markLocalModuleSourceAsRead(pctx *ParsingContext, cfgPath, rawSource string) {
+	if !pctx.FilesRead.Tracking() {
+		return
+	}
+
 	sourceWithoutSubdir, subdir := getter.SourceDirSubdir(rawSource)
 
 	// Anchor a relative config path to the working directory before deriving

--- a/pkg/config/files_read.go
+++ b/pkg/config/files_read.go
@@ -21,6 +21,12 @@ func NewFilesRead() *FilesRead {
 	return &FilesRead{}
 }
 
+// Tracking reports whether reads are being recorded. Work whose only product is
+// a recorded read can be skipped when it returns false.
+func (f *FilesRead) Tracking() bool {
+	return f != nil
+}
+
 // Add records path as read. Duplicate paths are ignored.
 func (f *FilesRead) Add(path string) {
 	if f == nil {

--- a/pkg/config/files_read.go
+++ b/pkg/config/files_read.go
@@ -8,8 +8,9 @@ import (
 
 // FilesRead is a concurrency-safe set of file paths that have been read while
 // parsing a configuration. A nil receiver is treated as a no-op for mutations
-// and returns zero values from accessors, so call sites that don't need to
-// track reads can pass nil.
+// and returns zero values from accessors, and nil is what a parsing context
+// carries until a caller asks for tracking, so every writer degrades to doing
+// nothing rather than the caller having to check first.
 type FilesRead struct {
 	seen     map[string]struct{}
 	seenDirs map[string]struct{}

--- a/pkg/config/mark_as_read_test.go
+++ b/pkg/config/mark_as_read_test.go
@@ -28,6 +28,7 @@ func TestMarkGlobAsRead(t *testing.T) {
 	l := logger.CreateLogger()
 	configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
 	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+	pctx = pctx.WithFileReadTracking()
 	pctx.WorkingDir = dir
 
 	// Drive the HCL function via a locals block so we exercise the registered cty wrapper.
@@ -65,6 +66,7 @@ func TestMarkGlobAsReadEscapesMetacharacter(t *testing.T) {
 	l := logger.CreateLogger()
 	configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
 	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+	pctx = pctx.WithFileReadTracking()
 	pctx.WorkingDir = dir
 
 	// The HCL string literal '"a\\*b.tf"' decodes to 'a\*b.tf', which the glob
@@ -97,6 +99,7 @@ func TestMarkGlobAsReadBoundaryFlag(t *testing.T) {
 	l := logger.CreateLogger()
 	configPath := filepath.Join(dir, config.DefaultTerragruntConfigPath)
 	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+	pctx = pctx.WithFileReadTracking()
 	pctx.WorkingDir = dir
 
 	hcl := `locals { matched = mark_glob_as_read("--terragrunt-boundary=.", "{*.yaml}") }`
@@ -135,6 +138,7 @@ func TestMarkGlobAsReadGitRootBoundary(t *testing.T) {
 		t.Parallel()
 
 		ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+		pctx = pctx.WithFileReadTracking()
 		pctx.WorkingDir = unitDir
 
 		hcl := `locals { matched = mark_glob_as_read("/{*.yaml}") }`
@@ -147,6 +151,7 @@ func TestMarkGlobAsReadGitRootBoundary(t *testing.T) {
 		t.Parallel()
 
 		ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+		pctx = pctx.WithFileReadTracking()
 		pctx.WorkingDir = unitDir
 
 		hcl := `locals {
@@ -161,9 +166,10 @@ func TestMarkGlobAsReadGitRootBoundary(t *testing.T) {
 	})
 }
 
-// TestMarkManyAsReadMarksModuleSourceFilesByDefault pins the default behavior:
-// a full parse of a config with a local terraform source marks the module's
-// configuration files as read, with no experiment flag required.
+// TestMarkManyAsReadMarksModuleSourceFilesByDefault pins that a tracking parse of
+// a config with a local terraform source marks the module's configuration files
+// as read with no experiment flag required. The "default" is the absence of the
+// experiment, not of tracking, which [TestMarkManyAsReadUntrackedByDefault] covers.
 func TestMarkManyAsReadMarksModuleSourceFilesByDefault(t *testing.T) {
 	t.Parallel()
 
@@ -185,6 +191,7 @@ func TestMarkManyAsReadMarksModuleSourceFilesByDefault(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+	pctx = pctx.WithFileReadTracking()
 	pctx.WorkingDir = unitDir
 
 	out, err := config.ParseConfigString(ctx, pctx, l, configPath, hcl, nil)
@@ -221,6 +228,7 @@ func TestMarkManyAsReadRelativeConfigPathAnchorsToWorkingDir(t *testing.T) {
 
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+	pctx = pctx.WithFileReadTracking()
 	pctx.WorkingDir = unitDir
 
 	out, err := config.ParseConfigString(ctx, pctx, l, config.DefaultTerragruntConfigPath, hcl, nil)
@@ -253,7 +261,7 @@ func TestMarkManyAsReadPartialParseSource(t *testing.T) {
 			l := logger.CreateLogger()
 			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 			pctx.WorkingDir = unitDir
-			pctx = pctx.WithDecodeList(decode)
+			pctx = pctx.WithDecodeList(decode).WithFileReadTracking()
 
 			out, err := config.PartialParseConfigString(ctx, pctx, l, configPath, hcl, nil)
 			require.NoError(t, err)
@@ -298,7 +306,7 @@ func TestMarkManyAsReadPartialParseIncludedSource(t *testing.T) {
 			l := logger.CreateLogger()
 			ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), childPath)
 			pctx.WorkingDir = unitDir
-			pctx = pctx.WithDecodeList(decode)
+			pctx = pctx.WithDecodeList(decode).WithFileReadTracking()
 
 			out, err := config.PartialParseConfigFile(ctx, pctx, l, childPath, nil)
 			require.NoError(t, err)
@@ -313,10 +321,10 @@ func TestMarkManyAsReadPartialParseIncludedSource(t *testing.T) {
 	}
 }
 
-// TestMarkManyAsReadSkippedWithoutTracking pins that a parse keeping no record of
-// its reads leaves the local module source unwalked, while the source itself still
-// decodes as it otherwise would.
-func TestMarkManyAsReadSkippedWithoutTracking(t *testing.T) {
+// TestMarkManyAsReadUntrackedByDefault pins the default: a parsing context nobody
+// asked to track reads keeps no record and leaves the local module source
+// unwalked, while the source itself decodes as it otherwise would.
+func TestMarkManyAsReadUntrackedByDefault(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -332,7 +340,7 @@ func TestMarkManyAsReadSkippedWithoutTracking(t *testing.T) {
 	l := logger.CreateLogger()
 	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
 	pctx.WorkingDir = unitDir
-	pctx = pctx.WithDecodeList(config.TerraformSource).WithoutFileReadTracking()
+	pctx = pctx.WithDecodeList(config.TerraformSource)
 
 	out, err := config.PartialParseConfigString(ctx, pctx, l, configPath, hcl, nil)
 	require.NoError(t, err)

--- a/pkg/config/mark_as_read_test.go
+++ b/pkg/config/mark_as_read_test.go
@@ -313,6 +313,38 @@ func TestMarkManyAsReadPartialParseIncludedSource(t *testing.T) {
 	}
 }
 
+// TestMarkManyAsReadSkippedWithoutTracking pins that a parse keeping no record of
+// its reads leaves the local module source unwalked, while the source itself still
+// decodes as it otherwise would.
+func TestMarkManyAsReadSkippedWithoutTracking(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "modules", "foo")
+	unitDir := filepath.Join(root, "units", "bar")
+
+	writeFile(t, filepath.Join(moduleDir, "main.tf"), "")
+
+	configPath := filepath.Join(unitDir, config.DefaultTerragruntConfigPath)
+	hcl := `terraform { source = "../../modules/foo" }`
+	writeFile(t, configPath, hcl)
+
+	l := logger.CreateLogger()
+	ctx, pctx := newTestParsingContext(t, venvtest.NewOSWithEmptyEnv(), configPath)
+	pctx.WorkingDir = unitDir
+	pctx = pctx.WithDecodeList(config.TerraformSource).WithoutFileReadTracking()
+
+	out, err := config.PartialParseConfigString(ctx, pctx, l, configPath, hcl, nil)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.Terraform)
+	require.NotNil(t, out.Terraform.Source)
+	assert.Equal(t, "../../modules/foo", *out.Terraform.Source)
+
+	assert.False(t, pctx.FilesRead.Tracking())
+	assert.Empty(t, pctx.FilesRead.Paths())
+}
+
 func writeFile(t *testing.T, path, contents string) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))

--- a/pkg/config/parsing_context.go
+++ b/pkg/config/parsing_context.go
@@ -130,6 +130,11 @@ type ParsingContext struct {
 
 // NewParsingContext builds a parsing context whose file reads, subprocesses,
 // and decryption all travel on v.
+//
+// The returned context keeps no record of the files it reads. Recording them
+// costs a walk of every local module a config sources, and only a caller that
+// surfaces the record has any use for it, so those call
+// [ParsingContext.WithFileReadTracking] and the rest pay nothing.
 func NewParsingContext(
 	ctx context.Context,
 	l log.Logger,
@@ -142,7 +147,6 @@ func NewParsingContext(
 
 	pctx := &ParsingContext{
 		TerraformCliArgs: iacargs.New(),
-		FilesRead:        NewFilesRead(),
 		Venv:             v,
 	}
 
@@ -256,13 +260,12 @@ func (ctx *ParsingContext) WithDiagnosticsSuppressed(l log.Logger) *ParsingConte
 	return c
 }
 
-// WithoutFileReadTracking returns a copy that keeps no record of the files it
-// reads. Only callers that surface reads consume that record, so a parse with no
-// such caller can skip the bookkeeping and, more to the point, the walk of every
-// local module source that feeds it.
-func (ctx *ParsingContext) WithoutFileReadTracking() *ParsingContext {
+// WithFileReadTracking returns a copy that records every file it reads, so that
+// the caller can read them back off [ParsingContext.FilesRead] once parsing is
+// done. Clones made from the returned context share the one record.
+func (ctx *ParsingContext) WithFileReadTracking() *ParsingContext {
 	c := ctx.Clone()
-	c.FilesRead = nil
+	c.FilesRead = NewFilesRead()
 
 	return c
 }

--- a/pkg/config/parsing_context.go
+++ b/pkg/config/parsing_context.go
@@ -256,6 +256,17 @@ func (ctx *ParsingContext) WithDiagnosticsSuppressed(l log.Logger) *ParsingConte
 	return c
 }
 
+// WithoutFileReadTracking returns a copy that keeps no record of the files it
+// reads. Only callers that surface reads consume that record, so a parse with no
+// such caller can skip the bookkeeping and, more to the point, the walk of every
+// local module source that feeds it.
+func (ctx *ParsingContext) WithoutFileReadTracking() *ParsingContext {
+	c := ctx.Clone()
+	c.FilesRead = nil
+
+	return c
+}
+
 func (ctx *ParsingContext) WithSkipOutputsResolution() *ParsingContext {
 	c := ctx.Clone()
 	c.SkipOutputsResolution = true


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Makes tracking file reads opt-in to avoid paying the performance penalty when the information isn't used by users.

Results in some significant wins locally, scaling on the number of local module files skipped:

| files in the module | `find --dependencies` | `render --all` |
| --- | --- | --- |
| 50 | 148 ms → 135 ms | 352 ms → 259 ms |
| 150 | 180 ms → 135 ms | 430 ms → 263 ms |
| 400 | 268 ms → 137 ms | 631 ms → 270 ms |

Necessary to support something like #6858

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary local-module scanning during commands that do not inspect file-read information.
  * File-read tracking is now enabled only when required by reading-based filters, `--queue-include-units-reading`, `find --reading`, or `terragrunt browse`.
  * Commands that inspect file reads continue to report the relevant files.
* **Documentation**
  * Added v1.1.5 changelog documentation covering the updated behavior and benchmark results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->