### PR TITLE
fix: Fixing catalog nil logger panic

### DIFF
--- a/docs/src/data/changelog/v1.1.5/catalog-unreachable-repository.mdx
+++ b/docs/src/data/changelog/v1.1.5/catalog-unreachable-repository.mdx
@@ -1,0 +1,8 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### Fixed a crash in `terragrunt catalog` when a repository cannot be reached
+
+`terragrunt catalog` now reports the underlying git error when it cannot reach a repository listed in the `catalog` block. Previously, this could cause a crash part-way through loading. This affected any repository Terragrunt could not clone, e.g. an SSH URL with no usable key, a private repository without credentials, or a remote that timed out.

--- a/internal/cli/commands/catalog/catalog_test.go
+++ b/internal/cli/commands/catalog/catalog_test.go
@@ -1,9 +1,11 @@
 package catalog_test
 
 import (
+	"context"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -136,6 +138,66 @@ func TestRunLoadsARepoNamedTwiceOnce(t *testing.T) {
 	require.ErrorAs(t, err, &loadErr)
 	assert.Equal(t, []string{repoURL}, failedURLs(loadErr), "the repo must be loaded once, not once per discoverer")
 	assert.Equal(t, 1, loadErr.Attempted)
+}
+
+// TestRunReportsASourceWhoseGitCommandsFail pins that a source whose clone
+// fails inside git reaches the caller as a [tui.SourceLoadError]. The clone
+// runs in a loader goroutine, so a failure that panics there ends the process
+// rather than reaching the screen.
+func TestRunReportsASourceWhoseGitCommandsFail(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+
+	// A file:// remote keeps the fallback the getter runs after the CAS
+	// clone fails off the network too.
+	repoURL := "git::file://" + filepath.ToSlash(filepath.Join(rootDir, "absent.git"))
+
+	var (
+		spawnedMu sync.Mutex
+		spawned   [][]string
+	)
+
+	failGit := func(_ context.Context, inv vexec.Invocation) vexec.Result {
+		spawnedMu.Lock()
+
+		spawned = append(spawned, inv.Args)
+
+		spawnedMu.Unlock()
+
+		return vexec.Result{ExitCode: 128, Stderr: []byte("fatal: repository not found")}
+	}
+
+	v := venvtest.NewWithOSFS().
+		WithExec(vexec.NewMemExec(failGit)).
+		WithTempDir(func() string { return rootDir }).
+		WithUserCacheDir(func() (string, error) { return filepath.Join(rootDir, "cache"), nil })
+
+	require.NoError(t, vfs.WriteFile(
+		v.FS,
+		filepath.Join(rootDir, "root.hcl"),
+		[]byte("catalog {\n  urls = [\""+repoURL+"\"]\n}\n"),
+		0o644,
+	))
+
+	err := catalog.Run(
+		t.Context(), logger.CreateLogger(), v, newOptions(t, rootDir, catalog.FormatJSONL), "",
+	)
+
+	var loadErr *tui.SourceLoadError
+
+	require.ErrorAs(t, err, &loadErr)
+	assert.Equal(t, []string{repoURL}, failedURLs(loadErr))
+
+	spawnedMu.Lock()
+	defer spawnedMu.Unlock()
+
+	assert.True(t,
+		slices.ContainsFunc(spawned, func(args []string) bool {
+			return slices.Contains(args, "ls-remote")
+		}),
+		"the load must reach the CAS source probe, where the crash used to happen",
+	)
 }
 
 // TestRunWritesComponentsFromTheCatalogBlock pins that the catalog block of

--- a/internal/cli/commands/scaffold/scaffold.go
+++ b/internal/cli/commands/scaffold/scaffold.go
@@ -266,7 +266,7 @@ func Prepare(
 		Collect(ctx, l, "scaffold_get_module", map[string]any{
 			"module_url": resolvedURL,
 		}, func(ctx context.Context, l log.Logger) error {
-			if _, getErr := getter.GetAny(ctx, v, tempDir, resolvedURL); getErr != nil {
+			if _, getErr := getter.GetAny(ctx, l, v, tempDir, resolvedURL); getErr != nil {
 				return fmt.Errorf("downloading scaffold module from %s: %w", resolvedURL, getErr)
 			}
 
@@ -683,7 +683,7 @@ func downloadTemplate(
 		Collect(ctx, l, "scaffold_get_template", map[string]any{
 			"template_url": baseURL.String(),
 		}, func(ctx context.Context, l log.Logger) error {
-			if _, getErr := getter.GetAny(ctx, v, templateDir, baseURL.String()); getErr != nil {
+			if _, getErr := getter.GetAny(ctx, l, v, templateDir, baseURL.String()); getErr != nil {
 				return fmt.Errorf(
 					"downloading scaffold template from %s: %w",
 					baseURL.String(),

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -385,7 +385,7 @@ func downloadEngine(
 		}
 
 		// Create download client and download assets
-		downloadClient := github.NewGitHubReleasesDownloadClient(github.WithLogger(l))
+		downloadClient := github.NewGitHubReleasesDownloadClient(l)
 
 		result, err := downloadClient.DownloadReleaseAssets(ctx, v, assets)
 		if err != nil {

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -553,10 +553,11 @@ func pinnedOCIURL(rawURL, digestValue string) string {
 // default protocol set is available for [RegistryGetter]'s delegated
 // archive download. Every other scheme uses a single-getter client.
 func defaultInnerClientBuilder(bare getter.Getter, scheme string) *getter.Client {
-	// The bare tfr getter carries the venv its delegated archive download
-	// needs; the fallback client builds s3 and gcs getters that require one.
+	// The bare tfr getter carries the logger and venv its delegated archive
+	// download needs; the fallback client builds s3 and gcs getters that
+	// require the venv.
 	if tfr, ok := bare.(*RegistryGetter); ok && scheme == SchemeTFR {
-		return NewClient(tfr.Venv, WithCustomGettersPrepended(bare))
+		return NewClient(tfr.Logger, tfr.Venv, WithCustomGettersPrepended(bare))
 	}
 
 	return &getter.Client{Getters: []getter.Getter{bare}}

--- a/internal/getter/casgetter_tfr_test.go
+++ b/internal/getter/casgetter_tfr_test.go
@@ -58,7 +58,7 @@ func TestCASGetter_TFRRoutesThroughCAS(t *testing.T) {
 	// not need this hook — the default builder uses the standard
 	// HttpGetter, which is fine for a real registry.
 	innerBuilder := func(bare gogetter.Getter, _ string) *gogetter.Client {
-		return getter.NewClient(venvtest.NewWithOSFS(),
+		return getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 			getter.WithCustomGettersPrepended(
 				bare,
 				&gogetter.HttpGetter{Client: httpClient, Netrc: true},

--- a/internal/getter/client.go
+++ b/internal/getter/client.go
@@ -6,6 +6,7 @@ import (
 	getter "github.com/hashicorp/go-getter/v2"
 
 	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
 )
 
 // NewClient returns a *go-getter/v2.Client configured for Terragrunt.
@@ -14,8 +15,8 @@ import (
 // directly, as it will consistently configure the client with the
 // default protocol set (s3, gcs, git, hg, smb, http(s), file) plus
 // the FileCopy and tfr customizations.
-func NewClient(v *venv.Venv, opts ...Option) *getter.Client {
-	b := &builder{v: v}
+func NewClient(l log.Logger, v *venv.Venv, opts ...Option) *getter.Client {
+	b := &builder{logger: l, v: v}
 	for _, opt := range opts {
 		opt(b)
 	}
@@ -34,11 +35,12 @@ func NewClient(v *venv.Venv, opts ...Option) *getter.Client {
 // Get is a convenience wrapper for downloading directories.
 func Get(
 	ctx context.Context,
+	l log.Logger,
 	v *venv.Venv,
 	dst, src string,
 	opts ...Option,
 ) (*GetResult, error) {
-	return NewClient(v, opts...).Get(ctx, &Request{
+	return NewClient(l, v, opts...).Get(ctx, &Request{
 		Src:     src,
 		Dst:     dst,
 		GetMode: ModeDir,
@@ -49,11 +51,12 @@ func Get(
 // through a Terragrunt-configured client whose getter list includes s3 and gcs.
 func GetAny(
 	ctx context.Context,
+	l log.Logger,
 	v *venv.Venv,
 	dst, src string,
 	opts ...Option,
 ) (*GetResult, error) {
-	return NewClient(v, opts...).Get(ctx, &Request{
+	return NewClient(l, v, opts...).Get(ctx, &Request{
 		Src:     src,
 		Dst:     dst,
 		GetMode: ModeAny,
@@ -63,11 +66,12 @@ func GetAny(
 // GetFile is a convenience wrapper for downloading a single file.
 func GetFile(
 	ctx context.Context,
+	l log.Logger,
 	v *venv.Venv,
 	dst, src string,
 	opts ...Option,
 ) (*GetResult, error) {
-	return NewClient(v, opts...).Get(ctx, &Request{
+	return NewClient(l, v, opts...).Get(ctx, &Request{
 		Src:     src,
 		Dst:     dst,
 		GetMode: ModeFile,

--- a/internal/getter/client_test.go
+++ b/internal/getter/client_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,7 @@ func TestGetFileConvenience(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "out.txt")
-	res, err := getter.GetFile(t.Context(), venvtest.NewWithOSFS(), dst, server.URL+"/blob")
+	res, err := getter.GetFile(t.Context(), logger.CreateLogger(), venvtest.NewWithOSFS(), dst, server.URL+"/blob")
 	require.NoError(t, err)
 	assert.Equal(t, dst, res.Dst)
 
@@ -48,7 +49,7 @@ func TestGetAnyConvenience(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(src, "main.tf"), []byte("# fixture\n"), 0644))
 
 	dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "copy")
-	_, err := getter.GetAny(t.Context(), venvtest.NewWithOSFS(), dst, "file://"+src,
+	_, err := getter.GetAny(t.Context(), logger.CreateLogger(), venvtest.NewWithOSFS(), dst, "file://"+src,
 		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
 	)
 	require.NoError(t, err)
@@ -66,7 +67,7 @@ func TestGetConvenience(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(src, "main.tf"), []byte("# fixture\n"), 0644))
 
 	dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "copy")
-	_, err := getter.Get(t.Context(), venvtest.NewWithOSFS(), dst, "file://"+src,
+	_, err := getter.Get(t.Context(), logger.CreateLogger(), venvtest.NewWithOSFS(), dst, "file://"+src,
 		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
 	)
 	require.NoError(t, err)
@@ -79,13 +80,13 @@ func TestGetConvenience(t *testing.T) {
 func TestNewClientWithDecompressorsEmptyMap(t *testing.T) {
 	t.Parallel()
 
-	disabled := getter.NewClient(venvtest.NewWithOSFS(),
+	disabled := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithDecompressors(map[string]getter.Decompressor{}),
 	)
 	require.NotNil(t, disabled.Decompressors)
 	assert.Empty(t, disabled.Decompressors)
 
-	def := getter.NewClient(venvtest.NewWithOSFS(),
+	def := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithDecompressors(nil))
 	assert.Nil(t, def.Decompressors, "nil map must leave the v2 default decompressors untouched")
 }

--- a/internal/getter/defaults_test.go
+++ b/internal/getter/defaults_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 
 	"github.com/gruntwork-io/terragrunt/internal/getter"
@@ -19,7 +20,7 @@ import (
 func TestDefaultClientRegistersS3GCS(t *testing.T) {
 	t.Parallel()
 
-	client := getter.NewClient(venvtest.NewWithOSFS())
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS())
 
 	assert.True(
 		t,
@@ -38,7 +39,7 @@ func TestDefaultClientRegistersS3GCS(t *testing.T) {
 func TestDefaultClientCoversCanonicalProtocols(t *testing.T) {
 	t.Parallel()
 
-	client := getter.NewClient(venvtest.NewWithOSFS())
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS())
 
 	assert.True(t, hasGetter[*getter.GitGetter](client.Getters), "git")
 	assert.True(t, hasGetter[*getter.HgGetter](client.Getters), "hg")
@@ -53,7 +54,7 @@ func TestDefaultClientCoversCanonicalProtocols(t *testing.T) {
 func TestWithFileCopyReplacesFileGetter(t *testing.T) {
 	t.Parallel()
 
-	client := getter.NewClient(venvtest.NewWithOSFS(),
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
 	)
 
@@ -97,7 +98,7 @@ func TestForcedGettersRouteToTheirGetter(t *testing.T) {
 			t.Parallel()
 
 			stub := &forcedRecordingGetter{forced: tc.forced}
-			client := getter.NewClient(venvtest.NewWithOSFS(),
+			client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 				getter.WithCustomGettersPrepended(stub))
 
 			_, err := client.Get(t.Context(), &getter.Request{

--- a/internal/getter/oci_registry_test.go
+++ b/internal/getter/oci_registry_test.go
@@ -169,7 +169,7 @@ func TestOCIGetterAgainstLocalRegistryRepositoryNamedLikeAPIPath(t *testing.T) {
 
 // ociRegistryClient builds the production getter chain resolving through v.
 func ociRegistryClient(v *venv.Venv) *getter.Client {
-	return getter.NewClient(venvtest.NewWithOSFS(),
+	return getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithOCI(getter.NewOCIGetter(logger.CreateLogger(), v)),
 	)
 }

--- a/internal/getter/oci_test.go
+++ b/internal/getter/oci_test.go
@@ -999,8 +999,7 @@ func TestNewClientWithOCIDetectOrdering(t *testing.T) {
 	manifestBytes, manifestDesc := manifestFor(t, getter.ArtifactTypeModulePkg, layer)
 	store := newFakeStore(manifestBytes, &manifestDesc, zipBytes, &layer)
 
-	client := getter.NewClient(venvtest.NewWithOSFS(),
-		getter.WithLogger(logger.CreateLogger()),
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithOCI(newTestOCIGetter(staticStore(store))),
 	)
 
@@ -1022,8 +1021,7 @@ func TestNewClientWithOCIDetectOrdering(t *testing.T) {
 func TestNewClientWithoutOCIRejectsOCISources(t *testing.T) {
 	t.Parallel()
 
-	client := getter.NewClient(venvtest.NewWithOSFS(),
-		getter.WithLogger(logger.CreateLogger()))
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS())
 	dst := filepath.Join(t.TempDir(), "module")
 
 	_, err := client.Get(t.Context(), &gogetter.Request{
@@ -1154,7 +1152,7 @@ func newTestOCIGetter(newStore getter.OCINewStoreFunc) *getter.OCIGetter {
 }
 
 func newOCITestClient(g *getter.OCIGetter) *gogetter.Client {
-	return getter.NewClient(venvtest.NewWithOSFS(),
+	return getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithCustomGettersPrepended(g))
 }
 

--- a/internal/getter/options.go
+++ b/internal/getter/options.go
@@ -12,11 +12,6 @@ import (
 // Option mutates a Client builder.
 type Option func(*builder)
 
-// WithLogger sets a default logger used by getters that don't carry their own.
-func WithLogger(l log.Logger) Option {
-	return func(b *builder) { b.logger = l }
-}
-
 // WithFileCopy substitutes the default file-protocol getter with the supplied
 // FileCopyGetter, which copies directories instead of symlinking them. Use
 // NewFileCopyGetter to build one with sensible defaults.

--- a/internal/getter/options_test.go
+++ b/internal/getter/options_test.go
@@ -33,7 +33,7 @@ func TestWithCASRegistersCASGetter(t *testing.T) {
 
 	v := venvtest.NewOSWithEmptyEnv()
 
-	client := getter.NewClient(v,
+	client := getter.NewClient(logger.CreateLogger(), v,
 		getter.WithCAS(c, &cas.CloneOptions{}),
 		getter.WithHTTP(vhttp.NewNoNetworkClient()),
 	)
@@ -58,7 +58,7 @@ func TestWithCASRoutesCASProtocolURLs(t *testing.T) {
 
 	v := venvtest.NewOSWithEmptyEnv()
 
-	client := getter.NewClient(v,
+	client := getter.NewClient(logger.CreateLogger(), v,
 		getter.WithCAS(c, &cas.CloneOptions{}),
 		getter.WithHTTP(vhttp.NewNoNetworkClient()),
 	)
@@ -103,7 +103,7 @@ func TestWithHTTPSAuthHeaderReachesServer(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := getter.NewClient(venvtest.NewWithOSFS(),
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithHTTPSAuth(http.Header{"Authorization": {want}}),
 		getter.WithCustomGettersPrepended(&gogetter.HttpGetter{
 			Client: server.Client(),
@@ -132,7 +132,7 @@ func TestHTTPSchemeRoutingChoosesAuthSlot(t *testing.T) {
 	httpsHeader := http.Header{"X-Auth": {"https-token"}}
 	httpHeader := http.Header{"X-Auth": {"http-token"}}
 
-	client := getter.NewClient(venvtest.NewWithOSFS(),
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithHTTPSAuth(httpsHeader),
 		getter.WithHTTPAuth(httpHeader),
 	)
@@ -189,7 +189,7 @@ func TestWithHTTPSAuthSetsBuilderField(t *testing.T) {
 	t.Parallel()
 
 	header := http.Header{"X-Test": {"yes"}}
-	client := getter.NewClient(venvtest.NewWithOSFS(),
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithHTTPSAuth(header))
 
 	httpGetters := allHTTPGetters(client.Getters)
@@ -218,7 +218,7 @@ func TestFileCopyGetIncludeExcludeFiltersHonor(t *testing.T) {
 		WithLogger(logger.CreateLogger()).
 		WithExcludeFromCopy("*.txt")
 
-	client := getter.NewClient(venvtest.NewWithOSFS(),
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithFileCopy(fcg))
 
 	_, err := client.Get(t.Context(), &getter.Request{
@@ -239,7 +239,7 @@ func TestFileCopyGetMissingPath(t *testing.T) {
 
 	missing := filepath.Join(helpers.TmpDirWOSymlinks(t), "does-not-exist")
 
-	client := getter.NewClient(venvtest.NewWithOSFS(),
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
 	)
 	_, err := client.Get(t.Context(), &getter.Request{
@@ -259,7 +259,7 @@ func TestFileCopyGetSourceIsFile(t *testing.T) {
 	srcFile := filepath.Join(helpers.TmpDirWOSymlinks(t), "main.tf")
 	require.NoError(t, writeFile(srcFile, "# main\n"))
 
-	client := getter.NewClient(venvtest.NewWithOSFS(),
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
 	)
 	_, err := client.Get(t.Context(), &getter.Request{
@@ -279,7 +279,7 @@ func TestFileCopyGetFileSourceIsDir(t *testing.T) {
 	srcDir := helpers.TmpDirWOSymlinks(t)
 	require.NoError(t, writeFile(filepath.Join(srcDir, "main.tf"), "# main\n"))
 
-	client := getter.NewClient(venvtest.NewWithOSFS(),
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
 	)
 	_, err := client.Get(t.Context(), &getter.Request{
@@ -302,7 +302,7 @@ func TestFileCopyGetFileDelegates(t *testing.T) {
 
 	dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "out.tf")
 
-	client := getter.NewClient(venvtest.NewWithOSFS(),
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithFileCopy(getter.NewFileCopyGetter(vfs.NewOSFS())),
 	)
 	_, err := client.Get(t.Context(), &getter.Request{

--- a/internal/getter/s3_test.go
+++ b/internal/getter/s3_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck // deprecated v1 SDK, per the note above
 	"github.com/aws/aws-sdk-go/aws/session" //nolint:staticcheck // deprecated v1 SDK, per the note above
 	"github.com/gruntwork-io/terragrunt/internal/getter"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	gogetter "github.com/hashicorp/go-getter/v2"
 	"github.com/stretchr/testify/assert"
@@ -80,7 +81,7 @@ func TestDefaultClientCanonicalizesS3SourceURLs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			client := getter.NewClient(venvtest.NewWithOSFS())
+			client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS())
 			req := &gogetter.Request{Src: tt.src, GetMode: getter.ModeAny}
 
 			claimed := false

--- a/internal/getter/tfr.go
+++ b/internal/getter/tfr.go
@@ -181,7 +181,7 @@ func (r *RegistryGetter) GetFile(_ context.Context, _ *getter.Request) error {
 func (r *RegistryGetter) delegateGet(ctx context.Context, dst, src string) error {
 	parent := getter.ClientFromContext(ctx)
 	if parent == nil {
-		parent = NewClient(r.Venv)
+		parent = NewClient(r.Logger, r.Venv)
 	}
 
 	_, err := parent.Get(ctx, &getter.Request{

--- a/internal/getter/tfr_test.go
+++ b/internal/getter/tfr_test.go
@@ -250,7 +250,7 @@ credentials %q {
 		WithHTTP(server.Client()).
 		WithEnv(map[string]string{cliconfig.EnvNameTFCLIConfigFile: configPath})
 	tfr := getter.NewRegistryGetter(logger.CreateLogger(), v).WithTofuImplementation(tfimpl.Terraform)
-	client := getter.NewClient(venvtest.NewWithOSFS(),
+	client := getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithCustomGettersPrepended(
 			tfr,
 			&gogetter.HttpGetter{Client: server.Client(), Netrc: true},
@@ -340,7 +340,7 @@ func newRegistryTestClientWithVenv(t *testing.T, v *venv.Venv, impl tfimpl.Type)
 
 	tfr := getter.NewRegistryGetter(l, v).WithTofuImplementation(impl)
 
-	return getter.NewClient(venvtest.NewWithOSFS(),
+	return getter.NewClient(logger.CreateLogger(), venvtest.NewWithOSFS(),
 		getter.WithCustomGettersPrepended(
 			tfr,
 			&gogetter.HttpGetter{Client: v.HTTP, Netrc: true},

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -206,27 +206,9 @@ type DownloadResult struct {
 	ChecksumSigFile string
 }
 
-// GitHubReleasesDownloadClientOption is a function that configures a GitHubReleasesDownloadClient.
-type GitHubReleasesDownloadClientOption func(*GitHubReleasesDownloadClient)
-
-// WithLogger sets the logger for the download client.
-func WithLogger(l log.Logger) GitHubReleasesDownloadClientOption {
-	return func(c *GitHubReleasesDownloadClient) {
-		c.logger = l
-	}
-}
-
 // NewGitHubReleasesDownloadClient creates a new GitHub releases download client.
-func NewGitHubReleasesDownloadClient(
-	opts ...GitHubReleasesDownloadClientOption,
-) *GitHubReleasesDownloadClient {
-	client := &GitHubReleasesDownloadClient{}
-
-	for _, opt := range opts {
-		opt(client)
-	}
-
-	return client
+func NewGitHubReleasesDownloadClient(l log.Logger) *GitHubReleasesDownloadClient {
+	return &GitHubReleasesDownloadClient{logger: l}
 }
 
 // DownloadReleaseAssets downloads the specified release assets from a GitHub repository.
@@ -293,9 +275,7 @@ func (c *GitHubReleasesDownloadClient) DownloadReleaseAssets(
 
 	for url, localPath := range downloads {
 		g.Go(func() error {
-			if c.logger != nil {
-				c.logger.Infof("Downloading %s to %s", url, localPath)
-			}
+			c.logger.Infof("Downloading %s to %s", url, localPath)
 
 			opts := []getter.Option{
 				getter.WithHTTP(v.HTTP),
@@ -310,7 +290,7 @@ func (c *GitHubReleasesDownloadClient) DownloadReleaseAssets(
 				opts = append(opts, getter.WithHTTPSAuth(http.Header{"Authorization": {"Bearer " + tok}}))
 			}
 
-			if _, err := getter.GetFile(downloadCtx, v, localPath, url, opts...); err != nil {
+			if _, err := getter.GetFile(downloadCtx, c.logger, v, localPath, url, opts...); err != nil {
 				return fmt.Errorf("failed to download %s: %w", url, err)
 			}
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/github"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
-	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -253,22 +253,14 @@ func TestGetLatestReleaseCaching(t *testing.T) {
 func TestNewGitHubReleasesDownloadClient(t *testing.T) {
 	t.Parallel()
 
-	client := github.NewGitHubReleasesDownloadClient()
-	require.NotNil(t, client)
-}
-
-func TestNewGitHubReleasesDownloadClientWithOptions(t *testing.T) {
-	t.Parallel()
-
-	logger := log.New()
-	client := github.NewGitHubReleasesDownloadClient(github.WithLogger(logger))
+	client := github.NewGitHubReleasesDownloadClient(logger.CreateLogger())
 	require.NotNil(t, client)
 }
 
 func TestDownloadReleaseAssetsValidation(t *testing.T) {
 	t.Parallel()
 
-	client := github.NewGitHubReleasesDownloadClient()
+	client := github.NewGitHubReleasesDownloadClient(logger.CreateLogger())
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -340,7 +332,7 @@ func TestDownloadReleaseAssetsGitHubRelease(t *testing.T) {
 	defer server.Close()
 
 	// Use direct URL approach for testing since mock servers are complex to set up for GitHub releases format
-	client := github.NewGitHubReleasesDownloadClient()
+	client := github.NewGitHubReleasesDownloadClient(logger.CreateLogger())
 
 	assets := &github.ReleaseAssets{
 		Repository:  server.URL + "/package.zip", // Direct URL
@@ -394,7 +386,7 @@ func TestDownloadReleaseAssetsGitHubReleaseUsesToken(t *testing.T) {
 	}
 
 	// Use direct URL approach for testing since mock servers are complex to set up for GitHub releases format
-	client := github.NewGitHubReleasesDownloadClient()
+	client := github.NewGitHubReleasesDownloadClient(logger.CreateLogger())
 
 	t.Run("prefer GH_TOKEN", func(t *testing.T) {
 		t.Parallel()
@@ -463,7 +455,7 @@ func TestDownloadReleaseAssetsDirectURL(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := github.NewGitHubReleasesDownloadClient()
+	client := github.NewGitHubReleasesDownloadClient(logger.CreateLogger())
 
 	assets := &github.ReleaseAssets{
 		Repository:  server.URL + "/direct-download.zip",

--- a/internal/runner/run/download_source.go
+++ b/internal/runner/run/download_source.go
@@ -720,7 +720,6 @@ func BuildDownloadClient(
 	cfg *runcfg.RunConfig,
 ) (*getter.Client, error) {
 	clientOpts := []getter.Option{
-		getter.WithLogger(l),
 		getter.WithHTTP(v.HTTP),
 		getter.WithFileCopy(getter.NewFileCopyGetter(v.FS).
 			WithLogger(l).
@@ -736,7 +735,7 @@ func BuildDownloadClient(
 		clientOpts = append(clientOpts, getter.WithOCI(getter.NewOCIGetter(l, v)))
 	}
 
-	return getter.NewClient(v, clientOpts...), nil
+	return getter.NewClient(l, v, clientOpts...), nil
 }
 
 // ValidateWorkingDir checks if working terraformSource.WorkingDir exists and is a directory

--- a/internal/services/catalog/module/clone_test.go
+++ b/internal/services/catalog/module/clone_test.go
@@ -1,0 +1,42 @@
+package module_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terragrunt/internal/services/catalog/module"
+	"github.com/gruntwork-io/terragrunt/internal/vexec"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+)
+
+// TestCloneReportsFailingGitRemote pins that a catalog clone whose git
+// commands all fail surfaces the failure as an error. The CAS getters log the
+// probe failure before falling back to a content hash, so a getter client
+// built without a logger used to take the whole process down here instead
+// (gruntwork-io/terragrunt#6869).
+func TestCloneReportsFailingGitRemote(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	failGit := func(context.Context, vexec.Invocation) vexec.Result {
+		return vexec.Result{ExitCode: 128, Stderr: []byte("fatal: repository not found")}
+	}
+
+	v := venvtest.NewWithOSFS().
+		WithExec(vexec.NewMemExec(failGit)).
+		WithUserCacheDir(func() (string, error) { return filepath.Join(tmpDir, "cache"), nil })
+
+	_, err := module.NewRepo(t.Context(), logger.CreateLogger(), v, &module.RepoOpts{
+		CloneURL:      "git::https://example.invalid/acme/terraform-aws-modules.git",
+		Path:          filepath.Join(tmpDir, "repo"),
+		AllowCAS:      true,
+		CASCloneDepth: 1,
+	})
+	require.Error(t, err)
+}

--- a/internal/services/catalog/module/clone_test.go
+++ b/internal/services/catalog/module/clone_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -13,6 +15,13 @@ import (
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 )
+
+// absentRepoURL names a git remote that does not exist. The scheme is file://
+// so the plain git getter the download falls back to, which spawns git itself
+// rather than going through the venv, stays off the network too.
+func absentRepoURL(dir string) string {
+	return "git::file://" + filepath.ToSlash(filepath.Join(dir, "absent.git"))
+}
 
 // TestCloneReportsFailingGitRemote pins that a catalog clone whose git
 // commands all fail surfaces the failure as an error. The CAS getters log the
@@ -33,10 +42,43 @@ func TestCloneReportsFailingGitRemote(t *testing.T) {
 		WithUserCacheDir(func() (string, error) { return filepath.Join(tmpDir, "cache"), nil })
 
 	_, err := module.NewRepo(t.Context(), logger.CreateLogger(), v, &module.RepoOpts{
-		CloneURL:      "git::https://example.invalid/acme/terraform-aws-modules.git",
+		CloneURL:      absentRepoURL(tmpDir),
 		Path:          filepath.Join(tmpDir, "repo"),
 		AllowCAS:      true,
 		CASCloneDepth: 1,
 	})
 	require.Error(t, err)
+}
+
+// TestCloneReportsAGitRemoteThatNeverAnswers pins the same reporting for a
+// clone the caller's deadline cuts off. A cancelled git command fails the CAS
+// source probe the way an outright error does, so both shapes travel the path
+// that used to panic.
+func TestCloneReportsAGitRemoteThatNeverAnswers(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := helpers.TmpDirWOSymlinks(t)
+
+	synctest.Test(t, func(t *testing.T) {
+		hangGit := func(ctx context.Context, _ vexec.Invocation) vexec.Result {
+			<-ctx.Done()
+
+			return vexec.Result{Err: ctx.Err()}
+		}
+
+		v := venvtest.NewWithOSFS().
+			WithExec(vexec.NewMemExec(hangGit)).
+			WithUserCacheDir(func() (string, error) { return filepath.Join(tmpDir, "cache"), nil })
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+		defer cancel()
+
+		_, err := module.NewRepo(ctx, logger.CreateLogger(), v, &module.RepoOpts{
+			CloneURL:      absentRepoURL(tmpDir),
+			Path:          filepath.Join(tmpDir, "slow-repo"),
+			AllowCAS:      true,
+			CASCloneDepth: 1,
+		})
+		require.Error(t, err)
+	})
 }

--- a/internal/services/catalog/module/repo.go
+++ b/internal/services/catalog/module/repo.go
@@ -518,7 +518,7 @@ func (repo *Repo) performClone(
 		)
 	}
 
-	client := getter.NewClient(v, clientOpts...)
+	client := getter.NewClient(l, v, clientOpts...)
 
 	sourceURL, err := tf.ToSourceURL(opts.SourceURL, "")
 	if err != nil {

--- a/internal/venv/venv.go
+++ b/internal/venv/venv.go
@@ -268,6 +268,19 @@ func (v *Venv) WithUserHomeDir(userHomeDir func() (string, error)) *Venv {
 	return &c
 }
 
+// WithUserCacheDir returns a copy of v whose cache-directory lookup is userCacheDir.
+func (v *Venv) WithUserCacheDir(userCacheDir func() (string, error)) *Venv {
+	v.RequirePlatform()
+
+	platform := *v.Platform
+	platform.UserCacheDir = userCacheDir
+
+	c := *v
+	c.Platform = &platform
+
+	return &c
+}
+
 // WithTempDir returns a copy of v whose temp-directory lookup is tempDir.
 func (v *Venv) WithTempDir(tempDir func() string) *Venv {
 	v.RequirePlatform()

--- a/pkg/config/stack.go
+++ b/pkg/config/stack.go
@@ -1044,7 +1044,7 @@ func copyFiles(
 			return fmt.Errorf("failed to create directory %s for %s %w", cp.dest, cp.identifier, err)
 		}
 
-		if _, err := getter.GetAny(ctx, v, cp.dest, cp.src, stackGetterOptions(l, v, opts)...); err != nil {
+		if _, err := getter.GetAny(ctx, l, v, cp.dest, cp.src, stackGetterOptions(v, opts)...); err != nil {
 			return fmt.Errorf("failed to fetch %s %s for %s %w", cp.src, cp.dest, cp.identifier, err)
 		}
 
@@ -1102,8 +1102,8 @@ func isOCISource(source string) bool {
 }
 
 // stackGetterOptions builds the getter options a component fetch needs, adding oci:// when enabled.
-func stackGetterOptions(l log.Logger, v *venv.Venv, opts *generateOpts) []getter.Option {
-	clientOpts := []getter.Option{getter.WithLogger(l), getter.WithHTTP(v.HTTP)}
+func stackGetterOptions(v *venv.Venv, opts *generateOpts) []getter.Option {
+	clientOpts := []getter.Option{getter.WithHTTP(v.HTTP)}
 
 	if opts.ociGetter != nil {
 		clientOpts = append(clientOpts, getter.WithOCI(opts.ociGetter))

--- a/test/integration_cas_rustfs_test.go
+++ b/test/integration_cas_rustfs_test.go
@@ -241,7 +241,7 @@ func TestS3PrefixDownloadReproducesLayout(t *testing.T) { //nolint: paralleltest
 	v := venv.OSVenv()
 	dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "module")
 
-	_, err := tggetter.NewClient(v).Get(t.Context(), &tggetter.Request{
+	_, err := tggetter.NewClient(logger.CreateLogger(), v).Get(t.Context(), &tggetter.Request{
 		Src:     rustfsSourceURL(t, endpoint, bucket, prefix),
 		Dst:     dst,
 		GetMode: tggetter.ModeAny,

--- a/test/integration_engine_test.go
+++ b/test/integration_engine_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 
@@ -511,7 +512,7 @@ func setupLocalEngine(t *testing.T) string {
 		require.NoError(t, err)
 	}
 
-	_, err := getter.GetAny(t.Context(), venv.OSVenv(), engineDir, downloadURL)
+	_, err := getter.GetAny(t.Context(), logger.CreateLogger(), venv.OSVenv(), engineDir, downloadURL)
 	require.NoError(t, err)
 
 	helpers.CopyAndFillMapPlaceholders(

--- a/test/integration_oci_live_test.go
+++ b/test/integration_oci_live_test.go
@@ -115,7 +115,7 @@ func pullOCILiveModule(t *testing.T, home, src string) {
 	}
 
 	dst := filepath.Join(t.TempDir(), "module")
-	client := getter.NewClient(v, getter.WithOCI(getter.NewOCIGetter(logger.CreateLogger(), v)))
+	client := getter.NewClient(logger.CreateLogger(), v, getter.WithOCI(getter.NewOCIGetter(logger.CreateLogger(), v)))
 
 	_, err := client.Get(t.Context(), &getter.Request{Src: src, Dst: dst})
 	require.NoError(t, err)

--- a/test/integration_s3_source_test.go
+++ b/test/integration_s3_source_test.go
@@ -15,6 +15,7 @@ import (
 	tggetter "github.com/gruntwork-io/terragrunt/internal/getter"
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,7 +54,7 @@ func TestAwsS3SourceURLForms(t *testing.T) {
 
 			dst := filepath.Join(helpers.TmpDirWOSymlinks(t), "module")
 
-			_, err := tggetter.GetAny(t.Context(), venv.OSVenv(), dst, tt.src)
+			_, err := tggetter.GetAny(t.Context(), logger.CreateLogger(), venv.OSVenv(), dst, tt.src)
 			require.NoError(t, err)
 			require.FileExists(t, filepath.Join(dst, "main.tf"))
 		})


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #6869.

Logger is propagated by construction for getter clients now, so it can't be dropped again.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `terragrunt catalog` now reports underlying Git errors when catalog repositories are unreachable instead of crashing.
  - Catalog operations now handle failed or unresponsive Git remotes more reliably.
  - Download-related operations provide more consistent progress logging and error handling across supported sources.

- **Documentation**
  - Added a v1.1.5 changelog entry documenting the catalog repository error-handling fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->