### PR TITLE
docs(changelog): note report Cause for prerun failures

### DIFF
--- a/docs/src/data/changelog/v1.1.5/run-report-prerun-cause.mdx
+++ b/docs/src/data/changelog/v1.1.5/run-report-prerun-cause.mdx
@@ -1,0 +1,12 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### Run report includes cause for units that fail before OpenTofu/Terraform
+
+Units that failed during config evaluation or dependency output resolution were
+reported as a run error with an empty cause. The report now records the
+underlying error text in `Cause`.
+
+Thanks to [@Tensho](https://github.com/Tensho) for contributing this fix!


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes #000.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a v1.1.5 changelog entry documenting improved error reporting: failures during configuration evaluation or dependency output resolution now include the underlying error details in the `Cause` field instead of leaving it empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->