### PR TITLE
fix: normalize path_relative_to_include separators on Windows

### DIFF
--- a/docs/src/data/changelog/v1.1.5/windows-path-relative-to-include-separators.mdx
+++ b/docs/src/data/changelog/v1.1.5/windows-path-relative-to-include-separators.mdx
@@ -1,0 +1,10 @@
+---
+version: "v1.1.5"
+category: "bug-fixes"
+---
+
+#### Normalize `path_relative_to_include` separators on Windows
+
+On Windows, `path_relative_to_include()` and `path_relative_from_include()` returned paths with native backslash separators, because they were computed with `filepath.Rel`. When such a path is used as a remote-state `key` (for example the azurerm backend builds its blob URL from it), the backslashes end up in the URL and are rejected as an invalid control character.
+
+Both functions now normalize their result to forward slashes with `filepath.ToSlash`, matching the cross-platform contract documented by their tests. Unix and macOS behaviour is unchanged.

--- a/pkg/config/config_helpers.go
+++ b/pkg/config/config_helpers.go
@@ -912,7 +912,7 @@ func PathRelativeToInclude(
 		)
 	}
 
-	return result, nil
+	return filepath.ToSlash(result), nil
 }
 
 // PathRelativeFromInclude returns the relative path from the current Terragrunt configuration to the included Terragrunt configuration file
@@ -948,7 +948,7 @@ func PathRelativeFromInclude(
 		)
 	}
 
-	return result, nil
+	return filepath.ToSlash(result), nil
 }
 
 // getTerraformCommand returns the current terraform command in execution

--- a/pkg/config/config_helpers_windows_test.go
+++ b/pkg/config/config_helpers_windows_test.go
@@ -1,0 +1,73 @@
+//go:build windows
+
+package config_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/gruntwork-io/terragrunt/test/helpers"
+	"github.com/gruntwork-io/terragrunt/test/helpers/logger"
+	"github.com/gruntwork-io/terragrunt/test/helpers/venvtest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPathRelativeToIncludeWindowsSeparators pins that path_relative_to_include
+// returns forward-slash paths even though filepath.Rel produces native (backslash)
+// separators on Windows. The result is frequently embedded in a remote-state key
+// (e.g. the azurerm backend builds its blob URL from it), where a backslash is
+// rejected as an invalid control character. Gated to Windows because
+// filepath.ToSlash is a no-op on Unix separators.
+func TestPathRelativeToIncludeWindowsSeparators(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(
+		helpers.RootFolder,
+		"child",
+		"sub-child",
+		config.DefaultTerragruntConfigPath,
+	)
+	trackInclude := getTrackIncludeFromTestData(
+		map[string]config.IncludeConfig{
+			"": {Path: filepath.Join(helpers.RootFolder, config.DefaultTerragruntConfigPath)},
+		},
+		nil,
+		configPath,
+	)
+
+	l := logger.CreateLogger()
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), configPath)
+	pctx = pctx.WithTrackInclude(trackInclude)
+
+	actualPath, err := config.PathRelativeToInclude(ctx, pctx, l, nil)
+	require.NoError(t, err)
+	require.Equal(t, "child/sub-child", actualPath)
+}
+
+// TestPathRelativeFromIncludeWindowsSeparators mirrors the above for
+// path_relative_from_include.
+func TestPathRelativeFromIncludeWindowsSeparators(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(
+		helpers.RootFolder,
+		"child",
+		config.DefaultTerragruntConfigPath,
+	)
+	trackInclude := getTrackIncludeFromTestData(
+		map[string]config.IncludeConfig{
+			"": {Path: filepath.Join(helpers.RootFolder, "sibling", config.DefaultTerragruntConfigPath)},
+		},
+		nil,
+		configPath,
+	)
+
+	l := logger.CreateLogger()
+	ctx, pctx := newTestParsingContext(t, venvtest.NewWithOSFS(), configPath)
+	pctx = pctx.WithTrackInclude(trackInclude)
+
+	actualPath, err := config.PathRelativeFromInclude(ctx, pctx, l, nil)
+	require.NoError(t, err)
+	require.Equal(t, "../child", actualPath)
+}


### PR DESCRIPTION
## Description

Fixes #6749.

`path_relative_to_include()` and `path_relative_from_include()` compute their result with `filepath.Rel`, which returns native (backslash) separators on Windows. When that result is used as a remote-state `key` — for example the azurerm backend builds its blob URL from `${path_relative_to_include()}/terraform.tfstate` — the backslashes are embedded in the URL and rejected as an invalid control character, so `init`/`apply` fail with `net/url: invalid control character in URL`.

This normalizes both results to forward slashes with `filepath.ToSlash`, matching the cross-platform contract already documented by their tests. Unix and macOS behaviour is unchanged (`filepath.ToSlash` is a no-op there).

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] I authored this code entirely myself
- [ ] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [ ] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [ ] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [ ] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows-generated relative paths now consistently use forward slashes.
  * Prevents invalid backslash separators in remote-state URLs.
  * Unix and macOS path behavior remains unchanged.

* **Documentation**
  * Added a changelog entry describing the Windows path separator fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->