### PR TITLE
chore: Globally replacing `xsync.Map` with a map and mutex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.3
-	github.com/puzpuzpuz/xsync/v4 v4.5.0
 	github.com/rogpeppe/go-internal v1.16.0
 	github.com/sirupsen/logrus v1.10.2
 	github.com/spf13/afero v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -866,8 +866,6 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
-github.com/puzpuzpuz/xsync/v4 v4.5.0 h1:vOSWu6b57/emh+L/Cw0BeQfvxa/cogFywXHeGUxQxAg=
-github.com/puzpuzpuz/xsync/v4 v4.5.0/go.mod h1:VJDmTCJMBt8igNxnkQd86r+8KUeN1quSfNKu5bLYFQo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/internal/cli/flags/shared/feature.go
+++ b/internal/cli/flags/shared/feature.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"maps"
 
 	"github.com/gruntwork-io/terragrunt/internal/cli/flags"
 	"github.com/gruntwork-io/terragrunt/internal/clihelper"
@@ -24,9 +25,7 @@ func NewFeatureFlags(opts *options.TerragruntOptions, prefix flags.Prefix) clihe
 			Usage:   "Set feature flags for the HCL code.",
 			// Use default splitting behavior with comma separators via MapFlag defaults
 			Action: func(_ context.Context, _ *clihelper.Context, value map[string]string) error {
-				for key, val := range value {
-					opts.FeatureFlags.Store(key, val)
-				}
+				maps.Copy(opts.FeatureFlags, value)
 
 				return nil
 			},

--- a/internal/configbridge/copy_test.go
+++ b/internal/configbridge/copy_test.go
@@ -77,9 +77,7 @@ func TestNewParsingContextCopiesEveryOption(t *testing.T) {
 	assert.Equal(t, opts.TerragruntStackConfigPath, pctx.TerragruntStackConfigPath)
 	assert.Equal(t, opts.ProviderCacheOptions, pctx.ProviderCacheOptions)
 
-	require.NotNil(t, pctx.FeatureFlags)
-
-	flag, ok := pctx.FeatureFlags.Load("region")
+	flag, ok := pctx.FeatureFlags["region"]
 	require.True(t, ok, "feature flags supplied on the CLI must reach config parsing")
 	assert.Equal(t, "us-east-1", flag)
 }
@@ -165,9 +163,7 @@ func TestNewRunOptionsCopiesEveryOption(t *testing.T) {
 	assert.True(t, runOpts.NoCAS)
 	assert.True(t, runOpts.NoHooks, "NoHooks is fed by NoRunHooks, so before/after hooks stay disabled when asked")
 
-	require.NotNil(t, runOpts.FeatureFlags)
-
-	flag, ok := runOpts.FeatureFlags.Load("region")
+	flag, ok := runOpts.FeatureFlags["region"]
 	require.True(t, ok, "feature flags supplied on the CLI must reach the runner")
 	assert.Equal(t, "us-east-1", flag)
 }
@@ -278,7 +274,7 @@ func optionsWithDistinctValues(t *testing.T) *options.TerragruntOptions {
 	require.NoError(t, err)
 	require.NoError(t, opts.Experiments.EnableExperiment(experiment.Stacks))
 
-	opts.FeatureFlags.Store("region", "us-east-1")
+	opts.FeatureFlags["region"] = "us-east-1"
 
 	opts.TerragruntConfigPath = "/copy/unit/terragrunt.hcl"
 	opts.OriginalTerragruntConfigPath = "/copy/original/terragrunt.hcl"

--- a/internal/remotestate/backend/common.go
+++ b/internal/remotestate/backend/common.go
@@ -6,22 +6,22 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/venv"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/puzpuzpuz/xsync/v4"
 )
 
 var _ Backend = new(CommonBackend)
 
 type CommonBackend struct {
-	bucketLocks   *xsync.Map[string, *sync.Mutex]
-	initedConfigs *xsync.Map[string, bool]
+	bucketLocks   map[string]*sync.Mutex
+	initedConfigs map[string]struct{}
 	name          string
+	mu            sync.Mutex
 }
 
 func NewCommonBackend(name string) *CommonBackend {
 	return &CommonBackend{
 		name:          name,
-		bucketLocks:   xsync.NewMap[string, *sync.Mutex](),
-		initedConfigs: xsync.NewMap[string, bool](),
+		bucketLocks:   make(map[string]*sync.Mutex),
+		initedConfigs: make(map[string]struct{}),
 	}
 }
 
@@ -111,19 +111,34 @@ func (backend *CommonBackend) GetTFInitArgs(config Config) map[string]any {
 }
 
 func (backend *CommonBackend) GetBucketMutex(bucketName string) *sync.Mutex {
-	mu, _ := backend.bucketLocks.LoadOrCompute(bucketName, func() (*sync.Mutex, bool) {
-		return new(sync.Mutex), false
-	})
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
 
-	return mu
+	bucketMu, ok := backend.bucketLocks[bucketName]
+	if !ok {
+		bucketMu = new(sync.Mutex)
+		backend.bucketLocks[bucketName] = bucketMu
+	}
+
+	return bucketMu
 }
 
 func (backend *CommonBackend) IsConfigInited(config interface{ CacheKey() string }) bool {
-	status, ok := backend.initedConfigs.Load(config.CacheKey())
+	key := config.CacheKey()
 
-	return ok && status
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+
+	_, ok := backend.initedConfigs[key]
+
+	return ok
 }
 
 func (backend *CommonBackend) MarkConfigInited(config interface{ CacheKey() string }) {
-	backend.initedConfigs.Store(config.CacheKey(), true)
+	key := config.CacheKey()
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+
+	backend.initedConfigs[key] = struct{}{}
 }

--- a/internal/remotestate/backend/common_test.go
+++ b/internal/remotestate/backend/common_test.go
@@ -1,0 +1,73 @@
+package backend_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/remotestate/backend"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCommonBackendBootstrapsEachBucketOnceWithRacing pins that parallel callers sharing a
+// bucket run its bootstrap once. Each caller follows the remote state backends: it locks the
+// bucket mutex, returns if the config is inited, and otherwise bootstraps and marks it.
+// Two buckets run side by side, so init marks for different buckets are written concurrently.
+func TestCommonBackendBootstrapsEachBucketOnceWithRacing(t *testing.T) {
+	t.Parallel()
+
+	const callersPerBucket = 8
+
+	var (
+		start   = make(chan struct{})
+		group   sync.WaitGroup
+		buckets = []string{"bucket-a", "bucket-b"}
+	)
+
+	common := backend.NewCommonBackend("test")
+	bootstraps := make([]atomic.Int32, len(buckets))
+	mutexes := make([][]*sync.Mutex, len(buckets))
+
+	for b, bucket := range buckets {
+		mutexes[b] = make([]*sync.Mutex, callersPerBucket)
+
+		for i := range callersPerBucket {
+			group.Go(func() {
+				<-start
+
+				mu := common.GetBucketMutex(bucket)
+				mutexes[b][i] = mu
+
+				mu.Lock()
+				defer mu.Unlock()
+
+				cfg := bucketCacheKey(bucket)
+				if common.IsConfigInited(cfg) {
+					return
+				}
+
+				bootstraps[b].Add(1)
+				common.MarkConfigInited(cfg)
+			})
+		}
+	}
+
+	close(start)
+	group.Wait()
+
+	for b, bucket := range buckets {
+		assert.Equalf(t, int32(1), bootstraps[b].Load(), "bucket %s", bucket)
+
+		for i, mu := range mutexes[b] {
+			assert.Samef(t, mutexes[b][0], mu, "bucket %s caller %d", bucket, i)
+		}
+	}
+
+	assert.NotSame(t, mutexes[0][0], mutexes[1][0], "each bucket must get its own mutex")
+}
+
+type bucketCacheKey string
+
+func (key bucketCacheKey) CacheKey() string {
+	return string(key)
+}

--- a/internal/runner/controller.go
+++ b/internal/runner/controller.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/queue"
 	"github.com/gruntwork-io/terragrunt/internal/telemetry"
 
-	"github.com/puzpuzpuz/xsync/v4"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -28,7 +27,7 @@ type Controller struct {
 	runner      UnitRunnerFunc
 	readyCh     chan struct{}
 	unitsMap    map[string]*component.Unit
-	unitErrs    *xsync.Map[string, error]
+	unitErrs    map[string]error
 	concurrency int
 }
 
@@ -57,8 +56,7 @@ func WithMaxConcurrency(concurrency int) ControllerOption {
 // or nil if the unit did not run or succeeded. It must not be called while Run
 // is still executing.
 func (dr *Controller) UnitErr(path string) error {
-	err, _ := dr.unitErrs.Load(path)
-	return err
+	return dr.unitErrs[path]
 }
 
 // NewController creates a new Controller with the given options and a pre-built queue, which must not be nil.
@@ -67,7 +65,6 @@ func NewController(q *queue.Queue, units []*component.Unit, opts ...ControllerOp
 		q:           q,
 		readyCh:     make(chan struct{}, 1), // buffered to avoid blocking
 		concurrency: options.DefaultParallelism,
-		unitErrs:    xsync.NewMap[string, error](),
 	}
 	unitsMap := make(map[string]*component.Unit)
 
@@ -95,15 +92,23 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 			"ignore_dependency_order": dr.q.IgnoreDependencyOrder,
 		}, func(childCtx context.Context, l log.Logger) error {
 			var (
-				wg  sync.WaitGroup
-				sem = make(chan struct{}, dr.concurrency)
+				wg        sync.WaitGroup
+				resultsMu sync.Mutex
+				sem       = make(chan struct{}, dr.concurrency)
 			)
 
 			// Fresh map per execution, kept on the controller after Run returns:
 			// the report sweep must read only this execution's errors, never
 			// stale ones from a prior Run on the same controller.
-			results := xsync.NewMap[string, error]()
+			results := make(map[string]error)
 			dr.unitErrs = results
+
+			recordResult := func(path string, err error) {
+				resultsMu.Lock()
+				defer resultsMu.Unlock()
+
+				results[path] = err
+			}
 
 			if dr.runner == nil {
 				return ErrRunnerNotSet
@@ -157,13 +162,13 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 								ent.Component.Path(),
 							)
 							dr.q.FailEntry(ent)
-							results.Store(ent.Component.Path(), err)
+							recordResult(ent.Component.Path(), err)
 
 							return
 						}
 
 						err := dr.runner(childCtx, unit)
-						results.Store(ent.Component.Path(), err)
+						recordResult(ent.Component.Path(), err)
 
 						if err != nil {
 							l.Debugf("Runner Pool Controller: %s failed", ent.Component.Path())
@@ -211,7 +216,7 @@ func (dr *Controller) Run(ctx context.Context, l log.Logger) error {
 					// Non-terminal states are not counted in the summary.
 				}
 
-				if err, ok := results.Load(entry.Component.Path()); ok {
+				if err, ok := results[entry.Component.Path()]; ok {
 					if err == nil {
 						continue
 					}

--- a/internal/runner/run/options.go
+++ b/internal/runner/run/options.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/puzpuzpuz/xsync/v4"
-
 	"errors"
 
 	"github.com/gruntwork-io/terragrunt/internal/cloner"
@@ -47,7 +45,7 @@ type Options struct {
 	EngineConfig                 *engine.EngineConfig
 	EngineOptions                *engine.EngineOptions
 	Errors                       *errorconfig.Config
-	FeatureFlags                 *xsync.Map[string, string]
+	FeatureFlags                 map[string]string
 	Telemetry                    *telemetry.Options
 	SourceMap                    map[string]string
 	TFPath                       string

--- a/internal/stacks/output/output.go
+++ b/internal/stacks/output/output.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 
 	"errors"
 
@@ -21,7 +22,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
-	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -117,7 +117,9 @@ func StackOutput(
 		return cty.NilVal, nil
 	}
 
-	outputs := xsync.NewMap[string, map[string]cty.Value]()
+	var outputsMu sync.Mutex
+
+	outputs := make(map[string]map[string]cty.Value)
 	declaredStacks := make(map[string][]string)
 	declaredUnits := make(map[string]*config.Unit)
 	parsedStackFiles := make(map[string]*config.StackConfig, len(foundFiles))
@@ -198,7 +200,9 @@ func StackOutput(
 					return err
 				}
 
-				outputs.Store(key, out)
+				outputsMu.Lock()
+				outputs[key] = out
+				outputsMu.Unlock()
 
 				return nil
 			})
@@ -212,7 +216,7 @@ func StackOutput(
 	collected := make([]UnitOutput, 0, len(declaredUnits))
 
 	for path, unit := range declaredUnits {
-		output, found := outputs.Load(path)
+		output, found := outputs[path]
 		if !found {
 			l.Debugf("No output found for %s", path)
 			continue

--- a/internal/tf/cache/handlers/common_provider.go
+++ b/internal/tf/cache/handlers/common_provider.go
@@ -3,11 +3,11 @@ package handlers
 
 import (
 	"context"
+	"sync"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cache/models"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/puzpuzpuz/xsync/v4"
 )
 
 type CommonProviderHandler struct {
@@ -15,13 +15,13 @@ type CommonProviderHandler struct {
 	httpClient vhttp.Client
 
 	// discoveryURLCache stores discovered registry URLs
-	// We use [xsync.Map](https://github.com/puzpuzpuz/xsync?tab=readme-ov-file#map)
-	// instead of standard `sync.Map` since it's faster and has generic types.
-	discoveryURLCache *xsync.Map[string, *RegistryURLs]
+	discoveryURLCache map[string]*RegistryURLs
 
 	// includeProviders and excludeProviders are sets of provider matching patterns that together define which providers are eligible to be potentially installed from the corresponding Source.
 	includeProviders models.Providers
 	excludeProviders models.Providers
+
+	discoveryURLCacheMu sync.Mutex
 }
 
 // NewCommonProviderHandler returns a new `CommonProviderHandler` instance with the defined values.
@@ -47,7 +47,7 @@ func NewCommonProviderHandler(
 		httpClient:        c,
 		includeProviders:  includeProviders,
 		excludeProviders:  excludeProviders,
-		discoveryURLCache: xsync.NewMap[string, *RegistryURLs](),
+		discoveryURLCache: make(map[string]*RegistryURLs),
 	}
 }
 
@@ -68,7 +68,10 @@ func (handler *CommonProviderHandler) SetDiscoveryURLCache(
 	registryName string,
 	urls *RegistryURLs,
 ) {
-	handler.discoveryURLCache.Store(registryName, urls)
+	handler.discoveryURLCacheMu.Lock()
+	defer handler.discoveryURLCacheMu.Unlock()
+
+	handler.discoveryURLCache[registryName] = urls
 }
 
 // DiscoveryURL implements ProviderHandler.DiscoveryURL.
@@ -76,7 +79,11 @@ func (handler *CommonProviderHandler) DiscoveryURL(
 	ctx context.Context,
 	registryName string,
 ) (*RegistryURLs, error) {
-	if urls, ok := handler.discoveryURLCache.Load(registryName); ok {
+	handler.discoveryURLCacheMu.Lock()
+	urls, ok := handler.discoveryURLCache[registryName]
+	handler.discoveryURLCacheMu.Unlock()
+
+	if ok {
 		return urls, nil
 	}
 
@@ -97,7 +104,7 @@ func (handler *CommonProviderHandler) DiscoveryURL(
 		handler.logger.Debugf("Discovered %q registry URLs: %s", registryName, urls)
 	}
 
-	handler.discoveryURLCache.Store(registryName, urls)
+	handler.SetDiscoveryURLCache(registryName, urls)
 
 	return urls, nil
 }

--- a/internal/tf/cache/handlers/common_provider_test.go
+++ b/internal/tf/cache/handlers/common_provider_test.go
@@ -1,0 +1,80 @@
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/internal/tf/cache/handlers"
+	"github.com/gruntwork-io/terragrunt/internal/vhttp"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommonProviderHandlerDiscoveryURLConcurrentHitsAndMissesWithRacing pins that parallel
+// lookups all resolve while some callers read a cached registry and others store the
+// registries they discover. Cache hits return without logging or HTTP, so no shared step
+// orders their reads against the stores.
+func TestCommonProviderHandlerDiscoveryURLConcurrentHitsAndMissesWithRacing(t *testing.T) {
+	t.Parallel()
+
+	const (
+		callers        = 8
+		cachedRegistry = "cached.example.com"
+	)
+
+	body := []byte(`{"modules.v1":"/discovered/modules/","providers.v1":"/discovered/providers/"}`)
+
+	c := vhttp.NewMemClient(func(_ context.Context, _ *http.Request) (*http.Response, error) {
+		return vhttp.Respond(http.StatusOK, body, nil), nil
+	})
+
+	handler := handlers.NewCommonProviderHandler(logger.CreateLogger(), c, nil, nil)
+
+	cached := &handlers.RegistryURLs{
+		ModulesV1:   "/cached/modules/",
+		ProvidersV1: "/cached/providers/",
+	}
+	handler.SetDiscoveryURLCache(cachedRegistry, cached)
+
+	var (
+		ctx       = t.Context()
+		start     = make(chan struct{})
+		group     sync.WaitGroup
+		hits      = make([]*handlers.RegistryURLs, callers)
+		hitErrs   = make([]error, callers)
+		misses    = make([]*handlers.RegistryURLs, callers)
+		missErrs  = make([]error, callers)
+		discovery = &handlers.RegistryURLs{
+			ModulesV1:   "/discovered/modules/",
+			ProvidersV1: "/discovered/providers/",
+		}
+	)
+
+	for i := range callers {
+		group.Go(func() {
+			<-start
+
+			hits[i], hitErrs[i] = handler.DiscoveryURL(ctx, cachedRegistry)
+		})
+
+		group.Go(func() {
+			<-start
+
+			misses[i], missErrs[i] = handler.DiscoveryURL(ctx, "registry-"+strconv.Itoa(i)+".example.com")
+		})
+	}
+
+	close(start)
+	group.Wait()
+
+	for i := range callers {
+		require.NoErrorf(t, hitErrs[i], "hit %d", i)
+		require.NoErrorf(t, missErrs[i], "miss %d", i)
+		assert.Equalf(t, cached, hits[i], "hit %d", i)
+		assert.Equalf(t, discovery, misses[i], "miss %d", i)
+	}
+}

--- a/internal/tf/cache/helpers/client.go
+++ b/internal/tf/cache/helpers/client.go
@@ -7,11 +7,11 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sync"
 
 	"github.com/gruntwork-io/terragrunt/internal/tf/cliconfig"
 	"github.com/gruntwork-io/terragrunt/internal/vhttp"
 	svchost "github.com/hashicorp/terraform-svchost"
-	"github.com/puzpuzpuz/xsync/v4"
 )
 
 // maxResponseBody bounds a registry response body length.
@@ -24,7 +24,8 @@ type Client struct {
 	httpClient vhttp.Client
 
 	credsSource *cliconfig.CredentialsSource
-	cache       *xsync.Map[string, []byte]
+	cache       map[string][]byte
+	cacheMu     sync.Mutex
 }
 
 // NewClient returns a [Client] that dispatches requests through c.
@@ -33,14 +34,18 @@ func NewClient(c vhttp.Client, credsSource *cliconfig.CredentialsSource) *Client
 	return &Client{
 		httpClient:  c,
 		credsSource: credsSource,
-		cache:       xsync.NewMap[string, []byte](),
+		cache:       make(map[string][]byte),
 	}
 }
 
 // Do sends an HTTP request and decodes an HTTP response to the given `value`.
 func (client *Client) Do(ctx context.Context, method, reqURL string, value any) (err error) {
-	if bodyBytes, ok := client.cache.Load(reqURL); ok {
-		return unmarshalBody(bodyBytes, value)
+	client.cacheMu.Lock()
+	cached, ok := client.cache[reqURL]
+	client.cacheMu.Unlock()
+
+	if ok {
+		return unmarshalBody(cached, value)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
@@ -69,7 +74,9 @@ func (client *Client) Do(ctx context.Context, method, reqURL string, value any) 
 		return err
 	}
 
-	client.cache.Store(reqURL, bodyBytes)
+	client.cacheMu.Lock()
+	client.cache[reqURL] = bodyBytes
+	client.cacheMu.Unlock()
 
 	return unmarshalBody(bodyBytes, value)
 }

--- a/pkg/config/config_helpers_test.go
+++ b/pkg/config/config_helpers_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
 	tffuncs "github.com/hashicorp/terraform/lang/funcs"
-	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -1105,7 +1104,7 @@ func newTestParsingContext(
 	pctx.Experiments = experiment.NewExperiments()
 	pctx.Telemetry = new(telemetry.Options)
 	pctx.EngineOptions = new(engine.EngineOptions)
-	pctx.FeatureFlags = xsync.NewMap[string, string]()
+	pctx.FeatureFlags = map[string]string{}
 
 	return ctx, pctx
 }

--- a/pkg/config/config_partial.go
+++ b/pkg/config/config_partial.go
@@ -409,15 +409,9 @@ func cliFlagsToCty(
 	ctx *ParsingContext,
 	flagByName map[string]*FeatureFlag,
 ) (map[string]cty.Value, error) {
-	if ctx.FeatureFlags == nil {
-		return make(map[string]cty.Value), nil
-	}
-
 	evaluatedFlags := make(map[string]cty.Value)
 
-	var conversionErr error
-
-	ctx.FeatureFlags.Range(func(name, value string) bool {
+	for name, value := range ctx.FeatureFlags {
 		var flag cty.Value
 
 		var err error
@@ -429,18 +423,10 @@ func cliFlagsToCty(
 		}
 
 		if err != nil {
-			conversionErr = err
-
-			return false
+			return nil, err
 		}
 
 		evaluatedFlags[name] = flag
-
-		return true
-	})
-
-	if conversionErr != nil {
-		return nil, conversionErr
 	}
 
 	return evaluatedFlags, nil

--- a/pkg/config/config_partial_test.go
+++ b/pkg/config/config_partial_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1505,9 +1506,7 @@ exclude {
 			ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), childPath)
 			pctx = pctx.WithDecodeList(config.FeatureFlagsBlock, config.ExcludeBlock)
 
-			for name, value := range tc.cliFlags {
-				pctx.FeatureFlags[name] = value
-			}
+			maps.Copy(pctx.FeatureFlags, tc.cliFlags)
 
 			terragruntConfig, err := config.PartialParseConfigFile(ctx, pctx, l, childPath, nil)
 			if tc.expectedErr != "" {

--- a/pkg/config/config_partial_test.go
+++ b/pkg/config/config_partial_test.go
@@ -1506,7 +1506,7 @@ exclude {
 			pctx = pctx.WithDecodeList(config.FeatureFlagsBlock, config.ExcludeBlock)
 
 			for name, value := range tc.cliFlags {
-				pctx.FeatureFlags.Store(name, value)
+				pctx.FeatureFlags[name] = value
 			}
 
 			terragruntConfig, err := config.PartialParseConfigFile(ctx, pctx, l, childPath, nil)

--- a/pkg/config/dependency_run_options_test.go
+++ b/pkg/config/dependency_run_options_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
 	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
-	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -48,7 +47,7 @@ func TestRunOptionsFromParsingContextCopiesEveryOption(t *testing.T) {
 	assert.Equal(t, pctx.OriginalIAMRoleOptions, runOpts.OriginalIAMRoleOptions)
 	assert.True(t, runOpts.Experiments.Evaluate(experiment.Stacks))
 	assert.Equal(t, pctx.StrictControls, runOpts.StrictControls)
-	assert.Same(t, pctx.FeatureFlags, runOpts.FeatureFlags)
+	assert.Equal(t, pctx.FeatureFlags, runOpts.FeatureFlags)
 	assert.Same(t, pctx.EngineConfig, runOpts.EngineConfig)
 	assert.Same(t, pctx.EngineOptions, runOpts.EngineOptions)
 	assert.Equal(t, pctx.TFPath, runOpts.TFPath)
@@ -89,7 +88,7 @@ func parsingContextWithDistinctValues(t *testing.T) *config.ParsingContext {
 	pctx.Experiments = experiment.NewExperiments()
 	require.NoError(t, pctx.Experiments.EnableExperiment(experiment.Stacks))
 	pctx.StrictControls = controls.New()
-	pctx.FeatureFlags = xsync.NewMap[string, string]()
+	pctx.FeatureFlags = map[string]string{"region": "us-east-1"}
 	pctx.EngineConfig = &engine.EngineConfig{Source: "engine-source"}
 	pctx.EngineOptions = &engine.EngineOptions{}
 	pctx.TFPath = "/usr/local/bin/tofu"

--- a/pkg/config/parsing_context.go
+++ b/pkg/config/parsing_context.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 
@@ -54,7 +53,7 @@ type ParsingContext struct {
 	EngineOptions    *engine.EngineOptions
 
 	// FeatureFlags contains explicit feature flag overrides supplied by the user.
-	FeatureFlags *xsync.Map[string, string]
+	FeatureFlags map[string]string
 
 	FilesRead *FilesRead
 	Telemetry *telemetry.Options

--- a/pkg/log/format/options/color.go
+++ b/pkg/log/format/options/color.go
@@ -10,7 +10,6 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/gruntwork-io/terragrunt/pkg/log"
-	"github.com/puzpuzpuz/xsync/v4"
 )
 
 //go:generate go run ./colorgen
@@ -339,9 +338,7 @@ var (
 
 type gradientColor struct {
 	// cache stores unique text with their color code.
-	// We use [xsync.Map](https://github.com/puzpuzpuz/xsync?tab=readme-ov-file#map)
-	// instead of standard `sync.Map` since it's faster and has generic types.
-	cache  *xsync.Map[string, ColorValue]
+	cache  map[string]ColorValue
 	values []ColorValue
 	mu     sync.Mutex
 
@@ -351,7 +348,7 @@ type gradientColor struct {
 
 func newGradientColor() *gradientColor {
 	return &gradientColor{
-		cache:  xsync.NewMap[string, ColorValue](),
+		cache:  make(map[string]ColorValue),
 		values: defaultAutoColorValues,
 	}
 }
@@ -360,7 +357,7 @@ func (color *gradientColor) Value(text string) ColorValue {
 	color.mu.Lock()
 	defer color.mu.Unlock()
 
-	if colorCode, ok := color.cache.Load(text); ok {
+	if colorCode, ok := color.cache[text]; ok {
 		return colorCode
 	}
 
@@ -370,7 +367,7 @@ func (color *gradientColor) Value(text string) ColorValue {
 
 	colorCode := color.values[color.nextStyleIndex]
 
-	color.cache.Store(text, colorCode)
+	color.cache[text] = colorCode
 
 	color.nextStyleIndex++
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -33,7 +33,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/pkg/log"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format"
 	"github.com/gruntwork-io/terragrunt/pkg/log/format/placeholders"
-	"github.com/puzpuzpuz/xsync/v4"
 )
 
 const ContextKey ctxKey = iota
@@ -79,7 +78,7 @@ type TerragruntOptions struct {
 	// Version of terragrunt
 	TerragruntVersion *semver.Version `clone:"shadowcopy"`
 	// FeatureFlags is a map of feature flags to enable.
-	FeatureFlags *xsync.Map[string, string] `clone:"shadowcopy"`
+	FeatureFlags map[string]string `clone:"shadowcopy"`
 	// EngineConfig holds the resolved engine configuration from HCL.
 	EngineConfig *engine.EngineConfig
 	// EngineOptions groups CLI-supplied engine options.
@@ -357,7 +356,7 @@ func NewTerragruntOptions(e vexec.Exec) *TerragruntOptions {
 		ProviderCacheOptions: pcoptions.ProviderCacheOptions{
 			RegistryNames: pcoptions.DefaultRegistryNames,
 		},
-		FeatureFlags:           xsync.NewMap[string, string](),
+		FeatureFlags:           map[string]string{},
 		Errors:                 defaultErrorsConfig(),
 		StrictControls:         controls.New(),
 		Experiments:            experiment.NewExperiments(),


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Allows us to drop a dependency, and we don't actually benefit from how xsync.Map approaches locking in any of these use-cases.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced internal concurrent map usage with native Go maps and mutex protection.
  * Feature flag handling now uses standard map operations across configuration and runtime options.
  * Preserved caching, error tracking, output collection, and remote-state behavior while simplifying concurrency management.
  * Removed the unused concurrency-map dependency.

* **Tests**
  * Added coverage for concurrent bucket initialization and provider discovery cache access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->