### PR TITLE
fix: Preventing Windows flag usage panic in tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -365,7 +365,7 @@ jobs:
           echo "Failed Tests in ${{ matrix.integration.name }}"
           if [[ -f test_output.log ]]; then
             # Count only test failure lines in a way that is safe with -e -o pipefail
-            failed_count=$(grep -E -c '^--- FAIL:' test_output.log || echo 0)
+            failed_count=$(grep -E -c '^--- FAIL:' test_output.log || true)
             echo "Failed tests count: $failed_count"
             if [[ "${failed_count}" -gt 0 ]]; then
               echo "Failed test names:"

--- a/internal/clihelper/flag.go
+++ b/internal/clihelper/flag.go
@@ -215,6 +215,11 @@ func (flag *flagValue) Set(str string) error {
 }
 
 func (flag *flagValue) String() string {
+	// The stdlib flag package calls String on a zero flagValueGetter when printing usage, and its embedded *flagValue is nil.
+	if flag == nil {
+		return ""
+	}
+
 	if val := flag.value.Get(); val == nil {
 		return ""
 	}

--- a/internal/clihelper/flag_test.go
+++ b/internal/clihelper/flag_test.go
@@ -3,6 +3,7 @@ package clihelper_test
 import (
 	libflag "flag"
 	"io"
+	"reflect"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
@@ -50,4 +51,39 @@ func TestApplyFlagPanicsOnUnsetEnv(t *testing.T) {
 	assert.PanicsWithError(t, clihelper.ErrEnvUnset.Error(), func() {
 		require.NoError(t, flag.Apply(set, nil))
 	})
+}
+
+// TestFlagZeroValueStringDoesNotPanic mirrors stdlib flag's isZeroValue, which calls String on a zero value of
+// each registered type whenever a FlagSet prints usage, including on every parse error.
+func TestFlagZeroValueStringDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		flag clihelper.Flag
+		name string
+	}{
+		{name: "bool", flag: &clihelper.BoolFlag{Name: "foo"}},
+		{name: "generic", flag: &clihelper.GenericFlag[string]{Name: "foo"}},
+		{name: "slice", flag: &clihelper.SliceFlag[string]{Name: "foo"}},
+		{name: "map", flag: &clihelper.MapFlag[string, string]{Name: "foo"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			set := libflag.NewFlagSet("test-cmd", libflag.ContinueOnError)
+			set.SetOutput(io.Discard)
+
+			require.NoError(t, tc.flag.Apply(set, map[string]string{}))
+
+			registered := set.Lookup("foo")
+			require.NotNil(t, registered)
+
+			zero, ok := reflect.New(reflect.TypeOf(registered.Value).Elem()).Interface().(libflag.Value)
+			require.True(t, ok)
+
+			assert.NotPanics(t, func() { assert.Empty(t, zero.String()) })
+		})
+	}
 }


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Noticed a panic in a Windows test that this should solve.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line usage rendering to safely handle uninitialized flag values without errors.
  * Fixed integration test reporting so zero failed tests are recorded correctly when no failures are found.

* **Tests**
  * Added coverage for safe handling of zero-value flags across supported flag types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->