### PR TITLE
chore: Fixing sandbox tests

### DIFF
--- a/test/integration_report_test.go
+++ b/test/integration_report_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terragrunt/internal/report"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,42 +33,6 @@ func TestTerragruntReportDisableSummary(t *testing.T) {
 
 	// Verify the report output does not contain the summary
 	assert.NotContains(t, stdout, "Run Summary")
-}
-
-// TestTerragruntReportRunErrorCause verifies that a unit that fails before
-// OpenTofu/Terraform runs still carries the failure text as its report cause.
-//
-// Only chain-b is put on the queue: its dependency chain-a is neither in the
-// queue (so there is no failed ancestor to blame) nor applied (so resolving its
-// outputs fails during config evaluation, before OpenTofu/Terraform runs).
-func TestTerragruntReportRunErrorCause(t *testing.T) {
-	t.Parallel()
-
-	helpers.CleanupTerraformFolder(t, testFixtureReportPath)
-	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureReportPath)
-	rootPath := filepath.Join(tmpEnvPath, testFixtureReportPath)
-
-	_, _, err := helpers.RunTerragruntCommandWithOutput(
-		t,
-		"terragrunt run --all --non-interactive --working-dir "+rootPath+
-			" --queue-strict-include --queue-include-dir chain-b"+
-			" --report-file "+helpers.ReportFile+" -- apply",
-	)
-	require.Error(t, err)
-
-	reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
-	assert.FileExists(t, reportFilePath)
-
-	runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
-	require.NoError(t, err)
-
-	run := runs.FindByName("chain-b")
-	require.NotNil(t, run)
-	assert.Equal(t, "failed", run.Result)
-	require.NotNil(t, run.Reason)
-	assert.Equal(t, "run error", *run.Reason)
-	require.NotNil(t, run.Cause, "config evaluation failure must populate the run cause")
-	assert.Contains(t, *run.Cause, "detected no outputs")
 }
 
 // lineType represents the type of line we're processing

--- a/test/integration_report_tf_test.go
+++ b/test/integration_report_tf_test.go
@@ -82,6 +82,42 @@ func TestTFTerragruntReport(t *testing.T) {
 `), strings.TrimSpace(stdoutStr))
 }
 
+// TestTFTerragruntReportRunErrorCause verifies that a unit that fails before
+// OpenTofu/Terraform runs still carries the failure text as its report cause.
+//
+// Only chain-b is put on the queue: its dependency chain-a is neither in the
+// queue (so there is no failed ancestor to blame) nor applied (so resolving its
+// outputs fails during config evaluation, before OpenTofu/Terraform runs).
+func TestTFTerragruntReportRunErrorCause(t *testing.T) {
+	t.Parallel()
+
+	helpers.CleanupTerraformFolder(t, testFixtureReportPath)
+	tmpEnvPath := helpers.CopyEnvironment(t, testFixtureReportPath)
+	rootPath := filepath.Join(tmpEnvPath, testFixtureReportPath)
+
+	_, _, err := helpers.RunTerragruntCommandWithOutput(
+		t,
+		"terragrunt run --all --non-interactive --working-dir "+rootPath+
+			" --queue-strict-include --queue-include-dir chain-b"+
+			" --report-file "+helpers.ReportFile+" -- apply",
+	)
+	require.Error(t, err)
+
+	reportFilePath := filepath.Join(rootPath, helpers.ReportFile)
+	assert.FileExists(t, reportFilePath)
+
+	runs, err := report.ParseJSONRunsFromFile(vfs.NewOSFS(), reportFilePath)
+	require.NoError(t, err)
+
+	run := runs.FindByName("chain-b")
+	require.NotNil(t, run)
+	assert.Equal(t, "failed", run.Result)
+	require.NotNil(t, run.Reason)
+	assert.Equal(t, "run error", *run.Reason)
+	require.NotNil(t, run.Cause, "config evaluation failure must populate the run cause")
+	assert.Contains(t, *run.Cause, "detected no outputs")
+}
+
 func TestTFTerragruntReportSaveToFile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Fixes sandbox testing.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded integration coverage for report generation when configuration evaluation fails before OpenTofu/Terraform execution.
  - Verified that failed components are identified correctly, including a “run error” reason and the underlying missing-outputs cause.
  - Consolidated report-cause validation into the appropriate integration test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->