### PR TITLE
fix(config): use backend assume_role for direct dependency state reads

### DIFF
--- a/docs/src/data/changelog/v1.1.5/dependency-state-backend-role.mdx
+++ b/docs/src/data/changelog/v1.1.5/dependency-state-backend-role.mdx
@@ -3,8 +3,6 @@ version: "v1.1.5"
 category: "bug-fixes"
 ---
 
-#### Direct dependency state reads use the backend assume_role
+#### Support backend assume_role during direct dependency state reads
 
-With the [`dependency-fetch-output-from-state`](/reference/experiments/active#dependency-fetch-output-from-state) experiment enabled, the S3 direct state reader now keeps the resolved IAM role options in sync with the credential getter. Previously, `resolveOutputJSON` could clear the parsing context's IAM role before the S3 client was built, making the base identity inconsistent with the credentials the getter had already resolved. The backend's `assume_role.role_arn` was still chained on top, but the base identity it chained onto could be stale or empty.
-
-This affected cross-account setups where one IAM role handles planning and a separate role in the `remote_state` block's `assume_role` reads state.
+With [`dependency-fetch-output-from-state`](/reference/experiments/active#dependency-fetch-output-from-state) enabled, direct S3 state reads now preserve the resolved IAM role from the credential getter before chaining the backend's `assume_role`. Previously, `resolveOutputJSON` wiped `pctx.IAMRoleOptions` during cross-account dependency resolution, causing direct S3 state reads to fail with `403 AccessDenied`.

--- a/docs/src/data/changelog/v1.1.5/dependency-state-backend-role.mdx
+++ b/docs/src/data/changelog/v1.1.5/dependency-state-backend-role.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### Direct dependency state reads use the backend assume_role
+
+With the [`dependency-fetch-output-from-state`](/reference/experiments/active#dependency-fetch-output-from-state) experiment enabled, the S3 direct state reader now keeps the resolved IAM role options in sync with the credential getter. Previously, `resolveOutputJSON` could clear the parsing context's IAM role before the S3 client was built, making the base identity inconsistent with the credentials the getter had already resolved. The backend's `assume_role.role_arn` was still chained on top, but the base identity it chained onto could be stale or empty.
+
+This affected cross-account setups where one IAM role handles planning and a separate role in the `remote_state` block's `assume_role` reads state.

--- a/docs/src/data/changelog/v1.1.5/dependency-state-backend-role.mdx
+++ b/docs/src/data/changelog/v1.1.5/dependency-state-backend-role.mdx
@@ -5,4 +5,4 @@ category: "bug-fixes"
 
 #### Support backend assume_role during direct dependency state reads
 
-With [`dependency-fetch-output-from-state`](/reference/experiments/active#dependency-fetch-output-from-state) enabled, direct S3 state reads now preserve the resolved IAM role from the credential getter before chaining the backend's `assume_role`. Previously, `resolveOutputJSON` wiped `pctx.IAMRoleOptions` during cross-account dependency resolution, causing direct S3 state reads to fail with `403 AccessDenied`.
+With [`dependency-fetch-output-from-state`](/reference/experiments/active#dependency-fetch-output-from-state) enabled, direct S3 state reads now correctly chain the backend's `assume_role` onto the dependency's execution role. Previously, cross-account dependency state reads failed with `403 AccessDenied` when the `remote_state` block configured a separate `assume_role` for state access.

--- a/internal/awshelper/buildable_client_test.go
+++ b/internal/awshelper/buildable_client_test.go
@@ -228,6 +228,58 @@ func TestAssumeIamRoleFallsBackToIMDSv1WhenTokenEndpointHangs(t *testing.T) {
 		"STS call must be signed with the IMDSv1 instance credentials")
 }
 
+// TestAssumeIamRoleUsesEnvCredentials verifies that AssumeIamRole signs the STS request with v.Env credentials.
+func TestAssumeIamRoleUsesEnvCredentials(t *testing.T) {
+	t.Parallel()
+
+	const (
+		envAccessKeyID = "AKIAENVCREDSTESTKEY"
+		assumedKeyID   = "ASIAASSUMEDTESTKEY"
+	)
+
+	var authHead atomic.Value
+	authHead.Store("")
+
+	memHTTP := vhttp.NewMemClient(func(_ context.Context, req *http.Request) (*http.Response, error) {
+		authHead.Store(req.Header.Get("Authorization"))
+
+		xml := `<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">` +
+			`<AssumeRoleResult><Credentials>` +
+			`<AccessKeyId>` + assumedKeyID + `</AccessKeyId>` +
+			`<SecretAccessKey>assumed-secret</SecretAccessKey>` +
+			`<SessionToken>assumed-token</SessionToken>` +
+			`<Expiration>2030-12-31T23:59:59Z</Expiration>` +
+			`</Credentials>` +
+			`<AssumedRoleUser>` +
+			`<AssumedRoleId>AROATEST:session</AssumedRoleId>` +
+			`<Arn>arn:aws:iam::123456789012:role/test-role</Arn>` +
+			`</AssumedRoleUser>` +
+			`</AssumeRoleResult></AssumeRoleResponse>`
+
+		return vhttp.Respond(http.StatusOK, []byte(xml), nil), nil
+	})
+
+	v := venvtest.New().
+		WithHTTP(memHTTP).
+		WithEnv(map[string]string{
+			"AWS_REGION":            "us-east-1",
+			"AWS_ACCESS_KEY_ID":     envAccessKeyID,
+			"AWS_SECRET_ACCESS_KEY": "env-secret-key",
+		})
+
+	creds, err := awshelper.AssumeIamRole(
+		t.Context(),
+		v,
+		iam.RoleOptions{RoleARN: "arn:aws:iam::123456789012:role/test-role"},
+		"",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	assert.Equal(t, assumedKeyID, aws.ToString(creds.AccessKeyId))
+	assert.Contains(t, authHead.Load().(string), "Credential="+envAccessKeyID+"/",
+		"STS call must be signed with the v.Env credentials")
+}
+
 // TestAWSBuildableClientOSTransportIsBuildable explicitly tests the
 // function's return type with a production OS client.
 func TestAWSBuildableClientOSTransportIsBuildable(t *testing.T) {

--- a/internal/awshelper/config.go
+++ b/internal/awshelper/config.go
@@ -309,14 +309,17 @@ func AssumeIamRole(
 
 	region := cmp.Or(getRegionFromEnv(v.Env), defaultAWSRegion)
 
-	// Set user agent to include terragrunt version
-	//nolint:forbidigo // This is the wrapper the rule points callers at; WithHTTPClient below carries the venv's client.
-	cfg, err := config.LoadDefaultConfig(
-		ctx,
+	configOptions := []func(*config.LoadOptions) error{
 		config.WithRegion(region),
-		config.WithAppID("terragrunt/"+version.GetVersion()),
+		config.WithAppID("terragrunt/" + version.GetVersion()),
 		config.WithHTTPClient(AWSBuildableClient(v.HTTP)),
-	)
+	}
+	if envCreds := createCredentialsFromEnv(v.Env); envCreds != nil {
+		configOptions = append(configOptions, config.WithCredentialsProvider(envCreds))
+	}
+
+	//nolint:forbidigo // This is the wrapper the rule points callers at; WithHTTPClient below carries the venv's client.
+	cfg, err := config.LoadDefaultConfig(ctx, configOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("error loading AWS config: %w", err)
 	}

--- a/internal/runner/dependents.go
+++ b/internal/runner/dependents.go
@@ -50,7 +50,7 @@ func FindDependentUnits(
 // or the parents of the processed includes when git detection fails.
 func discoverPathsToCheck(
 	ctx context.Context,
-	l log.Logger,
+	_ log.Logger,
 	v *venv.Venv,
 	opts *options.TerragruntOptions,
 	terragruntConfig *config.TerragruntConfig,

--- a/internal/runner/dependents.go
+++ b/internal/runner/dependents.go
@@ -55,21 +55,21 @@ func discoverPathsToCheck(
 	opts *options.TerragruntOptions,
 	terragruntConfig *config.TerragruntConfig,
 ) []string {
+	repoRoot, err := git.GoRepoRoot(ctx, v, opts.WorkingDir)
+	if err == nil {
+		return []string{repoRoot}
+	}
+
+	l.Debugf("Could not determine git repo root for %s: %v", opts.WorkingDir, err)
+
+	uniquePaths := make(map[string]bool)
+	for _, includePath := range terragruntConfig.ProcessedIncludes {
+		uniquePaths[filepath.Dir(includePath.Path)] = true
+	}
+
 	var pathsToCheck []string
-
-	if repoRoot, err := git.GoRepoRoot(ctx, v, opts.WorkingDir); err == nil {
-		pathsToCheck = append(pathsToCheck, repoRoot)
-	} else {
-		l.Debugf("Could not determine git repo root for %s: %v", opts.WorkingDir, err)
-
-		uniquePaths := make(map[string]bool)
-		for _, includePath := range terragruntConfig.ProcessedIncludes {
-			uniquePaths[filepath.Dir(includePath.Path)] = true
-		}
-
-		for path := range uniquePaths {
-			pathsToCheck = append(pathsToCheck, path)
-		}
+	for path := range uniquePaths {
+		pathsToCheck = append(pathsToCheck, path)
 	}
 
 	return pathsToCheck

--- a/internal/runner/dependents.go
+++ b/internal/runner/dependents.go
@@ -50,7 +50,7 @@ func FindDependentUnits(
 // or the parents of the processed includes when git detection fails.
 func discoverPathsToCheck(
 	ctx context.Context,
-	_ log.Logger,
+	l log.Logger,
 	v *venv.Venv,
 	opts *options.TerragruntOptions,
 	terragruntConfig *config.TerragruntConfig,
@@ -60,6 +60,8 @@ func discoverPathsToCheck(
 	if repoRoot, err := git.GoRepoRoot(ctx, v, opts.WorkingDir); err == nil {
 		pathsToCheck = append(pathsToCheck, repoRoot)
 	} else {
+		l.Debugf("Could not determine git repo root for %s: %v", opts.WorkingDir, err)
+
 		uniquePaths := make(map[string]bool)
 		for _, includePath := range terragruntConfig.ProcessedIncludes {
 			uniquePaths[filepath.Dir(includePath.Path)] = true

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1707,6 +1707,9 @@ func resolveOutputJSON(
 		return nil, "", err
 	}
 
+	// Sync parsing context with credential getter's assumed role for direct state readers.
+	pctx.IAMRoleOptions = mergedIAM
+
 	// Match the normal runner: output-specific environment variables are the
 	// final override after auth-provider and IAM/STS credentials.
 	applyExtraArgsEnvVarsForOutput(pctx, partialTerragruntConfig.Terraform)

--- a/pkg/config/dependency_state_test.go
+++ b/pkg/config/dependency_state_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/internal/experiment"
 	"github.com/gruntwork-io/terragrunt/internal/iacargs"
+	"github.com/gruntwork-io/terragrunt/internal/iam"
 	"github.com/gruntwork-io/terragrunt/internal/tf"
 	"github.com/gruntwork-io/terragrunt/internal/util"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
@@ -144,6 +146,201 @@ func TestDependencyStateDirectReadRoutesByBackendAndWorkspace(t *testing.T) {
 			assert.Equal(t, testCase.wantRequest, requestPaths[0])
 		})
 	}
+}
+
+// TestDependencyStateS3AssumeRoleUsedForDirectRead verifies backend assume_role.role_arn is used for direct S3 read (issue #4979).
+func TestDependencyStateS3AssumeRoleUsedForDirectRead(t *testing.T) {
+	t.Parallel()
+
+	const backendRoleARN = "arn:aws:iam::999999999999:role/backend-state-reader"
+
+	var (
+		rolesMu        sync.Mutex
+		requestedRoles []string
+	)
+
+	recordRole := func(roleARN string) {
+		rolesMu.Lock()
+		defer rolesMu.Unlock()
+
+		requestedRoles = append(requestedRoles, roleARN)
+	}
+
+	recorder := newDependencyStateRecorder(t, 0, nil)
+	recorder.respond = stsAndS3Responder(t, backendRoleARN, recordRole) //nolint:bodyclose // returns a callback, not an HTTP response
+
+	cfg, err := parseDependencyStateFixture(
+		t,
+		recorder,
+		"s3",
+		fmt.Sprintf(`
+        bucket              = "state-bucket"
+        key                 = "service.tfstate"
+        region              = "us-east-1"
+        endpoint            = "https://s3.example.com"
+        force_path_style    = true
+        skip_credentials_validation = true
+        assume_role = {
+          role_arn = %q
+        }`, backendRoleARN),
+		map[string]string{
+			"AWS_ACCESS_KEY_ID":     "base-access-key",
+			"AWS_SECRET_ACCESS_KEY": "base-secret-key",
+		},
+		false,
+		"",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "from-assumed-role", cfg.Inputs["result"])
+
+	requestPaths := recorder.requestPaths()
+	stsIdx := slices.IndexFunc(requestPaths, func(p string) bool {
+		return strings.Contains(p, "sts")
+	})
+	s3Idx := slices.IndexFunc(requestPaths, func(p string) bool {
+		return strings.Contains(p, "s3.example.com")
+	})
+
+	require.GreaterOrEqual(t, stsIdx, 0, "an STS AssumeRole request must be made for the backend role")
+	require.GreaterOrEqual(t, s3Idx, 0, "an S3 GetObject request must be made")
+	assert.Less(t, stsIdx, s3Idx, "STS role assumption must precede the S3 state read")
+
+	rolesMu.Lock()
+	defer rolesMu.Unlock()
+
+	require.Equal(t, []string{backendRoleARN}, requestedRoles)
+}
+
+// stsAndS3Responder returns an HTTP callback handling STS AssumeRole and S3 state requests.
+func stsAndS3Responder(t *testing.T, defaultRoleARN string, onAssumeRole func(string)) func(*http.Request) *http.Response {
+	t.Helper()
+
+	return func(req *http.Request) *http.Response {
+		if strings.Contains(req.URL.Host, "sts") {
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+
+			if strings.Contains(string(body), "AssumeRole") {
+				roleARN := defaultRoleARN
+
+				if vals, err := url.ParseQuery(string(body)); err == nil {
+					if r := vals.Get("RoleArn"); r != "" {
+						roleARN = r
+					}
+				}
+
+				if onAssumeRole != nil {
+					onAssumeRole(roleARN)
+				}
+
+				return vhttp.Respond(http.StatusOK, stsAssumeRoleResponse(roleARN), nil)
+			}
+		}
+
+		if strings.Contains(req.URL.Host, "s3") {
+			return vhttp.Respond(http.StatusOK, terraformState("from-assumed-role"), nil)
+		}
+
+		return vhttp.Respond(http.StatusNotFound, nil, nil)
+	}
+}
+
+// stsAssumeRoleResponse returns a minimal valid STS AssumeRole XML response.
+func stsAssumeRoleResponse(roleARN string) []byte {
+	return []byte(fmt.Sprintf(`<AssumeRoleResponse>
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>ASSUMED_ACCESS_KEY</AccessKeyId>
+      <SecretAccessKey>ASSUMED_SECRET_KEY</SecretAccessKey>
+      <SessionToken>ASSUMED_SESSION_TOKEN</SessionToken>
+      <Expiration>2030-12-31T23:59:59Z</Expiration>
+    </Credentials>
+    <AssumedRoleUser>
+      <AssumedRoleId>AROA_ASSUMED:terragrunt-session</AssumedRoleId>
+      <Arn>%s</Arn>
+    </AssumedRoleUser>
+  </AssumeRoleResult>
+</AssumeRoleResponse>`, roleARN))
+}
+
+// TestDependencyStateS3AssumeRoleWithClearedIAMOptions checks target iam_role and backend assume_role are used when caller IAM differs (issue #4979).
+func TestDependencyStateS3AssumeRoleWithClearedIAMOptions(t *testing.T) {
+	t.Parallel()
+
+	const (
+		callerRoleARN   = "arn:aws:iam::111111111111:role/caller-deploy-role"
+		producerRoleARN = "arn:aws:iam::222222222222:role/producer-base-role"
+		backendRoleARN  = "arn:aws:iam::999999999999:role/backend-state-reader"
+	)
+
+	var (
+		rolesMu        sync.Mutex
+		requestedRoles []string
+	)
+
+	recordRole := func(roleARN string) {
+		rolesMu.Lock()
+		defer rolesMu.Unlock()
+
+		requestedRoles = append(requestedRoles, roleARN)
+	}
+
+	recorder := newDependencyStateRecorder(t, 0, nil)
+	recorder.respond = stsAndS3Responder(t, backendRoleARN, recordRole) //nolint:bodyclose // returns a callback, not an HTTP response
+
+	ctx, pctx, configPath := prepareDependencyStateFixture(
+		t,
+		recorder,
+		"s3",
+		"",
+		map[string]string{
+			"AWS_ACCESS_KEY_ID":     "caller-access-key",
+			"AWS_SECRET_ACCESS_KEY": "caller-secret-key",
+		},
+		false,
+		"",
+	)
+
+	producerHCL := fmt.Sprintf(`iam_role = %q
+
+remote_state {
+  backend = "s3"
+  config = {
+    bucket              = "state-bucket"
+    key                 = "service.tfstate"
+    region              = "us-east-1"
+    endpoint            = "https://s3.example.com"
+    force_path_style    = true
+    skip_credentials_validation = true
+    assume_role = {
+      role_arn = %q
+    }
+  }
+}
+`, producerRoleARN, backendRoleARN)
+	require.NoError(t, vfs.WriteFile(pctx.Venv.FS, "/repo/producer/terragrunt.hcl", []byte(producerHCL), 0o600))
+
+	pctx.IAMRoleOptions = iam.RoleOptions{
+		RoleARN: callerRoleARN,
+	}
+
+	cfg, err := config.ParseConfigFile(ctx, pctx, logger.CreateLogger(), configPath, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "from-assumed-role", cfg.Inputs["result"])
+
+	requestPaths := recorder.requestPaths()
+	require.True(t, slices.ContainsFunc(requestPaths, func(p string) bool {
+		return strings.Contains(p, "sts")
+	}), "STS AssumeRole must be called")
+	require.True(t, slices.ContainsFunc(requestPaths, func(p string) bool {
+		return strings.Contains(p, "s3.example.com")
+	}), "S3 GetObject must be called for the state file")
+
+	rolesMu.Lock()
+	defer rolesMu.Unlock()
+
+	require.Equal(t, []string{producerRoleARN, backendRoleARN}, requestedRoles)
+	assert.NotContains(t, requestedRoles, callerRoleARN)
 }
 
 func TestDependencyStateUnsupportedConfigFallsBackToNativeOutput(t *testing.T) {

--- a/pkg/config/dependency_state_test.go
+++ b/pkg/config/dependency_state_test.go
@@ -343,6 +343,53 @@ remote_state {
 	assert.NotContains(t, requestedRoles, callerRoleARN)
 }
 
+// TestDependencyStateS3DirectReadFailureFallsBackToNativeOutput verifies fallback to native output when direct S3 read fails.
+func TestDependencyStateS3DirectReadFailureFallsBackToNativeOutput(t *testing.T) {
+	t.Parallel()
+
+	const backendRoleARN = "arn:aws:iam::999999999999:role/backend-state-reader"
+
+	recorder := newDependencyStateRecorder(t, 0, nil)
+	recorder.respond = func(req *http.Request) *http.Response {
+		if strings.Contains(req.URL.Host, "sts") {
+			return vhttp.Respond(http.StatusOK, stsAssumeRoleResponse(backendRoleARN), nil)
+		}
+
+		if strings.Contains(req.URL.Host, "s3") {
+			return vhttp.Respond(http.StatusInternalServerError, []byte("Internal Server Error"), nil)
+		}
+
+		return vhttp.Respond(http.StatusNotFound, nil, nil)
+	}
+
+	cfg, err := parseDependencyStateFixture(
+		t,
+		recorder,
+		"s3",
+		fmt.Sprintf(`
+        bucket              = "state-bucket"
+        key                 = "service.tfstate"
+        region              = "us-east-1"
+        endpoint            = "https://s3.example.com"
+        force_path_style    = true
+        skip_credentials_validation = true
+        assume_role = {
+          role_arn = %q
+        }`, backendRoleARN),
+		map[string]string{
+			"AWS_ACCESS_KEY_ID":     "base-access-key",
+			"AWS_SECRET_ACCESS_KEY": "base-secret-key",
+		},
+		false,
+		"",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "from-native-output", cfg.Inputs["result"])
+
+	outputs := recorder.outputInvocations()
+	require.Len(t, outputs, 1, "direct read failure must trigger native output retrieval")
+}
+
 func TestDependencyStateUnsupportedConfigFallsBackToNativeOutput(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

- Sync pctx.IAMRoleOptions with credential getter's resolved identity before direct state read
- Wire venv credentials into AssumeIamRole so STS calls honor virtual environment instead of IMDS fallback
- Add tests verifying backend assume_role triggers STS before S3 state read

Fixes #4979

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed direct S3 dependency-state reads when backend role assumption is configured, preventing authorization failures.
  * Preserved credential and IAM role settings during cross-account dependency resolution.
  * Added fallback to native output when a direct S3 state read fails.

* **Tests**
  * Added coverage for environment-based credentials, role assumption, cross-account access, request ordering, and fallback behavior.

* **Documentation**
  * Documented the dependency-state access fix in the v1.1.5 changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->