### PR TITLE
fix: Adding store repair for corrupted CAS stores

### DIFF
--- a/docs/src/data/changelog/v1.1.5/cas-restores-deleted-store-content.mdx
+++ b/docs/src/data/changelog/v1.1.5/cas-restores-deleted-store-content.mdx
@@ -9,4 +9,4 @@ When something removes a file from the [Content Addressable Store (CAS)](/featur
 
 Terragrunt used to treat a cached source as complete once it had been downloaded, so a file deleted from the store afterwards ended the run with a read failure naming a path inside the store. Recovering meant clearing the store by hand.
 
-A source that no longer supplies the missing content still fails, and now says which object the store is missing. The same is true of a `cas::` reference in a stack file, which names stored content directly and has no source behind it to download again.
+A source that no longer supplies the missing content still fails, and now says which object the store is missing. The same is true of a `cas::` reference in a stack file, which names stored content directly and has no source behind it to download again, and of a run under `--cas-offline`, which forbids the download that would restore the store.

--- a/docs/src/data/changelog/v1.1.5/cas-restores-deleted-store-content.mdx
+++ b/docs/src/data/changelog/v1.1.5/cas-restores-deleted-store-content.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### Deleted files in the CAS are fetched again instead of failing the run
+
+When something removes a file from the [Content Addressable Store (CAS)](/features/caching/cas) that a cached source still needs, Terragrunt now downloads that source again and restores what is missing, then carries on.
+
+Terragrunt used to treat a cached source as complete once it had been downloaded, so a file deleted from the store afterwards ended the run with a read failure naming a path inside the store. Recovering meant clearing the store by hand.
+
+A source that no longer supplies the missing content still fails, and now says which object the store is missing. The same is true of a `cas::` reference in a stack file, which names stored content directly and has no source behind it to download again.

--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -13,6 +13,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"time"
 
 	"errors"
@@ -567,7 +569,13 @@ func (c *CAS) EnsureBlob(
 // rev-parse against the central GitStore canonicalizes the user ref after
 // fetching.
 func (c *CAS) gitFetcher(url string, opts *CloneOptions) SourceFetcher {
-	return func(ctx context.Context, l log.Logger, v *venv.Venv, suggestedKey string) (string, error) {
+	return func(
+		ctx context.Context,
+		l log.Logger,
+		v *venv.Venv,
+		suggestedKey string,
+		mode IngestMode,
+	) (string, error) {
 		var ref resolvedRef
 		if suggestedKey != "" {
 			ref = &symbolicRef{URL: url, Branch: opts.Branch, Hash: suggestedKey}
@@ -575,7 +583,7 @@ func (c *CAS) gitFetcher(url string, opts *CloneOptions) SourceFetcher {
 			ref = &commitRef{URL: url, RawRef: opts.Branch}
 		}
 
-		return c.populateTreeFromRef(ctx, l, v, opts, ref)
+		return c.populateTreeFromRef(ctx, l, v, opts, ref, mode)
 	}
 }
 
@@ -584,14 +592,18 @@ func (c *CAS) gitFetcher(url string, opts *CloneOptions) SourceFetcher {
 // anywhere in the process share one flight; the flight runs with the
 // first caller's logger, venv, and clone options, and later callers only
 // wait for its tree.
+//
+// Under [IngestRepair] the store hit is passed over, so the tree is
+// ingested again and the objects it names are written back.
 func (c *CAS) populateTreeFromRef(
 	ctx context.Context,
 	l log.Logger,
 	v *venv.Venv,
 	opts *CloneOptions,
 	ref resolvedRef,
+	mode IngestMode,
 ) (string, error) {
-	if hash := ref.knownHash(); hash != "" && !c.treeStore.NeedsWrite(v, hash) {
+	if hash := ref.knownHash(); mode.trustsStoreHits() && hash != "" && !c.treeStore.NeedsWrite(v, hash) {
 		return hash, nil
 	}
 
@@ -601,22 +613,28 @@ func (c *CAS) populateTreeFromRef(
 		return "", &OfflineMissError{Source: RedactURL(url), Ref: probeRefName(requested)}
 	}
 
-	return flights.ingest.do(ctx, c.ingestFlightKey(ref), func(ctx context.Context) (string, error) {
-		return c.ingestRef(ctx, l, v, opts, ref)
+	return flights.ingest.do(ctx, c.ingestFlightKey(ref, mode), func(ctx context.Context) (string, error) {
+		return c.ingestRef(ctx, l, v, opts, ref, mode)
 	})
 }
 
 // ingestFlightKey identifies the tree an ingest writes into this store:
 // the commit hash when it is already known, otherwise the (URL, ref) pair
 // that will resolve to it.
-func (c *CAS) ingestFlightKey(ref resolvedRef) string {
+//
+// The mode is part of the key because a repair that joined a cached
+// ingest would get back an ingest that trusted the store hit the repair
+// was started to correct.
+func (c *CAS) ingestFlightKey(ref resolvedRef, mode IngestMode) string {
+	scope := c.storePath + "\x00" + strconv.Itoa(int(mode))
+
 	if hash := ref.knownHash(); hash != "" {
-		return c.storePath + "\x00commit\x00" + hash
+		return scope + "\x00commit\x00" + hash
 	}
 
 	url, requested := ref.origin()
 
-	return c.storePath + "\x00ref\x00" + url + "\x00" + requested
+	return scope + "\x00ref\x00" + url + "\x00" + requested
 }
 
 // ingestRef dispatches by ref kind to the populate that fills the store.
@@ -627,17 +645,18 @@ func (c *CAS) ingestRef(
 	v *venv.Venv,
 	opts *CloneOptions,
 	ref resolvedRef,
+	mode IngestMode,
 ) (string, error) {
 	switch ref := ref.(type) {
 	case *symbolicRef:
-		if err := c.populateTreeFromSymbolicRef(ctx, l, v, opts, ref); err != nil {
+		if err := c.populateTreeFromSymbolicRef(ctx, l, v, opts, ref, mode); err != nil {
 			return "", err
 		}
 
 		return ref.Hash, nil
 
 	case *commitRef:
-		return c.populateTreeFromCommitRef(ctx, l, v, opts, ref)
+		return c.populateTreeFromCommitRef(ctx, l, v, opts, ref, mode)
 
 	default:
 		return "", fmt.Errorf("unsupported resolved ref type %T", ref)
@@ -654,6 +673,7 @@ func (c *CAS) populateTreeFromSymbolicRef(
 	v *venv.Venv,
 	opts *CloneOptions,
 	ref *symbolicRef,
+	mode IngestMode,
 ) error {
 	gitRunner, err := git.NewGitRunner(v)
 	if err != nil {
@@ -668,7 +688,7 @@ func (c *CAS) populateTreeFromSymbolicRef(
 
 		runner := gitRunner.WithWorkDir(repo.Path)
 
-		return c.storeRootTreeFrom(ctx, l, v, runner, ref.URL, ref.Hash, opts)
+		return c.storeRootTreeFrom(ctx, l, v, runner, ref.URL, ref.Hash, opts, mode)
 	}
 
 	l.Warnf(
@@ -691,7 +711,7 @@ func (c *CAS) populateTreeFromSymbolicRef(
 		return err
 	}
 
-	return c.storeRootTreeFrom(ctx, l, v, runner, ref.URL, ref.Hash, opts)
+	return c.storeRootTreeFrom(ctx, l, v, runner, ref.URL, ref.Hash, opts, mode)
 }
 
 // populateTreeFromCommitRef resolves ref via [GitStore.EnsureCommit]
@@ -704,6 +724,7 @@ func (c *CAS) populateTreeFromCommitRef(
 	v *venv.Venv,
 	opts *CloneOptions,
 	ref *commitRef,
+	mode IngestMode,
 ) (string, error) {
 	gitRunner, err := git.NewGitRunner(v)
 	if err != nil {
@@ -714,13 +735,13 @@ func (c *CAS) populateTreeFromCommitRef(
 	if err == nil {
 		defer repo.Release(l)
 
-		if !c.treeStore.NeedsWrite(v, repo.Hash) {
+		if mode.trustsStoreHits() && !c.treeStore.NeedsWrite(v, repo.Hash) {
 			return repo.Hash, nil
 		}
 
 		runner := gitRunner.WithWorkDir(repo.Path)
 
-		if err := c.storeRootTreeFrom(ctx, l, v, runner, ref.URL, repo.Hash, opts); err != nil {
+		if err := c.storeRootTreeFrom(ctx, l, v, runner, ref.URL, repo.Hash, opts, mode); err != nil {
 			return "", err
 		}
 
@@ -764,11 +785,11 @@ func (c *CAS) populateTreeFromCommitRef(
 		return "", err
 	}
 
-	if !c.treeStore.NeedsWrite(v, canonicalHash) {
+	if mode.trustsStoreHits() && !c.treeStore.NeedsWrite(v, canonicalHash) {
 		return canonicalHash, nil
 	}
 
-	if err := c.storeRootTreeFrom(ctx, l, v, runner, ref.URL, canonicalHash, opts); err != nil {
+	if err := c.storeRootTreeFrom(ctx, l, v, runner, ref.URL, canonicalHash, opts, mode); err != nil {
 		return "", err
 	}
 
@@ -932,13 +953,14 @@ func (c *CAS) storeRootTreeFrom(
 	runner *git.GitRunner,
 	url, hash string,
 	opts *CloneOptions,
+	mode IngestMode,
 ) error {
 	tree, err := runner.LsTreeRecursive(ctx, hash)
 	if err != nil {
 		return err
 	}
 
-	if err = c.storeTreeRecursive(ctx, l, v, runner, url, hash, tree); err != nil {
+	if err = c.storeTreeRecursive(ctx, l, v, runner, url, hash, tree, mode); err != nil {
 		return err
 	}
 
@@ -948,10 +970,7 @@ func (c *CAS) storeRootTreeFrom(
 
 	treeContent := NewContent(c.treeStore)
 
-	data, err := treeContent.Read(v, hash)
-	if err != nil {
-		return err
-	}
+	data := slices.Clone(tree.Data())
 
 	for _, file := range opts.IncludedGitFiles {
 		stat, err := v.FS.Stat(filepath.Join(runner.WorkDir, file))
@@ -989,6 +1008,11 @@ func (c *CAS) storeRootTreeFrom(
 // storeTreeRecursive stores a tree fetched from git ls-tree -r. The tree
 // object is written last so a tree-store hit implies every blob and
 // submodule tree it references is already present.
+//
+// [IngestRepair] is what to pass once that implication has been shown
+// false. The listing is walked again and every object it names that the
+// store lacks is written, so a store missing one blob is read back out of
+// the repository one blob at a time, not wholesale.
 func (c *CAS) storeTreeRecursive(
 	ctx context.Context,
 	l log.Logger,
@@ -996,8 +1020,9 @@ func (c *CAS) storeTreeRecursive(
 	runner *git.GitRunner,
 	url, hash string,
 	tree *git.Tree,
+	mode IngestMode,
 ) error {
-	if !c.treeStore.NeedsWrite(v, hash) {
+	if mode.trustsStoreHits() && !c.treeStore.NeedsWrite(v, hash) {
 		return nil
 	}
 
@@ -1005,7 +1030,7 @@ func (c *CAS) storeTreeRecursive(
 		return err
 	}
 
-	if err := c.storeSubmodules(ctx, l, v, runner, url, tree); err != nil {
+	if err := c.storeSubmodules(ctx, l, v, runner, url, tree, mode); err != nil {
 		return err
 	}
 
@@ -1142,6 +1167,7 @@ func (c *CAS) storeSubmodules(
 	runner *git.GitRunner,
 	url string,
 	tree *git.Tree,
+	mode IngestMode,
 ) error {
 	var gitlinks []git.TreeEntry
 
@@ -1174,7 +1200,7 @@ func (c *CAS) storeSubmodules(
 		resolvedURL := git.ResolveSubmoduleURL(url, subURL)
 
 		ref := &commitRef{URL: resolvedURL, RawRef: entry.Hash, Hash: entry.Hash}
-		if _, err := c.populateTreeFromRef(ctx, l, v, &CloneOptions{}, ref); err != nil {
+		if _, err := c.populateTreeFromRef(ctx, l, v, &CloneOptions{}, ref, mode); err != nil {
 			return fmt.Errorf("fetch submodule %s from %s: %w", entry.Path, resolvedURL, err)
 		}
 	}

--- a/internal/cas/content.go
+++ b/internal/cas/content.go
@@ -131,11 +131,7 @@ func (c *Content) Link(
 
 		data, readErr := vfs.ReadFile(v.FS, sourcePath)
 		if readErr != nil {
-			return &WrappedError{
-				Op:   "read_source",
-				Path: sourcePath,
-				Err:  ErrReadFile,
-			}
+			return storeReadError(hash, sourcePath, readErr)
 		}
 
 		// A unique, freshly-writable temp avoids a fixed "<target>.tmp":
@@ -457,7 +453,29 @@ func (c *Content) GetTmpHandle(v *venv.Venv, hash string) (vfs.File, error) {
 // Read retrieves content from the store by hash.
 func (c *Content) Read(v *venv.Venv, hash string) ([]byte, error) {
 	path := c.getPath(hash)
-	return vfs.ReadFile(v.FS, path)
+
+	data, err := vfs.ReadFile(v.FS, path)
+	if err != nil {
+		return nil, storeReadError(hash, path, err)
+	}
+
+	return data, nil
+}
+
+// storeReadError classifies a failed read of a stored object. An object
+// that is not there is the store missing content the source can supply
+// again, which [CAS.FetchSource] repairs, so it is reported as
+// [MissingObjectError] rather than as an ordinary read failure.
+func storeReadError(hash, path string, err error) error {
+	if errors.Is(err, fs.ErrNotExist) {
+		return &MissingObjectError{Hash: hash, Path: path}
+	}
+
+	return &WrappedError{
+		Op:   "read_source",
+		Path: path,
+		Err:  errors.Join(ErrReadFile, err),
+	}
 }
 
 // writeContentToFile writes data to a temporary file, sets appropriate

--- a/internal/cas/errors.go
+++ b/internal/cas/errors.go
@@ -146,8 +146,9 @@ func (e *GitStoreObjectMissingError) Error() string {
 //
 // [CAS.FetchSource] answers this by re-ingesting from the source, so the
 // error only reaches a caller when the source cannot supply the object
-// either, or when the entry point had no source to go back to
-// ([CAS.MaterializeTree] serving a cas:: reference).
+// either, when [WithOffline] forbids going back to it (wrapped in
+// [OfflineRepairError]), or when the entry point had no source to go back
+// to ([CAS.MaterializeTree] serving a cas:: reference).
 type MissingObjectError struct {
 	// Hash is the object the store was asked for.
 	Hash string
@@ -165,6 +166,24 @@ func (e *MissingObjectError) Error() string {
 func (e *MissingObjectError) Unwrap() error {
 	return fs.ErrNotExist
 }
+
+// OfflineRepairError reports that the store is missing an object and
+// --cas-offline forbade the re-ingest that would restore it. It unwraps
+// to the [MissingObjectError] and not to [ErrCASOffline]: the source was
+// in the store, so a caller must not read this as content never fetched.
+type OfflineRepairError struct {
+	// Missing is the object the store could not produce.
+	Missing *MissingObjectError
+	// Source is the source URL with any credentials removed.
+	Source string
+}
+
+func (e *OfflineRepairError) Error() string {
+	return e.Missing.Error() + "; --cas-offline forbids fetching " + e.Source +
+		" to restore it; run once without --cas-offline to repair the store, or drop the flag"
+}
+
+func (e *OfflineRepairError) Unwrap() error { return e.Missing }
 
 // TreeDepthExceededError is returned when materializing a tree hits the
 // nesting bound. Only a repository built to exhaust the stack reaches it.

--- a/internal/cas/errors.go
+++ b/internal/cas/errors.go
@@ -2,6 +2,7 @@ package cas
 
 import (
 	"fmt"
+	"io/fs"
 
 	"errors"
 )
@@ -135,6 +136,34 @@ func (e *GitStoreObjectMissingError) Error() string {
 		"object %s not present in central git store after fetching %s from %s",
 		e.Hash, e.Ref, e.URL,
 	)
+}
+
+// MissingObjectError reports that the store holds no file for an object
+// something still names: a blob a stored tree lists, or a tree a gitlink
+// pins. Ingest writes a tree only after every object that tree names, so a
+// store only Terragrunt has touched never reaches this state, and reaching
+// it means an entry was removed out from under it.
+//
+// [CAS.FetchSource] answers this by re-ingesting from the source, so the
+// error only reaches a caller when the source cannot supply the object
+// either, or when the entry point had no source to go back to
+// ([CAS.MaterializeTree] serving a cas:: reference).
+type MissingObjectError struct {
+	// Hash is the object the store was asked for.
+	Hash string
+	// Path is where the store expected to find it.
+	Path string
+}
+
+func (e *MissingObjectError) Error() string {
+	return fmt.Sprintf("CAS store is missing object %s, expected at %s", e.Hash, e.Path)
+}
+
+// Unwrap reports the miss as [fs.ErrNotExist], which is what it is on
+// disk, so a caller that only asks whether the object was there keeps
+// working without knowing this type.
+func (e *MissingObjectError) Unwrap() error {
+	return fs.ErrNotExist
 }
 
 // TreeDepthExceededError is returned when materializing a tree hits the

--- a/internal/cas/probeorigin_test.go
+++ b/internal/cas/probeorigin_test.go
@@ -76,7 +76,13 @@ func TestProbeOriginStampedOnlyByFetchSource(t *testing.T) {
 func ingestFixture(t *testing.T, c *cas.CAS) cas.SourceFetcher {
 	t.Helper()
 
-	return func(_ context.Context, l log.Logger, v *venv.Venv, suggestedKey string) (string, error) {
+	return func(
+		_ context.Context,
+		l log.Logger,
+		v *venv.Venv,
+		suggestedKey string,
+		_ cas.IngestMode,
+	) (string, error) {
 		dir := t.TempDir()
 		if err := vfs.WriteFile(v.FS, filepath.Join(dir, "main.tf"), []byte("# hello\n"), cas.RegularFilePerms); err != nil {
 			return "", err

--- a/internal/cas/repair_test.go
+++ b/internal/cas/repair_test.go
@@ -1,0 +1,337 @@
+package cas_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gruntwork-io/terragrunt/internal/cas"
+	"github.com/gruntwork-io/terragrunt/internal/git"
+	"github.com/gruntwork-io/terragrunt/internal/venv"
+	"github.com/gruntwork-io/terragrunt/internal/vfs"
+	"github.com/gruntwork-io/terragrunt/pkg/log"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+)
+
+func TestFetchSource_MissingBlobIsReIngested(t *testing.T) {
+	t.Parallel()
+
+	c, v := newCAS(t)
+	l := logger.CreateLogger()
+
+	const url = "https://example.com/mod.tgz"
+
+	key := cas.OpaqueKey("http", url, "etag-abc")
+	resolver := &fakeResolver{scheme: "http", key: key}
+
+	var fetchCalls atomic.Int32
+
+	files := map[string]string{
+		"main.tf":  `# hello`,
+		"sub/x.tf": `variable "x" {}`,
+	}
+
+	dst1 := filepath.Join(t.TempDir(), "dst1")
+	require.NoError(t, c.FetchSource(t.Context(), l, v, &cas.CloneOptions{Dir: dst1}, cas.SourceRequest{
+		Scheme:   "http",
+		URL:      url,
+		Resolver: resolver,
+		Fetch:    fakeFetcher(c, files, &fetchCalls),
+	}))
+	require.Equal(t, int32(1), fetchCalls.Load())
+
+	require.NoError(t, v.FS.Remove(storedBlobPath(t, c, v, key, "main.tf")))
+
+	dst2 := filepath.Join(t.TempDir(), "dst2")
+	require.NoError(t, c.FetchSource(t.Context(), l, v, &cas.CloneOptions{Dir: dst2}, cas.SourceRequest{
+		Scheme:   "http",
+		URL:      url,
+		Resolver: resolver,
+		Fetch:    fakeFetcher(c, files, &fetchCalls),
+	}))
+
+	assert.Equal(
+		t,
+		int32(2),
+		fetchCalls.Load(),
+		"the cached tree no longer covers the store, so the source must be fetched again",
+	)
+	assertFileContent(t, v, filepath.Join(dst2, "main.tf"), files["main.tf"])
+	assertFileContent(t, v, filepath.Join(dst2, "sub", "x.tf"), files["sub/x.tf"])
+}
+
+// TestFetchSource_MissingBlobTheSourceCannotSupply pins what happens when
+// re-ingesting does not restore the object: the caller is told which object
+// the store is missing, rather than being handed a read failure or a
+// directory silently short a file.
+func TestFetchSource_MissingBlobTheSourceCannotSupply(t *testing.T) {
+	t.Parallel()
+
+	c, v := newCAS(t)
+	l := logger.CreateLogger()
+
+	const url = "https://example.com/mod.tgz"
+
+	key := cas.OpaqueKey("http", url, "etag-abc")
+	resolver := &fakeResolver{scheme: "http", key: key}
+
+	var fetchCalls atomic.Int32
+
+	dst1 := filepath.Join(t.TempDir(), "dst1")
+	require.NoError(t, c.FetchSource(t.Context(), l, v, &cas.CloneOptions{Dir: dst1}, cas.SourceRequest{
+		Scheme:   "http",
+		URL:      url,
+		Resolver: resolver,
+		Fetch:    fakeFetcher(c, map[string]string{"main.tf": "# hello"}, &fetchCalls),
+	}))
+
+	blobPath := storedBlobPath(t, c, v, key, "main.tf")
+	require.NoError(t, v.FS.Remove(blobPath))
+
+	// A source that answers with the cached key without ingesting anything
+	// stands in for one that can no longer produce the content, such as a
+	// remote whose artifact has been deleted.
+	emptyHanded := func(
+		_ context.Context,
+		_ log.Logger,
+		_ *venv.Venv,
+		suggestedKey string,
+		_ cas.IngestMode,
+	) (string, error) {
+		fetchCalls.Add(1)
+
+		return suggestedKey, nil
+	}
+
+	dst2 := filepath.Join(t.TempDir(), "dst2")
+	err := c.FetchSource(t.Context(), l, v, &cas.CloneOptions{Dir: dst2}, cas.SourceRequest{
+		Scheme:   "http",
+		URL:      url,
+		Resolver: resolver,
+		Fetch:    emptyHanded,
+	})
+
+	var missing *cas.MissingObjectError
+	require.ErrorAs(t, err, &missing)
+	assert.Equal(t, blobPath, missing.Path)
+	assert.Equal(t, int32(2), fetchCalls.Load(), "repair is one attempt, not a retry loop")
+}
+
+// TestFetchSource_ConcurrentRepairWithRacing has every worker find the same
+// blob missing at once, so they race to restore it. CI runs this test under
+// -race per the WithRacing suffix convention.
+func TestFetchSource_ConcurrentRepairWithRacing(t *testing.T) {
+	t.Parallel()
+
+	c, v := newCAS(t)
+	l := logger.CreateLogger()
+
+	const url = "https://example.com/mod.tgz"
+
+	key := cas.OpaqueKey("http", url, "etag-abc")
+	resolver := &fakeResolver{scheme: "http", key: key}
+
+	var fetchCalls atomic.Int32
+
+	files := map[string]string{
+		"main.tf":   `# hello`,
+		"vars.tf":   `variable "x" {}`,
+		"sub/y.tf":  `# nested`,
+		"README.md": "readme",
+	}
+
+	dst := filepath.Join(t.TempDir(), "dst")
+	require.NoError(t, c.FetchSource(t.Context(), l, v, &cas.CloneOptions{Dir: dst}, cas.SourceRequest{
+		Scheme:   "http",
+		URL:      url,
+		Resolver: resolver,
+		Fetch:    fakeFetcher(c, files, &fetchCalls),
+	}))
+
+	require.NoError(t, v.FS.Remove(storedBlobPath(t, c, v, key, "main.tf")))
+
+	const workers = 8
+
+	dsts := make([]string, workers)
+	for i := range workers {
+		dsts[i] = filepath.Join(t.TempDir(), "dst")
+	}
+
+	var g errgroup.Group
+
+	for i := range workers {
+		g.Go(func() error {
+			return c.FetchSource(t.Context(), l, v, &cas.CloneOptions{Dir: dsts[i]}, cas.SourceRequest{
+				Scheme:   "http",
+				URL:      url,
+				Resolver: resolver,
+				Fetch:    fakeFetcher(c, files, &fetchCalls),
+			})
+		})
+	}
+
+	require.NoError(t, g.Wait())
+
+	for _, dir := range dsts {
+		assertFileContent(t, v, filepath.Join(dir, "main.tf"), files["main.tf"])
+		assertFileContent(t, v, filepath.Join(dir, "sub", "y.tf"), files["sub/y.tf"])
+	}
+}
+
+// TestMaterializeTree_MissingBlob covers the entry point that has no source
+// to go back to. A cas:: reference names a tree and nothing else, so the
+// miss can only be reported.
+func TestMaterializeTree_MissingBlob(t *testing.T) {
+	t.Parallel()
+
+	c, v := newCAS(t)
+	l := logger.CreateLogger()
+
+	src := writeLocalFixture(t, map[string]string{"main.tf": "# hello"})
+
+	key, err := c.IngestDirectory(l, v, src, "")
+	require.NoError(t, err)
+
+	blobPath := storedBlobPath(t, c, v, key, "main.tf")
+	require.NoError(t, v.FS.Remove(blobPath))
+
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	var missing *cas.MissingObjectError
+	require.ErrorAs(t, c.MaterializeTree(t.Context(), l, v, key, dst), &missing)
+	assert.Equal(t, blobPath, missing.Path)
+}
+
+func TestCASClone_E2E_MissingBlobIsReIngested(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startTestServer(t)
+	headHash := resolveHeadE2E(t, repoURL)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
+	require.NoError(t, err)
+
+	v := venvtest.NewOSWithEmptyEnv()
+	l := logger.CreateLogger()
+
+	dst1 := filepath.Join(tempDir, "dst1")
+	require.NoError(t, c.Clone(t.Context(), l, v, repoURL,
+		cas.WithDir(dst1),
+		cas.WithBranch("main"),
+		cas.WithDepth(-1)))
+
+	want := readFile(t, v, filepath.Join(dst1, "main.tf"))
+
+	require.NoError(t, v.FS.Remove(storedBlobPath(t, c, v, headHash, "main.tf")))
+
+	// The tree is still stored under the commit SHA, so this clone takes the
+	// probe hit that skips the fetch entirely until the miss turns up.
+	dst2 := filepath.Join(tempDir, "dst2")
+	require.NoError(t, c.Clone(t.Context(), l, v, repoURL,
+		cas.WithDir(dst2),
+		cas.WithBranch("main"),
+		cas.WithDepth(-1)))
+
+	assertFileContent(t, v, filepath.Join(dst2, "main.tf"), want)
+	require.FileExists(t, filepath.Join(dst2, "README.md"))
+}
+
+// TestCASClone_E2E_RepairKeepsIncludedGitFilesOnce pins that re-ingesting a
+// tree that already carries included .git files does not list them twice.
+// The included entries are appended to the listing the ingest just read, not
+// to the stored tree they were previously appended to.
+func TestCASClone_E2E_RepairKeepsIncludedGitFilesOnce(t *testing.T) {
+	t.Parallel()
+
+	repoURL := startTestServer(t)
+	headHash := resolveHeadE2E(t, repoURL)
+
+	tempDir := helpers.TmpDirWOSymlinks(t)
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(filepath.Join(tempDir, "store")))
+	require.NoError(t, err)
+
+	v := venvtest.NewOSWithEmptyEnv()
+	l := logger.CreateLogger()
+
+	clone := func(dst string) {
+		t.Helper()
+
+		require.NoError(t, c.Clone(t.Context(), l, v, repoURL,
+			cas.WithDir(dst),
+			cas.WithBranch("main"),
+			cas.WithIncludedGitFiles([]string{"HEAD", "config"}),
+			cas.WithDepth(-1)))
+	}
+
+	clone(filepath.Join(tempDir, "dst1"))
+
+	require.NoError(t, v.FS.Remove(storedBlobPath(t, c, v, headHash, "main.tf")))
+
+	dst2 := filepath.Join(tempDir, "dst2")
+	clone(dst2)
+
+	require.FileExists(t, filepath.Join(dst2, ".git", "HEAD"))
+	require.FileExists(t, filepath.Join(dst2, ".git", "config"))
+
+	counts := map[string]int{}
+	for _, entry := range storedTree(t, c, v, headHash).Entries() {
+		counts[entry.Path]++
+	}
+
+	assert.Equal(t, 1, counts[filepath.Join(".git", "HEAD")])
+	assert.Equal(t, 1, counts[filepath.Join(".git", "config")])
+}
+
+// storedTree parses the tree the store holds under treeKey.
+func storedTree(t *testing.T, c *cas.CAS, v *venv.Venv, treeKey string) *git.Tree {
+	t.Helper()
+
+	data, err := cas.NewContent(c.TreeStore()).Read(v, treeKey)
+	require.NoError(t, err)
+
+	tree, err := git.ParseTree(data, "")
+	require.NoError(t, err)
+
+	return tree
+}
+
+// storedBlobPath returns where the store keeps the blob for relPath in the
+// tree stored under treeKey.
+func storedBlobPath(t *testing.T, c *cas.CAS, v *venv.Venv, treeKey, relPath string) string {
+	t.Helper()
+
+	for _, entry := range storedTree(t, c, v, treeKey).Entries() {
+		if entry.Path == relPath && entry.Type == git.EntryTypeBlob {
+			return filepath.Join(c.BlobStore().Path(), entry.Hash[:2], entry.Hash)
+		}
+	}
+
+	t.Fatalf("tree %s holds no blob for %s", treeKey, relPath)
+
+	return ""
+}
+
+func readFile(t *testing.T, v *venv.Venv, path string) string {
+	t.Helper()
+
+	data, err := vfs.ReadFile(v.FS, path)
+	require.NoError(t, err)
+
+	return string(data)
+}
+
+func assertFileContent(t *testing.T, v *venv.Venv, path, want string) {
+	t.Helper()
+
+	data, err := vfs.ReadFile(v.FS, path)
+	require.NoError(t, err)
+	assert.Equal(t, want, string(data))
+}

--- a/internal/cas/source.go
+++ b/internal/cas/source.go
@@ -135,7 +135,9 @@ type SourceRequest struct {
 // costs one extra pass: src is ingested again under [IngestRepair], which
 // writes the missing object back, and the link is retried. The second
 // failure is returned as it stands, so a source that can no longer supply
-// the object reports [MissingObjectError] rather than looping.
+// the object reports [MissingObjectError] rather than looping. Under
+// [WithOffline] there is no second pass: the miss is returned as an
+// [OfflineRepairError] instead of asking the remote the flag forbids.
 //
 // opts.Dir is the destination. opts.Mutable selects copy vs hardlink
 // for the final link, matching the git path.
@@ -185,6 +187,10 @@ func (c *CAS) FetchSource(
 			var missing *MissingObjectError
 			if !errors.As(err, &missing) {
 				return err
+			}
+
+			if c.probeMode == ProbeModeOffline {
+				return &OfflineRepairError{Missing: missing, Source: RedactURL(src.URL)}
 			}
 
 			l.Warnf(

--- a/internal/cas/source.go
+++ b/internal/cas/source.go
@@ -49,6 +49,28 @@ type SourceResolver interface {
 	Probe(ctx context.Context, rawURL string) (cacheKey string, err error)
 }
 
+// IngestMode says whether an ingest may trust what the store already
+// holds. Ingest writes a tree only after every object that tree names, so
+// a tree in the store normally means its blobs are there too and the work
+// behind it can be skipped.
+type IngestMode int
+
+const (
+	// IngestCached takes that shortcut, and is where every fetch starts.
+	IngestCached IngestMode = iota
+
+	// IngestRepair skips no work, re-ingesting from the source so that
+	// objects missing from the store are written again. [CAS.FetchSource]
+	// switches to it for a single retry after a [MissingObjectError].
+	IngestRepair
+)
+
+// trustsStoreHits reports whether m may skip work the store appears to
+// have done already.
+func (m IngestMode) trustsStoreHits() bool {
+	return m == IngestCached
+}
+
 // SourceFetcher downloads and ingests a source into CAS, returning the
 // tree-store key the materialized tree was written under.
 //
@@ -56,8 +78,14 @@ type SourceResolver interface {
 // produced none. Fetchers that learn the canonical key only after
 // downloading (the git rev-parse path) may ignore it and return the
 // canonical key instead.
+//
+// mode is [IngestRepair] when the store turned out to be missing an
+// object and this call is the attempt to restore it. A fetcher that
+// downloads and re-ingests everything it is handed needs no special
+// handling, since storing content checks the store per object anyway; a
+// fetcher carrying store shortcuts of its own must skip them.
 type SourceFetcher func(
-	ctx context.Context, l log.Logger, v *venv.Venv, suggestedKey string,
+	ctx context.Context, l log.Logger, v *venv.Venv, suggestedKey string, mode IngestMode,
 ) (treeKey string, err error)
 
 // ProbeCaching says which layer consults and records the probe cache for
@@ -103,6 +131,12 @@ type SourceRequest struct {
 // cached tree into opts.Dir without invoking Fetch. On a probe miss it
 // calls Fetch and links the resulting tree.
 //
+// A store that turns out to be missing an object the cached tree names
+// costs one extra pass: src is ingested again under [IngestRepair], which
+// writes the missing object back, and the link is retried. The second
+// failure is returned as it stands, so a source that can no longer supply
+// the object reports [MissingObjectError] rather than looping.
+//
 // opts.Dir is the destination. opts.Mutable selects copy vs hardlink
 // for the final link, matching the git path.
 //
@@ -146,22 +180,65 @@ func (c *CAS) FetchSource(
 				return err
 			}
 
-			if suggestedKey != "" && !c.treeStore.NeedsWrite(v, suggestedKey) {
-				recordFetchOutcome(childCtx, true)
+			err = c.fetchAndLink(childCtx, l, v, opts, src, suggestedKey, IngestCached)
 
-				return c.linkStoredTree(childCtx, l, v, opts, suggestedKey)
+			var missing *MissingObjectError
+			if !errors.As(err, &missing) {
+				return err
 			}
 
-			recordFetchOutcome(childCtx, false)
+			l.Warnf(
+				"cas: store is missing object %s, re-ingesting %s to restore it",
+				missing.Hash,
+				RedactURL(src.URL),
+			)
+			RecordFallback(childCtx, l, FallbackReasonStoreRepair, map[string]any{
+				"url":    RedactURL(src.URL),
+				"scheme": src.Scheme,
+				"hash":   missing.Hash,
+			})
 
-			treeKey, err := src.Fetch(childCtx, l, v, suggestedKey)
-			if err != nil {
-				return fmt.Errorf("fetch %s: %w", RedactURL(src.URL), err)
+			// One attempt. A source that answered the re-ingest without
+			// producing the object cannot produce it on a third pass
+			// either, so the second failure is the one the caller sees.
+			if err := c.fetchAndLink(
+				childCtx, l, v, opts, src, suggestedKey, IngestRepair,
+			); err != nil {
+				return fmt.Errorf("re-ingest %s: %w", RedactURL(src.URL), err)
 			}
 
-			return c.linkStoredTree(childCtx, l, v, opts, treeKey)
+			return nil
 		},
 	)
+}
+
+// fetchAndLink ingests src unless the store already holds the tree
+// suggestedKey names, then materializes that tree into opts.Dir. Under
+// [IngestRepair] the store hit is passed over, so the fetcher runs and
+// writes back whatever the store has lost.
+func (c *CAS) fetchAndLink(
+	ctx context.Context,
+	l log.Logger,
+	v *venv.Venv,
+	opts *CloneOptions,
+	src SourceRequest,
+	suggestedKey string,
+	mode IngestMode,
+) error {
+	if mode.trustsStoreHits() && suggestedKey != "" && !c.treeStore.NeedsWrite(v, suggestedKey) {
+		recordFetchOutcome(ctx, true)
+
+		return c.linkStoredTree(ctx, l, v, opts, suggestedKey)
+	}
+
+	recordFetchOutcome(ctx, false)
+
+	treeKey, err := src.Fetch(ctx, l, v, suggestedKey, mode)
+	if err != nil {
+		return fmt.Errorf("fetch %s: %w", RedactURL(src.URL), err)
+	}
+
+	return c.linkStoredTree(ctx, l, v, opts, treeKey)
 }
 
 // ContentKey derives a cache key for a probe token that is a content

--- a/internal/cas/source_probecache_test.go
+++ b/internal/cas/source_probecache_test.go
@@ -276,3 +276,55 @@ func fetchThroughNewCAS(
 			Fetch:    fakeFetcher(c, map[string]string{"main.tf": "# hello"}, &fetchCalls),
 		})
 }
+
+// TestFetchSourceOfflineRefusesRepair pins that a store missing an object
+// behind a recorded probe fails an offline run by naming the object, not
+// by re-ingesting from the remote the flag forbids and not as a miss for
+// content that was in fact fetched.
+func TestFetchSourceOfflineRefusesRepair(t *testing.T) {
+	t.Parallel()
+
+	storePath := filepath.Join(helpers.TmpDirWOSymlinks(t), "store")
+	v := venvtest.NewOSWithEmptyEnv()
+	l := logger.CreateLogger()
+
+	key := cas.OpaqueKey("http", probeCacheTestURL, "etag-abc")
+	resolver := &fakeResolver{scheme: "http", key: key}
+
+	c, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithProbeCache())
+	require.NoError(t, err)
+
+	var fetchCalls atomic.Int32
+
+	files := map[string]string{"main.tf": "# hello"}
+	require.NoError(t, c.FetchSource(t.Context(), l, v, &cas.CloneOptions{Dir: filepath.Join(t.TempDir(), "dst1")},
+		cas.SourceRequest{
+			Scheme:   "http",
+			URL:      probeCacheTestURL,
+			Resolver: resolver,
+			Fetch:    fakeFetcher(c, files, &fetchCalls),
+		}))
+	require.NoError(t, v.FS.Remove(storedBlobPath(t, c, v, key, "main.tf")))
+
+	offline, err := cas.New(venvtest.NewWithOSFS(), cas.WithStorePath(storePath), cas.WithOffline())
+	require.NoError(t, err)
+
+	err = offline.FetchSource(t.Context(), l, v, &cas.CloneOptions{Dir: filepath.Join(t.TempDir(), "dst2")},
+		cas.SourceRequest{
+			Scheme:   "http",
+			URL:      probeCacheTestURL,
+			Resolver: resolver,
+			Fetch:    fakeFetcher(offline, files, &fetchCalls),
+		})
+
+	var refused *cas.OfflineRepairError
+
+	require.ErrorAs(t, err, &refused)
+	require.NotErrorIs(t, err, cas.ErrCASOffline)
+	assert.Equal(t, probeCacheTestURL, refused.Source)
+
+	var missing *cas.MissingObjectError
+
+	require.ErrorAs(t, err, &missing)
+	assert.Equal(t, int32(1), fetchCalls.Load(), "the offline run must not re-ingest the source")
+}

--- a/internal/cas/source_test.go
+++ b/internal/cas/source_test.go
@@ -357,7 +357,13 @@ func (f *fakeResolver) Probe(_ context.Context, _ string) (string, error) {
 // ingests it into CAS via IngestDirectory, and returns the resulting
 // tree key. It counts invocations for assertions.
 func fakeFetcher(c *cas.CAS, files map[string]string, calls *atomic.Int32) cas.SourceFetcher {
-	return func(_ context.Context, l log.Logger, v *venv.Venv, suggestedKey string) (string, error) {
+	return func(
+		_ context.Context,
+		l log.Logger,
+		v *venv.Venv,
+		suggestedKey string,
+		_ cas.IngestMode,
+	) (string, error) {
 		calls.Add(1)
 
 		tempDir, cleanup, err := c.MakeFetchTempDir(l, v)

--- a/internal/cas/telemetry.go
+++ b/internal/cas/telemetry.go
@@ -34,6 +34,11 @@ const (
 	// tree and re-downloaded the source.
 	FallbackReasonProbeFailure FallbackReason = "probe_failure"
 
+	// FallbackReasonStoreRepair reports that an object a stored tree
+	// names was missing from the store, so [CAS.FetchSource] re-ingested
+	// the source to restore it instead of trusting the cached tree.
+	FallbackReasonStoreRepair FallbackReason = "store_repair"
+
 	// FallbackReasonStackGenerationError reports that CAS-backed stack
 	// generation failed for a component, falling back to the standard
 	// copy or getter path.

--- a/internal/cas/tree.go
+++ b/internal/cas/tree.go
@@ -329,6 +329,11 @@ func (tl *treeLinker) submodule(v *venv.Venv, work *treeWork) ([]treeWork, error
 	// created up front: a gitlink with no stored tree had no .gitmodules
 	// entry to fetch it by, and `git clone` leaves an empty directory there
 	// too.
+	//
+	// Which is also why a submodule tree deleted from the store reads as that
+	// same skip and leaves an empty directory rather than a
+	// [MissingObjectError] that repair could act on. Telling the two apart
+	// needs the .gitmodules blob parsed here, at materialization time.
 	if err := v.FS.MkdirAll(work.path, DefaultDirPerms); err != nil {
 		return nil, fmt.Errorf("mkdir submodule %s: %w", work.path, err)
 	}

--- a/internal/getter/casgetter.go
+++ b/internal/getter/casgetter.go
@@ -475,8 +475,18 @@ func (g *CASGetter) getGeneric(ctx context.Context, req *getter.Request) error {
 // s3 and gcs getters reject `http://`/`gs://` URLs unless Forced matches
 // their validScheme; without this the inner client falls through with a
 // generic "error downloading".
+//
+// The ingest mode is ignored: this shape downloads and re-ingests every
+// time it runs, and ingesting content already writes each object the
+// store lacks, so a repair pass needs nothing extra from it.
 func (g *CASGetter) buildInnerFetch(bare getter.Getter, scheme, urlStr string) cas.SourceFetcher {
-	return func(ctx context.Context, l log.Logger, v *venv.Venv, suggestedKey string) (string, error) {
+	return func(
+		ctx context.Context,
+		l log.Logger,
+		v *venv.Venv,
+		suggestedKey string,
+		_ cas.IngestMode,
+	) (string, error) {
 		tempDir, cleanup, err := g.CAS.MakeFetchTempDir(l, v)
 		if err != nil {
 			return "", err

--- a/internal/runner/run/download_source_test.go
+++ b/internal/runner/run/download_source_test.go
@@ -1329,6 +1329,10 @@ func TestDownloadSourceWithCASOfflineDamagedStoreFails(t *testing.T) {
 	require.Error(t, err)
 	require.NotErrorIs(t, err, cas.ErrCASOffline, "the probe is answered; the store fails on the content behind it")
 
+	var refused *cas.OfflineRepairError
+
+	require.ErrorAs(t, err, &refused, "the flag forbids the re-ingest that would repair the store")
+
 	assert.NoFileExists(t, filepath.Join(offline.DownloadDir, "main.tf"), "the standard getter must not have fetched the source")
 }
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Adds graceful restoration logic to repair broken trees when attempting to link a blob that is no longer present, but referenced by a tree.

Right now, Terragrunt assumes that if a blob referenced by a tree is missing, there's nothing that it can do, and users have to manually intervene by wiping their CAS. This adds one layer of graceful fallback, allowing the clone to attempt recovery by re-fetching the source on failed linking. This protects against users manually removing blobs from their stores without properly clearing out the trees that reference them, corrupting the store.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cached source content is now automatically refetched when required content has been deleted.
  * Improved recovery for missing cached files, including safer concurrent repairs and preservation of included Git files.
  * Error messages now identify missing content and its expected location more clearly.
  * Direct `cas::` references and sources unable to provide missing content continue to fail with detailed missing-object information.
  * Offline fetches now report clearer errors and refuse repairs when remote content cannot be accessed.

* **Documentation**
  * Added release documentation describing the updated recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->