### PR TITLE
chore: Clean-up partial worktrees on failure

### DIFF
--- a/internal/cli/commands/discoverysetup/discoverysetup.go
+++ b/internal/cli/commands/discoverysetup/discoverysetup.go
@@ -41,7 +41,7 @@ func Worktrees(
 	}
 
 	cleanup := func(ctx context.Context) {
-		if cleanupErr := wts.Cleanup(ctx, l, v.FS); cleanupErr != nil {
+		if cleanupErr := wts.Cleanup(ctx, l, v); cleanupErr != nil {
 			l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 		}
 	}

--- a/internal/cli/commands/hcl/validate/validate.go
+++ b/internal/cli/commands/hcl/validate/validate.go
@@ -133,7 +133,7 @@ func RunValidate(
 	}
 
 	defer func() {
-		cleanupErr := worktrees.Cleanup(ctx, l, v.FS)
+		cleanupErr := worktrees.Cleanup(ctx, l, v)
 		if cleanupErr != nil {
 			l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 		}
@@ -328,7 +328,7 @@ func RunValidateInputs(
 	}
 
 	defer func() {
-		cleanupErr := worktrees.Cleanup(ctx, l, v.FS)
+		cleanupErr := worktrees.Cleanup(ctx, l, v)
 		if cleanupErr != nil {
 			l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 		}

--- a/internal/cli/commands/stack/stack.go
+++ b/internal/cli/commands/stack/stack.go
@@ -82,7 +82,7 @@ func RunGenerate(
 		}
 
 		defer func() {
-			cleanupErr := wts.Cleanup(ctx, l, v.FS)
+			cleanupErr := wts.Cleanup(ctx, l, v)
 			if cleanupErr != nil {
 				l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 			}

--- a/internal/discovery/phase_worktree_expansion_integration_test.go
+++ b/internal/discovery/phase_worktree_expansion_integration_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
@@ -87,7 +86,7 @@ func discoverExpansionChanges(
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS()))
+		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv()))
 	})
 
 	filters := make(filter.Filters, 0, len(gitExpressions)+len(extraFilters))

--- a/internal/discovery/phase_worktree_integration_test.go
+++ b/internal/discovery/phase_worktree_integration_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gruntwork-io/terragrunt/internal/git"
 	"github.com/gruntwork-io/terragrunt/internal/stacks/generate"
 	"github.com/gruntwork-io/terragrunt/internal/vexec"
-	"github.com/gruntwork-io/terragrunt/internal/vfs"
 	"github.com/gruntwork-io/terragrunt/internal/worktrees"
 	"github.com/gruntwork-io/terragrunt/pkg/options"
 	"github.com/gruntwork-io/terragrunt/test/helpers"
@@ -481,7 +480,7 @@ func TestWorktreePhase_Integration_CommandArgs(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 				require.NoError(t, cleanupErr)
 			})
 
@@ -767,7 +766,7 @@ unit "unit_to_be_untouched" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -922,7 +921,7 @@ func TestWorktreePhase_Integration_StackSourceOnlyInOneRef(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -1225,7 +1224,7 @@ locals {
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 				require.NoError(t, cleanupErr)
 			})
 
@@ -1323,7 +1322,7 @@ locals {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -1600,7 +1599,7 @@ locals {
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 				require.NoError(t, cleanupErr)
 			})
 
@@ -1708,7 +1707,7 @@ func TestWorktreePhase_Integration_FromSubdirectory_MultipleCommits(t *testing.T
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+				cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 				require.NoError(t, cleanupErr)
 			})
 
@@ -1897,7 +1896,7 @@ unit "app" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2091,7 +2090,7 @@ unit "app" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2275,7 +2274,7 @@ unit "app" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2443,7 +2442,7 @@ unit "myapp" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2584,7 +2583,7 @@ unit "myapp" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2710,7 +2709,7 @@ unit "myapp" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2764,7 +2763,7 @@ func runWorktreeDiscovery(
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -2880,7 +2879,7 @@ unit "myapp" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -3034,7 +3033,7 @@ unit "app" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS()))
+		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv()))
 	})
 
 	opts := options.NewTerragruntOptions(vexec.NewOSExec())
@@ -3159,7 +3158,7 @@ unit "app" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS()))
+		require.NoError(t, w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv()))
 	})
 
 	opts := options.NewTerragruntOptions(vexec.NewOSExec())
@@ -3259,7 +3258,7 @@ locals {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -3342,7 +3341,7 @@ locals {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -3448,7 +3447,7 @@ unit "myapp" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -3553,7 +3552,7 @@ unit "app" {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.WithoutCancel(t.Context()), l, venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 

--- a/internal/runner/runall/runall.go
+++ b/internal/runner/runall/runall.go
@@ -134,7 +134,7 @@ func Run(
 		}
 
 		defer func() {
-			cleanupErr := wts.Cleanup(ctx, l, v.FS)
+			cleanupErr := wts.Cleanup(ctx, l, v)
 			if cleanupErr != nil {
 				l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 			}

--- a/internal/stacks/output/output.go
+++ b/internal/stacks/output/output.go
@@ -100,7 +100,7 @@ func StackOutput(
 
 	if wts != nil {
 		defer func() {
-			if cleanupErr := wts.Cleanup(ctx, l, v.FS); cleanupErr != nil {
+			if cleanupErr := wts.Cleanup(ctx, l, v); cleanupErr != nil {
 				l.Errorf("failed to cleanup worktrees: %v", cleanupErr)
 			}
 		}()

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -41,8 +41,6 @@ const (
 type Worktrees struct {
 	// WorktreePairs maps Git expression strings to their corresponding worktree pairs.
 	WorktreePairs map[string]*WorktreePair
-	// gitRunner is the Git runner used to create and manage the worktrees.
-	gitRunner *git.GitRunner
 	// OriginalWorkingDir is the user's working directory before worktrees were created.
 	OriginalWorkingDir string
 	// ReadingAffectedStacks holds stacks identified during generation as affected by
@@ -108,32 +106,34 @@ func (w *Worktrees) DisplayPath(worktreePath string) string {
 }
 
 // Cleanup removes all created Git worktrees and their temporary directories.
-func (w *Worktrees) Cleanup(ctx context.Context, l log.Logger, fsys vfs.FS) error {
-	// Get repo remote for telemetry
-	var repoRemote string
-	if w.gitRunner != nil {
-		repoRemote = w.gitRunner.GetRemoteURL(ctx)
+func (w *Worktrees) Cleanup(ctx context.Context, l log.Logger, v *venv.Venv) error {
+	toRemove := w.worktreesToRemove()
+
+	if len(toRemove) == 0 {
+		return nil
 	}
+
+	gitRunner, err := git.NewGitRunner(v)
+	if err != nil {
+		return fmt.Errorf("failed to create Git runner for worktree cleanup: %w", err)
+	}
+
+	gitRunner = gitRunner.WithWorkDir(w.OriginalWorkingDir)
 
 	return filter.TraceGitWorktreesCleanup(
 		ctx,
 		len(w.WorktreePairs),
-		repoRemote,
+		gitRunner.GetRemoteURL(ctx),
 		func(ctx context.Context) error {
-			toRemove := w.worktreesToRemove()
-			if len(toRemove) == 0 {
-				return nil
-			}
-
 			g, groupCtx := errgroup.WithContext(ctx)
 			// Every worktree was created under the same temporary directory, so
 			// the first one's filesystem sizes removal for all of them.
-			g.SetLimit(min(vfs.FSWorkersFor(fsys, toRemove[0].Path), len(toRemove)))
+			g.SetLimit(min(vfs.FSWorkersFor(v.FS, toRemove[0].Path), len(toRemove)))
 
 			for _, worktree := range toRemove {
 				g.Go(func() error {
 					// Skip removal if the worktree path doesn't exist (may have been cleaned up already)
-					if _, err := fsys.Stat(worktree.Path); errors.Is(err, fs.ErrNotExist) {
+					if _, err := v.FS.Stat(worktree.Path); errors.Is(err, fs.ErrNotExist) {
 						l.Debugf(
 							"Worktree path %s already removed, skipping cleanup",
 							worktree.Path,
@@ -147,7 +147,7 @@ func (w *Worktrees) Cleanup(ctx context.Context, l log.Logger, fsys vfs.FS) erro
 						worktree.Ref,
 						worktree.Path,
 						func(ctx context.Context) error {
-							return w.gitRunner.RemoveWorktree(ctx, worktree.Path)
+							return gitRunner.RemoveWorktree(ctx, worktree.Path)
 						},
 					)
 					if err != nil {
@@ -538,13 +538,12 @@ func filterPaths(filters filter.Filters) ([]string, bool) {
 	return paths, true
 }
 
-// newEmptyWorktrees returns a Worktrees with no pairs, for a run that failed
-// before it had any.
-func newEmptyWorktrees(workingDir string, gitRunner *git.GitRunner) *Worktrees {
+// newEmptyWorktrees returns a Worktrees with no pairs, for a run with no Git
+// expressions or one that failed before it had any pairs.
+func newEmptyWorktrees(workingDir string) *Worktrees {
 	return &Worktrees{
 		WorktreePairs:      make(map[string]*WorktreePair),
 		OriginalWorkingDir: workingDir,
-		gitRunner:          gitRunner,
 	}
 }
 
@@ -706,10 +705,7 @@ func NewWorktrees(
 	experiments := opts.Experiments
 
 	if len(gitExpressions) == 0 {
-		return &Worktrees{
-			WorktreePairs:      make(map[string]*WorktreePair),
-			OriginalWorkingDir: workingDir,
-		}, nil
+		return newEmptyWorktrees(workingDir), nil
 	}
 
 	gitRefs := gitExpressions.UniqueGitRefs()
@@ -741,7 +737,7 @@ func NewWorktrees(
 			// of each one is checked out, so it runs before any of them are.
 			survey, err := surveyGitExpressions(ctx, v, gitRunner, gitExpressions, gitRefs, repoRemote)
 			if err != nil {
-				worktrees = newEmptyWorktrees(workingDir, gitRunner)
+				worktrees = newEmptyWorktrees(workingDir)
 				outerErr = err
 
 				return err
@@ -766,42 +762,22 @@ func NewWorktrees(
 				experiments,
 				pathspecs,
 			)
+
+			worktrees = &Worktrees{
+				WorktreePairs:      survey.worktreePairs(gitExpressions, refsToPaths),
+				OriginalWorkingDir: workingDir,
+			}
+
 			if err != nil {
-				worktrees = newEmptyWorktrees(workingDir, gitRunner)
 				outerErr = err
 
 				return err
 			}
 
-			worktreePairs := make(map[string]*WorktreePair, len(gitExpressions))
 			for _, gitExpression := range gitExpressions {
-				expansion := survey.expansions[gitExpression.String()]
-
-				worktreePairs[gitExpression.String()] = &WorktreePair{
-					GitExpression: gitExpression,
-					Diffs:         expansion.diffs,
-					FromFilters:   expansion.fromFilters,
-					ToFilters:     expansion.toFilters,
-					FromWorktree: Worktree{
-						Ref:  gitExpression.FromRef,
-						Path: refsToPaths[gitExpression.FromRef],
-					},
-					ToWorktree: Worktree{
-						Ref:  gitExpression.ToRef,
-						Path: refsToPaths[gitExpression.ToRef],
-					},
-				}
-
-				// Record telemetry for diff results
-				if diffs := expansion.diffs; diffs != nil {
+				if diffs := survey.expansions[gitExpression.String()].diffs; diffs != nil {
 					recordDiffTelemetry(ctx, diffs)
 				}
-			}
-
-			worktrees = &Worktrees{
-				WorktreePairs:      worktreePairs,
-				OriginalWorkingDir: workingDir,
-				gitRunner:          gitRunner,
 			}
 
 			return nil
@@ -813,12 +789,43 @@ func NewWorktrees(
 
 	// cleanup worktrees
 	if outerErr != nil && worktrees != nil {
-		if cleanupErr := worktrees.Cleanup(ctx, l, v.FS); cleanupErr != nil {
+		if cleanupErr := worktrees.Cleanup(ctx, l, v); cleanupErr != nil {
 			l.Warnf("failed to cleanup worktrees: %v", cleanupErr)
 		}
 	}
 
 	return worktrees, outerErr
+}
+
+// worktreePairs pairs each Git expression with its expansion and the worktrees
+// of its references. A reference absent from refsToPaths gets a worktree with
+// no path.
+func (s *gitSurvey) worktreePairs(
+	gitExpressions filter.GitExpressions,
+	refsToPaths map[string]string,
+) map[string]*WorktreePair {
+	pairs := make(map[string]*WorktreePair, len(gitExpressions))
+
+	for _, gitExpression := range gitExpressions {
+		expansion := s.expansions[gitExpression.String()]
+
+		pairs[gitExpression.String()] = &WorktreePair{
+			GitExpression: gitExpression,
+			Diffs:         expansion.diffs,
+			FromFilters:   expansion.fromFilters,
+			ToFilters:     expansion.toFilters,
+			FromWorktree: Worktree{
+				Ref:  gitExpression.FromRef,
+				Path: refsToPaths[gitExpression.FromRef],
+			},
+			ToWorktree: Worktree{
+				Ref:  gitExpression.ToRef,
+				Path: refsToPaths[gitExpression.ToRef],
+			},
+		}
+	}
+
+	return pairs
 }
 
 // expandDiffPaths processes a list of added or removed paths from a worktree diff, creating filter
@@ -1054,7 +1061,7 @@ func createGitWorktree(
 	err = filter.TraceGitWorktreeCreate(
 		ctx, opts.ref, tmpDir, opts.repoRemote, opts.repoBranch, opts.repoCommit,
 		func(ctx context.Context) error {
-			return materializeGitWorktree(ctx, v, gitRunner, registerMu, tmpDir, opts, altering)
+			return materializeGitWorktree(ctx, l, v, gitRunner, registerMu, tmpDir, opts, altering)
 		})
 	if err != nil {
 		if cleanErr := v.FS.RemoveAll(tmpDir); cleanErr != nil {
@@ -1089,9 +1096,11 @@ func worktreeTempDir(v *venv.Venv, ref string) (string, error) {
 }
 
 // materializeGitWorktree registers dir as a worktree for the reference and puts
-// the reference's files in it.
+// the reference's files in it. A worktree registered but left unfilled is
+// removed again.
 func materializeGitWorktree(
 	ctx context.Context,
+	l log.Logger,
 	v *venv.Venv,
 	gitRunner *git.GitRunner,
 	registerMu *sync.Mutex,
@@ -1112,6 +1121,24 @@ func materializeGitWorktree(
 		return nil
 	}
 
+	if err := fillGitWorktree(ctx, v, gitRunner, dir, opts); err != nil {
+		unregisterWorktree(ctx, l, gitRunner, registerMu, dir)
+
+		return err
+	}
+
+	return nil
+}
+
+// fillGitWorktree puts the reference's files in dir, a worktree registered
+// without a checkout.
+func fillGitWorktree(
+	ctx context.Context,
+	v *venv.Venv,
+	gitRunner *git.GitRunner,
+	dir string,
+	opts *worktreeOpts,
+) error {
 	if err := extractGitWorktree(ctx, v, gitRunner, dir, opts); err != nil {
 		return err
 	}
@@ -1143,6 +1170,25 @@ func registerWorktree(
 	defer registerMu.Unlock()
 
 	return gitRunner.CreateDetachedWorktree(ctx, v, dir, ref, checkout)
+}
+
+// unregisterWorktree removes the worktree registered at dir, logging a failure
+// to do so. It holds registerMu because git deletes the repository's
+// `.git/worktrees/` directory along with its last registration, while a
+// concurrent `git worktree add` may be creating an entry in it.
+func unregisterWorktree(
+	ctx context.Context,
+	l log.Logger,
+	gitRunner *git.GitRunner,
+	registerMu *sync.Mutex,
+	dir string,
+) {
+	registerMu.Lock()
+	defer registerMu.Unlock()
+
+	if err := gitRunner.RemoveWorktree(ctx, dir); err != nil {
+		l.Warnf("failed to remove Git worktree %s: %v", dir, err)
+	}
 }
 
 // extractGitWorktree streams the archive of ref into dir. Git writes the

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -43,7 +43,7 @@ func TestNewWorktrees(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupErr := w.Cleanup(context.Background(), logger.CreateLogger(), vfs.NewOSFS())
+		cleanupErr := w.Cleanup(context.Background(), logger.CreateLogger(), venvtest.NewOSWithEmptyEnv())
 		require.NoError(t, cleanupErr)
 	})
 
@@ -87,7 +87,7 @@ func TestNewWorktreesForSeveralRefsWithRacing(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, w.Cleanup(context.Background(), logger.CreateLogger(), vfs.NewOSFS()))
+		require.NoError(t, w.Cleanup(context.Background(), logger.CreateLogger(), venvtest.NewOSWithEmptyEnv()))
 	})
 
 	require.Len(t, w.WorktreePairs, 2)
@@ -222,7 +222,7 @@ func TestNewWorktreesFilteredPathsOnly(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
-				require.NoError(t, w.Cleanup(context.Background(), logger.CreateLogger(), v.FS))
+				require.NoError(t, w.Cleanup(context.Background(), logger.CreateLogger(), v))
 			})
 
 			materialized := 0
@@ -277,6 +277,59 @@ func TestNewWorktreesWithInvalidReference(t *testing.T) {
 		worktrees.WorktreeOpts{WorkingDir: tmpDir, GitExpressions: filters.UniqueGitFilters()},
 	)
 	require.Error(t, err)
+}
+
+// TestNewWorktreesPartialFailureCleanup pins that a reference failing to
+// materialize leaves neither its own worktree nor the ones created beside it
+// in the temporary directory or in the repository's worktree list.
+func TestNewWorktreesPartialFailureCleanup(t *testing.T) {
+	t.Parallel()
+
+	if helpers.IsWindows() {
+		t.Skip("os.Symlink on Windows requires special permissions; covered by Unix CI")
+	}
+
+	repoDir := helpers.TmpDirWOSymlinks(t)
+	tempDir := helpers.TmpDirWOSymlinks(t)
+
+	runner := helpers.InitTestGitRunner(t, repoDir)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "unit"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoDir, "unit", "terragrunt.hcl"),
+		[]byte("inputs = {}\n"),
+		0o600,
+	))
+
+	// Extraction refuses a link pointing out of the worktree, so HEAD~1 fails
+	// to materialize after it is registered, while HEAD without the link
+	// succeeds.
+	link := filepath.Join(repoDir, "escape")
+	require.NoError(t, os.Symlink("../outside", link))
+	require.NoError(t, runner.Add(t.Context(), "."))
+	require.NoError(t, runner.Commit(t.Context(), "Initial commit"))
+
+	require.NoError(t, os.Remove(link))
+	require.NoError(t, runner.Add(t.Context(), "."))
+	require.NoError(t, runner.Commit(t.Context(), "Remove link"))
+
+	filters, err := filter.ParseFilterQueries(logger.CreateLogger(), []string{"[HEAD~1...HEAD]"})
+	require.NoError(t, err)
+
+	v := venvtest.NewOSWithEmptyEnv().WithTempDir(func() string { return tempDir })
+
+	_, err = worktrees.NewWorktrees(t.Context(), logger.CreateLogger(), v, worktrees.WorktreeOpts{
+		WorkingDir:     repoDir,
+		GitExpressions: filters.UniqueGitFilters(),
+	})
+	require.ErrorIs(t, err, vfs.ErrSymlinkEscapes)
+
+	entries, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+
+	// Git deletes its worktrees directory along with the last registration.
+	assert.NoDirExists(t, filepath.Join(repoDir, ".git", "worktrees"))
 }
 
 func TestExpressionExpansion(t *testing.T) {


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

Cleans up partial worktree creation on failure.

Addresses feedback from #6864

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary worktrees across validation, discovery, stack, and execution workflows.
  * Prevented leftover temporary worktrees and registrations when worktree setup fails partway through.
  * Improved error handling during worktree creation and cleanup.
* **Tests**
  * Added coverage for cleanup after failed worktree materialization, including failures involving symbolic links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->