### PR TITLE
fix(s3): support ACL-disabled access-logging buckets via bucket policy

### DIFF
--- a/internal/remotestate/backend/s3/access_logging_test.go
+++ b/internal/remotestate/backend/s3/access_logging_test.go
@@ -1,0 +1,121 @@
+package s3
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/require"
+)
+
+// mockS3Transport is an http.RoundTripper that fakes the AWS endpoints the
+// access-logging fallback touches: STS GetCallerIdentity (for partition
+// lookup), S3 PutBucketAcl, GetBucketPolicy and PutBucketPolicy.
+type mockS3Transport struct {
+	mu                sync.Mutex
+	putBucketAclCalls int
+	putPolicyCalls    int
+	lastPolicy        string
+}
+
+func (m *mockS3Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body string
+
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Body.Close()
+
+		body = string(b)
+	}
+
+	// STS GetCallerIdentity is a form-encoded POST whose body carries the action.
+	if strings.Contains(body, "GetCallerIdentity") {
+		return m.xmlResponse(http.StatusOK, `<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult>
+    <Arn>arn:aws:iam::123456789012:user/test-user</Arn>
+    <UserId>AIDATESTUSER</UserId>
+    <Account>123456789012</Account>
+  </GetCallerIdentityResult>
+  <ResponseMetadata>
+    <RequestId>11111111-1111-1111-1111-111111111111</RequestId>
+  </ResponseMetadata>
+</GetCallerIdentityResponse>`), nil
+	}
+
+	query := req.URL.Query()
+
+	switch {
+	case req.Method == http.MethodPut && query.Has("acl"):
+		m.mu.Lock()
+		m.putBucketAclCalls++
+		m.mu.Unlock()
+
+		return m.xmlResponse(http.StatusBadRequest, `<Error><Code>AccessControlListNotSupported</Code><Message>The bucket does not allow ACLs</Message><RequestId>test-request-id</RequestId></Error>`), nil
+
+	case req.Method == http.MethodGet && query.Has("policy"):
+		return m.xmlResponse(http.StatusNotFound, `<Error><Code>NoSuchBucketPolicy</Code><Message>The bucket policy does not exist</Message><RequestId>test-request-id</RequestId></Error>`), nil
+
+	case req.Method == http.MethodPut && query.Has("policy"):
+		m.mu.Lock()
+		m.putPolicyCalls++
+		m.lastPolicy = body
+		m.mu.Unlock()
+
+		return m.xmlResponse(http.StatusOK, ``), nil
+	}
+
+	return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.String())
+}
+
+func (m *mockS3Transport) xmlResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Header:     http.Header{"Content-Type": []string{"application/xml"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestConfigureBucketAccessLoggingACLFallsBackToBucketPolicy(t *testing.T) {
+	t.Parallel()
+
+	transport := &mockS3Transport{}
+
+	cfg := aws.Config{
+		Region:      "us-east-1",
+		Credentials: credentials.NewStaticCredentialsProvider("AKID", "SECRET", ""),
+		HTTPClient:  &http.Client{Transport: transport},
+	}
+
+	s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.UsePathStyle = true
+	})
+
+	client := &Client{
+		s3Client:  s3Client,
+		awsConfig: cfg,
+	}
+
+	l := logger.CreateLogger()
+
+	err := client.configureBucketAccessLoggingACL(t.Context(), l, "my-logs-bucket")
+	require.NoError(t, err)
+
+	require.Equal(t, 1, transport.putBucketAclCalls, "PutBucketAcl should be attempted once")
+	require.Equal(t, 1, transport.putPolicyCalls, "PutBucketPolicy should be called as the fallback")
+
+	require.Contains(t, transport.lastPolicy, `"Service":"logging.s3.amazonaws.com"`)
+	require.Contains(t, transport.lastPolicy, `"s3:PutObject"`)
+	require.Contains(t, transport.lastPolicy, `"arn:aws:s3:::my-logs-bucket/*"`)
+}

--- a/internal/remotestate/backend/s3/client.go
+++ b/internal/remotestate/backend/s3/client.go
@@ -24,8 +24,9 @@ import (
 )
 
 const (
-	SidRootPolicy        = "RootAccess"
-	SidEnforcedTLSPolicy = "EnforcedTLS"
+	SidRootPolicy          = "RootAccess"
+	SidEnforcedTLSPolicy   = "EnforcedTLS"
+	SidAccessLoggingPolicy = "AccessLogging"
 
 	s3TimeBetweenRetries  = 5 * time.Second
 	s3MaxRetries          = 3
@@ -1327,6 +1328,17 @@ func (client *Client) configureBucketAccessLoggingACL(
 	}
 
 	if _, err := client.s3Client.PutBucketAcl(ctx, &aclInput); err != nil {
+		var apiErr smithy.APIError
+
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessControlListNotSupported" {
+			l.Warnf(
+				"Bucket %s does not support ACLs (object ownership is enforced). Falling back to a bucket policy to grant S3 Log Delivery access for server access logging.",
+				bucketName,
+			)
+
+			return client.configureBucketAccessLoggingPolicy(ctx, l, bucketName)
+		}
+
 		return fmt.Errorf(
 			"error granting WRITE and READ_ACP permissions to S3 Log Delivery (%s) for bucket %s: %w",
 			s3LogDeliveryGranteeURI,
@@ -1336,6 +1348,88 @@ func (client *Client) configureBucketAccessLoggingACL(
 	}
 
 	return client.waitUntilBucketHasAccessLoggingACL(ctx, l, bucketName)
+}
+
+// configureBucketAccessLoggingPolicy grants the S3 Log Delivery service permission to write server access logs
+// to the access logging bucket via a bucket policy. This is required when the bucket has ACLs disabled
+// (Object Ownership set to BucketOwnerEnforced), because the Log Delivery group ACL grant used by
+// configureBucketAccessLoggingACL is rejected with AccessControlListNotSupported.
+//
+// See https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-ownership-migrating-acls-prerequisites.html#object-ownership-server-access-logs
+func (client *Client) configureBucketAccessLoggingPolicy(
+	ctx context.Context,
+	l log.Logger,
+	bucketName string,
+) error {
+	l.Debugf(
+		"Granting s3:PutObject to the S3 Log Delivery service via a bucket policy for bucket %s. This is required for access logging when ACLs are disabled.",
+		bucketName,
+	)
+
+	partition, err := awshelper.GetAWSPartition(ctx, &client.awsConfig)
+	if err != nil {
+		return fmt.Errorf("error getting AWS partition for bucket %s: %w", bucketName, err)
+	}
+
+	policyOutput, err := client.s3Client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		l.Debugf("Policy does not exist for bucket %s", bucketName)
+	}
+
+	var policyInBucket awshelper.Policy
+
+	if policyOutput != nil && policyOutput.Policy != nil {
+		policyInBucket, err = awshelper.UnmarshalPolicy(*policyOutput.Policy)
+		if err != nil {
+			return fmt.Errorf("error unmarshalling policy for bucket %s: %w", bucketName, err)
+		}
+	}
+
+	// Ensure Statement is never nil to avoid nil pointer dereference
+	if policyInBucket.Statement == nil {
+		policyInBucket.Statement = []awshelper.Statement{}
+	}
+
+	for _, statement := range policyInBucket.Statement {
+		if statement.Sid == SidAccessLoggingPolicy {
+			l.Debugf("Policy for access logging already exists for bucket %s", bucketName)
+
+			return nil
+		}
+	}
+
+	accessLoggingPolicy := awshelper.Policy{
+		Version: "2012-10-17",
+		Statement: []awshelper.Statement{
+			{
+				Sid:       SidAccessLoggingPolicy,
+				Effect:    "Allow",
+				Action:    "s3:PutObject",
+				Resource:  "arn:" + partition + ":s3:::" + bucketName + "/*",
+				Principal: map[string]string{"Service": "logging.s3.amazonaws.com"},
+			},
+		},
+	}
+
+	accessLoggingPolicy.Statement = append(accessLoggingPolicy.Statement, policyInBucket.Statement...)
+
+	policy, err := awshelper.MarshalPolicy(accessLoggingPolicy)
+	if err != nil {
+		return fmt.Errorf("error marshalling policy for bucket %s: %w", bucketName, err)
+	}
+
+	if _, err = client.s3Client.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{
+		Bucket: aws.String(bucketName),
+		Policy: aws.String(string(policy)),
+	}); err != nil {
+		return fmt.Errorf("error putting access logging policy for bucket %s: %w", bucketName, err)
+	}
+
+	l.Debugf("Enabled access logging policy for bucket %s", bucketName)
+
+	return nil
 }
 
 func (client *Client) waitUntilBucketHasAccessLoggingACL(


### PR DESCRIPTION
## What this does

When an S3 access-logging bucket has Object Ownership set to `BucketOwnerEnforced` (ACLs disabled), the Log Delivery group ACL grant in `configureBucketAccessLoggingACL` fails with `AccessControlListNotSupported`, which aborts `terragrunt backend bootstrap`.

This PR falls back to a bucket policy in that case, granting the S3 Log Delivery service (`logging.s3.amazonaws.com`) `s3:PutObject` on the log bucket, following the guidance in the AWS docs:

https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-ownership-migrating-acls-prerequisites.html#object-ownership-server-access-logs

The policy statement uses a stable `Sid` (`AccessLogging`) so it is idempotent and preserves any existing bucket policy statements.

## Why

ACL usage is discouraged by AWS, and buckets created with the now-default `BucketOwnerEnforced` ownership can no longer accept the `PutBucketAcl` grant. Access logging should keep working on those buckets.

## Testing

Added a unit test (`TestConfigureBucketAccessLoggingACLFallsBackToBucketPolicy`) that mocks the AWS SDK HTTP layer so `PutBucketAcl` returns `AccessControlListNotSupported` and asserts that `PutBucketPolicy` is called with the expected principal, action, and resource.

Fixes #6875.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - S3 server access logging now supports buckets configured with Bucket Owner Enforced object ownership.
  - When ACL-based configuration is unavailable, access logging automatically falls back to a bucket policy.
  - Existing bucket policy statements are preserved, and duplicate access-logging permissions are avoided.
- **Bug Fixes**
  - Prevented access-logging configuration from failing when bucket ACLs are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->