### PR TITLE
docs: Adding `sign-commits` to the use of `peter-evans/create-pull-request` for docs clean-up PRs

### DIFF
--- a/.github/workflows/docs-cleanup-version-gates.yml
+++ b/.github/workflows/docs-cleanup-version-gates.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v7
         with:
+          sign-commits: true
           branch: docs/cleanup-version-gates
           commit-message: 'docs: clean up released version gates for ${{ github.event.release.tag_name || inputs.tag_name }}'
           title: 'docs: clean up released version gates for ${{ github.event.release.tag_name || inputs.tag_name }}'

--- a/.github/workflows/gopls.yml
+++ b/.github/workflows/gopls.yml
@@ -45,6 +45,7 @@ jobs:
         if: steps.gopls_run.outputs.has_fixes == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v7
         with:
+          sign-commits: true
           branch: chore/gopls-quickfixes
           commit-message: 'chore: Apply gopls quickfixes'
           title: 'chore: Apply gopls quickfixes'

--- a/.github/workflows/update-codified-remote-deps.yml
+++ b/.github/workflows/update-codified-remote-deps.yml
@@ -43,6 +43,7 @@ jobs:
         if: steps.check.outputs.needs_update == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v7
         with:
+          sign-commits: true
           branch: chore/update-live-stacks-example-commit
           commit-message: 'chore: Update live stacks example commit to ${{ steps.check.outputs.latest }}'
           title: 'chore: Update live stacks example commit'


### PR DESCRIPTION
<!-- Keep this PR in draft while it is still a work-in-progress. Mark it as ready for review once it is ready for review by maintainers. -->

## Description

These workflows were silently failing because they weren't signing their commits.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] I authored this code entirely myself
- [x] I am submitting code based on open source software (e.g. MIT, MPL-2.0, Apache)
- [x] I am adding or upgrading a dependency or adapted code and confirm it has a compatible open source license
- [x] Update the docs.
- [x] Update the changelog in the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] This change is backwards compatible.
- [x] If this change is not forwards compatible (e.g. a new feature), it is gated behind a feature flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Automated pull requests created by documentation cleanup, quick-fix, and dependency update workflows now use signed commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->